### PR TITLE
Add JSONL export endpoint for conversations (#36)

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -416,6 +416,7 @@ func (s *Server) handleSearchConversations(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *Server) handleExportConversation(w http.ResponseWriter, r *http.Request, convID string) {
+	// Try in-memory first (active run), fall back to store.
 	msgs, ok := s.runner.ConversationMessages(convID)
 	if !ok {
 		store := s.runner.GetConversationStore()
@@ -428,13 +429,19 @@ func (s *Server) handleExportConversation(w http.ResponseWriter, r *http.Request
 			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 			return
 		}
+		if len(loaded) == 0 {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+			return
+		}
 		msgs = loaded
 	}
 	w.Header().Set("Content-Type", "application/x-ndjson")
 	w.WriteHeader(http.StatusOK)
 	enc := json.NewEncoder(w)
 	for _, msg := range msgs {
-		_ = enc.Encode(msg)
+		if err := enc.Encode(msg); err != nil {
+			return
+		}
 	}
 }
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -1396,3 +1396,21 @@ func TestHandleExportConversation_StoreError(t *testing.T) {
 		t.Fatalf("expected 500, got %d", res.StatusCode)
 	}
 }
+
+func TestHandleExportConversation_StoreNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	// No ConversationStore configured, conversation not in memory → 404
+	runner := harness.NewRunner(&staticProvider{result: harness.CompletionResult{Content: "ok"}}, harness.NewRegistry(), harness.RunnerConfig{})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/v1/conversations/nonexistent/export")
+	if err != nil {
+		t.Fatalf("GET export: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 when not in memory and no store, got %d", res.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `GET /v1/conversations/{id}/export` that streams messages as JSONL (`application/x-ndjson`), one `Message` JSON object per line
- Checks in-memory first (active run), then falls back to the `ConversationStore`
- Returns 404 if not found in either place, 405 for wrong method, 500 on store error

## Files Changed

| File | Change |
|------|--------|
| `internal/server/http.go` | Added route + `handleExportConversation` handler |
| `internal/server/http_test.go` | 5 tests; extended `mockConversationStore` with per-conversation `LoadMessages` |

## Test plan

- [x] 404 for nonexistent conversation (no store, not in memory)
- [x] 405 for non-GET method
- [x] 200 with valid JSONL — each line parses as a `Message` with correct role
- [x] Content-Type is `application/x-ndjson`
- [x] 500 when store returns error
- [x] Full suite passes with `-race`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)