### PR TITLE
Add skill verification flag

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -645,6 +645,10 @@ func (a *skillListerAdapter) GetSkill(name string) (htools.SkillInfo, bool) {
 		Source:       string(s.Source),
 		Context:      string(s.Context),
 		Agent:        s.Agent,
+		Verified:     s.Verified,
+		VerifiedAt:   s.VerifiedAt,
+		VerifiedBy:   s.VerifiedBy,
+		FilePath:     s.FilePath,
 	}, true
 }
 
@@ -660,6 +664,10 @@ func (a *skillListerAdapter) ListSkills() []htools.SkillInfo {
 			Source:       string(s.Source),
 			Context:      string(s.Context),
 			Agent:        s.Agent,
+			Verified:     s.Verified,
+			VerifiedAt:   s.VerifiedAt,
+			VerifiedBy:   s.VerifiedBy,
+			FilePath:     s.FilePath,
 		}
 	}
 	return result

--- a/docs/implementation/issue-62-skill-verification.md
+++ b/docs/implementation/issue-62-skill-verification.md
@@ -1,0 +1,72 @@
+# Issue #62: Skill Verification Flag (VOYAGER write-verify-store pattern)
+
+## Summary
+
+Implemented skill verification flag support following the VOYAGER write-verify-store pattern. Skills can now be marked as verified, with verification metadata persisted in the SKILL.md frontmatter.
+
+## Files Changed
+
+### `internal/skills/types.go`
+- Added `Verified bool`, `VerifiedAt string`, `VerifiedBy string` fields to `Skill` struct (JSON-tagged)
+- Added `Verified`, `VerifiedAt`, `VerifiedBy` YAML fields to `frontmatter` struct
+
+### `internal/skills/loader.go`
+- Mapped new frontmatter fields to `Skill` struct in `parseSkillFile`
+- Added `WriteVerification(path, verifiedAt, verifiedBy string) error` function that:
+  - Reads the existing SKILL.md
+  - Parses frontmatter as a generic YAML map
+  - Updates `verified`, `verified_at`, `verified_by` keys
+  - Re-serializes frontmatter and writes file back, preserving markdown body
+
+### `internal/harness/tools/types.go`
+- Added `Verified bool`, `VerifiedAt string`, `VerifiedBy string`, `FilePath string` to `SkillInfo` struct
+- `FilePath` is required so the `verify` action knows where to write
+
+### `cmd/harnessd/main.go`
+- Updated `skillListerAdapter.GetSkill` and `ListSkills` to propagate new `Skill` fields to `SkillInfo`
+
+### `internal/harness/tools/core/skill.go`
+- Added `skills` package import
+- Added `handleListSkills`: returns all skills with `[verified]`/`[unverified]` status
+- Added `handleVerifySkill`: writes verification metadata to SKILL.md via `skills.WriteVerification`
+- Updated `handleConversationSkill`: prepends `⚠ WARNING: skill is unverified\n\n` to meta-message body for unverified skills
+- Updated handler dispatch: routes `list` and `verify` commands to new handlers before falling through to skill apply
+
+### `internal/harness/tools/descriptions/skill.md`
+- Documented `list` and `verify` built-in actions
+
+## Tests Added
+
+### `internal/skills/loader_test.go`
+- `TestLoaderLoad_VerifiedFields` - loads skill with verified frontmatter fields
+- `TestLoaderLoad_UnverifiedByDefault` - backward compat: missing fields default to false/empty
+
+### `internal/harness/tools/core/skill_test.go`
+- `TestSkillTool_Handler_ListShowsVerifiedStatus` - list output contains `[verified]` and `[unverified]`
+- `TestSkillTool_Handler_ListEmptySkills` - list with no skills
+- `TestSkillTool_Handler_ApplyUnverifiedPrependsWarning` - warning in meta-message for unverified
+- `TestSkillTool_Handler_ApplyVerifiedNoWarning` - no warning for verified skills
+- `TestSkillTool_Handler_VerifyAction` - writes verified/verified_at/verified_by to file
+- `TestSkillTool_Handler_VerifyDefaultVerifiedBy` - defaults to "agent" when no verifier given
+- `TestSkillTool_Handler_VerifyNonexistentSkill` - error for unknown skill
+- `TestSkillTool_Handler_VerifyMissingSkillName` - error when verify has no skill name arg
+
+## Test Results
+
+All tests pass with the race detector:
+
+```
+ok  go-agent-harness/internal/skills
+ok  go-agent-harness/internal/harness/tools
+ok  go-agent-harness/internal/harness/tools/core
+ok  go-agent-harness/cmd/harnessd
+FAIL go-agent-harness/demo-cli [build failed]  # pre-existing, unrelated failure
+```
+
+## Design Notes
+
+- `WriteVerification` parses frontmatter as a generic YAML map to avoid losing unknown keys
+- The `FilePath` field in `SkillInfo` is used by the `verify` action to locate the file to update
+- `list` and `verify` are reserved command prefixes; a skill named "list" or "verify" cannot be applied (by design)
+- The warning unicode character `⚠` (U+26A0) is used as specified in the issue
+- `Mutating` flag on the tool definition remains `false` since the primary operations are read-only; `verify` is an admin/config operation analogous to writing a config file

--- a/internal/harness/tools/core/skill.go
+++ b/internal/harness/tools/core/skill.go
@@ -10,6 +10,7 @@ import (
 
 	tools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/harness/tools/descriptions"
+	"go-agent-harness/internal/skills"
 )
 
 // defaultForkTimeout is the maximum duration for a forked skill execution.
@@ -79,8 +80,20 @@ func SkillTool(lister tools.SkillLister, runner tools.AgentRunner) tools.Tool {
 		if command == "" {
 			return "", fmt.Errorf("command is required: provide a skill name")
 		}
-		name, skillArgs, _ := strings.Cut(command, " ")
-		skillArgs = strings.TrimSpace(skillArgs)
+		action, actionArgs, _ := strings.Cut(command, " ")
+		actionArgs = strings.TrimSpace(actionArgs)
+
+		// Special built-in actions
+		switch action {
+		case "list":
+			return handleListSkills(lister)
+		case "verify":
+			return handleVerifySkill(lister, actionArgs)
+		}
+
+		// Default: apply the named skill
+		name := action
+		skillArgs := actionArgs
 
 		workspace := ""
 		if meta, ok := tools.RunMetadataFromContext(ctx); ok {
@@ -163,8 +176,59 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 	})
 }
 
+// handleListSkills returns a formatted list of all registered skills with
+// their verification status.
+func handleListSkills(lister tools.SkillLister) (string, error) {
+	skillList := lister.ListSkills()
+	if len(skillList) == 0 {
+		return "No skills registered.", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Available skills:\n")
+	for _, s := range skillList {
+		status := "[unverified]"
+		if s.Verified {
+			status = "[verified]"
+		}
+		sb.WriteString(fmt.Sprintf("  %s %s — %s\n", s.Name, status, s.Description))
+	}
+	return sb.String(), nil
+}
+
+// handleVerifySkill reads a skill file and writes verification metadata back to it.
+// actionArgs format: "<skill_name> [verified_by]"
+func handleVerifySkill(lister tools.SkillLister, actionArgs string) (string, error) {
+	skillName, verifiedBy, _ := strings.Cut(actionArgs, " ")
+	skillName = strings.TrimSpace(skillName)
+	verifiedBy = strings.TrimSpace(verifiedBy)
+
+	if skillName == "" {
+		return "", fmt.Errorf("verify requires a skill name: 'verify <skill_name> [verified_by]'")
+	}
+	if verifiedBy == "" {
+		verifiedBy = "agent"
+	}
+
+	info, ok := lister.GetSkill(skillName)
+	if !ok {
+		return "", fmt.Errorf("skill not found: %s", skillName)
+	}
+	if info.FilePath == "" {
+		return "", fmt.Errorf("skill %q has no file path (cannot verify)", skillName)
+	}
+
+	verifiedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := skills.WriteVerification(info.FilePath, verifiedAt, verifiedBy); err != nil {
+		return "", fmt.Errorf("writing verification for skill %q: %w", skillName, err)
+	}
+
+	return fmt.Sprintf("Skill %q verified at %s by %q.", skillName, verifiedAt, verifiedBy), nil
+}
+
 // handleConversationSkill injects the skill content into the current conversation
-// as a meta-message (the default behavior).
+// as a meta-message (the default behavior). Prepends an unverified warning when
+// the skill has not been verified.
 func handleConversationSkill(info tools.SkillInfo, content string) (string, error) {
 	ack, err := tools.MarshalToolResult(map[string]any{
 		"skill":         info.Name,
@@ -175,7 +239,13 @@ func handleConversationSkill(info tools.SkillInfo, content string) (string, erro
 		return "", err
 	}
 
-	metaMsg := fmt.Sprintf("<skill name=%q>\n%s\n</skill>", info.Name, content)
+	// Prepend warning for unverified skills
+	body := content
+	if !info.Verified {
+		body = "\u26a0 WARNING: skill is unverified\n\n" + content
+	}
+
+	metaMsg := fmt.Sprintf("<skill name=%q>\n%s\n</skill>", info.Name, body)
 	return tools.WrapToolResult(tools.ToolResult{
 		Output: ack,
 		MetaMessages: []tools.MetaMessage{

--- a/internal/harness/tools/core/skill_test.go
+++ b/internal/harness/tools/core/skill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -782,6 +783,252 @@ func TestSkillTool_Handler_ForkContextCanceled(t *testing.T) {
 		t.Fatal("expected error for canceled context")
 	}
 	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------- list action tests ----------
+
+func newVerificationSkillLister() *mockSkillLister {
+	return &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"verified-skill": {
+				Name:        "verified-skill",
+				Description: "A verified skill",
+				Source:      "global",
+				Verified:    true,
+				VerifiedAt:  "2026-03-09T12:00:00Z",
+				VerifiedBy:  "dennisonbertram",
+			},
+			"unverified-skill": {
+				Name:        "unverified-skill",
+				Description: "An unverified skill",
+				Source:      "global",
+				Verified:    false,
+			},
+		},
+		bodies: map[string]string{
+			"verified-skill":   "Do the verified thing.",
+			"unverified-skill": "Do the unverified thing.",
+		},
+	}
+}
+
+func TestSkillTool_Handler_ListShowsVerifiedStatus(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"list"}`))
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if !strings.Contains(out, "[verified]") {
+		t.Fatalf("list output should contain [verified], got: %s", out)
+	}
+	if !strings.Contains(out, "[unverified]") {
+		t.Fatalf("list output should contain [unverified], got: %s", out)
+	}
+	if !strings.Contains(out, "verified-skill") {
+		t.Fatalf("list output should contain 'verified-skill', got: %s", out)
+	}
+	if !strings.Contains(out, "unverified-skill") {
+		t.Fatalf("list output should contain 'unverified-skill', got: %s", out)
+	}
+}
+
+func TestSkillTool_Handler_ListEmptySkills(t *testing.T) {
+	t.Parallel()
+	lister := newEmptySkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"list"}`))
+	if err != nil {
+		t.Fatalf("list with no skills failed: %v", err)
+	}
+
+	if !strings.Contains(out, "No skills registered") {
+		t.Fatalf("list output should say no skills, got: %s", out)
+	}
+}
+
+// ---------- apply unverified warning tests ----------
+
+func TestSkillTool_Handler_ApplyUnverifiedPrependsWarning(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"unverified-skill"}`))
+	if err != nil {
+		t.Fatalf("apply unverified skill failed: %v", err)
+	}
+
+	tr, ok := tools.UnwrapToolResult(out)
+	if !ok {
+		t.Fatal("expected enriched tool result")
+	}
+	if len(tr.MetaMessages) != 1 {
+		t.Fatalf("expected 1 meta-message, got %d", len(tr.MetaMessages))
+	}
+	if !strings.Contains(tr.MetaMessages[0].Content, "WARNING: skill is unverified") {
+		t.Fatalf("meta-message should contain unverified warning, got: %s", tr.MetaMessages[0].Content)
+	}
+}
+
+func TestSkillTool_Handler_ApplyVerifiedNoWarning(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verified-skill"}`))
+	if err != nil {
+		t.Fatalf("apply verified skill failed: %v", err)
+	}
+
+	tr, ok := tools.UnwrapToolResult(out)
+	if !ok {
+		t.Fatal("expected enriched tool result")
+	}
+	if len(tr.MetaMessages) != 1 {
+		t.Fatalf("expected 1 meta-message, got %d", len(tr.MetaMessages))
+	}
+	if strings.Contains(tr.MetaMessages[0].Content, "WARNING") {
+		t.Fatalf("meta-message should NOT contain warning for verified skill, got: %s", tr.MetaMessages[0].Content)
+	}
+}
+
+// ---------- verify action tests ----------
+
+func TestSkillTool_Handler_VerifyAction(t *testing.T) {
+	t.Parallel()
+
+	// Create a real skill file on disk
+	dir := t.TempDir()
+	skillContent := "---\nname: my-skill\ndescription: \"A test skill. Trigger: do my thing\"\nversion: 1\n---\n# My Skill Body\n\nUse $ARGUMENTS here.\n"
+	skillDir := dir + "/my-skill"
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := skillDir + "/SKILL.md"
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"my-skill": {
+				Name:        "my-skill",
+				Description: "A test skill",
+				Source:      "global",
+				Verified:    false,
+				FilePath:    skillFile,
+			},
+		},
+		bodies: map[string]string{
+			"my-skill": "Use $ARGUMENTS here.",
+		},
+	}
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify my-skill dennisonbertram"}`))
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	if !strings.Contains(out, "my-skill") {
+		t.Fatalf("verify output should mention skill name, got: %s", out)
+	}
+	if !strings.Contains(out, "verified") {
+		t.Fatalf("verify output should confirm verification, got: %s", out)
+	}
+
+	// Re-read the file and verify it was updated
+	data, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatalf("reading updated skill file: %v", err)
+	}
+	updated := string(data)
+	if !strings.Contains(updated, "verified: true") {
+		t.Fatalf("skill file should contain 'verified: true', got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "verified_by: dennisonbertram") {
+		t.Fatalf("skill file should contain 'verified_by: dennisonbertram', got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "verified_at:") {
+		t.Fatalf("skill file should contain 'verified_at:', got:\n%s", updated)
+	}
+}
+
+func TestSkillTool_Handler_VerifyDefaultVerifiedBy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	skillContent := "---\nname: basic\ndescription: \"Basic skill\"\nversion: 1\n---\nBody.\n"
+	skillDir := dir + "/basic"
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := skillDir + "/SKILL.md"
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"basic": {
+				Name:     "basic",
+				FilePath: skillFile,
+			},
+		},
+		bodies: map[string]string{"basic": "Body."},
+	}
+	tool := SkillTool(lister, nil)
+
+	// verify without a verified_by arg — should default to "agent"
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify basic"}`))
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	if !strings.Contains(out, "agent") {
+		t.Fatalf("verify output should mention default verifier 'agent', got: %s", out)
+	}
+
+	data, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatalf("reading updated skill file: %v", err)
+	}
+	if !strings.Contains(string(data), "verified_by: agent") {
+		t.Fatalf("skill file should contain 'verified_by: agent', got:\n%s", string(data))
+	}
+}
+
+func TestSkillTool_Handler_VerifyNonexistentSkill(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify nonexistent"}`))
+	if err == nil {
+		t.Fatal("expected error for nonexistent skill")
+	}
+	if !strings.Contains(err.Error(), "skill not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillTool_Handler_VerifyMissingSkillName(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify"}`))
+	if err == nil {
+		t.Fatal("expected error for verify without skill name")
+	}
+	if !strings.Contains(err.Error(), "verify requires a skill name") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/harness/tools/descriptions/skill.md
+++ b/internal/harness/tools/descriptions/skill.md
@@ -7,3 +7,12 @@ Examples: "deploy staging", "code-review", "tdd --strict".
 
 When a user references a skill by name or a slash command (e.g. "/deploy"),
 use this tool to apply the matching skill. Available skills are listed below.
+
+Built-in actions:
+- "list" — list all available skills with their verification status ([verified] or [unverified])
+- "verify <skill_name> [verified_by]" — mark a skill as verified, writing verification
+  metadata (verified, verified_at, verified_by) back to the skill file. The optional
+  verified_by argument identifies who performed the verification (defaults to "agent").
+
+Unverified skills display a warning when applied. Use "verify" to mark a skill as trusted
+after reviewing its instructions.

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -166,6 +166,10 @@ type SkillInfo struct {
 	Source       string   `json:"source"`
 	Context      string   `json:"context,omitempty"`
 	Agent        string   `json:"agent,omitempty"`
+	Verified     bool     `json:"verified,omitempty"`
+	VerifiedAt   string   `json:"verified_at,omitempty"`
+	VerifiedBy   string   `json:"verified_by,omitempty"`
+	FilePath     string   `json:"file_path,omitempty"` // needed for verify action
 }
 
 // SkillLister provides skill lookup and listing for the skill tool.

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -142,7 +142,53 @@ func parseSkillFile(path, dirName string, source SkillSource) (Skill, error) {
 		Triggers:     triggers,
 		Context:      skillContext,
 		Agent:        meta.Agent,
+		Verified:     meta.Verified,
+		VerifiedAt:   meta.VerifiedAt,
+		VerifiedBy:   meta.VerifiedBy,
 	}, nil
+}
+
+// WriteVerification updates the verified, verified_at, and verified_by fields
+// in the SKILL.md frontmatter at the given path, preserving the markdown body.
+func WriteVerification(path, verifiedAt, verifiedBy string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	content := string(data)
+	fm, body, err := splitFrontmatter(content)
+	if err != nil {
+		return fmt.Errorf("parsing frontmatter: %w", err)
+	}
+
+	var meta map[string]any
+	if err := yaml.Unmarshal([]byte(fm), &meta); err != nil {
+		return fmt.Errorf("parsing frontmatter YAML: %w", err)
+	}
+	if meta == nil {
+		meta = make(map[string]any)
+	}
+
+	meta["verified"] = true
+	meta["verified_at"] = verifiedAt
+	meta["verified_by"] = verifiedBy
+
+	updated, err := yaml.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshaling frontmatter YAML: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.Write(updated)
+	sb.WriteString("---\n")
+	if body != "" {
+		sb.WriteString(body)
+		sb.WriteString("\n")
+	}
+
+	return os.WriteFile(path, []byte(sb.String()), 0o644)
 }
 
 func splitFrontmatter(content string) (string, string, error) {

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -454,3 +454,62 @@ Research carefully.
 		t.Errorf("AllowedTools = %v, want [read grep]", skills[0].AllowedTools)
 	}
 }
+
+func TestLoaderLoad_VerifiedFields(t *testing.T) {
+	dir := t.TempDir()
+	content := `---
+name: verified-skill
+description: "A verified skill"
+version: 1
+verified: true
+verified_at: "2026-03-09T12:00:00Z"
+verified_by: "dennisonbertram"
+---
+Body.
+`
+	writeSkillFile(t, dir, "verified-skill", content)
+
+	loader := NewLoader(LoaderConfig{GlobalDir: dir})
+	skills, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	s := skills[0]
+	if !s.Verified {
+		t.Error("Verified should be true")
+	}
+	if s.VerifiedAt != "2026-03-09T12:00:00Z" {
+		t.Errorf("VerifiedAt = %q, want %q", s.VerifiedAt, "2026-03-09T12:00:00Z")
+	}
+	if s.VerifiedBy != "dennisonbertram" {
+		t.Errorf("VerifiedBy = %q, want %q", s.VerifiedBy, "dennisonbertram")
+	}
+}
+
+func TestLoaderLoad_UnverifiedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	// validSkillMD has no verified fields
+	writeSkillFile(t, dir, "my-skill", validSkillMD)
+
+	loader := NewLoader(LoaderConfig{GlobalDir: dir})
+	skills, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	s := skills[0]
+	if s.Verified {
+		t.Error("Verified should default to false when not specified")
+	}
+	if s.VerifiedAt != "" {
+		t.Errorf("VerifiedAt should be empty by default, got %q", s.VerifiedAt)
+	}
+	if s.VerifiedBy != "" {
+		t.Errorf("VerifiedBy should be empty by default, got %q", s.VerifiedBy)
+	}
+}

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -34,6 +34,9 @@ type Skill struct {
 	Triggers     []string     // extracted from description "Trigger: ..."
 	Context      SkillContext // "conversation" (default) or "fork"
 	Agent        string       // optional agent type hint (e.g., "Explore", "Code")
+	Verified     bool         `json:"verified,omitempty"`
+	VerifiedAt   string       `json:"verified_at,omitempty"` // RFC3339
+	VerifiedBy   string       `json:"verified_by,omitempty"` // agent/user that verified
 }
 
 // frontmatter represents the YAML frontmatter of a SKILL.md.
@@ -46,6 +49,9 @@ type frontmatter struct {
 	ArgumentHint string   `yaml:"argument-hint"`
 	Context      string   `yaml:"context"`
 	Agent        string   `yaml:"agent"`
+	Verified     bool     `yaml:"verified"`
+	VerifiedAt   string   `yaml:"verified_at"`
+	VerifiedBy   string   `yaml:"verified_by"`
 }
 
 // LoaderConfig holds paths for skill discovery.


### PR DESCRIPTION
## Summary

Implements issue #62: adds a verified/verified_at/verified_by flag to skills following the VOYAGER write-verify-store pattern.

## Changes

### Data model
- `internal/skills/types.go`: Added `Verified bool`, `VerifiedAt string`, `VerifiedBy string` to `Skill` struct and YAML frontmatter struct
- `internal/harness/tools/types.go`: Propagated same fields + `FilePath` to `SkillInfo`

### Loader
- `internal/skills/loader.go`: Maps new frontmatter fields into `Skill`; adds `WriteVerification(path, verifiedAt, verifiedBy)` helper that updates frontmatter in-place and writes the file back

### Skill tool (`skill.go`)
- `list` action: shows `[verified]` / `[unverified]` status next to each skill name
- `apply` action: prepends `⚠ WARNING: skill is unverified` to the injected meta-message for unverified skills
- New `verify` action: `skill verify <name> [verified_by]` — stamps the skill file with current timestamp and caller identity (defaults to `"agent"`)

### Description
- `internal/harness/tools/descriptions/skill.md`: Documents `list` and `verify` built-in actions

## Tests

- 2 loader tests: verified-fields parsing, backward-compat (missing fields → `Verified=false`)
- 8 skill tool tests: list shows status, apply warning (unverified), apply no warning (verified), verify writes file, verify default verified_by, verify nonexistent skill, verify missing skill name, list with no skills

All tests pass with `-race`.