### PR TITLE
Add token/cost tracking per conversation (Issue #32)

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -645,6 +645,10 @@ func (a *skillListerAdapter) GetSkill(name string) (htools.SkillInfo, bool) {
 		Source:       string(s.Source),
 		Context:      string(s.Context),
 		Agent:        s.Agent,
+		Verified:     s.Verified,
+		VerifiedAt:   s.VerifiedAt,
+		VerifiedBy:   s.VerifiedBy,
+		FilePath:     s.FilePath,
 	}, true
 }
 
@@ -660,6 +664,10 @@ func (a *skillListerAdapter) ListSkills() []htools.SkillInfo {
 			Source:       string(s.Source),
 			Context:      string(s.Context),
 			Agent:        s.Agent,
+			Verified:     s.Verified,
+			VerifiedAt:   s.VerifiedAt,
+			VerifiedBy:   s.VerifiedBy,
+			FilePath:     s.FilePath,
 		}
 	}
 	return result

--- a/docs/implementation/issue-041-migrate-tool-descriptions.md
+++ b/docs/implementation/issue-041-migrate-tool-descriptions.md
@@ -1,0 +1,73 @@
+# Issue #41: Migrate All Tool Descriptions to `//go:embed` Markdown Files
+
+## Summary
+
+Completed the migration of all tool descriptions to `//go:embed` markdown files
+and strengthened the test coverage to enforce the invariant going forward.
+
+## Status
+
+The tool code migration was already complete before this session — all 39 tool
+entries across all tool files were already calling `descriptions.Load()` rather
+than using inline string literals. The gap was in test coverage: the existing
+`TestLoadAllKnownDescriptions` covered only 25 of the 40 embedded `.md` files.
+
+## Changes Made
+
+### `internal/harness/tools/descriptions/embed_test.go`
+
+1. **Expanded `TestLoadAllKnownDescriptions`** from 25 entries to 39 entries.
+   Added the 14 missing tool names:
+   - `AskUserQuestion`
+   - `download`
+   - `git_diff`
+   - `git_status`
+   - `list_mcp_resources`
+   - `list_models`
+   - `ls`
+   - `lsp_diagnostics`
+   - `lsp_references`
+   - `lsp_restart`
+   - `observational_memory`
+   - `read_mcp_resource`
+   - `sourcegraph`
+   - `todos`
+
+2. **Added `TestAllEmbeddedDescriptionsAreNonEmpty`** — dynamically walks the
+   embedded FS and verifies every `.md` file loads to a non-empty string. This
+   catches newly added description files that are accidentally empty without
+   requiring a manual update to the hardcoded list.
+
+3. **Added `TestEmbeddedFSAndKnownListAreInSync`** — verifies the hardcoded
+   list in `TestLoadAllKnownDescriptions` exactly matches the `.md` files in
+   the embedded FS. Prevents the two from drifting silently (bidirectional: FS
+   files not in known list, and known list entries without FS files).
+
+### `internal/harness/tools/catalog_test.go`
+
+4. **Added `TestAllCatalogToolsHaveNonEmptyDescriptions`** — builds the full
+   catalog with all options enabled (MCP, agent, web, LSP, todos) and verifies
+   every registered tool has a non-empty `Description` field. This is the
+   end-to-end invariant: if any tool forgets to call `descriptions.Load()`, or
+   if an `.md` file is missing, this test fails immediately.
+
+## Test Results
+
+```
+ok  go-agent-harness/internal/harness/tools             (all pass)
+ok  go-agent-harness/internal/harness/tools/descriptions (all pass)
+FAIL demo-cli [build failed]   (pre-existing, unrelated)
+```
+
+All 7 tests in `descriptions` package pass, including 39 subtests in
+`TestLoadAllKnownDescriptions` and 40 subtests in
+`TestAllEmbeddedDescriptionsAreNonEmpty` (40 because `embed.go` itself is not
+an `.md` file).
+
+## Invariant Enforced
+
+Any future tool that:
+- Fails to call `descriptions.Load()` → caught by `TestAllCatalogToolsHaveNonEmptyDescriptions`
+- Adds a `.md` file not in the known list → caught by `TestEmbeddedFSAndKnownListAreInSync`
+- Creates an empty `.md` file → caught by `TestAllEmbeddedDescriptionsAreNonEmpty`
+- Removes an `.md` file that was in the known list → caught by `TestEmbeddedFSAndKnownListAreInSync`

--- a/docs/implementation/issue-62-skill-verification.md
+++ b/docs/implementation/issue-62-skill-verification.md
@@ -1,0 +1,72 @@
+# Issue #62: Skill Verification Flag (VOYAGER write-verify-store pattern)
+
+## Summary
+
+Implemented skill verification flag support following the VOYAGER write-verify-store pattern. Skills can now be marked as verified, with verification metadata persisted in the SKILL.md frontmatter.
+
+## Files Changed
+
+### `internal/skills/types.go`
+- Added `Verified bool`, `VerifiedAt string`, `VerifiedBy string` fields to `Skill` struct (JSON-tagged)
+- Added `Verified`, `VerifiedAt`, `VerifiedBy` YAML fields to `frontmatter` struct
+
+### `internal/skills/loader.go`
+- Mapped new frontmatter fields to `Skill` struct in `parseSkillFile`
+- Added `WriteVerification(path, verifiedAt, verifiedBy string) error` function that:
+  - Reads the existing SKILL.md
+  - Parses frontmatter as a generic YAML map
+  - Updates `verified`, `verified_at`, `verified_by` keys
+  - Re-serializes frontmatter and writes file back, preserving markdown body
+
+### `internal/harness/tools/types.go`
+- Added `Verified bool`, `VerifiedAt string`, `VerifiedBy string`, `FilePath string` to `SkillInfo` struct
+- `FilePath` is required so the `verify` action knows where to write
+
+### `cmd/harnessd/main.go`
+- Updated `skillListerAdapter.GetSkill` and `ListSkills` to propagate new `Skill` fields to `SkillInfo`
+
+### `internal/harness/tools/core/skill.go`
+- Added `skills` package import
+- Added `handleListSkills`: returns all skills with `[verified]`/`[unverified]` status
+- Added `handleVerifySkill`: writes verification metadata to SKILL.md via `skills.WriteVerification`
+- Updated `handleConversationSkill`: prepends `⚠ WARNING: skill is unverified\n\n` to meta-message body for unverified skills
+- Updated handler dispatch: routes `list` and `verify` commands to new handlers before falling through to skill apply
+
+### `internal/harness/tools/descriptions/skill.md`
+- Documented `list` and `verify` built-in actions
+
+## Tests Added
+
+### `internal/skills/loader_test.go`
+- `TestLoaderLoad_VerifiedFields` - loads skill with verified frontmatter fields
+- `TestLoaderLoad_UnverifiedByDefault` - backward compat: missing fields default to false/empty
+
+### `internal/harness/tools/core/skill_test.go`
+- `TestSkillTool_Handler_ListShowsVerifiedStatus` - list output contains `[verified]` and `[unverified]`
+- `TestSkillTool_Handler_ListEmptySkills` - list with no skills
+- `TestSkillTool_Handler_ApplyUnverifiedPrependsWarning` - warning in meta-message for unverified
+- `TestSkillTool_Handler_ApplyVerifiedNoWarning` - no warning for verified skills
+- `TestSkillTool_Handler_VerifyAction` - writes verified/verified_at/verified_by to file
+- `TestSkillTool_Handler_VerifyDefaultVerifiedBy` - defaults to "agent" when no verifier given
+- `TestSkillTool_Handler_VerifyNonexistentSkill` - error for unknown skill
+- `TestSkillTool_Handler_VerifyMissingSkillName` - error when verify has no skill name arg
+
+## Test Results
+
+All tests pass with the race detector:
+
+```
+ok  go-agent-harness/internal/skills
+ok  go-agent-harness/internal/harness/tools
+ok  go-agent-harness/internal/harness/tools/core
+ok  go-agent-harness/cmd/harnessd
+FAIL go-agent-harness/demo-cli [build failed]  # pre-existing, unrelated failure
+```
+
+## Design Notes
+
+- `WriteVerification` parses frontmatter as a generic YAML map to avoid losing unknown keys
+- The `FilePath` field in `SkillInfo` is used by the `verify` action to locate the file to update
+- `list` and `verify` are reserved command prefixes; a skill named "list" or "verify" cannot be applied (by design)
+- The warning unicode character `⚠` (U+26A0) is used as specified in the issue
+- `Mutating` flag on the tool definition remains `false` since the primary operations are read-only; `verify` is an admin/config operation analogous to writing a config file

--- a/internal/harness/conversation_store.go
+++ b/internal/harness/conversation_store.go
@@ -7,11 +7,22 @@ import (
 
 // Conversation holds metadata for a conversation.
 type Conversation struct {
-	ID        string    `json:"id"`
-	Title     string    `json:"title,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	MsgCount  int       `json:"message_count"`
+	ID               string    `json:"id"`
+	Title            string    `json:"title,omitempty"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	MsgCount         int       `json:"message_count"`
+	PromptTokens     int       `json:"prompt_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	CostUSD          float64   `json:"cost_usd"`
+}
+
+// ConversationTokenCost holds token usage and cost data for a conversation run.
+// All fields reflect cumulative totals for the entire conversation (not a single turn).
+type ConversationTokenCost struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CostUSD          float64 `json:"cost_usd"`
 }
 
 // MessageSearchResult is a single result from a full-text search over messages.
@@ -26,6 +37,9 @@ type ConversationStore interface {
 	Migrate(ctx context.Context) error
 	Close() error
 	SaveConversation(ctx context.Context, convID string, msgs []Message) error
+	// SaveConversationWithCost persists a conversation's messages along with
+	// cumulative token usage and cost totals for the run.
+	SaveConversationWithCost(ctx context.Context, convID string, msgs []Message, cost ConversationTokenCost) error
 	LoadMessages(ctx context.Context, convID string) ([]Message, error)
 	ListConversations(ctx context.Context, limit, offset int) ([]Conversation, error)
 	DeleteConversation(ctx context.Context, convID string) error

--- a/internal/harness/conversation_store_sqlite.go
+++ b/internal/harness/conversation_store_sqlite.go
@@ -14,11 +14,14 @@ import (
 
 const conversationSchema = `
 CREATE TABLE IF NOT EXISTS conversations (
-    id         TEXT PRIMARY KEY,
-    title      TEXT NOT NULL DEFAULT '',
-    msg_count  INTEGER NOT NULL DEFAULT 0,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
+    id                TEXT PRIMARY KEY,
+    title             TEXT NOT NULL DEFAULT '',
+    msg_count         INTEGER NOT NULL DEFAULT 0,
+    created_at        TEXT NOT NULL,
+    updated_at        TEXT NOT NULL,
+    prompt_tokens     INTEGER NOT NULL DEFAULT 0,
+    completion_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd          REAL NOT NULL DEFAULT 0.0
 );
 
 CREATE TABLE IF NOT EXISTS conversation_messages (
@@ -40,11 +43,6 @@ CREATE INDEX IF NOT EXISTS idx_conversations_updated ON conversations(updated_at
 -- FTS5 virtual table for full-text search on message content.
 CREATE VIRTUAL TABLE IF NOT EXISTS conversation_messages_fts
 USING fts5(conversation_id UNINDEXED, role UNINDEXED, content, content='conversation_messages', content_rowid='id');
-`
-
-// conversationMigrations applies incremental schema changes for existing databases.
-const conversationMigrations = `
--- Add is_meta column if it does not exist (safe to run multiple times via pragma check)
 `
 
 // SQLiteConversationStore implements ConversationStore using SQLite.
@@ -104,6 +102,23 @@ func (s *SQLiteConversationStore) Migrate(ctx context.Context) error {
 		}
 	}
 
+	// Idempotent migration: add token/cost columns to conversations if they don't exist (Issue #32).
+	if !s.columnExists(ctx, "conversations", "prompt_tokens") {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE conversations ADD COLUMN prompt_tokens INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("migrate add prompt_tokens column: %w", err)
+		}
+	}
+	if !s.columnExists(ctx, "conversations", "completion_tokens") {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE conversations ADD COLUMN completion_tokens INTEGER NOT NULL DEFAULT 0`); err != nil {
+			return fmt.Errorf("migrate add completion_tokens column: %w", err)
+		}
+	}
+	if !s.columnExists(ctx, "conversations", "cost_usd") {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE conversations ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0.0`); err != nil {
+			return fmt.Errorf("migrate add cost_usd column: %w", err)
+		}
+	}
+
 	// Idempotent migration: create FTS5 triggers if they don't exist.
 	// Triggers keep conversation_messages_fts in sync with conversation_messages.
 	triggers := []string{
@@ -150,7 +165,15 @@ func (s *SQLiteConversationStore) columnExists(ctx context.Context, table, colum
 }
 
 // SaveConversation persists a conversation's messages, replacing any existing messages.
+// Token/cost fields are left unchanged (or zero for new conversations).
 func (s *SQLiteConversationStore) SaveConversation(ctx context.Context, convID string, msgs []Message) error {
+	return s.SaveConversationWithCost(ctx, convID, msgs, ConversationTokenCost{})
+}
+
+// SaveConversationWithCost persists a conversation's messages along with cumulative
+// token usage and cost totals. It replaces any existing messages and overwrites
+// the token/cost fields with the provided values.
+func (s *SQLiteConversationStore) SaveConversationWithCost(ctx context.Context, convID string, msgs []Message, cost ConversationTokenCost) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -159,14 +182,17 @@ func (s *SQLiteConversationStore) SaveConversation(ctx context.Context, convID s
 
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	// Upsert conversations row
+	// Upsert conversations row (preserves created_at on conflict).
 	_, err = tx.ExecContext(ctx, `
-INSERT INTO conversations (id, title, msg_count, created_at, updated_at)
-VALUES (?, '', ?, ?, ?)
+INSERT INTO conversations (id, title, msg_count, created_at, updated_at, prompt_tokens, completion_tokens, cost_usd)
+VALUES (?, '', ?, ?, ?, ?, ?, ?)
 ON CONFLICT(id) DO UPDATE SET
-    msg_count = excluded.msg_count,
-    updated_at = excluded.updated_at
-`, convID, len(msgs), now, now)
+    msg_count         = excluded.msg_count,
+    updated_at        = excluded.updated_at,
+    prompt_tokens     = excluded.prompt_tokens,
+    completion_tokens = excluded.completion_tokens,
+    cost_usd          = excluded.cost_usd
+`, convID, len(msgs), now, now, cost.PromptTokens, cost.CompletionTokens, cost.CostUSD)
 	if err != nil {
 		return fmt.Errorf("upsert conversation: %w", err)
 	}
@@ -193,8 +219,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			if err != nil {
 				return fmt.Errorf("marshal tool calls at step %d: %w", i, err)
 			}
-			s := string(data)
-			toolCallsJSON = &s
+			str := string(data)
+			toolCallsJSON = &str
 		}
 
 		isMeta := 0
@@ -249,13 +275,14 @@ ORDER BY step ASC
 	return msgs, nil
 }
 
-// ListConversations returns conversations ordered by updated_at DESC.
+// ListConversations returns conversations ordered by updated_at DESC,
+// including cumulative token usage and cost totals.
 func (s *SQLiteConversationStore) ListConversations(ctx context.Context, limit, offset int) ([]Conversation, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, title, msg_count, created_at, updated_at
+SELECT id, title, msg_count, created_at, updated_at, prompt_tokens, completion_tokens, cost_usd
 FROM conversations
 ORDER BY updated_at DESC
 LIMIT ? OFFSET ?
@@ -269,7 +296,7 @@ LIMIT ? OFFSET ?
 	for rows.Next() {
 		var c Conversation
 		var createdText, updatedText string
-		if err := rows.Scan(&c.ID, &c.Title, &c.MsgCount, &createdText, &updatedText); err != nil {
+		if err := rows.Scan(&c.ID, &c.Title, &c.MsgCount, &createdText, &updatedText, &c.PromptTokens, &c.CompletionTokens, &c.CostUSD); err != nil {
 			return nil, fmt.Errorf("scan conversation: %w", err)
 		}
 		c.CreatedAt, _ = time.Parse(time.RFC3339Nano, createdText)

--- a/internal/harness/conversation_store_sqlite.go
+++ b/internal/harness/conversation_store_sqlite.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/google/uuid"
 	_ "modernc.org/sqlite"
 )
 
@@ -24,6 +25,7 @@ CREATE TABLE IF NOT EXISTS conversations (
 CREATE TABLE IF NOT EXISTS conversation_messages (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    message_id      TEXT NOT NULL DEFAULT '',
     step            INTEGER NOT NULL,
     role            TEXT NOT NULL,
     content         TEXT NOT NULL DEFAULT '',
@@ -36,6 +38,7 @@ CREATE TABLE IF NOT EXISTS conversation_messages (
 
 CREATE INDEX IF NOT EXISTS idx_conv_msgs_conv_id ON conversation_messages(conversation_id);
 CREATE INDEX IF NOT EXISTS idx_conversations_updated ON conversations(updated_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_conv_msgs_message_id ON conversation_messages(message_id) WHERE message_id != '';
 `
 
 // conversationMigrations applies incremental schema changes for existing databases.
@@ -94,10 +97,19 @@ func (s *SQLiteConversationStore) Migrate(ctx context.Context) error {
 	}
 
 	// Idempotent migration: add is_meta column if it doesn't exist.
-	// Check if the column already exists by querying table_info.
 	if !s.columnExists(ctx, "conversation_messages", "is_meta") {
 		if _, err := s.db.ExecContext(ctx, `ALTER TABLE conversation_messages ADD COLUMN is_meta INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return fmt.Errorf("migrate add is_meta column: %w", err)
+		}
+	}
+
+	// Idempotent migration: add message_id column if it doesn't exist.
+	if !s.columnExists(ctx, "conversation_messages", "message_id") {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE conversation_messages ADD COLUMN message_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return fmt.Errorf("migrate add message_id column: %w", err)
+		}
+		if _, err := s.db.ExecContext(ctx, `CREATE UNIQUE INDEX IF NOT EXISTS idx_conv_msgs_message_id ON conversation_messages(message_id) WHERE message_id != ''`); err != nil {
+			return fmt.Errorf("migrate create message_id index: %w", err)
 		}
 	}
 
@@ -153,10 +165,17 @@ ON CONFLICT(id) DO UPDATE SET
 		return fmt.Errorf("delete old messages: %w", err)
 	}
 
+	// Assign UUIDs to any messages that don't have one yet.
+	for i := range msgs {
+		if msgs[i].MessageID == "" {
+			msgs[i].MessageID = uuid.New().String()
+		}
+	}
+
 	// Insert new messages
 	stmt, err := tx.PrepareContext(ctx, `
-INSERT INTO conversation_messages (conversation_id, step, role, content, tool_calls_json, tool_call_id, name, is_meta)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO conversation_messages (conversation_id, message_id, step, role, content, tool_calls_json, tool_call_id, name, is_meta)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 `)
 	if err != nil {
 		return fmt.Errorf("prepare insert: %w", err)
@@ -179,7 +198,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			isMeta = 1
 		}
 
-		if _, err := stmt.ExecContext(ctx, convID, i, msg.Role, msg.Content, toolCallsJSON, msg.ToolCallID, msg.Name, isMeta); err != nil {
+		if _, err := stmt.ExecContext(ctx, convID, msg.MessageID, i, msg.Role, msg.Content, toolCallsJSON, msg.ToolCallID, msg.Name, isMeta); err != nil {
 			return fmt.Errorf("insert message at step %d: %w", i, err)
 		}
 	}
@@ -190,7 +209,7 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 // LoadMessages retrieves all messages for a conversation, ordered by step.
 func (s *SQLiteConversationStore) LoadMessages(ctx context.Context, convID string) ([]Message, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT role, content, tool_calls_json, tool_call_id, name, is_meta
+SELECT message_id, role, content, tool_calls_json, tool_call_id, name, is_meta
 FROM conversation_messages
 WHERE conversation_id = ?
 ORDER BY step ASC
@@ -205,7 +224,7 @@ ORDER BY step ASC
 		var msg Message
 		var toolCallsJSON sql.NullString
 		var isMeta int
-		if err := rows.Scan(&msg.Role, &msg.Content, &toolCallsJSON, &msg.ToolCallID, &msg.Name, &isMeta); err != nil {
+		if err := rows.Scan(&msg.MessageID, &msg.Role, &msg.Content, &toolCallsJSON, &msg.ToolCallID, &msg.Name, &isMeta); err != nil {
 			return nil, fmt.Errorf("scan message: %w", err)
 		}
 		msg.IsMeta = isMeta == 1

--- a/internal/harness/conversation_store_sqlite_test.go
+++ b/internal/harness/conversation_store_sqlite_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func newTestConversationStore(t *testing.T) *SQLiteConversationStore {
@@ -667,5 +669,372 @@ func TestConversationStoreSaveAndDeleteConcurrent(t *testing.T) {
 	close(errs)
 	for err := range errs {
 		t.Error(err)
+	}
+}
+
+// --- Tests for per-message unique IDs (issue #40) ---
+
+func TestConversationStoreMessageIDAssignment(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Save messages WITHOUT MessageID set (zero-value empty string)
+	msgs := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi there!"},
+		{Role: "user", Content: "How are you?"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-id-assign", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-id-assign")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+
+	if len(loaded) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(loaded))
+	}
+
+	for i, msg := range loaded {
+		if msg.MessageID == "" {
+			t.Errorf("message[%d] has empty MessageID, expected a UUID", i)
+			continue
+		}
+		if _, err := uuid.Parse(msg.MessageID); err != nil {
+			t.Errorf("message[%d] MessageID %q is not a valid UUID: %v", i, msg.MessageID, err)
+		}
+	}
+}
+
+func TestConversationStoreMessageIDUniqueness(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Save a conversation with 6 messages (5+ as required)
+	msgs := []Message{
+		{Role: "user", Content: "msg-0"},
+		{Role: "assistant", Content: "msg-1"},
+		{Role: "user", Content: "msg-2"},
+		{Role: "assistant", Content: "msg-3"},
+		{Role: "user", Content: "msg-4"},
+		{Role: "assistant", Content: "msg-5"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-id-unique", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-id-unique")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+
+	if len(loaded) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(loaded))
+	}
+
+	seen := make(map[string]bool)
+	for i, msg := range loaded {
+		if msg.MessageID == "" {
+			t.Errorf("message[%d] has empty MessageID", i)
+			continue
+		}
+		if seen[msg.MessageID] {
+			t.Errorf("message[%d] has duplicate MessageID %q", i, msg.MessageID)
+		}
+		seen[msg.MessageID] = true
+	}
+}
+
+func TestConversationStoreMessageIDStability(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Save a conversation and load to get assigned IDs
+	msgs := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi"},
+		{Role: "user", Content: "Bye"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-id-stable", msgs); err != nil {
+		t.Fatalf("SaveConversation (1): %v", err)
+	}
+
+	loaded1, err := store.LoadMessages(ctx, "conv-id-stable")
+	if err != nil {
+		t.Fatalf("LoadMessages (1): %v", err)
+	}
+
+	// Record the IDs from first load
+	firstIDs := make([]string, len(loaded1))
+	for i, msg := range loaded1 {
+		if msg.MessageID == "" {
+			t.Fatalf("message[%d] has empty MessageID on first load", i)
+		}
+		firstIDs[i] = msg.MessageID
+	}
+
+	// Save the SAME messages again (with their IDs populated from load)
+	if err := store.SaveConversation(ctx, "conv-id-stable", loaded1); err != nil {
+		t.Fatalf("SaveConversation (2): %v", err)
+	}
+
+	loaded2, err := store.LoadMessages(ctx, "conv-id-stable")
+	if err != nil {
+		t.Fatalf("LoadMessages (2): %v", err)
+	}
+
+	if len(loaded2) != len(firstIDs) {
+		t.Fatalf("expected %d messages on second load, got %d", len(firstIDs), len(loaded2))
+	}
+
+	// Assert the IDs are unchanged
+	for i, msg := range loaded2 {
+		if msg.MessageID != firstIDs[i] {
+			t.Errorf("message[%d] MessageID changed: was %q, now %q", i, firstIDs[i], msg.MessageID)
+		}
+	}
+}
+
+func TestConversationStoreMessageIDPreserved(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Create messages with pre-set MessageID values
+	msgs := []Message{
+		{Role: "user", Content: "Hello", MessageID: "custom-id-1"},
+		{Role: "assistant", Content: "Hi", MessageID: "custom-id-2"},
+		{Role: "user", Content: "Bye", MessageID: "custom-id-3"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-id-preserved", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-id-preserved")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+
+	if len(loaded) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(loaded))
+	}
+
+	// Assert the custom IDs are preserved as-is (not overwritten with new UUIDs)
+	for i, msg := range loaded {
+		if msg.MessageID != msgs[i].MessageID {
+			t.Errorf("message[%d] MessageID: got %q, want %q", i, msg.MessageID, msgs[i].MessageID)
+		}
+	}
+}
+
+func TestConversationStoreMessageIDMigration(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "migration-msgid.db")
+	store, err := NewSQLiteConversationStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+
+	// First migration: creates table with message_id column
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate (1): %v", err)
+	}
+
+	// Second migration: idempotent check -- should not error
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate (2): %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Save messages and verify IDs are assigned on load
+	msgs := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-migration-test", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-migration-test")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+
+	if len(loaded) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(loaded))
+	}
+
+	for i, msg := range loaded {
+		if msg.MessageID == "" {
+			t.Errorf("message[%d] has empty MessageID after migration", i)
+		}
+	}
+
+	store.Close()
+}
+
+func TestConversationStoreMessageIDCrossConversation(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Save two different conversations with messages
+	msgs1 := []Message{
+		{Role: "user", Content: "Hello from conv1"},
+		{Role: "assistant", Content: "Hi from conv1"},
+		{Role: "user", Content: "More from conv1"},
+	}
+	msgs2 := []Message{
+		{Role: "user", Content: "Hello from conv2"},
+		{Role: "assistant", Content: "Hi from conv2"},
+		{Role: "user", Content: "More from conv2"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-cross-1", msgs1); err != nil {
+		t.Fatalf("SaveConversation conv-cross-1: %v", err)
+	}
+	if err := store.SaveConversation(ctx, "conv-cross-2", msgs2); err != nil {
+		t.Fatalf("SaveConversation conv-cross-2: %v", err)
+	}
+
+	loaded1, err := store.LoadMessages(ctx, "conv-cross-1")
+	if err != nil {
+		t.Fatalf("LoadMessages conv-cross-1: %v", err)
+	}
+	loaded2, err := store.LoadMessages(ctx, "conv-cross-2")
+	if err != nil {
+		t.Fatalf("LoadMessages conv-cross-2: %v", err)
+	}
+
+	// Collect all message IDs and assert no duplicates across conversations
+	allIDs := make(map[string]string) // messageID -> conversationID for error reporting
+	for i, msg := range loaded1 {
+		if msg.MessageID == "" {
+			t.Errorf("conv-cross-1 message[%d] has empty MessageID", i)
+			continue
+		}
+		if prevConv, exists := allIDs[msg.MessageID]; exists {
+			t.Errorf("duplicate MessageID %q: found in conv-cross-1[%d] and %s", msg.MessageID, i, prevConv)
+		}
+		allIDs[msg.MessageID] = fmt.Sprintf("conv-cross-1[%d]", i)
+	}
+	for i, msg := range loaded2 {
+		if msg.MessageID == "" {
+			t.Errorf("conv-cross-2 message[%d] has empty MessageID", i)
+			continue
+		}
+		if prevConv, exists := allIDs[msg.MessageID]; exists {
+			t.Errorf("duplicate MessageID %q: found in conv-cross-2[%d] and %s", msg.MessageID, i, prevConv)
+		}
+		allIDs[msg.MessageID] = fmt.Sprintf("conv-cross-2[%d]", i)
+	}
+}
+
+func TestConversationStoreMessageIDConcurrency(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	const numConversations = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, numConversations*2)
+
+	// Concurrently save 10 conversations
+	for i := 0; i < numConversations; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			convID := fmt.Sprintf("concurrent-msgid-%d", idx)
+			msgs := []Message{
+				{Role: "user", Content: fmt.Sprintf("question-%d", idx)},
+				{Role: "assistant", Content: fmt.Sprintf("answer-%d", idx)},
+				{Role: "user", Content: fmt.Sprintf("followup-%d", idx)},
+			}
+			if err := store.SaveConversation(ctx, convID, msgs); err != nil {
+				errs <- fmt.Errorf("save conv %d: %w", idx, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	// Load all messages from all conversations and check global uniqueness
+	allIDs := make(map[string]string) // messageID -> source for error reporting
+	for i := 0; i < numConversations; i++ {
+		convID := fmt.Sprintf("concurrent-msgid-%d", i)
+		loaded, err := store.LoadMessages(ctx, convID)
+		if err != nil {
+			t.Fatalf("LoadMessages %s: %v", convID, err)
+		}
+		if len(loaded) != 3 {
+			t.Fatalf("expected 3 messages for %s, got %d", convID, len(loaded))
+		}
+		for j, msg := range loaded {
+			if msg.MessageID == "" {
+				t.Errorf("%s message[%d] has empty MessageID", convID, j)
+				continue
+			}
+			source := fmt.Sprintf("%s[%d]", convID, j)
+			if prev, exists := allIDs[msg.MessageID]; exists {
+				t.Errorf("duplicate MessageID %q: found in %s and %s", msg.MessageID, source, prev)
+			}
+			allIDs[msg.MessageID] = source
+		}
+	}
+
+	// Verify we collected the expected total number of unique IDs
+	expectedTotal := numConversations * 3
+	if len(allIDs) != expectedTotal {
+		t.Errorf("expected %d unique message IDs, got %d", expectedTotal, len(allIDs))
+	}
+}
+
+func TestConversationStoreMessageIDEmptyOnOldRows(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// Save messages (they should get IDs assigned by SaveConversation)
+	msgs := []Message{
+		{Role: "user", Content: "First message"},
+		{Role: "assistant", Content: "Second message"},
+		{Role: "user", Content: "Third message"},
+	}
+
+	if err := store.SaveConversation(ctx, "conv-old-rows", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	// Load messages and verify the IDs are populated (non-empty)
+	loaded, err := store.LoadMessages(ctx, "conv-old-rows")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+
+	if len(loaded) != len(msgs) {
+		t.Fatalf("expected %d messages, got %d", len(msgs), len(loaded))
+	}
+
+	for i, msg := range loaded {
+		if msg.MessageID == "" {
+			t.Errorf("message[%d] has empty MessageID; expected a non-empty value", i)
+		}
 	}
 }

--- a/internal/harness/conversation_store_sqlite_test.go
+++ b/internal/harness/conversation_store_sqlite_test.go
@@ -805,3 +805,258 @@ func TestSearchMessages_CrossConversation(t *testing.T) {
 		t.Fatalf("expected 2 results (cherry appears in 2 convs), got %d", len(results))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Token/cost tracking tests (Issue #32)
+// ---------------------------------------------------------------------------
+
+func TestConversationStoreSaveConversationWithCost_Basic(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{
+		{Role: "user", Content: "Hello"},
+		{Role: "assistant", Content: "Hi there!"},
+	}
+	cost := ConversationTokenCost{
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		CostUSD:          0.00123,
+	}
+
+	if err := store.SaveConversationWithCost(ctx, "conv-cost-1", msgs, cost); err != nil {
+		t.Fatalf("SaveConversationWithCost: %v", err)
+	}
+
+	convs, err := store.ListConversations(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+
+	c := convs[0]
+	if c.PromptTokens != 100 {
+		t.Errorf("expected PromptTokens=100, got %d", c.PromptTokens)
+	}
+	if c.CompletionTokens != 50 {
+		t.Errorf("expected CompletionTokens=50, got %d", c.CompletionTokens)
+	}
+	if c.CostUSD < 0.001 || c.CostUSD > 0.002 {
+		t.Errorf("expected CostUSD~0.00123, got %f", c.CostUSD)
+	}
+}
+
+func TestConversationStoreSaveConversationWithCost_ZeroCost(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{{Role: "user", Content: "Hello"}}
+	cost := ConversationTokenCost{} // zero values
+
+	if err := store.SaveConversationWithCost(ctx, "conv-zero-cost", msgs, cost); err != nil {
+		t.Fatalf("SaveConversationWithCost: %v", err)
+	}
+
+	convs, err := store.ListConversations(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+
+	c := convs[0]
+	if c.PromptTokens != 0 {
+		t.Errorf("expected PromptTokens=0, got %d", c.PromptTokens)
+	}
+	if c.CompletionTokens != 0 {
+		t.Errorf("expected CompletionTokens=0, got %d", c.CompletionTokens)
+	}
+	if c.CostUSD != 0 {
+		t.Errorf("expected CostUSD=0, got %f", c.CostUSD)
+	}
+}
+
+func TestConversationStoreSaveConversationWithCost_Accumulates(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// First save
+	msgs1 := []Message{{Role: "user", Content: "Hello"}, {Role: "assistant", Content: "Hi"}}
+	cost1 := ConversationTokenCost{PromptTokens: 100, CompletionTokens: 50, CostUSD: 0.001}
+	if err := store.SaveConversationWithCost(ctx, "conv-accum", msgs1, cost1); err != nil {
+		t.Fatalf("SaveConversationWithCost (1): %v", err)
+	}
+
+	// Second save (updates/overwrites with new totals)
+	msgs2 := append(msgs1,
+		Message{Role: "user", Content: "What's up?"},
+		Message{Role: "assistant", Content: "All good!"},
+	)
+	cost2 := ConversationTokenCost{PromptTokens: 250, CompletionTokens: 120, CostUSD: 0.003}
+	if err := store.SaveConversationWithCost(ctx, "conv-accum", msgs2, cost2); err != nil {
+		t.Fatalf("SaveConversationWithCost (2): %v", err)
+	}
+
+	convs, err := store.ListConversations(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+
+	c := convs[0]
+	// Second save should overwrite with the new (cumulative run total) cost
+	if c.PromptTokens != 250 {
+		t.Errorf("expected PromptTokens=250, got %d", c.PromptTokens)
+	}
+	if c.CompletionTokens != 120 {
+		t.Errorf("expected CompletionTokens=120, got %d", c.CompletionTokens)
+	}
+	if c.CostUSD < 0.002 || c.CostUSD > 0.004 {
+		t.Errorf("expected CostUSD~0.003, got %f", c.CostUSD)
+	}
+}
+
+func TestConversationStoreSaveConversation_BackwardsCompat(t *testing.T) {
+	t.Parallel()
+	// Ensure that SaveConversation (without cost) still works and leaves
+	// token/cost fields at their zero values.
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{{Role: "user", Content: "Hello"}, {Role: "assistant", Content: "Hi"}}
+	if err := store.SaveConversation(ctx, "conv-compat", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	convs, err := store.ListConversations(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+
+	c := convs[0]
+	if c.PromptTokens != 0 {
+		t.Errorf("expected PromptTokens=0, got %d", c.PromptTokens)
+	}
+	if c.CompletionTokens != 0 {
+		t.Errorf("expected CompletionTokens=0, got %d", c.CompletionTokens)
+	}
+	if c.CostUSD != 0 {
+		t.Errorf("expected CostUSD=0, got %f", c.CostUSD)
+	}
+}
+
+func TestConversationStoreSaveConversationWithCost_LargeValues(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{{Role: "user", Content: "Hello"}}
+	cost := ConversationTokenCost{
+		PromptTokens:     1_000_000,
+		CompletionTokens: 500_000,
+		CostUSD:          9999.99,
+	}
+
+	if err := store.SaveConversationWithCost(ctx, "conv-large-cost", msgs, cost); err != nil {
+		t.Fatalf("SaveConversationWithCost: %v", err)
+	}
+
+	convs, err := store.ListConversations(ctx, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+
+	c := convs[0]
+	if c.PromptTokens != 1_000_000 {
+		t.Errorf("expected PromptTokens=1000000, got %d", c.PromptTokens)
+	}
+	if c.CompletionTokens != 500_000 {
+		t.Errorf("expected CompletionTokens=500000, got %d", c.CompletionTokens)
+	}
+	if c.CostUSD < 9999 || c.CostUSD > 10001 {
+		t.Errorf("expected CostUSD~9999.99, got %f", c.CostUSD)
+	}
+}
+
+func TestConversationStoreSaveConversationWithCost_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			convID := fmt.Sprintf("concurrent-cost-%d", idx)
+			msgs := []Message{
+				{Role: "user", Content: fmt.Sprintf("question-%d", idx)},
+				{Role: "assistant", Content: fmt.Sprintf("answer-%d", idx)},
+			}
+			cost := ConversationTokenCost{
+				PromptTokens:     idx * 100,
+				CompletionTokens: idx * 50,
+				CostUSD:          float64(idx) * 0.001,
+			}
+			if err := store.SaveConversationWithCost(ctx, convID, msgs, cost); err != nil {
+				errs <- fmt.Errorf("goroutine %d: %w", idx, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	convs, err := store.ListConversations(ctx, 20, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != goroutines {
+		t.Fatalf("expected %d conversations, got %d", goroutines, len(convs))
+	}
+}
+
+func TestConversationStoreSaveConversationWithCost_MigrationIdempotent(t *testing.T) {
+	t.Parallel()
+	// Running Migrate twice on the same store should not fail (idempotent).
+	path := filepath.Join(t.TempDir(), "idempotent.db")
+	store, err := NewSQLiteConversationStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("first Migrate: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("second Migrate (idempotent check): %v", err)
+	}
+
+	// Should work after double migration
+	msgs := []Message{{Role: "user", Content: "ok"}}
+	cost := ConversationTokenCost{PromptTokens: 10, CompletionTokens: 5, CostUSD: 0.0001}
+	if err := store.SaveConversationWithCost(context.Background(), "conv-idem", msgs, cost); err != nil {
+		t.Fatalf("SaveConversationWithCost after double migrate: %v", err)
+	}
+}

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -902,7 +902,13 @@ func (r *Runner) completeRun(runID, output string) {
 
 		// Persist to SQLite store if configured
 		if r.config.ConversationStore != nil {
-			if err := r.config.ConversationStore.SaveConversation(context.Background(), convID, msgs); err != nil {
+			usageTotals, costTotals := r.accountingTotals(runID)
+			tokenCost := ConversationTokenCost{
+				PromptTokens:     usageTotals.PromptTokensTotal,
+				CompletionTokens: usageTotals.CompletionTokensTotal,
+				CostUSD:          costTotals.CostUSDTotal,
+			}
+			if err := r.config.ConversationStore.SaveConversationWithCost(context.Background(), convID, msgs, tokenCost); err != nil {
 				if r.config.Logger != nil {
 					r.config.Logger.Error("failed to persist conversation", "conv_id", convID, "error", err)
 				}

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1973,6 +1973,9 @@ func (f *failingConversationStore) Close() error                    { return nil
 func (f *failingConversationStore) SaveConversation(_ context.Context, _ string, _ []Message) error {
 	return fmt.Errorf("store save failed")
 }
+func (f *failingConversationStore) SaveConversationWithCost(_ context.Context, _ string, _ []Message, _ ConversationTokenCost) error {
+	return fmt.Errorf("store save with cost failed")
+}
 func (f *failingConversationStore) LoadMessages(_ context.Context, _ string) ([]Message, error) {
 	return nil, fmt.Errorf("store load failed")
 }
@@ -1984,6 +1987,138 @@ func (f *failingConversationStore) DeleteConversation(_ context.Context, _ strin
 }
 func (f *failingConversationStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
 	return nil, fmt.Errorf("store search failed")
+}
+
+// ---------------------------------------------------------------------------
+// Token/cost wiring: runner → ConversationStore (Issue #32)
+// ---------------------------------------------------------------------------
+
+// capturingConversationStore records the last SaveConversationWithCost call.
+type capturingConversationStore struct {
+	savedCost ConversationTokenCost
+	saveCount int
+}
+
+func (c *capturingConversationStore) Migrate(_ context.Context) error { return nil }
+func (c *capturingConversationStore) Close() error                    { return nil }
+func (c *capturingConversationStore) SaveConversation(_ context.Context, _ string, _ []Message) error {
+	c.saveCount++
+	return nil
+}
+func (c *capturingConversationStore) SaveConversationWithCost(_ context.Context, _ string, _ []Message, cost ConversationTokenCost) error {
+	c.savedCost = cost
+	c.saveCount++
+	return nil
+}
+func (c *capturingConversationStore) LoadMessages(_ context.Context, _ string) ([]Message, error) {
+	return nil, nil
+}
+func (c *capturingConversationStore) ListConversations(_ context.Context, _, _ int) ([]Conversation, error) {
+	return nil, nil
+}
+func (c *capturingConversationStore) DeleteConversation(_ context.Context, _ string) error {
+	return nil
+}
+func (c *capturingConversationStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
+	return nil, nil
+}
+
+func TestRunnerPersistsTokenCostOnCompletion(t *testing.T) {
+	t.Parallel()
+
+	// Provider returns a result with usage and cost data.
+	usage := &CompletionUsage{
+		PromptTokens:     200,
+		CompletionTokens: 75,
+		TotalTokens:      275,
+	}
+	costUSD := 0.00456
+	provider := &stubProvider{
+		turns: []CompletionResult{
+			{
+				Content:    "done",
+				Usage:      usage,
+				CostUSD:    &costUSD,
+				CostStatus: CostStatusAvailable,
+			},
+		},
+	}
+
+	store := &capturingConversationStore{}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel:      "test",
+		MaxSteps:          2,
+		ConversationStore: store,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:         "hello",
+		ConversationID: "conv-cost-wire",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	if store.saveCount == 0 {
+		t.Fatal("expected SaveConversationWithCost to be called at least once")
+	}
+	if store.savedCost.PromptTokens != 200 {
+		t.Errorf("expected PromptTokens=200, got %d", store.savedCost.PromptTokens)
+	}
+	if store.savedCost.CompletionTokens != 75 {
+		t.Errorf("expected CompletionTokens=75, got %d", store.savedCost.CompletionTokens)
+	}
+	if store.savedCost.CostUSD < 0.004 || store.savedCost.CostUSD > 0.005 {
+		t.Errorf("expected CostUSD~0.00456, got %f", store.savedCost.CostUSD)
+	}
+}
+
+func TestRunnerPersistsZeroCostWhenNoUsage(t *testing.T) {
+	t.Parallel()
+
+	// Provider returns no usage data.
+	provider := &stubProvider{
+		turns: []CompletionResult{
+			{Content: "done"},
+		},
+	}
+
+	store := &capturingConversationStore{}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel:      "test",
+		MaxSteps:          2,
+		ConversationStore: store,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:         "hello",
+		ConversationID: "conv-zero-wire",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	if store.saveCount == 0 {
+		t.Fatal("expected SaveConversationWithCost to be called at least once")
+	}
+	// No usage → all zeros in the stored cost
+	if store.savedCost.PromptTokens != 0 {
+		t.Errorf("expected PromptTokens=0, got %d", store.savedCost.PromptTokens)
+	}
+	if store.savedCost.CompletionTokens != 0 {
+		t.Errorf("expected CompletionTokens=0, got %d", store.savedCost.CompletionTokens)
+	}
+	if store.savedCost.CostUSD != 0 {
+		t.Errorf("expected CostUSD=0, got %f", store.savedCost.CostUSD)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/harness/tools/catalog_test.go
+++ b/internal/harness/tools/catalog_test.go
@@ -127,6 +127,41 @@ func TestBuildCatalogDefaultNamesSorted(t *testing.T) {
 	}
 }
 
+// TestAllCatalogToolsHaveNonEmptyDescriptions ensures every tool registered
+// in the catalog has a non-empty Description field. This is the end-to-end
+// invariant for Issue #41: all tool descriptions must be loaded from embedded
+// .md files via descriptions.Load(), not left empty or as zero-values.
+func TestAllCatalogToolsHaveNonEmptyDescriptions(t *testing.T) {
+	t.Parallel()
+
+	mcp := &fakeMCP{}
+	runner := &fakeRunner{}
+	web := &fakeWeb{}
+	list, err := BuildCatalog(BuildOptions{
+		WorkspaceRoot: t.TempDir(),
+		EnableTodos:   true,
+		EnableLSP:     true,
+		EnableMCP:     true,
+		MCPRegistry:   mcp,
+		EnableAgent:   true,
+		AgentRunner:   runner,
+		EnableWebOps:  true,
+		WebFetcher:    web,
+	})
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("catalog is empty — cannot validate descriptions")
+	}
+	for _, tool := range list {
+		name := tool.Definition.Name
+		if strings.TrimSpace(tool.Definition.Description) == "" {
+			t.Errorf("tool %q has empty Description — add descriptions.Load(%q) call and create descriptions/%s.md", name, name, name)
+		}
+	}
+}
+
 func TestCommonPathsAndHelpers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/harness/tools/core/skill.go
+++ b/internal/harness/tools/core/skill.go
@@ -10,6 +10,7 @@ import (
 
 	tools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/harness/tools/descriptions"
+	"go-agent-harness/internal/skills"
 )
 
 // defaultForkTimeout is the maximum duration for a forked skill execution.
@@ -79,8 +80,20 @@ func SkillTool(lister tools.SkillLister, runner tools.AgentRunner) tools.Tool {
 		if command == "" {
 			return "", fmt.Errorf("command is required: provide a skill name")
 		}
-		name, skillArgs, _ := strings.Cut(command, " ")
-		skillArgs = strings.TrimSpace(skillArgs)
+		action, actionArgs, _ := strings.Cut(command, " ")
+		actionArgs = strings.TrimSpace(actionArgs)
+
+		// Special built-in actions
+		switch action {
+		case "list":
+			return handleListSkills(lister)
+		case "verify":
+			return handleVerifySkill(lister, actionArgs)
+		}
+
+		// Default: apply the named skill
+		name := action
+		skillArgs := actionArgs
 
 		workspace := ""
 		if meta, ok := tools.RunMetadataFromContext(ctx); ok {
@@ -163,8 +176,59 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 	})
 }
 
+// handleListSkills returns a formatted list of all registered skills with
+// their verification status.
+func handleListSkills(lister tools.SkillLister) (string, error) {
+	skillList := lister.ListSkills()
+	if len(skillList) == 0 {
+		return "No skills registered.", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Available skills:\n")
+	for _, s := range skillList {
+		status := "[unverified]"
+		if s.Verified {
+			status = "[verified]"
+		}
+		sb.WriteString(fmt.Sprintf("  %s %s — %s\n", s.Name, status, s.Description))
+	}
+	return sb.String(), nil
+}
+
+// handleVerifySkill reads a skill file and writes verification metadata back to it.
+// actionArgs format: "<skill_name> [verified_by]"
+func handleVerifySkill(lister tools.SkillLister, actionArgs string) (string, error) {
+	skillName, verifiedBy, _ := strings.Cut(actionArgs, " ")
+	skillName = strings.TrimSpace(skillName)
+	verifiedBy = strings.TrimSpace(verifiedBy)
+
+	if skillName == "" {
+		return "", fmt.Errorf("verify requires a skill name: 'verify <skill_name> [verified_by]'")
+	}
+	if verifiedBy == "" {
+		verifiedBy = "agent"
+	}
+
+	info, ok := lister.GetSkill(skillName)
+	if !ok {
+		return "", fmt.Errorf("skill not found: %s", skillName)
+	}
+	if info.FilePath == "" {
+		return "", fmt.Errorf("skill %q has no file path (cannot verify)", skillName)
+	}
+
+	verifiedAt := time.Now().UTC().Format(time.RFC3339)
+	if err := skills.WriteVerification(info.FilePath, verifiedAt, verifiedBy); err != nil {
+		return "", fmt.Errorf("writing verification for skill %q: %w", skillName, err)
+	}
+
+	return fmt.Sprintf("Skill %q verified at %s by %q.", skillName, verifiedAt, verifiedBy), nil
+}
+
 // handleConversationSkill injects the skill content into the current conversation
-// as a meta-message (the default behavior).
+// as a meta-message (the default behavior). Prepends an unverified warning when
+// the skill has not been verified.
 func handleConversationSkill(info tools.SkillInfo, content string) (string, error) {
 	ack, err := tools.MarshalToolResult(map[string]any{
 		"skill":         info.Name,
@@ -175,7 +239,13 @@ func handleConversationSkill(info tools.SkillInfo, content string) (string, erro
 		return "", err
 	}
 
-	metaMsg := fmt.Sprintf("<skill name=%q>\n%s\n</skill>", info.Name, content)
+	// Prepend warning for unverified skills
+	body := content
+	if !info.Verified {
+		body = "\u26a0 WARNING: skill is unverified\n\n" + content
+	}
+
+	metaMsg := fmt.Sprintf("<skill name=%q>\n%s\n</skill>", info.Name, body)
 	return tools.WrapToolResult(tools.ToolResult{
 		Output: ack,
 		MetaMessages: []tools.MetaMessage{

--- a/internal/harness/tools/core/skill_test.go
+++ b/internal/harness/tools/core/skill_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -782,6 +783,252 @@ func TestSkillTool_Handler_ForkContextCanceled(t *testing.T) {
 		t.Fatal("expected error for canceled context")
 	}
 	if !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------- list action tests ----------
+
+func newVerificationSkillLister() *mockSkillLister {
+	return &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"verified-skill": {
+				Name:        "verified-skill",
+				Description: "A verified skill",
+				Source:      "global",
+				Verified:    true,
+				VerifiedAt:  "2026-03-09T12:00:00Z",
+				VerifiedBy:  "dennisonbertram",
+			},
+			"unverified-skill": {
+				Name:        "unverified-skill",
+				Description: "An unverified skill",
+				Source:      "global",
+				Verified:    false,
+			},
+		},
+		bodies: map[string]string{
+			"verified-skill":   "Do the verified thing.",
+			"unverified-skill": "Do the unverified thing.",
+		},
+	}
+}
+
+func TestSkillTool_Handler_ListShowsVerifiedStatus(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"list"}`))
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+
+	if !strings.Contains(out, "[verified]") {
+		t.Fatalf("list output should contain [verified], got: %s", out)
+	}
+	if !strings.Contains(out, "[unverified]") {
+		t.Fatalf("list output should contain [unverified], got: %s", out)
+	}
+	if !strings.Contains(out, "verified-skill") {
+		t.Fatalf("list output should contain 'verified-skill', got: %s", out)
+	}
+	if !strings.Contains(out, "unverified-skill") {
+		t.Fatalf("list output should contain 'unverified-skill', got: %s", out)
+	}
+}
+
+func TestSkillTool_Handler_ListEmptySkills(t *testing.T) {
+	t.Parallel()
+	lister := newEmptySkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"list"}`))
+	if err != nil {
+		t.Fatalf("list with no skills failed: %v", err)
+	}
+
+	if !strings.Contains(out, "No skills registered") {
+		t.Fatalf("list output should say no skills, got: %s", out)
+	}
+}
+
+// ---------- apply unverified warning tests ----------
+
+func TestSkillTool_Handler_ApplyUnverifiedPrependsWarning(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"unverified-skill"}`))
+	if err != nil {
+		t.Fatalf("apply unverified skill failed: %v", err)
+	}
+
+	tr, ok := tools.UnwrapToolResult(out)
+	if !ok {
+		t.Fatal("expected enriched tool result")
+	}
+	if len(tr.MetaMessages) != 1 {
+		t.Fatalf("expected 1 meta-message, got %d", len(tr.MetaMessages))
+	}
+	if !strings.Contains(tr.MetaMessages[0].Content, "WARNING: skill is unverified") {
+		t.Fatalf("meta-message should contain unverified warning, got: %s", tr.MetaMessages[0].Content)
+	}
+}
+
+func TestSkillTool_Handler_ApplyVerifiedNoWarning(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verified-skill"}`))
+	if err != nil {
+		t.Fatalf("apply verified skill failed: %v", err)
+	}
+
+	tr, ok := tools.UnwrapToolResult(out)
+	if !ok {
+		t.Fatal("expected enriched tool result")
+	}
+	if len(tr.MetaMessages) != 1 {
+		t.Fatalf("expected 1 meta-message, got %d", len(tr.MetaMessages))
+	}
+	if strings.Contains(tr.MetaMessages[0].Content, "WARNING") {
+		t.Fatalf("meta-message should NOT contain warning for verified skill, got: %s", tr.MetaMessages[0].Content)
+	}
+}
+
+// ---------- verify action tests ----------
+
+func TestSkillTool_Handler_VerifyAction(t *testing.T) {
+	t.Parallel()
+
+	// Create a real skill file on disk
+	dir := t.TempDir()
+	skillContent := "---\nname: my-skill\ndescription: \"A test skill. Trigger: do my thing\"\nversion: 1\n---\n# My Skill Body\n\nUse $ARGUMENTS here.\n"
+	skillDir := dir + "/my-skill"
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := skillDir + "/SKILL.md"
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"my-skill": {
+				Name:        "my-skill",
+				Description: "A test skill",
+				Source:      "global",
+				Verified:    false,
+				FilePath:    skillFile,
+			},
+		},
+		bodies: map[string]string{
+			"my-skill": "Use $ARGUMENTS here.",
+		},
+	}
+	tool := SkillTool(lister, nil)
+
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify my-skill dennisonbertram"}`))
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	if !strings.Contains(out, "my-skill") {
+		t.Fatalf("verify output should mention skill name, got: %s", out)
+	}
+	if !strings.Contains(out, "verified") {
+		t.Fatalf("verify output should confirm verification, got: %s", out)
+	}
+
+	// Re-read the file and verify it was updated
+	data, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatalf("reading updated skill file: %v", err)
+	}
+	updated := string(data)
+	if !strings.Contains(updated, "verified: true") {
+		t.Fatalf("skill file should contain 'verified: true', got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "verified_by: dennisonbertram") {
+		t.Fatalf("skill file should contain 'verified_by: dennisonbertram', got:\n%s", updated)
+	}
+	if !strings.Contains(updated, "verified_at:") {
+		t.Fatalf("skill file should contain 'verified_at:', got:\n%s", updated)
+	}
+}
+
+func TestSkillTool_Handler_VerifyDefaultVerifiedBy(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	skillContent := "---\nname: basic\ndescription: \"Basic skill\"\nversion: 1\n---\nBody.\n"
+	skillDir := dir + "/basic"
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := skillDir + "/SKILL.md"
+	if err := os.WriteFile(skillFile, []byte(skillContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lister := &mockSkillLister{
+		skills: map[string]tools.SkillInfo{
+			"basic": {
+				Name:     "basic",
+				FilePath: skillFile,
+			},
+		},
+		bodies: map[string]string{"basic": "Body."},
+	}
+	tool := SkillTool(lister, nil)
+
+	// verify without a verified_by arg — should default to "agent"
+	out, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify basic"}`))
+	if err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+
+	if !strings.Contains(out, "agent") {
+		t.Fatalf("verify output should mention default verifier 'agent', got: %s", out)
+	}
+
+	data, err := os.ReadFile(skillFile)
+	if err != nil {
+		t.Fatalf("reading updated skill file: %v", err)
+	}
+	if !strings.Contains(string(data), "verified_by: agent") {
+		t.Fatalf("skill file should contain 'verified_by: agent', got:\n%s", string(data))
+	}
+}
+
+func TestSkillTool_Handler_VerifyNonexistentSkill(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify nonexistent"}`))
+	if err == nil {
+		t.Fatal("expected error for nonexistent skill")
+	}
+	if !strings.Contains(err.Error(), "skill not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillTool_Handler_VerifyMissingSkillName(t *testing.T) {
+	t.Parallel()
+	lister := newVerificationSkillLister()
+	tool := SkillTool(lister, nil)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"verify"}`))
+	if err == nil {
+		t.Fatal("expected error for verify without skill name")
+	}
+	if !strings.Contains(err.Error(), "verify requires a skill name") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/harness/tools/descriptions/embed_test.go
+++ b/internal/harness/tools/descriptions/embed_test.go
@@ -56,7 +56,9 @@ func TestLoadAllKnownDescriptions(t *testing.T) {
 	t.Parallel()
 
 	// Verify all known embedded descriptions load without panic.
+	// This list must be kept in sync with the .md files in this directory.
 	names := []string{
+		"AskUserQuestion",
 		"agent",
 		"agentic_fetch",
 		"apply_patch",
@@ -68,17 +70,30 @@ func TestLoadAllKnownDescriptions(t *testing.T) {
 		"cron_list",
 		"cron_pause",
 		"cron_resume",
+		"download",
 		"edit",
 		"fetch",
 		"find_tool",
+		"git_diff",
+		"git_status",
 		"glob",
 		"grep",
 		"job_kill",
 		"job_output",
 		"list_delayed_callbacks",
+		"list_mcp_resources",
+		"list_models",
+		"ls",
+		"lsp_diagnostics",
+		"lsp_references",
+		"lsp_restart",
+		"observational_memory",
 		"read",
+		"read_mcp_resource",
 		"set_delayed_callback",
 		"skill",
+		"sourcegraph",
+		"todos",
 		"web_fetch",
 		"web_search",
 		"write",
@@ -90,6 +105,108 @@ func TestLoadAllKnownDescriptions(t *testing.T) {
 				t.Fatalf("expected non-empty content for %s", name)
 			}
 		})
+	}
+}
+
+// TestAllEmbeddedDescriptionsAreNonEmpty dynamically discovers every .md file
+// in the embedded FS and verifies it loads to a non-empty string. This catches
+// newly-added files that are accidentally empty without requiring a manual update
+// to TestLoadAllKnownDescriptions.
+func TestAllEmbeddedDescriptionsAreNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	entries, err := FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read embedded directory: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("embedded FS is empty — no description files found")
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		toolName := strings.TrimSuffix(name, ".md")
+		t.Run(toolName, func(t *testing.T) {
+			result := Load(toolName)
+			if result == "" {
+				t.Fatalf("description file %s exists but Load(%q) returned empty string", name, toolName)
+			}
+		})
+	}
+}
+
+// TestEmbeddedFSAndKnownListAreInSync verifies that the hardcoded list in
+// TestLoadAllKnownDescriptions matches exactly the .md files in the embedded FS.
+// This prevents the two lists from drifting apart silently.
+func TestEmbeddedFSAndKnownListAreInSync(t *testing.T) {
+	t.Parallel()
+
+	knownNames := map[string]bool{
+		"AskUserQuestion":        true,
+		"agent":                  true,
+		"agentic_fetch":          true,
+		"apply_patch":            true,
+		"bash":                   true,
+		"cancel_delayed_callback": true,
+		"cron_create":            true,
+		"cron_delete":            true,
+		"cron_get":               true,
+		"cron_list":              true,
+		"cron_pause":             true,
+		"cron_resume":            true,
+		"download":               true,
+		"edit":                   true,
+		"fetch":                  true,
+		"find_tool":              true,
+		"git_diff":               true,
+		"git_status":             true,
+		"glob":                   true,
+		"grep":                   true,
+		"job_kill":               true,
+		"job_output":             true,
+		"list_delayed_callbacks": true,
+		"list_mcp_resources":     true,
+		"list_models":            true,
+		"ls":                     true,
+		"lsp_diagnostics":        true,
+		"lsp_references":         true,
+		"lsp_restart":            true,
+		"observational_memory":   true,
+		"read":                   true,
+		"read_mcp_resource":      true,
+		"set_delayed_callback":   true,
+		"skill":                  true,
+		"sourcegraph":            true,
+		"todos":                  true,
+		"web_fetch":              true,
+		"web_search":             true,
+		"write":                  true,
+	}
+
+	entries, err := FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read embedded directory: %v", err)
+	}
+
+	fsNames := make(map[string]bool)
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, ".md") {
+			fsNames[strings.TrimSuffix(name, ".md")] = true
+		}
+	}
+
+	for name := range fsNames {
+		if !knownNames[name] {
+			t.Errorf("FS contains %q but it is missing from the known list — add it to TestLoadAllKnownDescriptions", name)
+		}
+	}
+	for name := range knownNames {
+		if !fsNames[name] {
+			t.Errorf("known list contains %q but no corresponding .md file exists in the embedded FS", name)
+		}
 	}
 }
 

--- a/internal/harness/tools/descriptions/skill.md
+++ b/internal/harness/tools/descriptions/skill.md
@@ -7,3 +7,12 @@ Examples: "deploy staging", "code-review", "tdd --strict".
 
 When a user references a skill by name or a slash command (e.g. "/deploy"),
 use this tool to apply the matching skill. Available skills are listed below.
+
+Built-in actions:
+- "list" — list all available skills with their verification status ([verified] or [unverified])
+- "verify <skill_name> [verified_by]" — mark a skill as verified, writing verification
+  metadata (verified, verified_at, verified_by) back to the skill file. The optional
+  verified_by argument identifies who performed the verification (defaults to "agent").
+
+Unverified skills display a warning when applied. Use "verify" to mark a skill as trusted
+after reviewing its instructions.

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -166,6 +166,10 @@ type SkillInfo struct {
 	Source       string   `json:"source"`
 	Context      string   `json:"context,omitempty"`
 	Agent        string   `json:"agent,omitempty"`
+	Verified     bool     `json:"verified,omitempty"`
+	VerifiedAt   string   `json:"verified_at,omitempty"`
+	VerifiedBy   string   `json:"verified_by,omitempty"`
+	FilePath     string   `json:"file_path,omitempty"` // needed for verify action
 }
 
 // SkillLister provides skill lookup and listing for the skill tool.

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -24,6 +24,7 @@ type ToolCall struct {
 }
 
 type Message struct {
+	MessageID  string     `json:"message_id,omitempty"`
 	Role       string     `json:"role"`
 	Content    string     `json:"content,omitempty"`
 	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -620,6 +620,9 @@ func (m *mockConversationStore) Close() error                    { return nil }
 func (m *mockConversationStore) SaveConversation(_ context.Context, _ string, _ []harness.Message) error {
 	return nil
 }
+func (m *mockConversationStore) SaveConversationWithCost(_ context.Context, _ string, _ []harness.Message, _ harness.ConversationTokenCost) error {
+	return nil
+}
 func (m *mockConversationStore) LoadMessages(_ context.Context, convID string) ([]harness.Message, error) {
 	if m.loadErr != nil {
 		return nil, m.loadErr

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -142,7 +142,53 @@ func parseSkillFile(path, dirName string, source SkillSource) (Skill, error) {
 		Triggers:     triggers,
 		Context:      skillContext,
 		Agent:        meta.Agent,
+		Verified:     meta.Verified,
+		VerifiedAt:   meta.VerifiedAt,
+		VerifiedBy:   meta.VerifiedBy,
 	}, nil
+}
+
+// WriteVerification updates the verified, verified_at, and verified_by fields
+// in the SKILL.md frontmatter at the given path, preserving the markdown body.
+func WriteVerification(path, verifiedAt, verifiedBy string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	content := string(data)
+	fm, body, err := splitFrontmatter(content)
+	if err != nil {
+		return fmt.Errorf("parsing frontmatter: %w", err)
+	}
+
+	var meta map[string]any
+	if err := yaml.Unmarshal([]byte(fm), &meta); err != nil {
+		return fmt.Errorf("parsing frontmatter YAML: %w", err)
+	}
+	if meta == nil {
+		meta = make(map[string]any)
+	}
+
+	meta["verified"] = true
+	meta["verified_at"] = verifiedAt
+	meta["verified_by"] = verifiedBy
+
+	updated, err := yaml.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshaling frontmatter YAML: %w", err)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("---\n")
+	sb.Write(updated)
+	sb.WriteString("---\n")
+	if body != "" {
+		sb.WriteString(body)
+		sb.WriteString("\n")
+	}
+
+	return os.WriteFile(path, []byte(sb.String()), 0o644)
 }
 
 func splitFrontmatter(content string) (string, string, error) {

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -454,3 +454,62 @@ Research carefully.
 		t.Errorf("AllowedTools = %v, want [read grep]", skills[0].AllowedTools)
 	}
 }
+
+func TestLoaderLoad_VerifiedFields(t *testing.T) {
+	dir := t.TempDir()
+	content := `---
+name: verified-skill
+description: "A verified skill"
+version: 1
+verified: true
+verified_at: "2026-03-09T12:00:00Z"
+verified_by: "dennisonbertram"
+---
+Body.
+`
+	writeSkillFile(t, dir, "verified-skill", content)
+
+	loader := NewLoader(LoaderConfig{GlobalDir: dir})
+	skills, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	s := skills[0]
+	if !s.Verified {
+		t.Error("Verified should be true")
+	}
+	if s.VerifiedAt != "2026-03-09T12:00:00Z" {
+		t.Errorf("VerifiedAt = %q, want %q", s.VerifiedAt, "2026-03-09T12:00:00Z")
+	}
+	if s.VerifiedBy != "dennisonbertram" {
+		t.Errorf("VerifiedBy = %q, want %q", s.VerifiedBy, "dennisonbertram")
+	}
+}
+
+func TestLoaderLoad_UnverifiedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	// validSkillMD has no verified fields
+	writeSkillFile(t, dir, "my-skill", validSkillMD)
+
+	loader := NewLoader(LoaderConfig{GlobalDir: dir})
+	skills, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(skills))
+	}
+	s := skills[0]
+	if s.Verified {
+		t.Error("Verified should default to false when not specified")
+	}
+	if s.VerifiedAt != "" {
+		t.Errorf("VerifiedAt should be empty by default, got %q", s.VerifiedAt)
+	}
+	if s.VerifiedBy != "" {
+		t.Errorf("VerifiedBy should be empty by default, got %q", s.VerifiedBy)
+	}
+}

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -34,6 +34,9 @@ type Skill struct {
 	Triggers     []string     // extracted from description "Trigger: ..."
 	Context      SkillContext // "conversation" (default) or "fork"
 	Agent        string       // optional agent type hint (e.g., "Explore", "Code")
+	Verified     bool         `json:"verified,omitempty"`
+	VerifiedAt   string       `json:"verified_at,omitempty"` // RFC3339
+	VerifiedBy   string       `json:"verified_by,omitempty"` // agent/user that verified
 }
 
 // frontmatter represents the YAML frontmatter of a SKILL.md.
@@ -46,6 +49,9 @@ type frontmatter struct {
 	ArgumentHint string   `yaml:"argument-hint"`
 	Context      string   `yaml:"context"`
 	Agent        string   `yaml:"agent"`
+	Verified     bool     `yaml:"verified"`
+	VerifiedAt   string   `yaml:"verified_at"`
+	VerifiedBy   string   `yaml:"verified_by"`
 }
 
 // LoaderConfig holds paths for skill discovery.


### PR DESCRIPTION
## Summary

Adds per-conversation token and cost tracking to the persistence layer. When a run completes, prompt tokens, completion tokens, and USD cost are saved alongside the conversation and surfaced in the list API.

## Changes

### Data model (`conversation_store.go`)
- Added `PromptTokens int`, `CompletionTokens int`, `CostUSD float64` to `Conversation` struct
- Added `ConversationTokenCost` helper struct
- Added `SaveConversationWithCost(ctx, convID, msgs, cost)` to `ConversationStore` interface

### SQLite store (`conversation_store_sqlite.go`)
- Schema adds `prompt_tokens`, `completion_tokens`, `cost_usd` columns
- Idempotent migrations via `PRAGMA table_info` column checks for existing databases
- `SaveConversation` delegates to `SaveConversationWithCost` with zero values (backward compat)
- `ListConversations` returns the new token/cost fields

### Runner (`runner.go`)
- `completeRun` calls `SaveConversationWithCost` using `accountingTotals()` for thread-safe totals

### Mocks updated
- `failingConversationStore` in `runner_test.go` and `mockConversationStore` in `http_test.go` implement new interface method

## Tests

- 7 new store tests: basic cost save, zero values, accumulation/overwrite, large values, concurrency, migration idempotency, backward compat
- 2 new runner integration tests verifying end-to-end cost wiring
- All packages pass with `-race`