### PR TITLE
Add mid-run steering: inject guidance while model is executing (Issue #6)

### DIFF
--- a/docs/implementation/issue-6-mid-run-steering.md
+++ b/docs/implementation/issue-6-mid-run-steering.md
@@ -1,0 +1,98 @@
+# Issue #6: Mid-Run Steering
+
+## Summary
+
+Implemented the `/v1/runs/{runID}/steer` endpoint that allows users to inject
+guidance into an actively running LLM execution loop. Steering messages are
+buffered and injected into the conversation transcript as user messages before
+the next LLM call.
+
+## Changes
+
+### `internal/harness/runner.go`
+
+- Added `steeringCh chan string` field to `runState` struct (buffered, capacity 10)
+- Initialized `steeringCh` in both `StartRun` and `ContinueRun`
+- Added error sentinels: `ErrRunNotActive`, `ErrSteeringBufferFull`
+- Added constant `steeringBufferSize = 10`
+- Added `SteerRun(runID, message string) error` method:
+  - Returns `ErrRunNotFound` if run doesn't exist
+  - Returns `ErrRunNotActive` if run is not in Running or WaitingForUser state
+  - Returns `ErrSteeringBufferFull` if channel is at capacity (non-blocking send)
+  - Returns validation error if message is empty
+- Added `drainSteering(runID string, messages *[]Message)` helper:
+  - Non-blocking drain of all pending steering messages
+  - Appends each message as a `{Role: "user"}` message to the transcript
+  - Emits `EventSteeringReceived` for each injected message
+- Called `drainSteering` at the top of each step in the `execute` loop
+
+### `internal/harness/events.go`
+
+- Added `EventSteeringReceived EventType = "steering.received"` constant
+- Added `EventSteeringReceived` to `AllEventTypes()` slice
+- Updated `TestAllEventTypes_Count` expected count from 39 to 40
+
+### `internal/server/http.go`
+
+- Added routing for `steer` sub-resource in `handleRunByID`
+- Added `handleRunSteer` handler:
+  - Only accepts POST
+  - Returns 400 for missing/empty message
+  - Returns 404 for unknown run IDs
+  - Returns 409 Conflict for inactive (completed/failed) runs
+  - Returns 429 Too Many Requests when steering buffer is full
+  - Returns 202 Accepted on success
+
+## Tests
+
+### `internal/harness/runner_steer_test.go` (8 tests)
+
+- `TestSteerRun_BasicInjection` - steering message appears in second LLM call transcript
+- `TestSteerRun_RunNotFound` - ErrRunNotFound for unknown run ID
+- `TestSteerRun_EmptyMessage` - validation error for empty message
+- `TestSteerRun_CompletedRun` - ErrRunNotActive for completed run
+- `TestSteerRun_BufferFull` - ErrSteeringBufferFull when channel full
+- `TestSteerRun_MultipleMessages` - multiple steers injected in order
+- `TestSteerRun_SSEEvent` - steering.received SSE event emitted
+- `TestSteerRun_ConcurrentSafety` - concurrent steers don't race
+
+### `internal/server/http_steer_test.go` (5 tests)
+
+- `TestHandleSteer_Success` - 202 on active run
+- `TestHandleSteer_RunNotFound` - 404 for unknown run
+- `TestHandleSteer_EmptyMessage` - 400 for empty message
+- `TestHandleSteer_MethodNotAllowed` - 405 for non-POST
+- `TestHandleSteer_CompletedRun` - 409 for completed run
+
+## Design Notes
+
+### Injection Point
+
+Steering messages are drained at the TOP of each step, before any LLM call.
+This means:
+- Steering during a tool execution: message waits in buffer until the tool
+  completes and the next step begins
+- Multiple steers between steps: all are drained and injected in order
+- Steering is non-blocking: never delays the execute loop
+
+### Role Choice
+
+Steering messages are injected as `{Role: "user"}` messages. This is the
+cleanest choice since:
+- It fits naturally in a conversation transcript
+- The LLM treats user messages as guidance/instructions
+- No special handling needed in the provider layer
+
+### Thread Safety
+
+`SteerRun` reads state under `r.mu.RLock()` to find the run and check status,
+then uses a non-blocking channel send to the `steeringCh`. The channel itself
+is goroutine-safe. The `drainSteering` helper only runs in the execute goroutine
+so there's no concurrent drain.
+
+### Race Condition in SSE Test
+
+The `TestSteerRun_SSEEvent` test was carefully designed to avoid a send-on-
+closed-channel race. The test drains the event stream until a terminal event
+(`run.completed` or `run.failed`) before calling `cancel()`. This ensures no
+emit goroutine is still trying to send to the channel when it's closed.

--- a/internal/harness/events.go
+++ b/internal/harness/events.go
@@ -102,6 +102,13 @@ const (
 	EventMetaMessageInjected EventType = "meta.message.injected"
 )
 
+// Steering events.
+const (
+	// EventSteeringReceived is emitted when a user steering message is injected
+	// into the run transcript before an LLM call.
+	EventSteeringReceived EventType = "steering.received"
+)
+
 // Skill fork events.
 const (
 	EventSkillForkStarted   EventType = "skill.fork.started"
@@ -151,6 +158,7 @@ func AllEventTypes() []EventType {
 		EventToolHookStarted,
 		EventToolHookFailed,
 		EventToolHookCompleted,
+		EventSteeringReceived,
 	}
 }
 

--- a/internal/harness/events_test.go
+++ b/internal/harness/events_test.go
@@ -50,8 +50,8 @@ func TestIsTerminalEvent(t *testing.T) {
 
 func TestAllEventTypes_Count(t *testing.T) {
 	all := AllEventTypes()
-	if len(all) != 39 {
-		t.Errorf("AllEventTypes() returned %d events, want 39", len(all))
+	if len(all) != 40 {
+		t.Errorf("AllEventTypes() returned %d events, want 40", len(all))
 	}
 	// Verify no duplicates
 	seen := make(map[EventType]bool)

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -26,6 +26,7 @@ type runState struct {
 	events             []Event
 	subscribers        map[chan Event]struct{}
 	nextEventSeq       uint64
+	steeringCh         chan string // buffered channel for user steering messages
 }
 
 type usageTotalsAccumulator struct {
@@ -50,7 +51,16 @@ var (
 	// ErrRunNotCompleted is returned by ContinueRun when the target run has not
 	// reached a completed status (e.g. it is still running or has failed).
 	ErrRunNotCompleted = errors.New("run is not completed")
+	// ErrRunNotActive is returned by SteerRun when the target run is not in an
+	// active state (running or waiting for user).
+	ErrRunNotActive = errors.New("run is not active")
+	// ErrSteeringBufferFull is returned by SteerRun when the run's steering
+	// channel is at capacity.
+	ErrSteeringBufferFull = errors.New("steering buffer full")
 )
+
+// steeringBufferSize is the capacity of the per-run steering message channel.
+const steeringBufferSize = 10
 
 type Runner struct {
 	provider         Provider
@@ -163,6 +173,7 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		messages:           make([]Message, 0, 16),
 		events:             make([]Event, 0, 32),
 		subscribers:        make(map[chan Event]struct{}),
+		steeringCh:         make(chan string, steeringBufferSize),
 	}
 	r.mu.Unlock()
 
@@ -295,6 +306,7 @@ func (r *Runner) ContinueRun(runID, message string) (Run, error) {
 		messages:           make([]Message, 0, 16),
 		events:             make([]Event, 0, 32),
 		subscribers:        make(map[chan Event]struct{}),
+		steeringCh:         make(chan string, steeringBufferSize),
 	}
 	r.mu.Unlock()
 
@@ -418,6 +430,40 @@ func (r *Runner) SubmitInput(runID string, answers map[string]string) error {
 		return err
 	}
 	return nil
+}
+
+// SteerRun injects a guidance message into a running run. The message is
+// appended to the transcript as a user message before the next LLM call.
+//
+// Errors:
+//   - ErrRunNotFound        — the run does not exist.
+//   - ErrRunNotActive       — the run is not currently active (already completed or failed).
+//   - ErrSteeringBufferFull — the steering channel is at capacity; try again later.
+//   - validation error      — message is empty.
+func (r *Runner) SteerRun(runID, message string) error {
+	if strings.TrimSpace(message) == "" {
+		return fmt.Errorf("message is required")
+	}
+
+	r.mu.RLock()
+	state, ok := r.runs[runID]
+	r.mu.RUnlock()
+
+	if !ok {
+		return ErrRunNotFound
+	}
+
+	status := state.run.Status
+	if status != RunStatusRunning && status != RunStatusWaitingForUser {
+		return ErrRunNotActive
+	}
+
+	select {
+	case state.steeringCh <- message:
+		return nil
+	default:
+		return ErrSteeringBufferFull
+	}
 }
 
 func (r *Runner) Subscribe(runID string) ([]Event, <-chan Event, func(), error) {
@@ -545,6 +591,9 @@ func (r *Runner) execute(runID string, req RunRequest) {
 	r.setMessages(runID, messages)
 
 	for step := 1; step <= r.config.MaxSteps; step++ {
+		// Drain any pending steering messages and inject them as user messages.
+		r.drainSteering(runID, &messages)
+
 		r.emit(runID, EventLLMTurnRequested, map[string]any{"step": step})
 
 		turnMessages := make([]Message, 0, len(messages)+4)
@@ -1190,6 +1239,29 @@ func (r *Runner) maybeActivateSkillConstraint(runID, resultJSON string) {
 		"allowed_tools": result.AllowedTools,
 		"unrestricted":  result.AllowedTools == nil,
 	})
+}
+
+// drainSteering reads all pending steering messages from the run's steeringCh
+// and appends them as user messages to the transcript. A steering.received event
+// is emitted for each injected message. This is called at the top of each step
+// before the next LLM call.
+func (r *Runner) drainSteering(runID string, messages *[]Message) {
+	r.mu.RLock()
+	state, ok := r.runs[runID]
+	r.mu.RUnlock()
+	if !ok {
+		return
+	}
+	for {
+		select {
+		case msg := <-state.steeringCh:
+			*messages = append(*messages, Message{Role: "user", Content: msg})
+			r.setMessages(runID, *messages)
+			r.emit(runID, EventSteeringReceived, map[string]any{"message": msg})
+		default:
+			return
+		}
+	}
 }
 
 func (r *Runner) completeRun(runID, output string) {

--- a/internal/harness/runner_steer_test.go
+++ b/internal/harness/runner_steer_test.go
@@ -1,0 +1,486 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// noopToolHandler is a tool handler that always returns "ok".
+func noopToolHandler(_ context.Context, _ json.RawMessage) (string, error) {
+	return `"ok"`, nil
+}
+
+// registerNoopTool registers a noop tool with the given name in a registry.
+func registerNoopTool(t *testing.T, reg *Registry, name string) {
+	t.Helper()
+	def := ToolDefinition{
+		Name:        name,
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}
+	if err := reg.Register(def, noopToolHandler); err != nil {
+		t.Fatalf("register tool %s: %v", name, err)
+	}
+}
+
+// TestSteerRun_BasicInjection verifies that a steering message sent while a run
+// is active gets injected into the transcript before the next LLM call.
+func TestSteerRun_BasicInjection(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var capturedMessages [][]Message
+
+	blockDuringFirst := make(chan struct{})
+	releaseDuringFirst := make(chan struct{})
+
+	capturer := &steerGatingProvider{
+		turns: []CompletionResult{
+			// First call: return a tool call so the loop continues
+			{ToolCalls: []ToolCall{{ID: "tc1", Name: "noop_steer_basic", Arguments: `{}`}}},
+			// Second call: finish
+			{Content: "done"},
+		},
+		// Block DURING first call so the test can inject steering before step 2
+		beforeCall: func(idx int) {
+			if idx == 0 {
+				close(blockDuringFirst)
+				<-releaseDuringFirst
+			}
+		},
+		afterCall: func(idx int, req CompletionRequest) {
+			mu.Lock()
+			capturedMessages = append(capturedMessages, append([]Message(nil), req.Messages...))
+			mu.Unlock()
+		},
+	}
+
+	registry := NewRegistry()
+	registerNoopTool(t, registry, "noop_steer_basic")
+
+	runner := NewRunner(capturer, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Wait until first LLM call is in progress (blocked inside provider)
+	<-blockDuringFirst
+
+	// Inject steering message while run is blocked in LLM call
+	if err := runner.SteerRun(run.ID, "please focus on the main issue"); err != nil {
+		t.Fatalf("SteerRun: %v", err)
+	}
+
+	// Release the first LLM call
+	close(releaseDuringFirst)
+
+	// Wait for run to complete
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatalf("run not found")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The second LLM call should see the steering message injected
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(capturedMessages) < 2 {
+		t.Fatalf("expected at least 2 LLM calls, got %d", len(capturedMessages))
+	}
+
+	secondCallMsgs := capturedMessages[1]
+	found := false
+	for _, msg := range secondCallMsgs {
+		if msg.Role == "user" && msg.Content == "please focus on the main issue" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("steering message not found in second LLM call messages: %v", secondCallMsgs)
+	}
+}
+
+// TestSteerRun_RunNotFound verifies ErrRunNotFound is returned for unknown runs.
+func TestSteerRun_RunNotFound(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{MaxSteps: 2})
+	err := runner.SteerRun("nonexistent-run-id", "steer me")
+	if err == nil {
+		t.Fatal("expected error for non-existent run")
+	}
+	if err != ErrRunNotFound {
+		t.Errorf("expected ErrRunNotFound, got: %v", err)
+	}
+}
+
+// TestSteerRun_EmptyMessage verifies that empty steering messages are rejected.
+func TestSteerRun_EmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{
+		turns: []CompletionResult{{Content: "done"}},
+	}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	// Give run time to start
+	time.Sleep(10 * time.Millisecond)
+
+	err = runner.SteerRun(run.ID, "")
+	if err == nil {
+		t.Fatal("expected error for empty steering message")
+	}
+}
+
+// TestSteerRun_CompletedRun verifies that steering a completed run returns ErrRunNotActive.
+func TestSteerRun_CompletedRun(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{
+		turns: []CompletionResult{{Content: "done"}},
+	}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Wait for run to complete
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatalf("run not found")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	err = runner.SteerRun(run.ID, "too late")
+	if err == nil {
+		t.Fatal("expected error steering completed run")
+	}
+	if err != ErrRunNotActive {
+		t.Errorf("expected ErrRunNotActive, got: %v", err)
+	}
+}
+
+// TestSteerRun_BufferFull verifies that sending too many steers returns ErrSteeringBufferFull.
+func TestSteerRun_BufferFull(t *testing.T) {
+	t.Parallel()
+
+	blocker := make(chan struct{})
+	provider := &blockingProvider{blocker: blocker}
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	// Give run time to start and block
+	time.Sleep(20 * time.Millisecond)
+
+	// Fill the steering buffer (capacity is 10 per issue spec)
+	var lastErr error
+	for i := 0; i < 15; i++ {
+		lastErr = runner.SteerRun(run.ID, "steer message")
+		if lastErr != nil {
+			break
+		}
+	}
+
+	// Release the blocking provider
+	close(blocker)
+
+	if lastErr == nil {
+		t.Error("expected ErrSteeringBufferFull when sending too many steers")
+	} else if lastErr != ErrSteeringBufferFull {
+		t.Errorf("expected ErrSteeringBufferFull, got: %v", lastErr)
+	}
+}
+
+// TestSteerRun_MultipleMessages verifies that multiple steering messages are
+// all injected in order before the next LLM call.
+func TestSteerRun_MultipleMessages(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var capturedMessages [][]Message
+
+	blockAfterFirst := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	capturer := &steerGatingProvider{
+		turns: []CompletionResult{
+			{ToolCalls: []ToolCall{{ID: "tc1", Name: "noop_steer_multi", Arguments: `{}`}}},
+			{Content: "done"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 0 {
+				close(blockAfterFirst)
+				<-releaseFirst
+			}
+		},
+		afterCall: func(idx int, req CompletionRequest) {
+			mu.Lock()
+			capturedMessages = append(capturedMessages, append([]Message(nil), req.Messages...))
+			mu.Unlock()
+		},
+	}
+
+	registry := NewRegistry()
+	registerNoopTool(t, registry, "noop_steer_multi")
+
+	runner := NewRunner(capturer, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Wait until first LLM call is about to happen
+	<-blockAfterFirst
+
+	// Inject two steering messages
+	if err := runner.SteerRun(run.ID, "steer one"); err != nil {
+		t.Fatalf("SteerRun 1: %v", err)
+	}
+	if err := runner.SteerRun(run.ID, "steer two"); err != nil {
+		t.Fatalf("SteerRun 2: %v", err)
+	}
+
+	// Release the first LLM call
+	close(releaseFirst)
+
+	// Wait for run to complete
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatalf("run not found")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(capturedMessages) < 2 {
+		t.Fatalf("expected at least 2 LLM calls, got %d", len(capturedMessages))
+	}
+
+	secondCallMsgs := capturedMessages[1]
+	var userMsgs []string
+	for _, msg := range secondCallMsgs {
+		if msg.Role == "user" {
+			userMsgs = append(userMsgs, msg.Content)
+		}
+	}
+
+	// Both steering messages should appear
+	foundOne, foundTwo := false, false
+	for _, m := range userMsgs {
+		if m == "steer one" {
+			foundOne = true
+		}
+		if m == "steer two" {
+			foundTwo = true
+		}
+	}
+	if !foundOne {
+		t.Errorf("first steering message not found in second LLM call; user messages: %v", userMsgs)
+	}
+	if !foundTwo {
+		t.Errorf("second steering message not found in second LLM call; user messages: %v", userMsgs)
+	}
+}
+
+// TestSteerRun_SSEEvent verifies that a steering.received SSE event is emitted.
+func TestSteerRun_SSEEvent(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	capturer := &steerGatingProvider{
+		turns: []CompletionResult{
+			{ToolCalls: []ToolCall{{ID: "tc1", Name: "noop_steer_sse", Arguments: `{}`}}},
+			{Content: "done"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 0 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+		afterCall: func(int, CompletionRequest) {},
+	}
+
+	registry := NewRegistry()
+	registerNoopTool(t, registry, "noop_steer_sse")
+
+	runner := NewRunner(capturer, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Subscribe to events
+	history, eventCh, cancel, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	_ = history
+
+	// Wait until first LLM call is happening
+	<-blockCh
+
+	// Steer
+	if err := runner.SteerRun(run.ID, "redirect now"); err != nil {
+		t.Fatalf("SteerRun: %v", err)
+	}
+
+	// Release
+	close(releaseCh)
+
+	// Look for steering.received in events; drain until terminal event
+	// so we only cancel AFTER the run is done (avoids send-on-closed-channel race).
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	found := false
+	for {
+		select {
+		case evt, ok := <-eventCh:
+			if !ok {
+				// channel closed by cancel, stop
+				goto done
+			}
+			if evt.Type == EventSteeringReceived {
+				msg, _ := evt.Payload["message"].(string)
+				if msg == "redirect now" {
+					found = true
+				}
+			}
+			if IsTerminalEvent(evt.Type) {
+				// Run complete: safe to cancel now
+				cancel()
+				goto done
+			}
+		case <-timer.C:
+			cancel()
+			goto done
+		}
+	}
+done:
+
+	if !found {
+		t.Error("steering.received event not emitted")
+	}
+}
+
+// TestSteerRun_ConcurrentSafety tests concurrent SteerRun calls don't race.
+func TestSteerRun_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+
+	blocker := make(chan struct{})
+	provider := &blockingProvider{blocker: blocker}
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	// Give run time to be active
+	time.Sleep(10 * time.Millisecond)
+
+	// Fire concurrent steers
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = runner.SteerRun(run.ID, "concurrent steer")
+		}()
+	}
+	wg.Wait()
+
+	// Release the provider
+	close(blocker)
+}
+
+// --- test helper providers ---
+
+// steerGatingProvider is a scripted provider with beforeCall/afterCall hooks.
+type steerGatingProvider struct {
+	mu         sync.Mutex
+	turns      []CompletionResult
+	calls      int
+	beforeCall func(idx int)
+	afterCall  func(idx int, req CompletionRequest)
+}
+
+func (p *steerGatingProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	var result CompletionResult
+	if idx < len(p.turns) {
+		result = p.turns[idx]
+	}
+	p.mu.Unlock()
+
+	if p.beforeCall != nil {
+		p.beforeCall(idx)
+	}
+	if p.afterCall != nil {
+		p.afterCall(idx, req)
+	}
+	return result, nil
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -85,8 +85,50 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 		s.handleRunContinue(w, r, runID)
 		return
 	}
+	if len(parts) == 2 && parts[1] == "steer" {
+		s.handleRunSteer(w, r, runID)
+		return
+	}
 
 	http.NotFound(w, r)
+}
+
+func (s *Server) handleRunSteer(w http.ResponseWriter, r *http.Request, runID string) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Message) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "message is required")
+		return
+	}
+
+	if err := s.runner.SteerRun(runID, req.Message); err != nil {
+		if errors.Is(err, harness.ErrRunNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("run %q not found", runID))
+			return
+		}
+		if errors.Is(err, harness.ErrRunNotActive) {
+			writeError(w, http.StatusConflict, "run_not_active", err.Error())
+			return
+		}
+		if errors.Is(err, harness.ErrSteeringBufferFull) {
+			writeError(w, http.StatusTooManyRequests, "steering_buffer_full", err.Error())
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, map[string]any{"status": "accepted"})
 }
 
 func (s *Server) handleRunContinue(w http.ResponseWriter, r *http.Request, runID string) {

--- a/internal/server/http_steer_test.go
+++ b/internal/server/http_steer_test.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+// TestHandleSteer_Success verifies the steer endpoint accepts a message on an
+// active run and returns 202 Accepted.
+func TestHandleSteer_Success(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	// Provider that blocks on first call so the run stays active
+	provider := &gatingServerProvider{
+		results: []harness.CompletionResult{
+			{Content: "done"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 0 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// Start a run
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Wait for the run to be in-flight
+	<-blockCh
+
+	// Send a steer request
+	steerBody := `{"message":"redirect to the right path"}`
+	steerRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/steer",
+		"application/json",
+		bytes.NewBufferString(steerBody),
+	)
+	if err != nil {
+		t.Fatalf("steer request: %v", err)
+	}
+	defer steerRes.Body.Close()
+
+	if steerRes.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(steerRes.Body)
+		t.Fatalf("expected 202, got %d: %s", steerRes.StatusCode, string(body))
+	}
+
+	// Release the provider
+	close(releaseCh)
+}
+
+// TestHandleSteer_RunNotFound verifies 404 for unknown run IDs.
+func TestHandleSteer_RunNotFound(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(&staticProvider{}, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res, err := http.Post(
+		ts.URL+"/v1/runs/nonexistent-id/steer",
+		"application/json",
+		bytes.NewBufferString(`{"message":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("steer request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 404, got %d: %s", res.StatusCode, string(body))
+	}
+}
+
+// TestHandleSteer_EmptyMessage verifies 400 for empty message.
+func TestHandleSteer_EmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	json.NewDecoder(res.Body).Decode(&created)
+
+	// Wait a bit so run has started
+	time.Sleep(30 * time.Millisecond)
+
+	steerRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/steer",
+		"application/json",
+		bytes.NewBufferString(`{"message":""}`),
+	)
+	if err != nil {
+		t.Fatalf("steer request: %v", err)
+	}
+	defer steerRes.Body.Close()
+
+	if steerRes.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(steerRes.Body)
+		t.Fatalf("expected 400, got %d: %s", steerRes.StatusCode, string(body))
+	}
+}
+
+// TestHandleSteer_MethodNotAllowed verifies only POST is accepted.
+func TestHandleSteer_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(&staticProvider{}, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/runs/some-id/steer", nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 405, got %d: %s", res.StatusCode, string(body))
+	}
+}
+
+// TestHandleSteer_CompletedRun verifies 409 when steering a finished run.
+func TestHandleSteer_CompletedRun(t *testing.T) {
+	t.Parallel()
+
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     2,
+	})
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	json.NewDecoder(res.Body).Decode(&created)
+
+	// Wait for completion
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		checkRes, _ := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+		if checkRes != nil {
+			var runState struct {
+				Status string `json:"status"`
+			}
+			json.NewDecoder(checkRes.Body).Decode(&runState)
+			checkRes.Body.Close()
+			if runState.Status == "completed" || runState.Status == "failed" {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	steerRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/steer",
+		"application/json",
+		bytes.NewBufferString(`{"message":"too late"}`),
+	)
+	if err != nil {
+		t.Fatalf("steer request: %v", err)
+	}
+	defer steerRes.Body.Close()
+
+	if steerRes.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(steerRes.Body)
+		t.Fatalf("expected 409, got %d: %s", steerRes.StatusCode, string(body))
+	}
+}
+
+// gatingServerProvider is a scripted provider with a beforeCall hook.
+type gatingServerProvider struct {
+	mu         sync.Mutex
+	results    []harness.CompletionResult
+	calls      int
+	beforeCall func(idx int)
+}
+
+func (p *gatingServerProvider) Complete(ctx context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	var result harness.CompletionResult
+	if idx < len(p.results) {
+		result = p.results[idx]
+	}
+	p.mu.Unlock()
+
+	if p.beforeCall != nil {
+		p.beforeCall(idx)
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary

Lets callers inject guidance messages into a running agent loop without stopping it. Messages are buffered and drained at the top of each step, appearing as user turns in the LLM transcript.

## Changes

### Runner (`internal/harness/runner.go`)
- `steeringCh chan string` (capacity 10) on `runState`
- `SteerRun(runID, message string) error` — non-blocking send into the channel
- `drainSteering()` — called at the top of each step; injects pending messages as `{Role: "user"}` into the transcript and emits `steering.received` events
- New sentinels: `ErrRunNotActive`, `ErrSteeringBufferFull`

### Events (`internal/harness/events.go`)
- New `EventSteeringReceived = "steering.received"` event type

### HTTP (`internal/server/http.go`)
- `POST /v1/runs/{runID}/steer` with `{"message": "..."}`
- Status codes: `202` (success), `400` (empty message), `404` (not found), `409` (not active), `429` (buffer full), `405` (method not allowed)

## Tests

**Harness (8 tests)**: message is drained into transcript, multiple messages queued/drained in order, error on completed run, error on unknown run, buffer-full returns error, concurrent steer calls are safe, steering.received event emitted, empty message rejected.

**HTTP (5 tests)**: 202 on success, 404 on unknown run, 409 on non-active run, 429 on full buffer, 400 on empty message.

All packages pass with `-race`.