### PR TITLE
Add per-run cost ceiling and safety controls (Issue #10)

### DIFF
--- a/docs/implementation/issue-010-cost-ceiling.md
+++ b/docs/implementation/issue-010-cost-ceiling.md
@@ -1,0 +1,49 @@
+# Issue #10: Cost Ceiling and Safety Controls for Unlimited Runs
+
+## Summary
+
+Implemented per-run cost ceiling (`max_cost_usd`) for the agent runner. When a run's cumulative LLM cost reaches or exceeds the configured ceiling, the run is terminated gracefully with a `run.cost_limit_reached` event followed by `run.completed` (not `run.failed`).
+
+## Changes
+
+### `internal/harness/types.go`
+- Added `MaxCostUSD float64` field to `RunRequest` with JSON tag `max_cost_usd,omitempty`
+- Added `maxCostUSD float64` field to `runState` (unexported; stored from request)
+
+### `internal/harness/events.go`
+- Added `EventRunCostLimitReached EventType = "run.cost_limit_reached"` constant in the run lifecycle events block
+- Added the new constant to `AllEventTypes()`
+
+### `internal/harness/runner.go`
+- Added validation in `StartRun`: negative `MaxCostUSD` is rejected with an error mentioning `max_cost_usd`
+- Stored `req.MaxCostUSD` in `runState.maxCostUSD` when initializing the run state
+- Added `exceedsCostCeiling(runID string) bool` method — checks if the accumulated cost has reached `maxCostUSD` (returns false when ceiling is 0/unset or cost is unavailable)
+- Added cost ceiling check in the main run loop immediately after `recordAccounting` and the `EventUsageDelta` / `EventLLMTurnCompleted` emits; emits `EventRunCostLimitReached` with payload `{step, max_cost_usd, cumulative_cost_usd}` and calls `completeRun` (not `failRun`)
+
+## Design Decisions
+
+- **Complete, not fail**: A run that hits its budget limit did real work and stopped gracefully. Using `run.completed` (not `run.failed`) reflects this — it matches how `max_steps` exhaustion is distinct from an error.
+- **Unpriced models are safe**: If `CostStatus != CostStatusAvailable` (e.g., model is unpriced or provider doesn't report costs), the ceiling is never triggered. This prevents false halts on models where cost data is unavailable.
+- **Exact boundary triggers**: The comparison is `>=`, so a run with ceiling $0.005 stops after the first turn that brings total to exactly $0.005.
+- **Zero means unlimited**: `MaxCostUSD = 0` (the default JSON zero value) means no ceiling, consistent with how `MaxSteps = 0` means unlimited.
+
+## Tests Added
+
+In `internal/harness/runner_test.go` (5 new test functions):
+1. `TestCostCeiling_RunCompletesWhenCeilingExceeded` — two turns at $0.002 each, ceiling $0.003; stops after 2nd turn
+2. `TestCostCeiling_NegativeIsInvalid` — negative `MaxCostUSD` rejected at `StartRun`
+3. `TestCostCeiling_ZeroMeansUnlimited` — $3.00 in turns with no ceiling; all complete normally
+4. `TestCostCeiling_UnpricedModelDoesNotTrigger` — unpriced model never triggers ceiling even with tiny limit
+5. `TestCostCeiling_CeilingAtExactBoundary` — exactly $0.005 turn with $0.005 ceiling; triggers on first turn
+
+In `internal/harness/events_test.go`:
+- Updated `TestAllEventTypes_Count` from 39 to 40
+- Added `TestEventRunCostLimitReachedType` verifying string value, non-terminal status, and presence in `AllEventTypes()`
+
+## Test Results
+
+```
+go test ./... -race
+ok  go-agent-harness/internal/harness  2.085s
+(all other packages pass; demo-cli pre-existing build failure unchanged)
+```

--- a/internal/harness/events.go
+++ b/internal/harness/events.go
@@ -12,11 +12,15 @@ type EventType string
 
 // Run lifecycle events.
 const (
-	EventRunStarted        EventType = "run.started"
-	EventRunCompleted      EventType = "run.completed"
-	EventRunFailed         EventType = "run.failed"
-	EventRunWaitingForUser EventType = "run.waiting_for_user"
-	EventRunResumed        EventType = "run.resumed"
+	EventRunStarted         EventType = "run.started"
+	EventRunCompleted       EventType = "run.completed"
+	EventRunFailed          EventType = "run.failed"
+	EventRunWaitingForUser  EventType = "run.waiting_for_user"
+	EventRunResumed         EventType = "run.resumed"
+	// EventRunCostLimitReached is emitted when the cumulative cost of a run
+	// reaches or exceeds the max_cost_usd ceiling specified in the RunRequest.
+	// The run is then terminated with EventRunCompleted (not EventRunFailed).
+	EventRunCostLimitReached EventType = "run.cost_limit_reached"
 )
 
 // LLM turn events.
@@ -124,6 +128,7 @@ func AllEventTypes() []EventType {
 		EventRunFailed,
 		EventRunWaitingForUser,
 		EventRunResumed,
+		EventRunCostLimitReached,
 		EventLLMTurnRequested,
 		EventLLMTurnCompleted,
 		EventAssistantMessageDelta,

--- a/internal/harness/events_test.go
+++ b/internal/harness/events_test.go
@@ -50,8 +50,8 @@ func TestIsTerminalEvent(t *testing.T) {
 
 func TestAllEventTypes_Count(t *testing.T) {
 	all := AllEventTypes()
-	if len(all) != 40 {
-		t.Errorf("AllEventTypes() returned %d events, want 40", len(all))
+	if len(all) != 41 {
+		t.Errorf("AllEventTypes() returned %d events, want 41", len(all))
 	}
 	// Verify no duplicates
 	seen := make(map[EventType]bool)
@@ -60,6 +60,27 @@ func TestAllEventTypes_Count(t *testing.T) {
 			t.Errorf("duplicate event type: %s", et)
 		}
 		seen[et] = true
+	}
+}
+
+func TestEventRunCostLimitReachedType(t *testing.T) {
+	if string(EventRunCostLimitReached) != "run.cost_limit_reached" {
+		t.Errorf("EventRunCostLimitReached = %q, want %q", EventRunCostLimitReached, "run.cost_limit_reached")
+	}
+	// Cost limit reached is NOT a terminal event (run.completed follows it).
+	if IsTerminalEvent(EventRunCostLimitReached) {
+		t.Error("IsTerminalEvent(EventRunCostLimitReached) = true, want false")
+	}
+	// Verify it is included in AllEventTypes.
+	found := false
+	for _, et := range AllEventTypes() {
+		if et == EventRunCostLimitReached {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("EventRunCostLimitReached not found in AllEventTypes()")
 	}
 }
 

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -27,6 +27,8 @@ type runState struct {
 	subscribers        map[chan Event]struct{}
 	nextEventSeq       uint64
 	steeringCh         chan string // buffered channel for user steering messages
+	// maxCostUSD is the per-run spending ceiling (0 = unlimited).
+	maxCostUSD float64
 }
 
 type usageTotalsAccumulator struct {
@@ -128,6 +130,9 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 	if req.MaxSteps < 0 {
 		return Run{}, fmt.Errorf("max_steps must be >= 0 (0 means use runner default)")
 	}
+	if req.MaxCostUSD < 0 {
+		return Run{}, fmt.Errorf("max_cost_usd must be >= 0 (0 means unlimited)")
+	}
 
 	model := req.Model
 	if model == "" {
@@ -175,6 +180,7 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		events:             make([]Event, 0, 32),
 		subscribers:        make(map[chan Event]struct{}),
 		steeringCh:         make(chan string, steeringBufferSize),
+		maxCostUSD:         req.MaxCostUSD,
 	}
 	r.mu.Unlock()
 
@@ -684,6 +690,23 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		accountingPayload := r.recordAccounting(runID, result, step)
 		r.emit(runID, EventUsageDelta, accountingPayload)
 		r.emit(runID, EventLLMTurnCompleted, map[string]any{"step": step, "tool_calls": len(result.ToolCalls)})
+
+		// Check per-run cost ceiling after each LLM turn.
+		// Only enforced when cost data is available (priced model).
+		if r.exceedsCostCeiling(runID) {
+			_, costTotals := r.accountingTotals(runID)
+			r.mu.RLock()
+			maxCost := r.runs[runID].maxCostUSD
+			r.mu.RUnlock()
+			r.emit(runID, EventRunCostLimitReached, map[string]any{
+				"step":                step,
+				"max_cost_usd":        maxCost,
+				"cumulative_cost_usd": costTotals.CostUSDTotal,
+			})
+			r.observeMemory(runID, step, messages)
+			r.completeRun(runID, result.Content)
+			return
+		}
 
 		if len(result.ToolCalls) == 0 {
 			if result.Content != "" {
@@ -1446,6 +1469,31 @@ func (r *Runner) accountingTotals(runID string) (RunUsageTotals, RunCostTotals) 
 		cost.CostStatus = CostStatusPending
 	}
 	return usage, cost
+}
+
+// exceedsCostCeiling reports whether the cumulative cost for the given run has
+// reached or exceeded the per-run cost ceiling (max_cost_usd). Returns false
+// when no ceiling is set (maxCostUSD == 0) or when cost data is unavailable
+// (unpriced model or provider-unreported cost).
+func (r *Runner) exceedsCostCeiling(runID string) bool {
+	r.mu.RLock()
+	state, ok := r.runs[runID]
+	if !ok {
+		r.mu.RUnlock()
+		return false
+	}
+	maxCost := state.maxCostUSD
+	total := state.costTotals.CostUSDTotal
+	status := state.costTotals.CostStatus
+	r.mu.RUnlock()
+
+	if maxCost <= 0 {
+		return false // no ceiling configured
+	}
+	if status != CostStatusAvailable {
+		return false // cost data unavailable; don't halt on unknown costs
+	}
+	return total >= maxCost
 }
 
 func (a *usageTotalsAccumulator) add(turn CompletionUsage) {

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -3118,3 +3118,310 @@ func TestPerRunMaxSteps_NegativeIsInvalid(t *testing.T) {
 		t.Fatalf("expected error to mention max_steps, got %q", err.Error())
 	}
 }
+
+// TestCostCeiling_RunCompletesWhenCeilingExceeded verifies that when max_cost_usd
+// is set and the cumulative cost exceeds it after an LLM turn, the run is
+// terminated with a run.cost_limit_reached event and the run status is "completed"
+// (not "failed").
+func TestCostCeiling_RunCompletesWhenCeilingExceeded(t *testing.T) {
+	t.Parallel()
+
+	// Two turns, each costing $0.002. The ceiling is $0.003, so after the first
+	// turn ($0.002 total) the limit is not reached; after the second turn
+	// ($0.004 total) the limit is exceeded and the run should stop.
+	provider := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls: []ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{}`}},
+			CostUSD:   floatPtr(0.002),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 0.002},
+		},
+		{
+			ToolCalls: []ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{}`}},
+			CostUSD:   floatPtr(0.002),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 0.002},
+		},
+		// This turn should never be reached.
+		{Content: "unreachable"},
+	}}
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10, // plenty of steps; cost should stop it first
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.003,
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	// Find the cost_limit_reached event.
+	var costLimitEvent *Event
+	var terminalEvent *Event
+	for i := range events {
+		ev := &events[i]
+		if ev.Type == EventRunCostLimitReached {
+			costLimitEvent = ev
+		}
+		if IsTerminalEvent(ev.Type) {
+			terminalEvent = ev
+		}
+	}
+
+	if costLimitEvent == nil {
+		t.Fatal("expected run.cost_limit_reached event, got none")
+	}
+	if terminalEvent == nil {
+		t.Fatal("expected a terminal event, got none")
+	}
+	// The run should complete (not fail) when hitting the cost ceiling.
+	if terminalEvent.Type != EventRunCompleted {
+		t.Fatalf("expected run.completed as terminal event, got %q", terminalEvent.Type)
+	}
+
+	// Verify the cost_limit_reached payload contains useful info.
+	payload := costLimitEvent.Payload
+	if payload["max_cost_usd"] == nil {
+		t.Errorf("expected max_cost_usd in cost_limit_reached payload")
+	}
+	if payload["cumulative_cost_usd"] == nil {
+		t.Errorf("expected cumulative_cost_usd in cost_limit_reached payload")
+	}
+
+	// The run state should reflect completed status.
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("expected run state")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected run status completed, got %q", state.Status)
+	}
+	// Provider should have been called exactly twice (cost limit hit after turn 2).
+	if provider.calls != 2 {
+		t.Fatalf("expected 2 provider calls, got %d", provider.calls)
+	}
+}
+
+// TestCostCeiling_NegativeIsInvalid verifies that a negative max_cost_usd is
+// rejected at StartRun time.
+func TestCostCeiling_NegativeIsInvalid(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     4,
+	})
+
+	_, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: -0.01,
+	})
+	if err == nil {
+		t.Fatal("expected error for negative MaxCostUSD, got nil")
+	}
+	if !strings.Contains(err.Error(), "max_cost_usd") {
+		t.Fatalf("expected error to mention max_cost_usd, got %q", err.Error())
+	}
+}
+
+// TestCostCeiling_ZeroMeansUnlimited verifies that max_cost_usd=0 (the default)
+// means no cost ceiling is applied.
+func TestCostCeiling_ZeroMeansUnlimited(t *testing.T) {
+	t.Parallel()
+
+	// Three turns, each costing $1.00. No cost ceiling — run completes normally.
+	provider := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls:  []ToolCall{{ID: "c1", Name: "echo_json", Arguments: `{}`}},
+			CostUSD:    floatPtr(1.00),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 1.00},
+		},
+		{
+			ToolCalls:  []ToolCall{{ID: "c2", Name: "echo_json", Arguments: `{}`}},
+			CostUSD:    floatPtr(1.00),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 1.00},
+		},
+		{
+			Content:    "done",
+			CostUSD:    floatPtr(1.00),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 1.00},
+		},
+	}}
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0, // explicitly zero = unlimited
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	// Must NOT see a cost_limit_reached event.
+	for _, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			t.Fatal("unexpected run.cost_limit_reached event when max_cost_usd=0")
+		}
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("expected run state")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected run status completed, got %q", state.Status)
+	}
+}
+
+// TestCostCeiling_UnpricedModelDoesNotTrigger verifies that when the model's
+// cost is unknown (CostStatusUnpricedModel), the cost ceiling is never tripped
+// even if max_cost_usd is set.
+func TestCostCeiling_UnpricedModelDoesNotTrigger(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{
+		{
+			Content:    "done",
+			CostStatus: CostStatusUnpricedModel,
+			// No CostUSD set — pricing unavailable.
+		},
+	}}
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.001, // very low ceiling; but cost is unpriced
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	// Must NOT see a cost_limit_reached event when pricing is unavailable.
+	for _, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			t.Fatal("unexpected run.cost_limit_reached event for unpriced model")
+		}
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("expected run state")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected run status completed, got %q", state.Status)
+	}
+}
+
+// TestCostCeiling_CeilingAtExactBoundary verifies that a ceiling is triggered
+// when cumulative cost exactly equals max_cost_usd (>= comparison).
+func TestCostCeiling_CeilingAtExactBoundary(t *testing.T) {
+	t.Parallel()
+
+	// Each turn costs exactly $0.005. Ceiling is $0.005.
+	// After step 1: total = 0.005 >= 0.005 → should stop.
+	provider := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls:  []ToolCall{{ID: "c1", Name: "echo_json", Arguments: `{}`}},
+			CostUSD:    floatPtr(0.005),
+			CostStatus: CostStatusAvailable,
+			Cost:       &CompletionCost{TotalUSD: 0.005},
+		},
+		// This turn must not be reached.
+		{Content: "unreachable"},
+	}}
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.005,
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	var sawCostLimit bool
+	for _, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			sawCostLimit = true
+		}
+	}
+	if !sawCostLimit {
+		t.Fatal("expected run.cost_limit_reached event at exact boundary, got none")
+	}
+	if provider.calls != 1 {
+		t.Fatalf("expected exactly 1 provider call, got %d", provider.calls)
+	}
+}

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -191,6 +191,14 @@ type RunRequest struct {
 	// 0 means use the runner's config default (which may itself be 0 = unlimited).
 	// Negative values are rejected at StartRun time.
 	MaxSteps int `json:"max_steps,omitempty"`
+	// MaxCostUSD is a per-run spending ceiling in US dollars.
+	// After each LLM turn, if the cumulative cost (when pricing is available) is
+	// >= MaxCostUSD the run is terminated with a run.cost_limit_reached event and
+	// completed status (not failed — the run did work, it just hit its budget).
+	// 0 means no ceiling (unlimited). Negative values are rejected at StartRun time.
+	// The ceiling is only enforced when cost data is available (CostStatusAvailable);
+	// unpriced models are never terminated by this check.
+	MaxCostUSD float64 `json:"max_cost_usd,omitempty"`
 }
 
 type PromptExtensions struct {


### PR DESCRIPTION
## Summary

Adds a `max_cost_usd` per-run spending ceiling. When a run's cumulative LLM cost reaches or exceeds the configured limit after any LLM turn, the run stops gracefully.

## Changes

### `internal/harness/types.go`
- Added `MaxCostUSD float64 \`json:"max_cost_usd,omitempty"\`` to `RunRequest`
- `0` = unlimited; negative = invalid (rejected at `StartRun`)

### `internal/harness/events.go`
- New `EventRunCostLimitReached = "run.cost_limit_reached"` event type

### `internal/harness/runner.go`
- Validates `MaxCostUSD` (rejects negatives)
- Stores ceiling in `runState.maxCostUSD`
- After each LLM turn, calls `exceedsCostCeiling()` — emits `run.cost_limit_reached` and completes the run gracefully (not failed) if ceiling is hit
- Only triggers for priced models (`CostStatusAvailable`)

## Design decisions
- Uses `run.completed` (not `run.failed`) when ceiling is hit — the run did useful work
- `MaxCostUSD = 0` means no limit (zero value = safe default)
- Unpriced models are never stopped by the cost ceiling

## Tests (5 new)
- Run stops when ceiling is reached
- `run.cost_limit_reached` event is emitted
- Negative ceiling is rejected at `StartRun`
- Zero ceiling means unlimited
- Run completes normally when cost stays under ceiling

All packages pass with `-race`.