### PR TITLE
Add JSONL rollout recorder for session replay and audit (Issue #16)

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -179,6 +179,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	callbacksEnabled := envBoolOrDefault("HARNESS_ENABLE_CALLBACKS", true)
 	sourcegraphEndpoint := strings.TrimSpace(getenv("HARNESS_SOURCEGRAPH_ENDPOINT"))
 	sourcegraphToken := strings.TrimSpace(getenv("HARNESS_SOURCEGRAPH_TOKEN"))
+	rolloutDir := strings.TrimSpace(getenv("HARNESS_ROLLOUT_DIR"))
 
 	var providerRegistry *catalog.ProviderRegistry
 	var modelCatalog *catalog.Catalog
@@ -363,6 +364,9 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 			Token:    sourcegraphToken,
 		},
 	})
+	if rolloutDir != "" {
+		log.Printf("rollout recording enabled: %s", rolloutDir)
+	}
 	runner := harness.NewRunner(provider, tools, harness.RunnerConfig{
 		DefaultModel:        model,
 		DefaultSystemPrompt: systemPrompt,
@@ -377,6 +381,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		ConversationStore:   convStore,
 		Logger:              &stdLogger{},
 		Activations:         activations,
+		RolloutDir:          rolloutDir,
 	})
 
 	// Wire the runner into the callback adapter now that it exists

--- a/docs/implementation/issue-016-jsonl-rollout-recorder.md
+++ b/docs/implementation/issue-016-jsonl-rollout-recorder.md
@@ -1,0 +1,69 @@
+# Issue #16: JSONL Rollout Recorder
+
+## Summary
+
+Implemented a JSONL rollout recorder that captures the complete event timeline of every run to a date-partitioned file. Enables session replay, audit, and future fork support.
+
+## Files Changed
+
+- `internal/rollout/recorder.go` — new package: `Recorder` type, `RecorderConfig`, `RecordableEvent`
+- `internal/rollout/recorder_test.go` — unit tests for the recorder
+- `internal/rollout/integration_test.go` — integration tests verifying runner produces JSONL files
+- `internal/harness/runner.go` — imports `rollout` package; creates recorder per run in `StartRun`/`ContinueRun`; hooks `Record` into `emit`; closes recorder after terminal events
+- `internal/harness/types.go` — added `RolloutDir string` field to `RunnerConfig`
+- `cmd/harnessd/main.go` — reads `HARNESS_ROLLOUT_DIR` env var; passes `RolloutDir` to `RunnerConfig`
+
+## Design
+
+### Storage layout
+
+```
+<HARNESS_ROLLOUT_DIR>/
+└── <YYYY-MM-DD>/
+    ├── run_1.jsonl
+    ├── run_2.jsonl
+    └── ...
+```
+
+Each line in a `.jsonl` file is a JSON object:
+
+```jsonl
+{"ts":"2026-03-09T14:30:00Z","seq":0,"type":"run.started","data":{"prompt":"hello"}}
+{"ts":"2026-03-09T14:30:01Z","seq":1,"type":"llm.turn.requested","data":{"step":1}}
+{"ts":"2026-03-09T14:30:02Z","seq":2,"type":"run.completed","data":{"output":"done"}}
+```
+
+### Key design decisions
+
+1. **Local type `RecordableEvent`** — avoids a circular import between `rollout` and `harness`. The runner converts `harness.Event` to `rollout.RecordableEvent` in the `emit` method.
+
+2. **Opt-in via `RolloutDir`** — leaving `RolloutDir` empty disables recording entirely with zero overhead.
+
+3. **Close on terminal event** — the recorder is closed immediately after `run.completed` or `run.failed` is recorded, flushing the file without waiting for GC.
+
+4. **Errors silently dropped** — recorder failures never crash or block the run loop. Creation errors are logged; per-event encoding errors are silently ignored.
+
+5. **Sequence counter managed by recorder** — the `seq` field is assigned by the `Recorder` (not copied from the event ID) to ensure a clean 0-based monotonic sequence per file.
+
+## Environment Variable
+
+| Variable | Default | Description |
+|---|---|---|
+| `HARNESS_ROLLOUT_DIR` | (empty, disabled) | Root directory for rollout JSONL files |
+
+## Tests
+
+- `TestRecorder_BasicWrite` — verifies correct JSONL format and field values
+- `TestRecorder_FileLayout` — verifies `<dir>/<YYYY-MM-DD>/<run_id>.jsonl` path
+- `TestRecorder_Seq` — verifies 0-based monotonic seq numbering
+- `TestRecorder_Concurrent` — 20 goroutines × 50 events with `-race`
+- `TestRecorder_NilPayload` — graceful handling of nil payload
+- `TestRecorder_CloseIdempotent` — double-close is safe
+- `TestNewRecorder_EmptyDir` — error on empty Dir
+- `TestNewRecorder_EmptyRunID` — error on empty RunID
+- `TestRunnerRollout_RunProducesJSONL` — integration: runner with `RolloutDir` set produces a parseable JSONL file with `run.started` and terminal events, correct `seq`, valid `ts`
+- `TestRunnerRollout_Disabled` — integration: runner without `RolloutDir` completes without error
+
+All 10 tests pass with `-race`.
+
+## Status: DONE

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -13,6 +13,7 @@ import (
 	htools "go-agent-harness/internal/harness/tools"
 	om "go-agent-harness/internal/observationalmemory"
 	"go-agent-harness/internal/provider/catalog"
+	"go-agent-harness/internal/rollout"
 	"go-agent-harness/internal/systemprompt"
 )
 
@@ -29,6 +30,8 @@ type runState struct {
 	steeringCh         chan string // buffered channel for user steering messages
 	// maxCostUSD is the per-run spending ceiling (0 = unlimited).
 	maxCostUSD float64
+	// recorder captures every event to a JSONL rollout file when RolloutDir is set.
+	recorder *rollout.Recorder
 }
 
 type usageTotalsAccumulator struct {
@@ -169,6 +172,20 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		run.ConversationID = run.ID
 	}
 
+	// Create rollout recorder before acquiring the run lock so that any
+	// filesystem error is surfaced at start time rather than mid-run.
+	var rec *rollout.Recorder
+	if r.config.RolloutDir != "" {
+		var recErr error
+		rec, recErr = rollout.NewRecorder(rollout.RecorderConfig{
+			Dir:   r.config.RolloutDir,
+			RunID: run.ID,
+		})
+		if recErr != nil && r.config.Logger != nil {
+			r.config.Logger.Error("rollout recorder: failed to create", "run_id", run.ID, "error", recErr)
+		}
+	}
+
 	r.mu.Lock()
 	r.runs[run.ID] = &runState{
 		run:                run,
@@ -181,6 +198,7 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		subscribers:        make(map[chan Event]struct{}),
 		steeringCh:         make(chan string, steeringBufferSize),
 		maxCostUSD:         req.MaxCostUSD,
+		recorder:           rec,
 	}
 	r.mu.Unlock()
 
@@ -304,6 +322,23 @@ func (r *Runner) ContinueRun(runID, message string) (Run, error) {
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
+	// Create rollout recorder for the continuation run (while lock is held,
+	// but recorder creation doesn't need it — release lock before creating).
+	r.mu.Unlock()
+
+	var contRec *rollout.Recorder
+	if r.config.RolloutDir != "" {
+		var recErr error
+		contRec, recErr = rollout.NewRecorder(rollout.RecorderConfig{
+			Dir:   r.config.RolloutDir,
+			RunID: newRun.ID,
+		})
+		if recErr != nil && r.config.Logger != nil {
+			r.config.Logger.Error("rollout recorder: failed to create for continuation", "run_id", newRun.ID, "error", recErr)
+		}
+	}
+
+	r.mu.Lock()
 	r.runs[newRun.ID] = &runState{
 		run:                newRun,
 		staticSystemPrompt: systemPrompt,
@@ -314,6 +349,7 @@ func (r *Runner) ContinueRun(runID, message string) (Run, error) {
 		events:             make([]Event, 0, 32),
 		subscribers:        make(map[chan Event]struct{}),
 		steeringCh:         make(chan string, steeringBufferSize),
+		recorder:           contRec,
 	}
 	r.mu.Unlock()
 
@@ -1801,7 +1837,23 @@ func (r *Runner) emit(runID string, eventType EventType, payload map[string]any)
 	for ch := range state.subscribers {
 		subscribers = append(subscribers, ch)
 	}
+	rec := state.recorder
 	r.mu.Unlock()
+
+	// Record to JSONL rollout file (outside the lock to avoid blocking).
+	if rec != nil {
+		rec.Record(rollout.RecordableEvent{
+			ID:        event.ID,
+			RunID:     event.RunID,
+			Type:      string(event.Type),
+			Timestamp: event.Timestamp,
+			Payload:   event.Payload,
+		})
+		// Close the recorder after terminal events so the file is flushed promptly.
+		if IsTerminalEvent(eventType) {
+			_ = rec.Close()
+		}
+	}
 
 	for _, ch := range subscribers {
 		select {

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -229,6 +229,10 @@ type RunnerConfig struct {
 	Logger              Logger                    `json:"-"`
 	Activations      *ActivationTracker        `json:"-"` // shared tracker for deferred tools
 	SkillConstraints *SkillConstraintTracker   `json:"-"` // shared tracker for skill tool constraints
+	// RolloutDir is the root directory for JSONL rollout files. When set, every
+	// run's events are recorded to <RolloutDir>/<YYYY-MM-DD>/<run_id>.jsonl.
+	// Leave empty to disable rollout recording.
+	RolloutDir string
 }
 
 // Logger is a minimal logging interface for the runner.

--- a/internal/rollout/integration_test.go
+++ b/internal/rollout/integration_test.go
@@ -1,0 +1,214 @@
+package rollout_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+// stubProvider is a minimal Provider implementation for integration tests.
+type stubProvider struct{}
+
+func (s *stubProvider) Complete(_ context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	// Return a simple assistant message with no tool calls so the run completes.
+	return harness.CompletionResult{
+		Content: "done",
+	}, nil
+}
+
+func readJSONLEntries(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open rollout file %s: %v", path, err)
+	}
+	defer f.Close()
+
+	var entries []map[string]any
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal line: %v", err)
+		}
+		entries = append(entries, e)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return entries
+}
+
+// TestRunnerRollout_RunProducesJSONL verifies that when RolloutDir is set on
+// RunnerConfig, a completed run produces a date-partitioned JSONL file containing
+// at minimum a run.started and run.completed event.
+func TestRunnerRollout_RunProducesJSONL(t *testing.T) {
+	t.Parallel()
+
+	rolloutDir := t.TempDir()
+	runner := harness.NewRunner(&stubProvider{}, nil, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     1,
+		RolloutDir:   rolloutDir,
+	})
+
+	run, err := runner.StartRun(harness.RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Wait for the run to complete.
+	_, ch, cancel, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cancel()
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				goto done
+			}
+			if harness.IsTerminalEvent(ev.Type) {
+				goto done
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for run to complete")
+		}
+	}
+done:
+	// Give a short moment for the recorder Close to happen (it's done in emit
+	// after publishing to subscribers).
+	time.Sleep(20 * time.Millisecond)
+
+	// Find the JSONL file.
+	today := time.Now().UTC().Format("2006-01-02")
+	expectedDir := filepath.Join(rolloutDir, today)
+	dirEntries, err := os.ReadDir(expectedDir)
+	if err != nil {
+		t.Fatalf("read rollout dir %s: %v", expectedDir, err)
+	}
+	var jsonlFiles []string
+	for _, de := range dirEntries {
+		if strings.HasSuffix(de.Name(), ".jsonl") {
+			jsonlFiles = append(jsonlFiles, filepath.Join(expectedDir, de.Name()))
+		}
+	}
+	if len(jsonlFiles) == 0 {
+		t.Fatalf("no .jsonl files found under %s", expectedDir)
+	}
+
+	// Find the file for our run.
+	var runFile string
+	for _, f := range jsonlFiles {
+		if strings.Contains(f, run.ID) {
+			runFile = f
+			break
+		}
+	}
+	if runFile == "" {
+		t.Fatalf("no .jsonl file found for run %q under %s", run.ID, expectedDir)
+	}
+
+	entries := readJSONLEntries(t, runFile)
+	if len(entries) == 0 {
+		t.Fatal("expected at least one entry in rollout file, got 0")
+	}
+
+	// Check for run.started and run.completed events.
+	types := make(map[string]bool)
+	for _, e := range entries {
+		if typ, ok := e["type"].(string); ok {
+			types[typ] = true
+		}
+	}
+	if !types["run.started"] {
+		t.Error("rollout missing run.started event")
+	}
+	if !types["run.completed"] && !types["run.failed"] {
+		t.Error("rollout missing terminal event (run.completed or run.failed)")
+	}
+
+	// Verify sequential seq values.
+	for i, e := range entries {
+		seqRaw, ok := e["seq"]
+		if !ok {
+			t.Errorf("entry %d missing seq", i)
+			continue
+		}
+		// JSON numbers are float64.
+		seq := int(seqRaw.(float64))
+		if seq != i {
+			t.Errorf("entry %d: seq = %d, want %d", i, seq, i)
+		}
+	}
+
+	// Verify ts is present and parseable.
+	for i, e := range entries {
+		tsRaw, ok := e["ts"]
+		if !ok {
+			t.Errorf("entry %d missing ts", i)
+			continue
+		}
+		tsStr, ok := tsRaw.(string)
+		if !ok {
+			t.Errorf("entry %d ts is not a string: %T", i, tsRaw)
+			continue
+		}
+		if _, err := time.Parse(time.RFC3339Nano, tsStr); err != nil {
+			t.Errorf("entry %d ts %q not parseable as RFC3339: %v", i, tsStr, err)
+		}
+	}
+}
+
+// TestRunnerRollout_Disabled verifies that when RolloutDir is empty, no
+// rollout files are written (and no error occurs).
+func TestRunnerRollout_Disabled(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(&stubProvider{}, nil, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     1,
+		// RolloutDir intentionally left empty.
+	})
+
+	run, err := runner.StartRun(harness.RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	_, ch, cancel, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cancel()
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			if harness.IsTerminalEvent(ev.Type) {
+				return
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for run to complete")
+		}
+	}
+}

--- a/internal/rollout/recorder.go
+++ b/internal/rollout/recorder.go
@@ -1,0 +1,138 @@
+// Package rollout implements a JSONL-based event recorder that captures the
+// complete timeline of a run for replay, fork, and audit purposes.
+//
+// Each run's events are written to a file at:
+//
+//	<dir>/<YYYY-MM-DD>/<run_id>.jsonl
+//
+// where each line is a JSON object with fields: ts, seq, type, data.
+//
+// The file is compatible with standard JSONL readers and can be grepped,
+// replayed, or forked without additional tooling.
+package rollout
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// RecordableEvent is the subset of harness.Event fields the recorder needs.
+// Using a local type avoids a circular dependency between rollout and harness.
+type RecordableEvent struct {
+	// ID is the per-run event ID, e.g. "run_1:42".
+	ID string
+	// RunID is the run this event belongs to.
+	RunID string
+	// Type is the event type string, e.g. "run.started".
+	Type string
+	// Timestamp is when the event occurred (UTC).
+	Timestamp time.Time
+	// Payload contains event-specific data. May be nil.
+	Payload map[string]any
+}
+
+// entry is the on-disk representation of a recorded event.
+type entry struct {
+	Ts   time.Time      `json:"ts"`
+	Seq  uint64         `json:"seq"`
+	Type string         `json:"type"`
+	Data map[string]any `json:"data,omitempty"`
+}
+
+// RecorderConfig holds configuration for a Recorder.
+type RecorderConfig struct {
+	// Dir is the root directory where rollout files are stored.
+	// Files are written under <Dir>/<YYYY-MM-DD>/<RunID>.jsonl.
+	// Must be non-empty.
+	Dir string
+	// RunID is the identifier of the run being recorded. Must be non-empty.
+	RunID string
+}
+
+// Recorder writes run events to a JSONL file in a date-partitioned directory.
+// It is safe for concurrent use.
+type Recorder struct {
+	mu     sync.Mutex
+	file   *os.File
+	enc    *json.Encoder
+	seq    uint64
+	closed bool
+}
+
+// NewRecorder creates a Recorder that stores events under cfg.Dir, partitioned
+// by the current UTC date. Call Close when the run completes to flush and
+// release the file handle.
+func NewRecorder(cfg RecorderConfig) (*Recorder, error) {
+	return NewRecorderAt(cfg, time.Now().UTC())
+}
+
+// NewRecorderAt is like NewRecorder but uses the provided time to determine the
+// date-partition directory. This is primarily useful for testing.
+func NewRecorderAt(cfg RecorderConfig, now time.Time) (*Recorder, error) {
+	if cfg.Dir == "" {
+		return nil, fmt.Errorf("rollout: Dir must not be empty")
+	}
+	if cfg.RunID == "" {
+		return nil, fmt.Errorf("rollout: RunID must not be empty")
+	}
+
+	dateDir := filepath.Join(cfg.Dir, now.UTC().Format("2006-01-02"))
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		return nil, fmt.Errorf("rollout: create directory %s: %w", dateDir, err)
+	}
+
+	path := filepath.Join(dateDir, cfg.RunID+".jsonl")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("rollout: open file %s: %w", path, err)
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetEscapeHTML(false)
+
+	return &Recorder{
+		file: f,
+		enc:  enc,
+	}, nil
+}
+
+// Record writes a single event to the JSONL file. It is safe for concurrent
+// use. Errors during encoding are silently dropped to avoid impacting the
+// primary run flow.
+func (r *Recorder) Record(ev RecordableEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return
+	}
+
+	e := entry{
+		Ts:   ev.Timestamp,
+		Seq:  r.seq,
+		Type: ev.Type,
+		Data: ev.Payload,
+	}
+	r.seq++
+
+	// Encoding errors are intentionally ignored: the recorder must never
+	// crash or block the run loop.
+	_ = r.enc.Encode(e)
+}
+
+// Close flushes any buffered data and closes the underlying file. Calling
+// Close more than once is safe and returns nil after the first call.
+func (r *Recorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	return r.file.Close()
+}

--- a/internal/rollout/recorder_test.go
+++ b/internal/rollout/recorder_test.go
@@ -1,0 +1,334 @@
+package rollout_test
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/rollout"
+)
+
+// entry matches the JSONL format written by the recorder.
+type entry struct {
+	Ts   time.Time      `json:"ts"`
+	Seq  uint64         `json:"seq"`
+	Type string         `json:"type"`
+	Data map[string]any `json:"data"`
+}
+
+func readEntries(t *testing.T, path string) []entry {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open rollout file: %v", err)
+	}
+	defer f.Close()
+
+	var entries []entry
+	sc := bufio.NewScanner(f)
+	// Increase buffer for potentially large lines.
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal entry: %v", err)
+		}
+		entries = append(entries, e)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return entries
+}
+
+// TestRecorder_BasicWrite verifies the recorder creates a JSONL file with the
+// correct format and content for a simple sequence of events.
+func TestRecorder_BasicWrite(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rec, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_1",
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	defer rec.Close()
+
+	events := []rollout.RecordableEvent{
+		{ID: "run_1:0", RunID: "run_1", Type: "run.started", Timestamp: time.Now().UTC(), Payload: map[string]any{"prompt": "hello"}},
+		{ID: "run_1:1", RunID: "run_1", Type: "llm.turn.requested", Timestamp: time.Now().UTC(), Payload: map[string]any{"step": 1}},
+		{ID: "run_1:2", RunID: "run_1", Type: "run.completed", Timestamp: time.Now().UTC(), Payload: map[string]any{"output": "done"}},
+	}
+	for _, e := range events {
+		rec.Record(e)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Find the file written.
+	var files []string
+	if err := filepath.Walk(dir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(p, ".jsonl") {
+			files = append(files, p)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("expected at least one .jsonl file, found none")
+	}
+
+	entries := readEntries(t, files[0])
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Verify first entry.
+	e0 := entries[0]
+	if e0.Type != "run.started" {
+		t.Errorf("entry[0].type = %q, want %q", e0.Type, "run.started")
+	}
+	if e0.Ts.IsZero() {
+		t.Error("entry[0].ts is zero")
+	}
+	if e0.Data["prompt"] != "hello" {
+		t.Errorf("entry[0].data[prompt] = %v, want %q", e0.Data["prompt"], "hello")
+	}
+
+	// Verify sequence ordering.
+	if entries[1].Type != "llm.turn.requested" {
+		t.Errorf("entry[1].type = %q, want %q", entries[1].Type, "llm.turn.requested")
+	}
+	if entries[2].Type != "run.completed" {
+		t.Errorf("entry[2].type = %q, want %q", entries[2].Type, "run.completed")
+	}
+}
+
+// TestRecorder_FileLayout verifies the JSONL file is stored at the expected path:
+// <dir>/<YYYY-MM-DD>/<runID>.jsonl
+func TestRecorder_FileLayout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	now := time.Date(2026, 3, 9, 14, 30, 0, 0, time.UTC)
+
+	rec, err := rollout.NewRecorderAt(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_abc",
+	}, now)
+	if err != nil {
+		t.Fatalf("NewRecorderAt: %v", err)
+	}
+	rec.Record(rollout.RecordableEvent{ID: "run_abc:0", RunID: "run_abc", Type: "run.started", Timestamp: now})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, "2026-03-09", "run_abc.jsonl")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected file at %s: %v", expectedPath, err)
+	}
+}
+
+// TestRecorder_Seq verifies that the seq field increments correctly.
+func TestRecorder_Seq(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rec, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_seq",
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	for i := uint64(0); i < 5; i++ {
+		rec.Record(rollout.RecordableEvent{
+			ID:        "run_seq:" + string(rune('0'+i)),
+			RunID:     "run_seq",
+			Type:      "run.started",
+			Timestamp: time.Now().UTC(),
+		})
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var files []string
+	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error { //nolint:errcheck
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, ".jsonl") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	entries := readEntries(t, files[0])
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+	for i, e := range entries {
+		if e.Seq != uint64(i) {
+			t.Errorf("entries[%d].seq = %d, want %d", i, e.Seq, i)
+		}
+	}
+}
+
+// TestRecorder_Concurrent verifies the recorder is safe under concurrent writes.
+func TestRecorder_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rec, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_concurrent",
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	const workers = 20
+	const eventsPerWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < eventsPerWorker; i++ {
+				rec.Record(rollout.RecordableEvent{
+					ID:        "run_concurrent:x",
+					RunID:     "run_concurrent",
+					Type:      "tool.call.started",
+					Timestamp: time.Now().UTC(),
+					Payload:   map[string]any{"tool": "bash"},
+				})
+			}
+		}()
+	}
+	wg.Wait()
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var files []string
+	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error { //nolint:errcheck
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, ".jsonl") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	entries := readEntries(t, files[0])
+	want := workers * eventsPerWorker
+	if len(entries) != want {
+		t.Errorf("expected %d entries, got %d", want, len(entries))
+	}
+}
+
+// TestRecorder_NilPayload verifies entries with nil payload are handled gracefully.
+func TestRecorder_NilPayload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rec, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_nil",
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+
+	rec.Record(rollout.RecordableEvent{
+		ID:        "run_nil:0",
+		RunID:     "run_nil",
+		Type:      "run.started",
+		Timestamp: time.Now().UTC(),
+		Payload:   nil,
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	var files []string
+	filepath.Walk(dir, func(p string, info os.FileInfo, err error) error { //nolint:errcheck
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, ".jsonl") {
+			files = append(files, p)
+		}
+		return nil
+	})
+	entries := readEntries(t, files[0])
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+// TestRecorder_CloseIdempotent verifies calling Close multiple times is safe.
+func TestRecorder_CloseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	rec, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "run_idempotent",
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	rec.Record(rollout.RecordableEvent{
+		ID:        "run_idempotent:0",
+		RunID:     "run_idempotent",
+		Type:      "run.started",
+		Timestamp: time.Now().UTC(),
+	})
+	if err := rec.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	// Second close should not panic or return error.
+	if err := rec.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// TestNewRecorder_InvalidDir verifies that NewRecorder returns an error when
+// the directory cannot be created (e.g. empty dir path).
+func TestNewRecorder_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	_, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   "",
+		RunID: "run_x",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty dir, got nil")
+	}
+}
+
+// TestNewRecorder_EmptyRunID verifies that NewRecorder returns an error when
+// RunID is empty.
+func TestNewRecorder_EmptyRunID(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	_, err := rollout.NewRecorder(rollout.RecorderConfig{
+		Dir:   dir,
+		RunID: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty RunID, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `HARNESS_ROLLOUT_DIR` opt-in JSONL recorder that writes every run's events to date-partitioned files for session replay, fork, and audit.

**Note:** This branch also includes changes from issues #3, #5, #10, and #75 which have their own PRs (#100, #102, #103, #99). The new code for issue #16 is in `internal/rollout/`.

## New Package: `internal/rollout`

### File layout
```
<HARNESS_ROLLOUT_DIR>/
└── 2026-03-09/
    ├── <run-id-1>.jsonl
    └── <run-id-2>.jsonl
```

### Each line format
```jsonl
{"ts":"2026-03-09T14:30:00Z","seq":0,"type":"run.started","data":{...}}
```

## Integration (`cmd/harnessd/main.go`)
- Reads `HARNESS_ROLLOUT_DIR`; if empty, recording is disabled with zero overhead
- Recorder is opened at run start, closed after terminal event
- Recorder errors never crash or block the run loop

## Tests (10 new in `internal/rollout/`)
- Records events to JSONL file
- Creates date-partitioned directories
- Handles disabled mode gracefully
- Multiple concurrent recordings
- File closed after terminal event
- Race detector clean

All packages pass with `-race`.