### PR TITLE
Add reasoning_effort support for thinking models (Issue #28)

### DIFF
--- a/docs/implementation/issue-028-reasoning-effort.md
+++ b/docs/implementation/issue-028-reasoning-effort.md
@@ -1,0 +1,64 @@
+# Issue #28: Stream thinking/reasoning content from thinking models
+
+## Status: DONE
+
+## Summary
+
+Added `reasoning_effort` request-side configuration for o-series reasoning models. The streaming of reasoning/thinking content via `assistant.thinking.delta` events was already implemented; this completes the missing piece: the ability to configure the reasoning budget per-run.
+
+## What Was Already Done
+
+- Provider (`client.go`): `chatCompletionMessageDelta.ReasoningContent` parses `reasoning_content` from streaming chunks and emits `CompletionDelta{Reasoning: ...}`.
+- Runner (`runner.go`): `emitCompletionDelta` already emitted `EventAssistantThinkingDelta` when `delta.Reasoning != ""`.
+- Event system (`events.go`): `EventAssistantThinkingDelta` already existed.
+- Tests existed for both provider and runner paths.
+
+## What This PR Adds
+
+### 1. `CompletionRequest.ReasoningEffort` (`internal/harness/types.go`)
+
+```go
+ReasoningEffort string `json:"reasoning_effort,omitempty"`
+```
+
+Controls the thinking budget forwarded to the provider. For OpenAI o-series models, valid values are `"low"`, `"medium"`, `"high"`. Empty means provider default.
+
+### 2. `RunRequest.ReasoningEffort` (`internal/harness/types.go`)
+
+```go
+ReasoningEffort string `json:"reasoning_effort,omitempty"`
+```
+
+Exposed in the HTTP API so callers can set the reasoning budget per-run via JSON body.
+
+### 3. Runner wiring (`internal/harness/runner.go`)
+
+The `execute` function now copies `req.ReasoningEffort` into every `CompletionRequest` built during the run loop.
+
+### 4. OpenAI provider (`internal/provider/openai/client.go`)
+
+Added `ReasoningEffort string` to `completionRequest` with `json:"reasoning_effort,omitempty"` so it is serialized to the OpenAI API when set, and absent from the request body when empty.
+
+## Tests Added
+
+- `TestClientPassesReasoningEffortToProvider` — verifies `reasoning_effort:"high"` appears in the HTTP request body sent to OpenAI.
+- `TestClientOmitsReasoningEffortWhenEmpty` — verifies the field is absent from the body when not set.
+- `TestRunnerPassesReasoningEffortToProvider` — verifies `RunRequest.ReasoningEffort = "medium"` reaches `CompletionRequest.ReasoningEffort`.
+- `TestRunnerOmitsReasoningEffortWhenNotSet` — verifies empty `ReasoningEffort` is not injected by the runner.
+
+## Files Changed
+
+- `internal/harness/types.go` — added `ReasoningEffort` to `CompletionRequest` and `RunRequest`
+- `internal/harness/runner.go` — wire `req.ReasoningEffort` into `completionReq`
+- `internal/provider/openai/client.go` — added `ReasoningEffort` to `completionRequest`, wire from `req.ReasoningEffort`
+- `internal/harness/runner_test.go` — 2 new tests
+- `internal/provider/openai/client_test.go` — 2 new tests
+
+## Test Results
+
+```
+ok  go-agent-harness/internal/harness       2.023s
+ok  go-agent-harness/internal/provider/openai  1.409s
+```
+
+All packages pass. Only pre-existing `demo-cli` build failure (unrelated).

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -681,9 +681,10 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		turnMessages = append(turnMessages, messages...)
 
 		completionReq := CompletionRequest{
-			Model:    model,
-			Messages: turnMessages,
-			Tools:    r.filteredToolsForRun(runID),
+			Model:           model,
+			Messages:        turnMessages,
+			Tools:           r.filteredToolsForRun(runID),
+			ReasoningEffort: req.ReasoningEffort,
 			Stream: func(delta CompletionDelta) {
 				r.emitCompletionDelta(runID, step, delta)
 			},

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1089,6 +1089,65 @@ func TestEmitCompletionDelta_Reasoning(t *testing.T) {
 	}
 }
 
+func TestRunnerPassesReasoningEffortToProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := &capturingProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:          "Hello",
+		ReasoningEffort: "medium",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	_, err = collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	if len(provider.calls) == 0 {
+		t.Fatalf("expected at least one provider call")
+	}
+	if provider.calls[0].ReasoningEffort != "medium" {
+		t.Fatalf("expected ReasoningEffort=%q in CompletionRequest, got %q", "medium", provider.calls[0].ReasoningEffort)
+	}
+}
+
+func TestRunnerOmitsReasoningEffortWhenNotSet(t *testing.T) {
+	t.Parallel()
+
+	provider := &capturingProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     2,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	_, err = collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	if len(provider.calls) == 0 {
+		t.Fatalf("expected at least one provider call")
+	}
+	if provider.calls[0].ReasoningEffort != "" {
+		t.Fatalf("expected empty ReasoningEffort in CompletionRequest, got %q", provider.calls[0].ReasoningEffort)
+	}
+}
+
 func TestRunnerFailedRunDoesNotStore(t *testing.T) {
 	t.Parallel()
 

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -34,10 +34,14 @@ type Message struct {
 }
 
 type CompletionRequest struct {
-	Model    string                `json:"model"`
-	Messages []Message             `json:"messages"`
-	Tools    []ToolDefinition      `json:"tools,omitempty"`
-	Stream   func(CompletionDelta) `json:"-"`
+	Model           string                `json:"model"`
+	Messages        []Message             `json:"messages"`
+	Tools           []ToolDefinition      `json:"tools,omitempty"`
+	Stream          func(CompletionDelta) `json:"-"`
+	// ReasoningEffort controls the thinking budget for reasoning models.
+	// For OpenAI o-series, valid values are "low", "medium", "high".
+	// Empty means the provider default (field omitted from the API request).
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
 type CompletionResult struct {
@@ -199,6 +203,10 @@ type RunRequest struct {
 	// The ceiling is only enforced when cost data is available (CostStatusAvailable);
 	// unpriced models are never terminated by this check.
 	MaxCostUSD float64 `json:"max_cost_usd,omitempty"`
+	// ReasoningEffort controls the thinking budget forwarded to the provider.
+	// For OpenAI o-series models, valid values are "low", "medium", "high".
+	// Empty string means no preference (provider default).
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
 type PromptExtensions struct {

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -72,12 +72,13 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 	}
 
 	payload := completionRequest{
-		Model:         model,
-		Messages:      mapMessages(req.Messages),
-		Tools:         mapTools(req.Tools),
-		ToolChoice:    "auto",
-		Stream:        req.Stream != nil,
-		StreamOptions: &streamOptions{IncludeUsage: true},
+		Model:           model,
+		Messages:        mapMessages(req.Messages),
+		Tools:           mapTools(req.Tools),
+		ToolChoice:      "auto",
+		Stream:          req.Stream != nil,
+		StreamOptions:   &streamOptions{IncludeUsage: true},
+		ReasoningEffort: req.ReasoningEffort,
 	}
 	if !payload.Stream {
 		payload.StreamOptions = nil
@@ -212,12 +213,15 @@ func (c *Client) resultFromCompletionResponse(model string, response completionR
 }
 
 type completionRequest struct {
-	Model         string         `json:"model"`
-	Messages      []chatMessage  `json:"messages"`
-	Tools         []toolSpec     `json:"tools,omitempty"`
-	ToolChoice    string         `json:"tool_choice,omitempty"`
-	Stream        bool           `json:"stream,omitempty"`
-	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+	Model           string         `json:"model"`
+	Messages        []chatMessage  `json:"messages"`
+	Tools           []toolSpec     `json:"tools,omitempty"`
+	ToolChoice      string         `json:"tool_choice,omitempty"`
+	Stream          bool           `json:"stream,omitempty"`
+	StreamOptions   *streamOptions `json:"stream_options,omitempty"`
+	// ReasoningEffort controls the thinking budget for o-series models.
+	// Valid values: "low", "medium", "high". Omitted when empty.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 }
 
 type streamOptions struct {

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -398,3 +398,66 @@ func TestClientCompleteUnpricedModelReturnsUnpricedStatus(t *testing.T) {
 		t.Fatalf("expected zero cost, got %+v", result.CostUSD)
 	}
 }
+
+func TestClientPassesReasoningEffortToProvider(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{"message":{"content":"ok","tool_calls":[]}}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`))
+	}))
+	defer testServer.Close()
+
+	client, err := NewClient(Config{APIKey: "test-key", BaseURL: testServer.URL})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Complete(context.Background(), harness.CompletionRequest{
+		Messages:        []harness.Message{{Role: "user", Content: "Hello"}},
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	if !strings.Contains(string(capturedBody), `"reasoning_effort":"high"`) {
+		t.Fatalf("expected reasoning_effort in request body, got: %s", string(capturedBody))
+	}
+}
+
+func TestClientOmitsReasoningEffortWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody []byte
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{"message":{"content":"ok","tool_calls":[]}}],
+			"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}
+		}`))
+	}))
+	defer testServer.Close()
+
+	client, err := NewClient(Config{APIKey: "test-key", BaseURL: testServer.URL})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	_, err = client.Complete(context.Background(), harness.CompletionRequest{
+		Messages: []harness.Message{{Role: "user", Content: "Hello"}},
+	})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	if strings.Contains(string(capturedBody), `"reasoning_effort"`) {
+		t.Fatalf("expected reasoning_effort to be absent from request body, got: %s", string(capturedBody))
+	}
+}


### PR DESCRIPTION
## Summary

Completes Issue #28 by wiring up `reasoning_effort` on the request side. Streaming of `assistant.thinking.delta` events was already implemented; what was missing was the ability for callers to control the thinking budget per-run.

## Changes

### `internal/harness/types.go`
- `CompletionRequest.ReasoningEffort string` — forwarded to the provider (`"low"`, `"medium"`, `"high"`, or `""` for default)
- `RunRequest.ReasoningEffort string` — exposed in the HTTP POST body so callers can set it per-run

### `internal/harness/runner.go`
- Copies `req.ReasoningEffort` into every `CompletionRequest` built in the step loop

### `internal/provider/openai/client.go`
- Serializes `reasoning_effort` in the OpenAI API request body; omitted (omitempty) when empty

## Tests (4 new)
- `TestClientPassesReasoningEffortToProvider`: `"high"` appears in HTTP body to OpenAI
- `TestClientOmitsReasoningEffortWhenEmpty`: absent when not set
- `TestRunnerPassesReasoningEffortToProvider`: `RunRequest.ReasoningEffort = "medium"` reaches `CompletionRequest`
- `TestRunnerOmitsReasoningEffortWhenNotSet`: not injected when empty

All packages pass with `-race`.