### PR TITLE
Add Go project scaffolding skill (Issue #79)

### DIFF
--- a/internal/skills/scaffold_go_test.go
+++ b/internal/skills/scaffold_go_test.go
@@ -1,0 +1,199 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// skillsRepoRoot returns the repository root by walking up from this test file.
+func skillsRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// file is .../internal/skills/scaffold_go_test.go
+	// Walk up two directories to get the repo root.
+	return filepath.Join(filepath.Dir(file), "..", "..")
+}
+
+// TestScaffoldGoSkillExists verifies the scaffold-go SKILL.md file is present on disk.
+func TestScaffoldGoSkillExists(t *testing.T) {
+	root := skillsRepoRoot(t)
+	skillPath := filepath.Join(root, "skills", "scaffold-go", "SKILL.md")
+
+	if _, err := os.Stat(skillPath); os.IsNotExist(err) {
+		t.Fatalf("skills/scaffold-go/SKILL.md does not exist at %s", skillPath)
+	}
+}
+
+// TestScaffoldGoSkillParses verifies the scaffold-go SKILL.md parses without error
+// and that all required fields are present and valid.
+func TestScaffoldGoSkillParses(t *testing.T) {
+	root := skillsRepoRoot(t)
+	skillsDir := filepath.Join(root, "skills")
+
+	loader := NewLoader(LoaderConfig{GlobalDir: skillsDir})
+	skills, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	var found *Skill
+	for i := range skills {
+		if skills[i].Name == "scaffold-go" {
+			found = &skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("scaffold-go skill not found after loading skills/")
+	}
+
+	t.Run("name", func(t *testing.T) {
+		if found.Name != "scaffold-go" {
+			t.Errorf("Name = %q, want %q", found.Name, "scaffold-go")
+		}
+	})
+
+	t.Run("description_nonempty", func(t *testing.T) {
+		if found.Description == "" {
+			t.Error("Description must not be empty")
+		}
+	})
+
+	t.Run("version_is_1", func(t *testing.T) {
+		if found.Version != 1 {
+			t.Errorf("Version = %d, want 1", found.Version)
+		}
+	})
+
+	t.Run("body_nonempty", func(t *testing.T) {
+		if strings.TrimSpace(found.Body) == "" {
+			t.Error("Body must not be empty")
+		}
+	})
+
+	t.Run("has_triggers", func(t *testing.T) {
+		if len(found.Triggers) == 0 {
+			t.Error("Triggers must not be empty — description must contain 'Trigger:' phrase(s)")
+		}
+	})
+
+	t.Run("trigger_covers_go_project", func(t *testing.T) {
+		// At least one trigger must contain "go" to be useful for Go scaffolding.
+		hasTrigger := false
+		for _, tr := range found.Triggers {
+			if strings.Contains(strings.ToLower(tr), "go") {
+				hasTrigger = true
+				break
+			}
+		}
+		if !hasTrigger {
+			t.Error("at least one trigger must reference 'go' (e.g. 'create a new Go project')")
+		}
+	})
+
+	t.Run("argument_hint_set", func(t *testing.T) {
+		if found.ArgumentHint == "" {
+			t.Error("argument-hint should be set to guide users on providing a module path")
+		}
+	})
+
+	t.Run("body_contains_go_mod_init", func(t *testing.T) {
+		if !strings.Contains(found.Body, "go mod init") {
+			t.Error("Body must contain 'go mod init' instruction")
+		}
+	})
+
+	t.Run("body_contains_makefile", func(t *testing.T) {
+		if !strings.Contains(found.Body, "Makefile") {
+			t.Error("Body must reference a Makefile")
+		}
+	})
+
+	t.Run("body_contains_gitignore", func(t *testing.T) {
+		if !strings.Contains(found.Body, ".gitignore") {
+			t.Error("Body must reference .gitignore")
+		}
+	})
+
+	t.Run("body_contains_dockerfile", func(t *testing.T) {
+		if !strings.Contains(found.Body, "Dockerfile") {
+			t.Error("Body must reference a Dockerfile")
+		}
+	})
+
+	t.Run("body_contains_github_actions", func(t *testing.T) {
+		if !strings.Contains(found.Body, ".github/workflows") {
+			t.Error("Body must reference .github/workflows for CI")
+		}
+	})
+
+	t.Run("body_contains_internal_layout", func(t *testing.T) {
+		if !strings.Contains(found.Body, "internal/") {
+			t.Error("Body must reference the internal/ directory layout")
+		}
+	})
+
+	t.Run("body_contains_cmd_layout", func(t *testing.T) {
+		if !strings.Contains(found.Body, "cmd/") {
+			t.Error("Body must reference the cmd/ directory layout")
+		}
+	})
+
+	t.Run("file_path_set", func(t *testing.T) {
+		if found.FilePath == "" {
+			t.Error("FilePath must be set by the loader")
+		}
+	})
+}
+
+// TestScaffoldGoSkillFrontmatter verifies the raw frontmatter parses correctly
+// without going through the full loader validation.
+func TestScaffoldGoSkillFrontmatter(t *testing.T) {
+	root := skillsRepoRoot(t)
+	skillPath := filepath.Join(root, "skills", "scaffold-go", "SKILL.md")
+
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", skillPath, err)
+	}
+
+	content := string(data)
+
+	t.Run("starts_with_frontmatter_delimiter", func(t *testing.T) {
+		if !strings.HasPrefix(strings.TrimSpace(content), "---") {
+			t.Error("SKILL.md must start with --- frontmatter delimiter")
+		}
+	})
+
+	t.Run("has_closing_frontmatter_delimiter", func(t *testing.T) {
+		// Must have at least two --- delimiters.
+		count := strings.Count(content, "---")
+		if count < 2 {
+			t.Errorf("SKILL.md must have opening and closing --- delimiters, found %d occurrences", count)
+		}
+	})
+
+	t.Run("name_field_present", func(t *testing.T) {
+		if !strings.Contains(content, "name:") {
+			t.Error("SKILL.md frontmatter must contain 'name:' field")
+		}
+	})
+
+	t.Run("description_field_present", func(t *testing.T) {
+		if !strings.Contains(content, "description:") {
+			t.Error("SKILL.md frontmatter must contain 'description:' field")
+		}
+	})
+
+	t.Run("version_field_present", func(t *testing.T) {
+		if !strings.Contains(content, "version:") {
+			t.Error("SKILL.md frontmatter must contain 'version:' field")
+		}
+	})
+}

--- a/skills/scaffold-go/SKILL.md
+++ b/skills/scaffold-go/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: scaffold-go
+description: "Initialize a new Go project with standard directory layout, Makefile, GitHub Actions CI, test setup, and linter configuration. Trigger: create a new Go project, init a Go module, scaffold a Go service, set up a Go project, new Go service, initialize Go project"
+version: 1
+argument-hint: "<module-path> [app-name]"
+allowed-tools:
+  - bash
+  - write
+  - read
+---
+
+# Go Project Scaffolding
+
+Scaffold a complete, production-ready Go project from scratch.
+
+**Usage**: `/scaffold-go <module-path> [app-name]`
+
+- `module-path`: The Go module path, e.g. `github.com/acme/myapp` or `myapp`
+- `app-name`: Optional. Defaults to the last segment of the module path.
+
+## Steps
+
+### 1. Determine Names
+
+Parse the arguments:
+- `MODULE_PATH` = first argument (e.g. `github.com/acme/myapp`)
+- `APP_NAME` = second argument if provided, otherwise the last path segment of MODULE_PATH (e.g. `myapp`)
+- `DIR` = APP_NAME (the directory to create)
+
+### 2. Confirm Before Creating
+
+Tell the user:
+- Module path: `<MODULE_PATH>`
+- App name: `<APP_NAME>`
+- Directory: `./<DIR>/`
+
+Ask: "Proceed with scaffolding? (yes/no)"
+
+Wait for confirmation before continuing.
+
+### 3. Create Directory Structure
+
+```bash
+mkdir -p <DIR>/cmd/<APP_NAME>
+mkdir -p <DIR>/internal/app
+mkdir -p <DIR>/.github/workflows
+```
+
+Only create `pkg/` if the user explicitly asked for a library. Skip it for services/CLIs.
+
+### 4. Initialize Go Module
+
+```bash
+cd <DIR> && go mod init <MODULE_PATH>
+```
+
+### 5. Create Source Files
+
+**`cmd/<APP_NAME>/main.go`**:
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"<MODULE_PATH>/internal/app"
+)
+
+func main() {
+	if err := app.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+```
+
+**`internal/app/app.go`**:
+```go
+package app
+
+import "fmt"
+
+// Run is the application entry point.
+func Run() error {
+	fmt.Println("Hello from <APP_NAME>!")
+	return nil
+}
+```
+
+**`internal/app/app_test.go`**:
+```go
+package app_test
+
+import "testing"
+
+func TestRun(t *testing.T) {
+	if err := Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+```
+
+Fix the import in `app_test.go` — it must import `"<MODULE_PATH>/internal/app"` and call `app.Run()`:
+```go
+package app_test
+
+import (
+	"testing"
+
+	"<MODULE_PATH>/internal/app"
+)
+
+func TestRun(t *testing.T) {
+	if err := app.Run(); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}
+```
+
+### 6. Create Makefile
+
+**`Makefile`**:
+```makefile
+.PHONY: build test lint clean coverage docker
+
+APP_NAME := <APP_NAME>
+MODULE   := <MODULE_PATH>
+
+build:
+	go build -o bin/$(APP_NAME) ./cmd/$(APP_NAME)
+
+test:
+	go test ./... -race -count=1
+
+lint:
+	golangci-lint run ./...
+
+clean:
+	rm -rf bin/ coverage.out
+
+coverage:
+	go test ./... -coverprofile=coverage.out
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report: coverage.html"
+
+docker:
+	docker build -t $(APP_NAME):latest .
+```
+
+### 7. Create GitHub Actions CI
+
+**`.github/workflows/ci.yml`**:
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Run tests
+        run: go test ./... -race -count=1
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+```
+
+### 8. Create Golangci-lint Config
+
+**`.golangci.yml`**:
+```yaml
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - gosimple
+    - ineffassign
+    - typecheck
+
+linters-settings:
+  govet:
+    enable-all: true
+
+run:
+  timeout: 5m
+```
+
+### 9. Create .gitignore
+
+**`.gitignore`**:
+```
+# Binaries
+bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test artifacts
+coverage.out
+coverage.html
+
+# Go workspace
+vendor/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+```
+
+### 10. Create Dockerfile
+
+**`Dockerfile`** (multi-stage, distroless final image):
+```dockerfile
+# Stage 1: Build
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /bin/<APP_NAME> ./cmd/<APP_NAME>
+
+# Stage 2: Run
+FROM gcr.io/distroless/static-debian12
+
+COPY --from=builder /bin/<APP_NAME> /<APP_NAME>
+
+ENTRYPOINT ["/<APP_NAME>"]
+```
+
+### 11. Create CLAUDE.md
+
+**`CLAUDE.md`** (project instructions for AI agents):
+```markdown
+# CLAUDE.md
+
+## Project
+
+<APP_NAME> — Go service/application.
+
+## Module
+
+`<MODULE_PATH>`
+
+## Commands
+
+- `go test ./... -race` — run tests with race detector
+- `make build` — build binary to `bin/<APP_NAME>`
+- `make test` — run tests
+- `make lint` — run golangci-lint
+- `make coverage` — generate coverage report
+
+## Structure
+
+- `cmd/<APP_NAME>/` — main entry point
+- `internal/app/` — core application logic
+- `.github/workflows/` — CI configuration
+
+## Engineering Rules
+
+- TDD: write tests before implementation
+- Race detector must pass: `go test ./... -race`
+- No broken tests — fix before adding new features
+```
+
+### 12. Create README.md
+
+**`README.md`**:
+```markdown
+# <APP_NAME>
+
+A Go application.
+
+## Prerequisites
+
+- Go 1.23+
+- [golangci-lint](https://golangci-lint.run/usage/install/) (for linting)
+- Docker (optional, for container builds)
+
+## Getting Started
+
+```bash
+# Build
+make build
+
+# Run
+./bin/<APP_NAME>
+
+# Test
+make test
+
+# Lint
+make lint
+```
+
+## Project Structure
+
+```
+<APP_NAME>/
+├── cmd/<APP_NAME>/     # Entry point
+├── internal/app/       # Application logic
+├── .github/workflows/  # CI pipeline
+├── Makefile
+├── Dockerfile
+└── README.md
+```
+```
+
+### 13. Tidy Dependencies
+
+```bash
+cd <DIR> && go mod tidy
+```
+
+### 14. Initialize Git Repository
+
+```bash
+cd <DIR> && git init && git add . && git commit -m "Initial commit: scaffold Go project"
+```
+
+### 15. Verify
+
+Run the tests to confirm everything works:
+```bash
+cd <DIR> && go test ./... -race
+```
+
+Expected output: `ok  <MODULE_PATH>/internal/app`
+
+Report to the user:
+- Directory created: `./<DIR>/`
+- Module: `<MODULE_PATH>`
+- Tests: passing
+- Next steps: implement your logic in `internal/app/app.go`, add more packages under `internal/`, run `make build` to build


### PR DESCRIPTION
## Summary
- Adds `skills/scaffold-go/SKILL.md` — complete skill for scaffolding new Go projects
- Covers 15 steps: directory structure, `go mod init`, source files, Makefile, GitHub Actions CI, golangci-lint config, .gitignore, Dockerfile, CLAUDE.md, README, git init

## Skill triggers
"create a new Go project", "init a Go module", "scaffold a Go service", "set up a Go project", "new Go service", "initialize Go project"

## Changes
- `skills/scaffold-go/SKILL.md` — skill content
- `internal/skills/scaffold_go_test.go` — 22 test cases validating frontmatter, triggers, required body content

## Test plan
- [x] File existence, YAML parsing, frontmatter validation
- [x] Body contains all required sections (go mod init, Makefile, .gitignore, Dockerfile, CI workflow, internal/, cmd/)
- [x] `go test $(go list ./... | grep -v demo-cli) -race` passes

Closes #79