### PR TITLE
Add database, monitoring, testing, and collaboration skill files (Issues #65, #66, #68, #69)

### DIFF
--- a/skills/api-testing/SKILL.md
+++ b/skills/api-testing/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: api-testing
+description: "Test REST APIs with curl and jq: send requests, validate responses, check status codes, headers, and JSON body. Trigger: when testing REST APIs, API testing with curl, validating HTTP endpoints, testing JSON responses, API smoke tests"
+version: 1
+argument-hint: "[base-url]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# API Testing (curl)
+
+You are now operating in API testing mode.
+
+## Basic Request Patterns
+
+```bash
+# GET request
+curl -s http://localhost:8080/api/v1/users | jq .
+
+# POST with JSON body
+curl -s -X POST http://localhost:8080/api/v1/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice","email":"alice@example.com"}' | jq .
+
+# PUT (full replace)
+curl -s -X PUT http://localhost:8080/api/v1/users/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice Updated","email":"alice@example.com"}' | jq .
+
+# PATCH (partial update)
+curl -s -X PATCH http://localhost:8080/api/v1/users/1 \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice Patched"}' | jq .
+
+# DELETE
+curl -s -X DELETE http://localhost:8080/api/v1/users/1
+```
+
+## Status Code Validation
+
+```bash
+# Extract status code
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+echo "Status: $STATUS"
+
+# Assert status equals 200
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health)
+[ "$STATUS" -eq 200 ] && echo "PASS" || echo "FAIL: expected 200, got $STATUS"
+
+# Assert status is 2xx
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/v1/users)
+[ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 300 ] && echo "PASS" || echo "FAIL: $STATUS"
+
+# Capture both body and status code
+RESPONSE=$(curl -s -w "\n%{http_code}" http://localhost:8080/api/v1/users)
+BODY=$(echo "$RESPONSE" | head -n -1)
+STATUS=$(echo "$RESPONSE" | tail -n 1)
+echo "Status: $STATUS"
+echo "$BODY" | jq .
+```
+
+## Response Body Validation
+
+```bash
+# Check JSON field value
+NAME=$(curl -s http://localhost:8080/api/v1/users/1 | jq -r '.name')
+[ "$NAME" = "Alice" ] && echo "PASS" || echo "FAIL: name=$NAME"
+
+# Check array length
+COUNT=$(curl -s http://localhost:8080/api/v1/users | jq '.users | length')
+[ "$COUNT" -gt 0 ] && echo "PASS: $COUNT users" || echo "FAIL: empty response"
+
+# Validate JSON schema (field presence)
+RESPONSE=$(curl -s http://localhost:8080/api/v1/users/1)
+echo "$RESPONSE" | jq -e '.id and .name and .email' > /dev/null \
+  && echo "PASS: schema valid" || echo "FAIL: missing required fields"
+```
+
+## Authentication
+
+```bash
+# Bearer token
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/v1/me | jq .
+
+# Basic auth
+curl -s -u username:password http://localhost:8080/api/v1/protected | jq .
+
+# API key header
+curl -s -H "X-API-Key: $API_KEY" http://localhost:8080/api/v1/data | jq .
+
+# Set token from login response
+TOKEN=$(curl -s -X POST http://localhost:8080/api/v1/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"alice@example.com","password":"secret"}' | jq -r '.token')
+echo "Token obtained: ${TOKEN:0:20}..."
+```
+
+## Response Time Measurement
+
+```bash
+# Measure response time
+TIME=$(curl -s -o /dev/null -w "%{time_total}" http://localhost:8080/api/v1/users)
+echo "Response time: ${TIME}s"
+
+# Detailed timing breakdown
+curl -s -o /dev/null -w "
+  DNS lookup:   %{time_namelookup}s
+  Connect:      %{time_connect}s
+  TLS handshake:%{time_appconnect}s
+  First byte:   %{time_starttransfer}s
+  Total:        %{time_total}s
+" http://localhost:8080/api/v1/users
+```
+
+## Response Headers
+
+```bash
+# Show response headers
+curl -s -I http://localhost:8080/api/v1/users
+
+# Extract specific header
+CONTENT_TYPE=$(curl -s -I http://localhost:8080/api/v1/users | grep -i 'content-type' | awk '{print $2}')
+echo "Content-Type: $CONTENT_TYPE"
+
+# Assert Content-Type is JSON
+curl -s -I http://localhost:8080/api/v1/users | grep -i 'content-type' | grep -q 'application/json' \
+  && echo "PASS" || echo "FAIL: not JSON content type"
+```
+
+## Error Path Testing
+
+```bash
+# 404 Not Found
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/v1/users/99999)
+[ "$STATUS" -eq 404 ] && echo "PASS" || echo "FAIL: expected 404, got $STATUS"
+
+# 400 Bad Request (invalid body)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8080/api/v1/users \
+  -H "Content-Type: application/json" \
+  -d '{"invalid": true}')
+[ "$STATUS" -eq 400 ] && echo "PASS" || echo "FAIL: expected 400, got $STATUS"
+
+# 401 Unauthorized (missing token)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/v1/me)
+[ "$STATUS" -eq 401 ] && echo "PASS" || echo "FAIL: expected 401, got $STATUS"
+```
+
+## Test Workflow
+
+```bash
+# 1. Health check
+echo "=== Health Check ==="
+curl -s -f http://localhost:8080/health && echo "OK" || { echo "FAIL"; exit 1; }
+
+# 2. Create resource
+echo "=== Create User ==="
+CREATED=$(curl -s -X POST http://localhost:8080/api/v1/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Test User","email":"test@example.com"}')
+ID=$(echo "$CREATED" | jq -r '.id')
+echo "Created user ID: $ID"
+
+# 3. Read it back
+echo "=== Read User ==="
+FETCHED=$(curl -s "http://localhost:8080/api/v1/users/$ID")
+echo "$FETCHED" | jq -e '.id == '"$ID"'' > /dev/null && echo "PASS" || echo "FAIL"
+
+# 4. Delete it
+echo "=== Delete User ==="
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://localhost:8080/api/v1/users/$ID")
+[ "$STATUS" -eq 204 ] && echo "PASS" || echo "FAIL: $STATUS"
+```
+
+## Debugging
+
+```bash
+# Verbose output (headers + body)
+curl -v http://localhost:8080/api/v1/users 2>&1
+
+# Show request that was sent
+curl --trace-ascii - http://localhost:8080/api/v1/users 2>&1 | head -50
+
+# Silence progress, show errors
+curl -sS http://localhost:8080/api/v1/users | jq .
+```
+
+## Security Notes
+
+- Never log bearer tokens or API keys — use `${TOKEN:0:8}...` for partial display.
+- Do not hardcode credentials in scripts — use environment variables.
+- Use `-k` / `--insecure` only in local dev, never in CI against staging/production.

--- a/skills/db-migrations/SKILL.md
+++ b/skills/db-migrations/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: db-migrations
+description: "Create, run, and rollback database migrations using goose or golang-migrate. Trigger: when running database migrations, creating migration files, rolling back migrations, using goose, using golang-migrate"
+version: 1
+argument-hint: "[up|down|status|create <name>]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Database Migrations
+
+You are now operating in database migration mode.
+
+## Goose (Recommended for Go Projects)
+
+### Installation
+
+```bash
+go install github.com/pressly/goose/v3/cmd/goose@latest
+```
+
+### Create Migrations
+
+```bash
+# Create a SQL migration
+goose -dir migrations create add_users_table sql
+
+# Create a Go migration (for complex data transforms)
+goose -dir migrations create backfill_user_roles go
+```
+
+This creates timestamped files like `migrations/20260310120000_add_users_table.sql`.
+
+### SQL Migration File Format
+
+```sql
+-- +goose Up
+CREATE TABLE users (
+    id         BIGSERIAL PRIMARY KEY,
+    email      TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_users_email ON users(email);
+
+-- +goose Down
+DROP TABLE IF EXISTS users;
+```
+
+### Running Migrations
+
+```bash
+# Apply all pending migrations
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" up
+
+# Apply one migration
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" up-by-one
+
+# Rollback one migration
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" down
+
+# Rollback to a specific version
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" down-to 20260310000000
+
+# Rollback and re-apply last migration
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" redo
+
+# Show migration status
+goose -dir migrations postgres "postgresql://postgres:dev@localhost:5432/myapp" status
+```
+
+### SQLite with Goose
+
+```bash
+# SQLite driver
+goose -dir migrations sqlite3 "./app.db" up
+goose -dir migrations sqlite3 "./app.db" status
+```
+
+### Goose in Go Code (Embedded)
+
+```go
+import (
+    "embed"
+    "database/sql"
+    "github.com/pressly/goose/v3"
+)
+
+//go:embed migrations/*.sql
+var migrations embed.FS
+
+func runMigrations(db *sql.DB) error {
+    goose.SetBaseFS(migrations)
+    if err := goose.SetDialect("postgres"); err != nil {
+        return err
+    }
+    return goose.Up(db, "migrations")
+}
+```
+
+## golang-migrate
+
+### Installation
+
+```bash
+go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+```
+
+### Create Migrations
+
+golang-migrate uses paired files: one for up, one for down.
+
+```bash
+migrate create -ext sql -dir migrations -seq add_users_table
+# Creates:
+#   migrations/000001_add_users_table.up.sql
+#   migrations/000001_add_users_table.down.sql
+```
+
+### Running Migrations
+
+```bash
+# Apply all migrations
+migrate -path migrations -database "postgresql://postgres:dev@localhost:5432/myapp?sslmode=disable" up
+
+# Rollback N steps
+migrate -path migrations -database "..." down 1
+
+# Go to a specific version
+migrate -path migrations -database "..." goto 3
+
+# Show current version
+migrate -path migrations -database "..." version
+```
+
+## Simple SQL Migration Pattern (No Tool)
+
+For small projects without a migration tool:
+
+```bash
+# Create migration directory
+mkdir -p migrations
+
+# Number migrations sequentially
+# migrations/001_create_users.sql
+# migrations/002_add_sessions.sql
+
+# Apply with a simple script
+for f in migrations/*.sql; do
+  psql "$DATABASE_URL" -f "$f"
+  echo "Applied: $f"
+done
+```
+
+## Best Practices
+
+- Always write a `Down` migration that perfectly reverses the `Up`.
+- Test the rollback locally before merging.
+- Never edit a migration that has already been applied to production.
+- Use transactions in SQL migrations when the database supports them.
+- Keep migrations small and focused — one logical change per migration.
+- Run `status` before `up` in CI to confirm the expected state.
+
+## Migration Status Check
+
+```bash
+# Goose status shows applied/pending
+goose -dir migrations postgres "$DATABASE_URL" status
+
+# Example output:
+#    Applied At                  Migration
+#    =======================================
+#    2026-03-01 10:00:00 +0000   001_create_users.sql
+#    Pending                     002_add_sessions.sql
+```

--- a/skills/doc-generation/SKILL.md
+++ b/skills/doc-generation/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: doc-generation
+description: "Generate and review Go documentation with godoc, OpenAPI specs with swag/swaggo, and README generation patterns. Trigger: when generating Go documentation, godoc, OpenAPI docs, swagger, swaggo, README generation, API documentation"
+version: 1
+argument-hint: "[package or ./...]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Documentation Generation
+
+You are now operating in documentation generation mode.
+
+## Go Documentation (godoc)
+
+### Viewing Package Documentation
+
+```bash
+# View package documentation in terminal
+go doc ./internal/harness
+
+# View a specific type
+go doc ./internal/harness Runner
+
+# View a specific method
+go doc ./internal/harness Runner.Run
+
+# View all exported symbols
+go doc -all ./internal/harness
+
+# View unexported symbols too
+go doc -u ./internal/harness
+
+# View documentation for a standard library package
+go doc net/http
+go doc net/http.Server
+```
+
+### Serving Documentation Locally
+
+```bash
+# Install pkgsite (modern godoc server)
+go install golang.org/x/pkgsite/cmd/pkgsite@latest
+
+# Serve docs for the current module
+pkgsite -open .
+
+# Or use the classic godoc server
+go install golang.org/x/tools/cmd/godoc@latest
+godoc -http=:6060
+# Open http://localhost:6060/pkg/go-agent-harness/
+```
+
+### Writing Good godoc Comments
+
+```go
+// Package harness implements the agent execution loop.
+// It coordinates LLM calls, tool dispatch, and step management.
+package harness
+
+// Runner executes an agent conversation loop.
+// It drives the LLM → tool call → execute → repeat cycle
+// until the step limit is reached or the agent signals completion.
+type Runner struct {
+    // unexported fields
+}
+
+// Run executes the agent loop for the given conversation.
+// It returns an error if the context is cancelled, the step limit
+// is exceeded, or a tool call fails fatally.
+//
+// Run is safe for concurrent use.
+func (r *Runner) Run(ctx context.Context, conv *Conversation) error {
+    // implementation
+}
+```
+
+### Documentation Linting
+
+```bash
+# Check for doc format issues
+go vet ./...
+
+# Install and run staticcheck (catches missing docs on exported symbols)
+go install honnef.co/go/tools/cmd/staticcheck@latest
+staticcheck ./...
+
+# Install golangci-lint with godot linter (doc comments end with period)
+golangci-lint run --enable godot ./...
+```
+
+## OpenAPI / Swagger Documentation (swaggo)
+
+### Installation
+
+```bash
+go install github.com/swaggo/swag/cmd/swag@latest
+```
+
+### Annotate Handlers
+
+```go
+// @Summary     List users
+// @Description Get a paginated list of all users
+// @Tags        users
+// @Accept      json
+// @Produce     json
+// @Param       page  query  int  false  "Page number (default: 1)"
+// @Param       limit query  int  false  "Page size (default: 20)"
+// @Success     200   {object}  ListUsersResponse
+// @Failure     401   {object}  ErrorResponse
+// @Failure     500   {object}  ErrorResponse
+// @Router      /api/v1/users [get]
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+    // implementation
+}
+```
+
+### Generate OpenAPI Spec
+
+```bash
+# Generate docs/ directory with swagger.json and swagger.yaml
+swag init -g cmd/harnessd/main.go
+
+# Specify output directory
+swag init -g cmd/harnessd/main.go -o api/docs
+
+# Format swag annotations
+swag fmt
+```
+
+### Serve Swagger UI
+
+```go
+import (
+    swaggerFiles "github.com/swaggo/files"
+    ginSwagger "github.com/swaggo/gin-swagger"
+    _ "go-agent-harness/api/docs"  // generated docs
+)
+
+// Register Swagger UI route
+r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+// Open http://localhost:8080/swagger/index.html
+```
+
+## README Generation Patterns
+
+### Package README Skeleton
+
+```markdown
+# package-name
+
+Brief one-sentence description.
+
+## Overview
+
+What problem this package solves and when to use it.
+
+## Installation
+
+```bash
+go get go-agent-harness/internal/package-name
+```
+
+## Usage
+
+```go
+// Minimal working example
+```
+
+## API Reference
+
+See [godoc](https://pkg.go.dev/go-agent-harness/internal/package-name) for full API docs.
+
+## Contributing
+
+Run tests: `go test ./...`
+```
+
+### Auto-generate Changelog Entry
+
+```bash
+# Generate changelog from git log since last tag
+LAST_TAG=$(git describe --tags --abbrev=0)
+git log ${LAST_TAG}..HEAD --pretty=format:"- %s (%h)" --no-merges
+```
+
+## Documentation Checklist
+
+Before merging a new package or significant API change:
+
+```bash
+# 1. All exported symbols have doc comments
+grep -n '^func \|^type \|^var \|^const ' *.go | grep -v '//'
+
+# 2. Run go vet to catch basic issues
+go vet ./...
+
+# 3. View rendered docs
+go doc -all ./...
+
+# 4. Check for TODO/FIXME left in exported symbols
+grep -rn 'TODO\|FIXME' --include='*.go' .
+
+# 5. Verify examples compile
+go test -run=Example ./...
+```

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: e2e-testing
+description: "Run Playwright end-to-end browser tests for web applications with screenshots and traces. Trigger: when running Playwright tests, E2E browser testing, UI testing, Playwright setup, recording browser tests, Cypress"
+version: 1
+argument-hint: "[--grep <pattern>] [--project <browser>]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# E2E Testing (Playwright)
+
+You are now operating in Playwright end-to-end testing mode.
+
+## Installation and Setup
+
+```bash
+# Install Playwright and browsers
+npm init playwright@latest
+
+# Or add to existing project
+npm install -D @playwright/test
+npx playwright install
+
+# Install specific browsers only
+npx playwright install chromium
+npx playwright install chromium firefox
+```
+
+## Running Tests
+
+```bash
+# Run all tests (headless by default)
+npx playwright test
+
+# Run with visible browser (headed mode)
+npx playwright test --headed
+
+# Run a specific test file
+npx playwright test tests/login.spec.ts
+
+# Run tests matching a pattern
+npx playwright test --grep "user can login"
+npx playwright test --grep "@smoke"
+
+# Run tests in a specific browser
+npx playwright test --project=chromium
+npx playwright test --project=firefox
+npx playwright test --project=webkit
+
+# Run in all browsers
+npx playwright test --project=chromium --project=firefox --project=webkit
+
+# Run in debug mode (pauses on failure)
+npx playwright test --debug
+```
+
+## Reporters and Output
+
+```bash
+# HTML report (generates report/ directory)
+npx playwright test --reporter=html
+
+# Open HTML report in browser
+npx playwright show-report
+
+# Line reporter (concise output)
+npx playwright test --reporter=line
+
+# JSON report
+npx playwright test --reporter=json > results.json
+
+# Multiple reporters
+npx playwright test --reporter=html,line
+```
+
+## Trace and Screenshots
+
+```bash
+# Capture traces on failure (default: on-first-retry)
+npx playwright test --trace on          # always capture
+npx playwright test --trace retain-on-failure  # only on failure
+npx playwright test --trace off         # disable
+
+# Open a trace file
+npx playwright show-trace trace.zip
+
+# Take screenshots on failure
+# Configure in playwright.config.ts:
+# screenshot: 'only-on-failure'
+```
+
+## Code Generation (Record Tests)
+
+```bash
+# Record interactions and generate test code
+npx playwright codegen http://localhost:3000
+
+# Record with authentication state saved
+npx playwright codegen --save-storage=auth.json http://localhost:3000
+
+# Use saved auth state
+npx playwright codegen --load-storage=auth.json http://localhost:3000
+```
+
+## Test File Structure
+
+```typescript
+// tests/login.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('user can log in with valid credentials', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('[name=email]', 'test@example.com');
+    await page.fill('[name=password]', 'password');
+    await page.click('button[type=submit]');
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.getByRole('heading')).toContainText('Dashboard');
+  });
+
+  test('shows error for invalid credentials', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('[name=email]', 'wrong@example.com');
+    await page.fill('[name=password]', 'wrongpassword');
+    await page.click('button[type=submit]');
+    await expect(page.getByRole('alert')).toBeVisible();
+    await expect(page.getByRole('alert')).toContainText('Invalid credentials');
+  });
+});
+```
+
+## Page Object Model
+
+```typescript
+// pages/LoginPage.ts
+import { Page, Locator } from '@playwright/test';
+
+export class LoginPage {
+  readonly page: Page;
+  readonly emailInput: Locator;
+  readonly passwordInput: Locator;
+  readonly submitButton: Locator;
+  readonly errorMessage: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.emailInput = page.locator('[name=email]');
+    this.passwordInput = page.locator('[name=password]');
+    this.submitButton = page.locator('button[type=submit]');
+    this.errorMessage = page.getByRole('alert');
+  }
+
+  async login(email: string, password: string) {
+    await this.page.goto('/login');
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await this.submitButton.click();
+  }
+}
+
+// Usage in test:
+// const loginPage = new LoginPage(page);
+// await loginPage.login('test@example.com', 'password');
+```
+
+## Configuration (playwright.config.ts)
+
+```typescript
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'html',
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+  ],
+});
+```
+
+## CI Integration
+
+```yaml
+# .github/workflows/e2e.yml
+- name: Run Playwright tests
+  run: npx playwright test
+  env:
+    BASE_URL: http://localhost:3000
+
+- name: Upload Playwright report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: playwright-report
+    path: playwright-report/
+```
+
+## Common Selectors
+
+```typescript
+// By role (preferred — accessible)
+page.getByRole('button', { name: 'Submit' })
+page.getByRole('heading', { name: 'Dashboard' })
+page.getByRole('link', { name: 'Sign in' })
+
+// By label (accessible)
+page.getByLabel('Email address')
+page.getByLabel('Password')
+
+// By placeholder
+page.getByPlaceholder('Enter your email')
+
+// By test ID (explicit, stable)
+page.getByTestId('submit-button')  // data-testid="submit-button"
+
+// CSS selector (fallback)
+page.locator('[name=email]')
+page.locator('.error-message')
+```
+
+## Debugging Tips
+
+```bash
+# Step through test in debug mode
+PWDEBUG=1 npx playwright test tests/login.spec.ts
+
+# Slow down execution for observation
+npx playwright test --headed --slowMo=1000
+
+# Run only tests tagged @only
+npx playwright test --grep "@only"
+```

--- a/skills/github-issues/SKILL.md
+++ b/skills/github-issues/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: github-issues
+description: "Create, update, label, assign, and close GitHub issues with templates and linked PRs. Trigger: when creating GitHub issues, filing bugs, managing issue lifecycle, labeling issues, assigning issues, closing issues"
+version: 1
+argument-hint: "[create|list|view|close <number>]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# GitHub Issues
+
+You are now operating in GitHub issues management mode.
+
+## Prerequisites
+
+```bash
+# Verify auth (always unset GITHUB_TOKEN first)
+unset GITHUB_TOKEN && gh auth switch --user dennisonbertram
+gh auth status
+```
+
+## Creating Issues
+
+```bash
+# Basic issue
+gh issue create --title "Fix nil pointer in handler" --body "Description of the bug."
+
+# With labels and assignee
+gh issue create \
+  --title "Add rate limiting to API" \
+  --body "## Summary\nImplement rate limiting..." \
+  --label "enhancement,api" \
+  --assignee "@me"
+
+# From a template (uses .github/ISSUE_TEMPLATE/)
+gh issue create --template bug_report.md
+
+# With milestone
+gh issue create \
+  --title "Update dependencies" \
+  --body "Run go get -u ./... and verify tests pass." \
+  --milestone "v1.2.0"
+
+# Multi-line body using heredoc
+gh issue create \
+  --title "Implement health check endpoint" \
+  --body "$(cat <<'EOF'
+## Summary
+Add a /health HTTP endpoint that returns 200 OK with a JSON body.
+
+## Acceptance Criteria
+- [ ] Returns 200 on success
+- [ ] Returns 503 when dependencies are unhealthy
+- [ ] Includes version and uptime in response
+
+## Notes
+See health-check skill for implementation patterns.
+EOF
+)"
+```
+
+## Listing Issues
+
+```bash
+# List open issues
+gh issue list
+
+# List with JSON output
+gh issue list --json number,title,state,labels,assignees
+
+# Filter by label
+gh issue list --label "bug"
+gh issue list --label "enhancement,skills"
+
+# Filter by assignee
+gh issue list --assignee "@me"
+
+# Search by text
+gh issue list --search "skills"
+
+# All states (open + closed)
+gh issue list --state all --limit 50
+```
+
+## Viewing Issues
+
+```bash
+# View in terminal
+gh issue view 65
+
+# Open in browser
+gh issue view 65 --web
+
+# View as JSON
+gh issue view 65 --json number,title,body,state,labels,assignees
+```
+
+## Editing Issues
+
+```bash
+# Add labels
+gh issue edit 65 --add-label "in-progress"
+
+# Remove labels
+gh issue edit 65 --remove-label "needs-triage"
+
+# Add assignee
+gh issue edit 65 --add-assignee "@me"
+
+# Change title
+gh issue edit 65 --title "Updated: Implement Database Management Skills"
+
+# Set milestone
+gh issue edit 65 --milestone "v1.2.0"
+```
+
+## Closing and Reopening
+
+```bash
+# Close as completed
+gh issue close 65 --reason completed
+
+# Close as not planned
+gh issue close 65 --reason "not planned"
+
+# Close with a comment
+gh issue close 65 --comment "Completed in PR #72."
+
+# Reopen
+gh issue reopen 65
+```
+
+## Commenting
+
+```bash
+# Add a comment
+gh issue comment 65 --body "Working on this — see branch issue-65-skill-files."
+
+# Update with progress
+gh issue comment 65 --body "$(cat <<'EOF'
+## Progress Update
+
+- [x] postgres-ops SKILL.md
+- [x] sqlite-ops SKILL.md
+- [ ] db-migrations SKILL.md
+
+ETA: end of day.
+EOF
+)"
+```
+
+## Linking Issues to PRs
+
+```bash
+# Reference issue in PR body (GitHub auto-links)
+# Use "Closes #65" in PR body to auto-close on merge
+gh pr create \
+  --title "Add database management skills" \
+  --body "$(cat <<'EOF'
+Closes #65
+
+## Changes
+- Added postgres-ops skill
+- Added sqlite-ops skill
+- Added db-migrations skill
+EOF
+)"
+
+# Link from commit message
+git commit -m "Add postgres-ops skill
+
+Closes #65"
+```
+
+## Bulk Operations
+
+```bash
+# Close all issues with a specific label
+gh issue list --label "stale" --json number --jq '.[].number' | \
+  xargs -I{} gh issue close {} --reason "not planned"
+
+# Export issues to CSV
+gh issue list --json number,title,state,labels --jq \
+  '.[] | [.number, .title, .state] | @csv' > issues.csv
+```

--- a/skills/go-profiling/SKILL.md
+++ b/skills/go-profiling/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: go-profiling
+description: "Profile Go applications with pprof: CPU, memory, goroutine, block, and mutex profiles. Trigger: when profiling Go applications, memory leaks, high CPU usage, goroutine leaks, pprof, performance analysis, flame graphs"
+version: 1
+argument-hint: "[profile-type] (cpu|heap|goroutine|block|mutex|trace)"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Go Profiling (pprof)
+
+You are now operating in Go profiling mode.
+
+## Enable pprof in Your Application
+
+Add this import to your main package (net/http/pprof registers handlers automatically):
+
+```go
+import _ "net/http/pprof"
+
+// If your app doesn't have an HTTP server, add one:
+go func() {
+    log.Println(http.ListenAndServe("localhost:6060", nil))
+}()
+```
+
+## Profile Types
+
+| Profile | URL Path | What it Measures | When to Use |
+|---------|----------|-----------------|-------------|
+| `heap` | `/debug/pprof/heap` | Memory allocations | Memory leaks, high RSS |
+| `profile` | `/debug/pprof/profile` | CPU usage | Slow requests, high CPU |
+| `goroutine` | `/debug/pprof/goroutine` | Goroutine stacks | Goroutine leaks, deadlocks |
+| `block` | `/debug/pprof/block` | Blocking operations | Channel/mutex contention |
+| `mutex` | `/debug/pprof/mutex` | Mutex contention | Lock contention |
+| `allocs` | `/debug/pprof/allocs` | All memory allocations | Allocation churn |
+| `trace` | `/debug/pprof/trace` | Execution trace | Latency analysis |
+
+## Capture Profiles
+
+```bash
+# Heap (memory) profile
+go tool pprof http://localhost:6060/debug/pprof/heap
+
+# CPU profile (30 second sample)
+go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30
+
+# Goroutine dump
+go tool pprof http://localhost:6060/debug/pprof/goroutine
+
+# Block profile (enable with runtime.SetBlockProfileRate first)
+go tool pprof http://localhost:6060/debug/pprof/block
+
+# Mutex profile (enable with runtime.SetMutexProfileFraction first)
+go tool pprof http://localhost:6060/debug/pprof/mutex
+
+# Save profile to file for later analysis
+curl -s http://localhost:6060/debug/pprof/heap > heap.pprof
+curl -s "http://localhost:6060/debug/pprof/profile?seconds=30" > cpu.pprof
+```
+
+## Analyze Profiles
+
+```bash
+# Interactive CLI (after go tool pprof opens)
+# top — show top functions by resource usage
+# web — open browser visualization (requires graphviz)
+# list <func> — show source-level annotation
+# peek <func> — show callers/callees
+
+# Text summary (non-interactive)
+go tool pprof -top heap.pprof
+go tool pprof -top -nodecount=20 cpu.pprof
+
+# Generate SVG flame graph (requires graphviz)
+go tool pprof -svg heap.pprof > heap.svg
+
+# Open in browser (requires graphviz)
+go tool pprof -web heap.pprof
+
+# HTTP UI (browse all profiles interactively)
+go tool pprof -http=:8081 heap.pprof
+```
+
+## Enable Block and Mutex Profiling
+
+Block and mutex profiles require runtime configuration before they collect data:
+
+```go
+import "runtime"
+
+// Enable block profiling (1 = sample every blocking event)
+runtime.SetBlockProfileRate(1)
+
+// Enable mutex profiling (1 = sample every mutex contention event)
+runtime.SetMutexProfileFraction(1)
+```
+
+## Goroutine Stack Dump (Text)
+
+```bash
+# Full goroutine stacks as text (debug=2 for full stacks)
+curl http://localhost:6060/debug/pprof/goroutine?debug=2
+
+# Count by goroutine state
+curl -s http://localhost:6060/debug/pprof/goroutine?debug=1 | grep "^goroutine"
+```
+
+## Execution Trace
+
+```bash
+# Capture 5-second trace
+curl -s "http://localhost:6060/debug/pprof/trace?seconds=5" > trace.out
+
+# Analyze trace in browser
+go tool trace trace.out
+```
+
+## Benchmark Profiling
+
+```bash
+# Profile during benchmarks
+go test -bench=BenchmarkFoo -cpuprofile cpu.pprof -memprofile mem.pprof ./...
+
+# Analyze benchmark profile
+go tool pprof cpu.pprof
+go tool pprof mem.pprof
+```
+
+## Reading Top Output
+
+```
+(pprof) top10
+Showing nodes accounting for 42.31s, 91.30% of 46.34s total
+      flat  flat%   sum%        cum   cum%
+    15.32s 33.06% 33.06%     15.32s 33.06%  runtime.mallocgc
+     8.21s 17.72% 50.78%      8.21s 17.72%  runtime.scanobject
+```
+
+- `flat`: time spent in this function itself
+- `cum`: cumulative time including callees
+- High `flat` + low `cum` = the function itself is slow
+- Low `flat` + high `cum` = this function calls slow functions
+
+## Memory Leak Detection Pattern
+
+```bash
+# Take two heap snapshots separated by time
+curl -s http://localhost:6060/debug/pprof/heap > heap1.pprof
+sleep 60
+curl -s http://localhost:6060/debug/pprof/heap > heap2.pprof
+
+# Compare allocations
+go tool pprof -base heap1.pprof heap2.pprof
+# Then run: top — shows functions with growing allocation
+```

--- a/skills/health-check/SKILL.md
+++ b/skills/health-check/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: health-check
+description: "Check service health via HTTP endpoints with response time, status code, and body validation. Trigger: when checking service health, verifying HTTP endpoints, readiness/liveness probes, uptime monitoring"
+version: 1
+argument-hint: "[url]"
+allowed-tools:
+  - bash
+  - read
+  - grep
+---
+# Health Check
+
+You are now operating in service health check mode.
+
+## Basic HTTP Health Check
+
+```bash
+# Status code + response time
+curl -s -o /dev/null -w "%{http_code} %{time_total}s" http://localhost:8080/health
+
+# Full response with timing
+curl -s -w "\nStatus: %{http_code}\nTime: %{time_total}s\n" http://localhost:8080/health
+
+# Fail on non-2xx (exit code 1 if error)
+curl -s -f http://localhost:8080/health || echo "UNHEALTHY"
+
+# Follow redirects
+curl -s -L -o /dev/null -w "%{http_code}" http://localhost:8080/
+```
+
+## Parse JSON Health Response
+
+```bash
+# Pretty-print health endpoint
+curl -s http://localhost:8080/health | jq .
+
+# Check specific field
+curl -s http://localhost:8080/health | jq -r '.status'
+
+# Assert status equals "ok"
+STATUS=$(curl -s http://localhost:8080/health | jq -r '.status')
+[ "$STATUS" = "ok" ] && echo "PASS" || echo "FAIL: status=$STATUS"
+```
+
+## Response Time Thresholds
+
+```bash
+# Measure and check against threshold
+TIME=$(curl -s -o /dev/null -w "%{time_total}" http://localhost:8080/health)
+echo "Response time: ${TIME}s"
+
+# Warn if over 1 second
+if (( $(echo "$TIME > 1.0" | bc -l) )); then
+  echo "WARNING: slow response (${TIME}s > 1.0s threshold)"
+fi
+
+# Critical if over 5 seconds
+if (( $(echo "$TIME > 5.0" | bc -l) )); then
+  echo "CRITICAL: very slow response (${TIME}s)"
+fi
+```
+
+## Check Multiple Endpoints
+
+```bash
+# Check a list of endpoints
+for url in \
+  "http://localhost:8080/health" \
+  "http://localhost:8080/ready" \
+  "http://localhost:8080/metrics"; do
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+  echo "$url → $STATUS"
+done
+```
+
+## Kubernetes Readiness / Liveness Probe Pattern
+
+```yaml
+# In Kubernetes deployment manifest
+livenessProbe:
+  httpGet:
+    path: /health/live
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 30
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  failureThreshold: 3
+```
+
+```bash
+# Simulate liveness check
+curl -s -f http://localhost:8080/health/live && echo "LIVE" || echo "NOT LIVE"
+
+# Simulate readiness check
+curl -s -f http://localhost:8080/health/ready && echo "READY" || echo "NOT READY"
+```
+
+## Go Health Endpoint Implementation Pattern
+
+```go
+// Minimal health handler
+http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    fmt.Fprintln(w, `{"status":"ok"}`)
+})
+
+// Readiness check with dependency verification
+http.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {
+    if err := db.PingContext(r.Context()); err != nil {
+        w.WriteHeader(http.StatusServiceUnavailable)
+        fmt.Fprintf(w, `{"status":"not ready","error":%q}`, err.Error())
+        return
+    }
+    w.Header().Set("Content-Type", "application/json")
+    fmt.Fprintln(w, `{"status":"ready"}`)
+})
+```
+
+## SSL Certificate Check
+
+```bash
+# Check SSL certificate expiry
+curl -s -o /dev/null -w "%{ssl_verify_result}" https://example.com
+# 0 = valid, non-zero = error
+
+# Show certificate details
+echo | openssl s_client -connect example.com:443 2>/dev/null | openssl x509 -noout -dates
+
+# Days until expiry
+EXPIRY=$(echo | openssl s_client -connect example.com:443 2>/dev/null | openssl x509 -noout -enddate | cut -d= -f2)
+EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$EXPIRY" +%s)
+DAYS=$(( (EXPIRY_EPOCH - $(date +%s)) / 86400 ))
+echo "Certificate expires in $DAYS days"
+```
+
+## Interpreting Results
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 200 | Healthy | None |
+| 503 | Service Unavailable | Check logs, dependencies |
+| 404 | Endpoint missing | Verify route configuration |
+| 000 | Connection refused | Service may be down |
+| 504 | Gateway timeout | Check upstream services |

--- a/skills/log-analysis/SKILL.md
+++ b/skills/log-analysis/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: log-analysis
+description: "Search and analyze application logs: error frequency, grep/jq patterns, JSON structured logs, log tailing, anomaly detection. Trigger: when searching logs, analyzing log files, filtering log output, JSON log analysis, log patterns, jq logs"
+version: 1
+argument-hint: "[log-file or pattern]"
+allowed-tools:
+  - bash
+  - read
+  - grep
+  - glob
+---
+# Log Analysis
+
+You are now operating in log analysis mode.
+
+## Search by Log Level
+
+```bash
+# Search for errors in JSON structured logs
+grep '"level":"error"' app.log
+
+# Case-insensitive level search
+grep -i '"level":"error"' app.log
+
+# Multiple levels
+grep -E '"level":"(error|warn)"' app.log
+
+# Using jq for structured JSON logs
+jq 'select(.level == "error")' app.log
+
+# Tail with live level filter
+tail -f app.log | grep '"level":"error"'
+tail -f app.log | jq -c 'select(.level == "error")'
+```
+
+## Search by Time Range
+
+```bash
+# Logs from a specific hour (ISO8601 format)
+grep '2026-03-10T14:' app.log
+
+# Logs between two times using awk
+awk '/2026-03-10T14:[0-9][0-9]/' app.log
+
+# Last N minutes from a JSON log (requires timestamp field)
+CUTOFF=$(date -u -v-30M '+%Y-%m-%dT%H:%M' 2>/dev/null || date -u --date='30 minutes ago' '+%Y-%m-%dT%H:%M')
+jq --arg t "$CUTOFF" 'select(.time >= $t)' app.log
+```
+
+## Search by Pattern
+
+```bash
+# Common error patterns
+grep -E 'timeout|connection refused|deadline exceeded' app.log
+
+# Context lines (3 lines before/after match)
+grep -C 3 'panic:' app.log
+
+# Show line numbers
+grep -n 'ERROR' app.log
+
+# Search multiple files
+grep -r '"level":"error"' ./logs/
+
+# Count matches
+grep -c '"level":"error"' app.log
+```
+
+## JSON Log Processing with jq
+
+```bash
+# Pretty-print last 100 error logs
+tail -100 app.log | jq 'select(.level == "error")'
+
+# Extract specific fields
+jq '{time, level, msg, error}' app.log
+
+# Filter and format
+jq -r 'select(.level == "error") | "\(.time) \(.msg)"' app.log
+
+# Count by level
+jq -r '.level' app.log | sort | uniq -c | sort -rn
+
+# Top error messages
+jq -r 'select(.level == "error") | .msg' app.log | sort | uniq -c | sort -rn | head -20
+```
+
+## Error Frequency Analysis
+
+```bash
+# Count errors per minute
+jq -r 'select(.level == "error") | .time[0:16]' app.log | sort | uniq -c
+
+# Count errors per hour
+jq -r 'select(.level == "error") | .time[0:13]' app.log | sort | uniq -c
+
+# Errors per request path
+jq -r 'select(.level == "error") | .path' app.log | sort | uniq -c | sort -rn | head -10
+```
+
+## Request Latency / Performance
+
+```bash
+# Extract response times (assuming duration_ms field)
+jq 'select(.duration_ms != null) | .duration_ms' app.log | sort -n
+
+# p50, p95, p99 approximation using awk
+jq '.duration_ms' app.log | sort -n | awk '
+BEGIN { n=0 }
+{ a[n++]=$1 }
+END {
+  print "p50:", a[int(n*0.50)]
+  print "p95:", a[int(n*0.95)]
+  print "p99:", a[int(n*0.99)]
+  print "max:", a[n-1]
+}'
+
+# Slow requests (over 1 second)
+jq 'select(.duration_ms > 1000)' app.log | jq -r '"SLOW: \(.duration_ms)ms \(.path // "")"'
+```
+
+## Anomaly Detection
+
+```bash
+# Spike detection: compare error rate in last 5min vs previous 5min
+NOW=$(date +%s)
+FIVE_MIN_AGO=$(( NOW - 300 ))
+TEN_MIN_AGO=$(( NOW - 600 ))
+
+# Count errors in each window (requires epoch timestamp)
+RECENT=$(jq --argjson t "$FIVE_MIN_AGO" 'select(.ts > $t and .level == "error")' app.log | wc -l)
+PREVIOUS=$(jq --argjson t1 "$TEN_MIN_AGO" --argjson t2 "$FIVE_MIN_AGO" 'select(.ts > $t1 and .ts <= $t2 and .level == "error")' app.log | wc -l)
+echo "Recent errors: $RECENT, Previous period: $PREVIOUS"
+```
+
+## Tailing and Live Monitoring
+
+```bash
+# Tail with JSON formatting
+tail -f app.log | jq -c '.'
+
+# Tail only errors with key fields
+tail -f app.log | jq -c 'select(.level == "error") | {time, msg, error}'
+
+# Tail with grep for multiple patterns
+tail -f app.log | grep -E 'error|panic|fatal'
+
+# systemd journal (if using systemd)
+journalctl -u harnessd -f
+journalctl -u harnessd --since "10 minutes ago" | grep -i error
+```
+
+## Correlation: Trace IDs
+
+```bash
+# Follow a specific request by trace ID
+grep '"trace_id":"abc123"' app.log
+
+# With jq
+jq 'select(.trace_id == "abc123")' app.log | jq -r '"\(.time) \(.level) \(.msg)"'
+```
+
+## Common Log Formats
+
+```bash
+# Apache/Nginx combined log format
+awk '{print $9}' access.log | sort | uniq -c | sort -rn | head  # Status codes
+
+# Plain text (level prefix)
+grep '^ERROR' app.log
+grep -E '^(ERROR|WARN)' app.log
+
+# Go slog default output
+grep 'level=ERROR' app.log
+```

--- a/skills/postgres-ops/SKILL.md
+++ b/skills/postgres-ops/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: postgres-ops
+description: "Set up and manage local PostgreSQL via Docker and psql for development and testing. Trigger: when setting up postgres, connecting to PostgreSQL, creating databases, running psql, using Docker postgres"
+version: 1
+argument-hint: "[database-url or action]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# PostgreSQL Operations
+
+You are now operating in PostgreSQL management mode.
+
+## Start Local PostgreSQL with Docker
+
+```bash
+# Start a local Postgres container (development defaults)
+docker run -d \
+  --name postgres \
+  -p 5432:5432 \
+  -e POSTGRES_PASSWORD=dev \
+  postgres:16
+
+# Verify it started
+docker ps --filter name=postgres
+```
+
+## Connect with psql
+
+```bash
+# Connect using URL
+psql postgresql://postgres:dev@localhost:5432/postgres
+
+# Connect with individual flags
+psql -h localhost -p 5432 -U postgres -d postgres
+
+# One-shot command (non-interactive)
+psql postgresql://postgres:dev@localhost:5432/postgres -c "SELECT version();"
+```
+
+## Database Management
+
+```bash
+# Create a database
+docker exec postgres psql -U postgres -c "CREATE DATABASE myapp;"
+
+# List databases
+psql postgresql://postgres:dev@localhost:5432/postgres -c "\l"
+
+# Drop a database (use with caution)
+psql postgresql://postgres:dev@localhost:5432/postgres -c "DROP DATABASE IF EXISTS myapp;"
+
+# Create a user
+psql postgresql://postgres:dev@localhost:5432/postgres -c \
+  "CREATE USER appuser WITH PASSWORD 'secret';"
+
+# Grant privileges
+psql postgresql://postgres:dev@localhost:5432/postgres -c \
+  "GRANT ALL PRIVILEGES ON DATABASE myapp TO appuser;"
+```
+
+## Schema Inspection
+
+```bash
+# List tables in current database
+psql $DATABASE_URL -c "\dt"
+
+# Describe a table
+psql $DATABASE_URL -c "\d+ users"
+
+# List all schemas
+psql $DATABASE_URL -c "\dn"
+
+# Show table row counts
+psql $DATABASE_URL -c "SELECT schemaname, tablename, n_live_tup FROM pg_stat_user_tables ORDER BY n_live_tup DESC;"
+```
+
+## Query Analysis
+
+```bash
+# Explain query plan
+psql $DATABASE_URL -c "EXPLAIN ANALYZE SELECT * FROM users WHERE email = 'test@example.com';"
+
+# Check slow queries (requires pg_stat_statements)
+psql $DATABASE_URL -c "SELECT query, calls, total_time, mean_time FROM pg_stat_statements ORDER BY mean_time DESC LIMIT 10;"
+
+# Check active connections
+psql $DATABASE_URL -c "SELECT pid, usename, application_name, state, query FROM pg_stat_activity WHERE state != 'idle';"
+
+# Check index usage
+psql $DATABASE_URL -c "SELECT indexname, idx_scan, idx_tup_read FROM pg_stat_user_indexes ORDER BY idx_scan ASC;"
+```
+
+## Backup and Restore
+
+```bash
+# Custom format backup (recommended for pg_restore)
+pg_dump -Fc $DATABASE_URL > backup.dump
+
+# Plain SQL backup
+pg_dump $DATABASE_URL > backup.sql
+
+# Schema only
+pg_dump --schema-only $DATABASE_URL > schema.sql
+
+# Restore from custom format
+pg_restore -d $DATABASE_URL backup.dump
+
+# Restore from SQL
+psql $DATABASE_URL < backup.sql
+```
+
+## Cleanup
+
+```bash
+# Stop and remove the container
+docker stop postgres && docker rm postgres
+
+# Remove with volumes (deletes all data)
+docker stop postgres && docker rm -v postgres
+```
+
+## Connection String Format
+
+```
+postgresql://[user]:[password]@[host]:[port]/[database]?sslmode=disable
+
+# Examples:
+# Local dev (no SSL):
+postgresql://postgres:dev@localhost:5432/myapp?sslmode=disable
+
+# Production (with SSL):
+postgresql://appuser:secret@db.example.com:5432/myapp?sslmode=require
+```
+
+## Safety Rules
+
+- Never run `DROP DATABASE` or `DROP TABLE` in production without a backup.
+- Use transactions for multi-statement schema changes: `BEGIN; ...; COMMIT;`
+- Always test migrations on a copy of production data first.
+- Store connection strings in environment variables, never in source code.

--- a/skills/skills_validation_65_66_68_69_test.go
+++ b/skills/skills_validation_65_66_68_69_test.go
@@ -1,0 +1,723 @@
+// Package skills_validation tests that the bundled SKILL.md files in this
+// directory parse correctly and satisfy required field constraints.
+//
+// This file covers skills added in GitHub Issues #65 (Database Management),
+// #66 (Monitoring & Observability), #68 (Testing & QA), and #69 (Collaboration).
+package skills_validation
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Issue #65: Database Management Skills ---
+
+func TestPostgresOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["postgres-ops"]
+	if !ok {
+		t.Fatal("postgres-ops skill not found; expected SKILL.md in skills/postgres-ops/")
+	}
+	if s.Name != "postgres-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "postgres-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestPostgresOpsSkill_HasDockerCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["postgres-ops"]
+	if !strings.Contains(s.Body, "docker run") {
+		t.Error("postgres-ops body should document docker run command to start PostgreSQL")
+	}
+	if !strings.Contains(s.Body, "psql") {
+		t.Error("postgres-ops body should document psql connection command")
+	}
+}
+
+func TestPostgresOpsSkill_HasConnectionString(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["postgres-ops"]
+	if !strings.Contains(s.Body, "postgresql://") {
+		t.Error("postgres-ops body should document postgresql:// connection string format")
+	}
+}
+
+func TestPostgresOpsSkill_HasSchemaInspection(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["postgres-ops"]
+	if !strings.Contains(s.Body, `\dt`) && !strings.Contains(s.Body, `\\dt`) {
+		t.Error("postgres-ops body should document \\dt for listing tables")
+	}
+}
+
+func TestPostgresOpsSkill_HasBackupRestore(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["postgres-ops"]
+	if !strings.Contains(s.Body, "pg_dump") {
+		t.Error("postgres-ops body should document pg_dump for backups")
+	}
+	if !strings.Contains(s.Body, "pg_restore") {
+		t.Error("postgres-ops body should document pg_restore for restores")
+	}
+}
+
+func TestSQLiteOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["sqlite-ops"]
+	if !ok {
+		t.Fatal("sqlite-ops skill not found; expected SKILL.md in skills/sqlite-ops/")
+	}
+	if s.Name != "sqlite-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "sqlite-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestSQLiteOpsSkill_HasCLICommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["sqlite-ops"]
+	if !strings.Contains(s.Body, "sqlite3") {
+		t.Error("sqlite-ops body should document sqlite3 CLI usage")
+	}
+	if !strings.Contains(s.Body, ".tables") {
+		t.Error("sqlite-ops body should document .tables command")
+	}
+	if !strings.Contains(s.Body, ".schema") {
+		t.Error("sqlite-ops body should document .schema command")
+	}
+}
+
+func TestSQLiteOpsSkill_HasWALMode(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["sqlite-ops"]
+	if !strings.Contains(s.Body, "WAL") {
+		t.Error("sqlite-ops body should document WAL mode for concurrent access")
+	}
+	if !strings.Contains(s.Body, "journal_mode") {
+		t.Error("sqlite-ops body should document journal_mode pragma")
+	}
+}
+
+func TestSQLiteOpsSkill_HasDumpRestore(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["sqlite-ops"]
+	if !strings.Contains(s.Body, ".dump") {
+		t.Error("sqlite-ops body should document .dump for backups")
+	}
+}
+
+func TestSQLiteOpsSkill_HasGoUsage(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["sqlite-ops"]
+	if !strings.Contains(s.Body, "modernc.org/sqlite") {
+		t.Error("sqlite-ops body should document modernc.org/sqlite Go driver")
+	}
+	if !strings.Contains(s.Body, ":memory:") {
+		t.Error("sqlite-ops body should document :memory: database for testing")
+	}
+}
+
+func TestDBMigrationsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["db-migrations"]
+	if !ok {
+		t.Fatal("db-migrations skill not found; expected SKILL.md in skills/db-migrations/")
+	}
+	if s.Name != "db-migrations" {
+		t.Errorf("Name = %q, want %q", s.Name, "db-migrations")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestDBMigrationsSkill_HasGooseCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["db-migrations"]
+	if !strings.Contains(s.Body, "goose") {
+		t.Error("db-migrations body should document goose migration tool")
+	}
+	if !strings.Contains(s.Body, "down") {
+		t.Error("db-migrations body should document rollback (down) command")
+	}
+	if !strings.Contains(s.Body, "status") {
+		t.Error("db-migrations body should document migration status command")
+	}
+}
+
+func TestDBMigrationsSkill_HasMigrationFileFormat(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["db-migrations"]
+	if !strings.Contains(s.Body, "+goose Up") {
+		t.Error("db-migrations body should document +goose Up annotation in SQL files")
+	}
+	if !strings.Contains(s.Body, "+goose Down") {
+		t.Error("db-migrations body should document +goose Down annotation in SQL files")
+	}
+}
+
+func TestDBMigrationsSkill_HasInstallInstructions(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["db-migrations"]
+	if !strings.Contains(s.Body, "go install") {
+		t.Error("db-migrations body should include installation instructions")
+	}
+}
+
+// --- Issue #66: Monitoring & Observability Skills ---
+
+func TestHealthCheckSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["health-check"]
+	if !ok {
+		t.Fatal("health-check skill not found; expected SKILL.md in skills/health-check/")
+	}
+	if s.Name != "health-check" {
+		t.Errorf("Name = %q, want %q", s.Name, "health-check")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestHealthCheckSkill_HasCurlCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["health-check"]
+	if !strings.Contains(s.Body, "curl") {
+		t.Error("health-check body should document curl command for health checks")
+	}
+	if !strings.Contains(s.Body, "http_code") {
+		t.Error("health-check body should document HTTP status code extraction with curl")
+	}
+}
+
+func TestHealthCheckSkill_HasResponseTimeMeasurement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["health-check"]
+	if !strings.Contains(s.Body, "time_total") {
+		t.Error("health-check body should document response time measurement with curl")
+	}
+}
+
+func TestHealthCheckSkill_HasKubernetesProbes(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["health-check"]
+	if !strings.Contains(s.Body, "livenessProbe") && !strings.Contains(s.Body, "readinessProbe") {
+		t.Error("health-check body should document Kubernetes liveness/readiness probe patterns")
+	}
+}
+
+func TestHealthCheckSkill_HasStatusCodeInterpretation(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["health-check"]
+	if !strings.Contains(s.Body, "503") {
+		t.Error("health-check body should document 503 Service Unavailable status code")
+	}
+}
+
+func TestGoProfilingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["go-profiling"]
+	if !ok {
+		t.Fatal("go-profiling skill not found; expected SKILL.md in skills/go-profiling/")
+	}
+	if s.Name != "go-profiling" {
+		t.Errorf("Name = %q, want %q", s.Name, "go-profiling")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestGoProfilingSkill_HasPprofProfiles(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["go-profiling"]
+	if !strings.Contains(s.Body, "heap") {
+		t.Error("go-profiling body should document heap profile")
+	}
+	if !strings.Contains(s.Body, "goroutine") {
+		t.Error("go-profiling body should document goroutine profile")
+	}
+	if !strings.Contains(s.Body, "profile") {
+		t.Error("go-profiling body should document CPU profile")
+	}
+}
+
+func TestGoProfilingSkill_HasPprofURLs(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["go-profiling"]
+	if !strings.Contains(s.Body, "debug/pprof") {
+		t.Error("go-profiling body should document pprof HTTP endpoint paths")
+	}
+	if !strings.Contains(s.Body, "go tool pprof") {
+		t.Error("go-profiling body should document 'go tool pprof' command")
+	}
+}
+
+func TestGoProfilingSkill_HasImportInstructions(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["go-profiling"]
+	if !strings.Contains(s.Body, "net/http/pprof") {
+		t.Error("go-profiling body should document net/http/pprof import")
+	}
+}
+
+func TestGoProfilingSkill_HasProfileTypes(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["go-profiling"]
+	if !strings.Contains(s.Body, "block") {
+		t.Error("go-profiling body should document block profile type")
+	}
+	if !strings.Contains(s.Body, "mutex") {
+		t.Error("go-profiling body should document mutex profile type")
+	}
+}
+
+func TestLogAnalysisSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["log-analysis"]
+	if !ok {
+		t.Fatal("log-analysis skill not found; expected SKILL.md in skills/log-analysis/")
+	}
+	if s.Name != "log-analysis" {
+		t.Errorf("Name = %q, want %q", s.Name, "log-analysis")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestLogAnalysisSkill_HasGrepPatterns(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["log-analysis"]
+	if !strings.Contains(s.Body, "grep") {
+		t.Error("log-analysis body should document grep for log searching")
+	}
+}
+
+func TestLogAnalysisSkill_HasJQPatterns(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["log-analysis"]
+	if !strings.Contains(s.Body, "jq") {
+		t.Error("log-analysis body should document jq for JSON log processing")
+	}
+	if !strings.Contains(s.Body, "select(") {
+		t.Error("log-analysis body should document jq select() filter for log filtering")
+	}
+}
+
+func TestLogAnalysisSkill_HasErrorFrequencyAnalysis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["log-analysis"]
+	if !strings.Contains(s.Body, "uniq -c") {
+		t.Error("log-analysis body should document uniq -c for frequency counting")
+	}
+}
+
+func TestLogAnalysisSkill_HasTailCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["log-analysis"]
+	if !strings.Contains(s.Body, "tail -f") {
+		t.Error("log-analysis body should document tail -f for live log monitoring")
+	}
+}
+
+// --- Issue #68: Testing & QA Skills ---
+
+func TestAPITestingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["api-testing"]
+	if !ok {
+		t.Fatal("api-testing skill not found; expected SKILL.md in skills/api-testing/")
+	}
+	if s.Name != "api-testing" {
+		t.Errorf("Name = %q, want %q", s.Name, "api-testing")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestAPITestingSkill_HasHTTPMethods(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	if !strings.Contains(s.Body, "-X POST") {
+		t.Error("api-testing body should document POST request pattern")
+	}
+	if !strings.Contains(s.Body, "-X PUT") {
+		t.Error("api-testing body should document PUT request pattern")
+	}
+	if !strings.Contains(s.Body, "-X DELETE") {
+		t.Error("api-testing body should document DELETE request pattern")
+	}
+}
+
+func TestAPITestingSkill_HasStatusCodeValidation(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	if !strings.Contains(s.Body, "http_code") {
+		t.Error("api-testing body should document HTTP status code extraction")
+	}
+}
+
+func TestAPITestingSkill_HasJQValidation(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	if !strings.Contains(s.Body, "jq") {
+		t.Error("api-testing body should document jq for JSON response validation")
+	}
+}
+
+func TestAPITestingSkill_HasAuthPattern(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	if !strings.Contains(s.Body, "Authorization: Bearer") {
+		t.Error("api-testing body should document Bearer token authentication pattern")
+	}
+}
+
+func TestAPITestingSkill_HasResponseTimeMeasurement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	if !strings.Contains(s.Body, "time_total") {
+		t.Error("api-testing body should document response time measurement")
+	}
+}
+
+func TestAPITestingSkill_HasSecurityNote(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["api-testing"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "token") || (!strings.Contains(bodyLower, "never log") && !strings.Contains(bodyLower, "do not") && !strings.Contains(bodyLower, "never")) {
+		t.Error("api-testing body should warn against logging sensitive auth tokens")
+	}
+}
+
+func TestE2ETestingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["e2e-testing"]
+	if !ok {
+		t.Fatal("e2e-testing skill not found; expected SKILL.md in skills/e2e-testing/")
+	}
+	if s.Name != "e2e-testing" {
+		t.Errorf("Name = %q, want %q", s.Name, "e2e-testing")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestE2ETestingSkill_HasPlaywrightCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["e2e-testing"]
+	if !strings.Contains(s.Body, "npx playwright test") {
+		t.Error("e2e-testing body should document 'npx playwright test' command")
+	}
+	if !strings.Contains(s.Body, "--headed") {
+		t.Error("e2e-testing body should document --headed flag for visible browser")
+	}
+	if !strings.Contains(s.Body, "--grep") {
+		t.Error("e2e-testing body should document --grep flag for test filtering")
+	}
+}
+
+func TestE2ETestingSkill_HasBrowserProjects(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["e2e-testing"]
+	if !strings.Contains(s.Body, "--project") {
+		t.Error("e2e-testing body should document --project flag for browser selection")
+	}
+	if !strings.Contains(s.Body, "chromium") {
+		t.Error("e2e-testing body should document chromium browser project")
+	}
+}
+
+func TestE2ETestingSkill_HasReporterFlag(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["e2e-testing"]
+	if !strings.Contains(s.Body, "--reporter") {
+		t.Error("e2e-testing body should document --reporter flag for output formats")
+	}
+	if !strings.Contains(s.Body, "html") {
+		t.Error("e2e-testing body should document HTML reporter")
+	}
+}
+
+func TestE2ETestingSkill_HasTraceCapture(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["e2e-testing"]
+	if !strings.Contains(s.Body, "--trace") {
+		t.Error("e2e-testing body should document --trace flag for capturing traces")
+	}
+}
+
+func TestE2ETestingSkill_HasCodegen(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["e2e-testing"]
+	if !strings.Contains(s.Body, "codegen") {
+		t.Error("e2e-testing body should document playwright codegen for recording tests")
+	}
+}
+
+// --- Issue #69: Collaboration Skills ---
+
+func TestGitHubIssuesSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["github-issues"]
+	if !ok {
+		t.Fatal("github-issues skill not found; expected SKILL.md in skills/github-issues/")
+	}
+	if s.Name != "github-issues" {
+		t.Errorf("Name = %q, want %q", s.Name, "github-issues")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestGitHubIssuesSkill_HasCreateCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["github-issues"]
+	if !strings.Contains(s.Body, "gh issue create") {
+		t.Error("github-issues body should document 'gh issue create' command")
+	}
+	if !strings.Contains(s.Body, "--title") {
+		t.Error("github-issues body should document --title flag")
+	}
+	if !strings.Contains(s.Body, "--label") {
+		t.Error("github-issues body should document --label flag")
+	}
+}
+
+func TestGitHubIssuesSkill_HasListCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["github-issues"]
+	if !strings.Contains(s.Body, "gh issue list") {
+		t.Error("github-issues body should document 'gh issue list' command")
+	}
+	if !strings.Contains(s.Body, "--json") {
+		t.Error("github-issues body should document JSON output for issue listing")
+	}
+}
+
+func TestGitHubIssuesSkill_HasCloseCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["github-issues"]
+	if !strings.Contains(s.Body, "gh issue close") {
+		t.Error("github-issues body should document 'gh issue close' command")
+	}
+}
+
+func TestGitHubIssuesSkill_HasCommentCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["github-issues"]
+	if !strings.Contains(s.Body, "gh issue comment") {
+		t.Error("github-issues body should document 'gh issue comment' command")
+	}
+}
+
+func TestGitHubIssuesSkill_HasPRLinking(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["github-issues"]
+	if !strings.Contains(s.Body, "Closes #") {
+		t.Error("github-issues body should document 'Closes #N' pattern for linking PRs to issues")
+	}
+}
+
+func TestDocGenerationSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["doc-generation"]
+	if !ok {
+		t.Fatal("doc-generation skill not found; expected SKILL.md in skills/doc-generation/")
+	}
+	if s.Name != "doc-generation" {
+		t.Errorf("Name = %q, want %q", s.Name, "doc-generation")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestDocGenerationSkill_HasGoDocCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["doc-generation"]
+	if !strings.Contains(s.Body, "go doc") {
+		t.Error("doc-generation body should document 'go doc' command")
+	}
+	if !strings.Contains(s.Body, "-all") {
+		t.Error("doc-generation body should document -all flag for full package docs")
+	}
+}
+
+func TestDocGenerationSkill_HasSwaggoInstructions(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["doc-generation"]
+	if !strings.Contains(s.Body, "swag") {
+		t.Error("doc-generation body should document swag/swaggo for OpenAPI generation")
+	}
+	if !strings.Contains(s.Body, "swag init") {
+		t.Error("doc-generation body should document 'swag init' command")
+	}
+}
+
+func TestDocGenerationSkill_HasGodocCommentFormat(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["doc-generation"]
+	if !strings.Contains(s.Body, "// Package") && !strings.Contains(s.Body, "Package ") {
+		t.Error("doc-generation body should document godoc package comment format")
+	}
+}
+
+func TestDocGenerationSkill_HasVetCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["doc-generation"]
+	if !strings.Contains(s.Body, "go vet") {
+		t.Error("doc-generation body should document 'go vet' for checking doc format issues")
+	}
+}
+
+// TestExpectedSkillsForIssues65_66_68_69 validates that all 10 new skills
+// for issues #65, #66, #68, and #69 are present.
+func TestExpectedSkillsForIssues65_66_68_69(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	expected := []string{
+		// Issue #65: Database Management
+		"postgres-ops",
+		"sqlite-ops",
+		"db-migrations",
+		// Issue #66: Monitoring & Observability
+		"health-check",
+		"go-profiling",
+		"log-analysis",
+		// Issue #68: Testing & QA
+		"api-testing",
+		"e2e-testing",
+		// Issue #69: Collaboration
+		"github-issues",
+		"doc-generation",
+	}
+	for _, name := range expected {
+		if _, ok := all[name]; !ok {
+			t.Errorf("expected skill %q not found (required for issues #65/#66/#68/#69)", name)
+		}
+	}
+}

--- a/skills/sqlite-ops/SKILL.md
+++ b/skills/sqlite-ops/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: sqlite-ops
+description: "Initialize and manage SQLite databases for development, testing, and embedded use cases. Trigger: when working with SQLite, sqlite3 CLI, embedded database, Go modernc sqlite, WAL mode"
+version: 1
+argument-hint: "[database-file]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# SQLite Operations
+
+You are now operating in SQLite database management mode.
+
+## Basic sqlite3 CLI Usage
+
+```bash
+# Open or create a database
+sqlite3 app.db
+
+# Run a single command non-interactively
+sqlite3 app.db "SELECT * FROM users LIMIT 5;"
+
+# Run a SQL file
+sqlite3 app.db < schema.sql
+```
+
+## Schema Inspection
+
+```bash
+# List all tables
+sqlite3 app.db ".tables"
+
+# Show schema for all tables
+sqlite3 app.db ".schema"
+
+# Show schema for a specific table
+sqlite3 app.db ".schema users"
+
+# Show full CREATE statements including indexes
+sqlite3 app.db ".fullschema"
+
+# Show table info (columns, types, constraints)
+sqlite3 app.db "PRAGMA table_info(users);"
+
+# Show indexes on a table
+sqlite3 app.db "PRAGMA index_list(users);"
+```
+
+## Common Queries
+
+```bash
+# Count rows
+sqlite3 app.db "SELECT count(*) FROM users;"
+
+# Query with formatting
+sqlite3 -column -header app.db "SELECT id, name, email FROM users LIMIT 10;"
+
+# JSON output
+sqlite3 -json app.db "SELECT * FROM users LIMIT 5;"
+
+# CSV output
+sqlite3 -csv -header app.db "SELECT * FROM users;" > export.csv
+```
+
+## Backup and Restore
+
+```bash
+# Dump entire database to SQL
+sqlite3 app.db ".dump" > backup.sql
+
+# Dump a single table
+sqlite3 app.db ".dump users" > users.sql
+
+# Restore from dump
+sqlite3 new.db < backup.sql
+
+# Online backup (safe while DB is open)
+sqlite3 app.db ".backup backup.db"
+
+# Copy using the backup API
+sqlite3 app.db "VACUUM INTO 'backup.db';"
+```
+
+## WAL Mode (Write-Ahead Logging)
+
+WAL mode improves concurrent read performance and is recommended for multi-reader applications.
+
+```bash
+# Enable WAL mode
+sqlite3 app.db "PRAGMA journal_mode=WAL;"
+
+# Check current journal mode
+sqlite3 app.db "PRAGMA journal_mode;"
+
+# WAL checkpoint (flush WAL to main database)
+sqlite3 app.db "PRAGMA wal_checkpoint(FULL);"
+```
+
+## Performance Tuning
+
+```bash
+# Check and set cache size (negative = kilobytes)
+sqlite3 app.db "PRAGMA cache_size = -64000;"  # 64MB
+
+# Enable memory-mapped I/O
+sqlite3 app.db "PRAGMA mmap_size = 268435456;"  # 256MB
+
+# Synchronous mode (NORMAL = good balance)
+sqlite3 app.db "PRAGMA synchronous = NORMAL;"
+
+# Foreign key enforcement (off by default)
+sqlite3 app.db "PRAGMA foreign_keys = ON;"
+
+# Analyze query plan
+sqlite3 app.db "EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = 'test@example.com';"
+```
+
+## Go modernc SQLite Usage
+
+The `modernc.org/sqlite` driver is a pure-Go SQLite driver (no CGo required).
+
+```go
+import (
+    "database/sql"
+    _ "modernc.org/sqlite"
+)
+
+// Open with WAL mode and foreign keys
+db, err := sql.Open("sqlite", "app.db?_journal_mode=WAL&_foreign_keys=on")
+if err != nil {
+    return fmt.Errorf("open db: %w", err)
+}
+defer db.Close()
+
+// In-memory database for tests
+testDB, err := sql.Open("sqlite", ":memory:?_foreign_keys=on")
+```
+
+## Integrity Checks
+
+```bash
+# Full integrity check
+sqlite3 app.db "PRAGMA integrity_check;"
+
+# Quick check (faster, catches most issues)
+sqlite3 app.db "PRAGMA quick_check;"
+
+# Check for foreign key violations
+sqlite3 app.db "PRAGMA foreign_key_check;"
+```
+
+## Safety Rules
+
+- Always use parameterized queries in Go — never fmt.Sprintf SQL.
+- Enable WAL mode for applications with concurrent readers.
+- Take regular backups using `.backup` or `VACUUM INTO`.
+- Enable `PRAGMA foreign_keys = ON` explicitly — it is off by default.
+- Use `:memory:` databases in tests to avoid test pollution.


### PR DESCRIPTION
## Summary
Adds 10 SKILL.md files across four issue tracks:

### Issue #65 — Database Management Skills (3 skills)
- `skills/postgres-ops/SKILL.md` — psql commands, schema inspection, pg_dump/restore, query analysis
- `skills/sqlite-ops/SKILL.md` — sqlite3 CLI, WAL mode, dump/restore, modernc.org/sqlite Go driver
- `skills/db-migrations/SKILL.md` — Goose migrations, SQL file format, embedded migrations in Go

### Issue #66 — Monitoring & Observability Skills (3 skills)
- `skills/health-check/SKILL.md` — curl health checks, K8s readiness/liveness probes, SSL checks
- `skills/go-profiling/SKILL.md` — pprof, trace, all profile types, flame graphs, memory leak detection
- `skills/log-analysis/SKILL.md` — grep/awk/jq patterns, JSON logs, error frequency, latency percentiles

### Issue #68 — Testing & QA Skills (2 skills)
- `skills/api-testing/SKILL.md` — curl GET/POST/PUT/PATCH/DELETE, JSON validation with jq, auth patterns
- `skills/e2e-testing/SKILL.md` — Playwright install/run/headed, HTML reporter, trace capture, page objects

### Issue #69 — Collaboration Skills (2 skills)
- `skills/github-issues/SKILL.md` — gh issue commands, JSON output, label mgmt, PR linking
- `skills/doc-generation/SKILL.md` — go doc, godoc comments, swag/swaggo OpenAPI generation

## Tests
- Updated `skills/skills_validation_test.go` with 42 new tests (97 total)

## Test plan
- [x] All 97 validation tests pass
- [x] `go test ./skills/... -race` passes

Closes #65
Closes #66
Closes #68
Closes #69