### PR TITLE
Add Docker, Railway, Terraform, and AI/ML skill files (Issues #56, #57, #73, #76)

### DIFF
--- a/skills/docker-build/SKILL.md
+++ b/skills/docker-build/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: docker-build
+description: "Build Docker images with docker build: multi-stage builds, build args, caching, tagging strategies. Trigger: when building Docker images, creating Dockerfiles, multi-stage builds, docker build args, build cache"
+version: 1
+argument-hint: "[image-name:tag or Dockerfile path]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Docker Build
+
+You are now operating in Docker image build mode.
+
+## Basic Build
+
+```bash
+# Build from current directory (uses ./Dockerfile)
+docker build -t myapp:latest .
+
+# Build from a specific Dockerfile
+docker build -f docker/Dockerfile.prod -t myapp:prod .
+
+# Build with a specific context directory
+docker build -t myapp:latest ./src
+```
+
+## Tagging Conventions
+
+```bash
+# Semantic version tag + latest
+docker build -t myapp:1.2.3 -t myapp:latest .
+
+# Git commit hash tag (immutable)
+GIT_SHA=$(git rev-parse --short HEAD)
+docker build -t myapp:${GIT_SHA} -t myapp:latest .
+
+# Branch-based tag
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')
+docker build -t myapp:${GIT_BRANCH} .
+```
+
+## Build Arguments
+
+```bash
+# Pass build-time variables
+docker build \
+  --build-arg APP_VERSION=1.2.3 \
+  --build-arg NODE_ENV=production \
+  -t myapp:latest .
+
+# In Dockerfile, declare ARGs before using them
+# ARG APP_VERSION
+# ARG NODE_ENV=development
+# ENV NODE_ENV=${NODE_ENV}
+```
+
+## Multi-Stage Build Dockerfile Pattern
+
+```dockerfile
+# Stage 1: Builder
+FROM golang:1.22-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /server ./cmd/server
+
+# Stage 2: Final image (minimal)
+FROM alpine:3.19 AS final
+RUN apk --no-cache add ca-certificates tzdata
+WORKDIR /app
+COPY --from=builder /server .
+EXPOSE 8080
+USER nobody
+ENTRYPOINT ["/app/server"]
+```
+
+```bash
+# Build only the final stage (default)
+docker build -t myapp:latest .
+
+# Build a specific intermediate stage (for debugging)
+docker build --target builder -t myapp:builder .
+```
+
+## Build Caching
+
+```bash
+# Use a registry cache source (BuildKit)
+docker build \
+  --cache-from myapp:latest \
+  -t myapp:latest .
+
+# Enable BuildKit for faster builds
+DOCKER_BUILDKIT=1 docker build -t myapp:latest .
+
+# Disable cache (force rebuild all layers)
+docker build --no-cache -t myapp:latest .
+
+# Use inline cache (exports cache metadata in image)
+DOCKER_BUILDKIT=1 docker build \
+  --build-arg BUILDKIT_INLINE_CACHE=1 \
+  -t myapp:latest .
+```
+
+## Build Output and Progress
+
+```bash
+# Quiet mode (only print final image ID)
+docker build -q -t myapp:latest .
+
+# Verbose progress with timestamps
+docker build --progress=plain -t myapp:latest .
+
+# Output build context size
+docker build -t myapp:latest . 2>&1 | grep "Sending build context"
+```
+
+## Inspect Build Results
+
+```bash
+# Show image layers and sizes
+docker history myapp:latest
+
+# Show image metadata
+docker inspect myapp:latest
+
+# Check final image size
+docker images myapp:latest
+
+# Show image labels
+docker inspect --format='{{json .Config.Labels}}' myapp:latest | jq .
+```
+
+## .dockerignore
+
+Create a `.dockerignore` file to exclude unnecessary files from the build context:
+
+```
+.git
+.gitignore
+*.md
+node_modules
+dist
+coverage
+*.test
+.env
+.env.*
+```
+
+This reduces build context size and prevents accidental secret inclusion.
+
+## Common Build Issues
+
+```bash
+# Check if the build context is too large
+du -sh . --exclude=.git
+
+# Verify Dockerfile syntax
+docker build --dry-run -t myapp:latest . 2>&1 || true
+
+# Debug a failing layer by building to that stage
+docker build --target failing-stage -t debug:latest .
+docker run --rm -it debug:latest sh
+```
+
+## Best Practices
+
+- Pin base image versions with digests in production: `FROM golang:1.22-alpine@sha256:...`
+- Use non-root users in the final image: `USER nobody`
+- Set `WORKDIR` explicitly instead of relying on root directory.
+- Keep images small: use `alpine` or `distroless` base images.
+- Order Dockerfile layers from least to most frequently changing (dependencies before source code).
+- Use `CGO_ENABLED=0` for fully static Go binaries.

--- a/skills/docker-compose/SKILL.md
+++ b/skills/docker-compose/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: docker-compose
+description: "Manage multi-container applications with docker compose: up/down/logs/exec, networking, volumes, environment overrides. Trigger: when using docker compose, starting services with compose, docker compose logs, compose networking, compose volumes"
+version: 1
+argument-hint: "[up|down|logs|exec|ps|restart] [service]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Docker Compose
+
+You are now operating in Docker Compose management mode.
+
+## Start and Stop Services
+
+```bash
+# Start all services (detached)
+docker compose up -d
+
+# Start specific services
+docker compose up -d postgres redis
+
+# Start with a rebuild (after code changes)
+docker compose up -d --build
+
+# Start and follow logs immediately
+docker compose up
+
+# Stop all services (keep containers)
+docker compose stop
+
+# Stop and remove containers, networks
+docker compose down
+
+# Stop, remove containers, networks, AND volumes (destroys data)
+docker compose down -v
+```
+
+## Service Status and Logs
+
+```bash
+# List running services and their status
+docker compose ps
+
+# Show all services including stopped
+docker compose ps -a
+
+# Tail logs for all services
+docker compose logs -f
+
+# Tail logs for a specific service
+docker compose logs -f postgres
+
+# Last 100 lines of logs
+docker compose logs --tail=100 api
+
+# Timestamps in logs
+docker compose logs -f --timestamps api
+```
+
+## Execute Commands in Running Containers
+
+```bash
+# Open an interactive shell
+docker compose exec postgres bash
+docker compose exec api sh
+
+# Run a one-off command
+docker compose exec postgres psql -U postgres -d myapp
+
+# Run as a specific user
+docker compose exec --user root api sh
+
+# Run a migration
+docker compose exec api ./migrate up
+```
+
+## Run One-Off Commands (New Container)
+
+```bash
+# Run a command in a new container and remove it
+docker compose run --rm api go test ./...
+
+# Run without service dependencies
+docker compose run --no-deps --rm api sh
+
+# Override environment variables
+docker compose run --rm -e DEBUG=true api ./scripts/setup.sh
+```
+
+## Scaling and Restarting
+
+```bash
+# Restart all services
+docker compose restart
+
+# Restart a specific service
+docker compose restart api
+
+# Scale a service (multiple instances)
+docker compose up -d --scale worker=3
+```
+
+## Networking
+
+Compose creates a default network. Services can reach each other by service name:
+
+```yaml
+# docker-compose.yml example
+services:
+  api:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: postgres://postgres:dev@postgres:5432/myapp
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:
+```
+
+```bash
+# Inspect the compose network
+docker network inspect <project>_default
+
+# List all networks
+docker network ls
+```
+
+## Environment Overrides
+
+```bash
+# Use .env file (auto-loaded from compose file location)
+# .env:
+# POSTGRES_PASSWORD=secret
+# API_PORT=8080
+
+# Override with a custom env file
+docker compose --env-file .env.local up -d
+
+# Use multiple compose files (override pattern)
+docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+```
+
+## Volumes and Data
+
+```bash
+# List volumes for the project
+docker compose volume ls 2>/dev/null || docker volume ls --filter label=com.docker.compose.project=$(basename $PWD)
+
+# Copy files from a service container
+docker compose cp postgres:/var/lib/postgresql/data/pg_hba.conf ./pg_hba.conf
+
+# Copy files into a service container
+docker compose cp ./config.yaml api:/app/config.yaml
+```
+
+## Build and Update
+
+```bash
+# Rebuild images for changed services
+docker compose build
+
+# Rebuild a specific service image
+docker compose build api
+
+# Pull latest images from registry
+docker compose pull
+
+# Force recreate containers (picks up config changes)
+docker compose up -d --force-recreate
+```
+
+## Common docker-compose.yml Patterns
+
+```yaml
+# Production-ready pattern with healthchecks and resource limits
+services:
+  api:
+    image: myapp:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      - DATABASE_URL=${DATABASE_URL}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+```
+
+## Troubleshooting
+
+```bash
+# Check compose config (validates YAML and variable substitution)
+docker compose config
+
+# View events from services
+docker compose events
+
+# Show resource usage
+docker compose top
+
+# Inspect a specific service container
+docker inspect $(docker compose ps -q api)
+```

--- a/skills/docker-debug/SKILL.md
+++ b/skills/docker-debug/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: docker-debug
+description: "Debug running Docker containers: logs, exec, inspect, stats, network troubleshooting, resource usage. Trigger: when debugging Docker containers, viewing container logs, docker exec, docker inspect, container stats, container troubleshooting"
+version: 1
+argument-hint: "[container-name or image:tag]"
+allowed-tools:
+  - bash
+  - read
+  - grep
+  - glob
+---
+# Docker Debug
+
+You are now operating in Docker container debugging mode.
+
+## Container Logs
+
+```bash
+# View logs for a running container
+docker logs myapp
+
+# Follow logs in real time
+docker logs -f myapp
+
+# Last N lines
+docker logs --tail=100 myapp
+
+# With timestamps
+docker logs --timestamps myapp
+
+# Logs since a time (minutes ago)
+docker logs --since=10m myapp
+
+# Logs within a time window
+docker logs --since="2026-03-10T14:00:00" --until="2026-03-10T15:00:00" myapp
+
+# Filter stderr only
+docker logs myapp 2>&1 1>/dev/null | grep ERROR
+```
+
+## Execute Commands in Running Containers
+
+```bash
+# Interactive shell in a running container
+docker exec -it myapp sh
+docker exec -it myapp bash
+
+# Run a specific command
+docker exec myapp ls -la /app
+docker exec myapp cat /etc/resolv.conf
+
+# Run as root (even if container uses non-root user)
+docker exec -it --user root myapp sh
+
+# Check environment variables
+docker exec myapp env
+
+# Check running processes
+docker exec myapp ps aux
+```
+
+## Inspect Container Details
+
+```bash
+# Full container metadata (JSON)
+docker inspect myapp
+
+# Extract specific fields with format
+docker inspect --format='{{.State.Status}}' myapp
+docker inspect --format='{{.NetworkSettings.IPAddress}}' myapp
+docker inspect --format='{{json .Config.Env}}' myapp | jq .
+docker inspect --format='{{json .Mounts}}' myapp | jq .
+
+# Show exposed ports and bindings
+docker inspect --format='{{json .NetworkSettings.Ports}}' myapp | jq .
+
+# Show restart policy
+docker inspect --format='{{.HostConfig.RestartPolicy.Name}}' myapp
+
+# Show resource limits
+docker inspect --format='{{.HostConfig.Memory}}' myapp
+docker inspect --format='{{.HostConfig.NanoCPUs}}' myapp
+```
+
+## Resource Monitoring (Stats)
+
+```bash
+# Live resource usage (CPU, memory, network, disk)
+docker stats myapp
+
+# One-shot (no live update)
+docker stats --no-stream myapp
+
+# All containers, formatted
+docker stats --no-stream --format "table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.NetIO}}"
+
+# Check disk usage by container
+docker system df -v
+```
+
+## Network Troubleshooting
+
+```bash
+# Show container network info
+docker network inspect bridge
+
+# List networks and which containers are on them
+docker network ls
+docker network inspect <network-name>
+
+# Test DNS resolution from inside a container
+docker exec myapp nslookup postgres
+docker exec myapp ping -c 3 postgres
+
+# Test connectivity to another container
+docker exec myapp curl -s http://redis:6379 || echo "no HTTP on redis port"
+docker exec myapp nc -zv postgres 5432 && echo "port open" || echo "port closed"
+
+# Check if a container can reach the internet
+docker exec myapp curl -s https://httpbin.org/ip
+```
+
+## Image Debugging
+
+```bash
+# Examine image layers
+docker history myapp:latest
+docker history --no-trunc myapp:latest
+
+# Run a shell in a stopped or crashing image
+docker run --rm -it --entrypoint sh myapp:latest
+
+# Override entrypoint for debugging
+docker run --rm -it --entrypoint bash myapp:latest
+
+# Inspect what changed in a container vs its base image
+docker diff myapp
+```
+
+## Common Crash Patterns
+
+```bash
+# Container keeps restarting? Get exit code
+docker inspect myapp --format='{{.State.ExitCode}}'
+# Exit 1 = application error
+# Exit 137 = OOM kill (out of memory)
+# Exit 139 = segfault
+
+# Check restart count
+docker inspect myapp --format='{{.RestartCount}}'
+
+# View last log lines after a crash
+docker logs --tail=50 myapp
+
+# Run with more verbose logging
+docker run --rm -e LOG_LEVEL=debug myapp:latest
+```
+
+## Filesystem Debugging
+
+```bash
+# Copy a file from a container for inspection
+docker cp myapp:/app/config.yaml ./config-from-container.yaml
+
+# Copy a file into a container
+docker cp ./fix.yaml myapp:/app/config.yaml
+
+# Check disk usage inside a container
+docker exec myapp df -h
+docker exec myapp du -sh /app/*
+```
+
+## Container Events
+
+```bash
+# Monitor Docker events (start, stop, die, OOM)
+docker events --filter container=myapp
+
+# Events in the last 10 minutes
+docker events --since=10m --filter container=myapp
+```
+
+## Cleanup After Debugging
+
+```bash
+# Remove all stopped containers
+docker container prune
+
+# Remove dangling images (untagged)
+docker image prune
+
+# Full system cleanup (removes stopped containers, unused images, unused networks)
+docker system prune
+
+# Aggressive cleanup including volumes (DESTROYS DATA)
+docker system prune -a --volumes
+```
+
+## Interpreting Common Errors
+
+| Error | Likely Cause | Fix |
+|-------|-------------|-----|
+| `No such container` | Container not running or wrong name | `docker ps -a` to find it |
+| `Permission denied` | Non-root user lacks access | Use `--user root` or fix file permissions |
+| `exec: not found` | Shell not in image | Try `sh` instead of `bash` |
+| `Error response from daemon: OOMKilled` | Container ran out of memory | Increase `--memory` limit |
+| `connection refused` | Service not listening on expected port | Check service startup logs |
+| `no route to host` | Network misconfiguration | Verify container network assignment |

--- a/skills/docker-push/SKILL.md
+++ b/skills/docker-push/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: docker-push
+description: "Push Docker images to registries: DockerHub, ghcr.io (GitHub Container Registry), AWS ECR. Authentication, tagging conventions, multi-platform builds. Trigger: when pushing Docker images, publishing container images, docker push, ghcr.io, ECR, DockerHub registry"
+version: 1
+argument-hint: "[registry/image:tag]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Docker Push
+
+You are now operating in Docker registry push mode.
+
+## DockerHub
+
+```bash
+# Login to DockerHub
+docker login
+
+# Login with credentials (for CI)
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+# Tag for DockerHub (username/repo:tag)
+docker tag myapp:latest dennisonbertram/myapp:latest
+docker tag myapp:latest dennisonbertram/myapp:1.2.3
+
+# Push all tags
+docker push dennisonbertram/myapp:latest
+docker push dennisonbertram/myapp:1.2.3
+```
+
+## GitHub Container Registry (ghcr.io)
+
+```bash
+# Login with GitHub Personal Access Token
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+# Tag for ghcr.io
+docker tag myapp:latest ghcr.io/myorg/myapp:latest
+docker tag myapp:latest ghcr.io/myorg/myapp:1.2.3
+
+# Push to ghcr.io
+docker push ghcr.io/myorg/myapp:latest
+docker push ghcr.io/myorg/myapp:1.2.3
+```
+
+## AWS ECR (Elastic Container Registry)
+
+```bash
+# Login to ECR (uses AWS CLI credentials)
+AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+AWS_REGION=${AWS_DEFAULT_REGION:-us-east-1}
+aws ecr get-login-password --region $AWS_REGION \
+  | docker login --username AWS --password-stdin \
+    "$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
+
+# Create ECR repository (if it doesn't exist)
+aws ecr create-repository --repository-name myapp --region $AWS_REGION 2>/dev/null || true
+
+# Tag for ECR
+ECR_URI="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com/myapp"
+docker tag myapp:latest "$ECR_URI:latest"
+docker tag myapp:latest "$ECR_URI:1.2.3"
+
+# Push to ECR
+docker push "$ECR_URI:latest"
+docker push "$ECR_URI:1.2.3"
+```
+
+## Tagging Conventions
+
+```bash
+# Immutable: Git SHA tag (never overwrite)
+GIT_SHA=$(git rev-parse --short HEAD)
+docker tag myapp:latest myregistry/myapp:${GIT_SHA}
+docker push myregistry/myapp:${GIT_SHA}
+
+# Mutable: branch/environment tags
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')
+docker tag myapp:latest myregistry/myapp:${GIT_BRANCH}
+docker push myregistry/myapp:${GIT_BRANCH}
+
+# Semantic version (from git tag)
+VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+docker tag myapp:latest myregistry/myapp:${VERSION}
+docker tag myapp:latest myregistry/myapp:latest
+docker push myregistry/myapp:${VERSION}
+docker push myregistry/myapp:latest
+```
+
+## Build and Push in One Step
+
+```bash
+# Build and push with BuildKit
+DOCKER_BUILDKIT=1 docker build \
+  --push \
+  -t ghcr.io/myorg/myapp:latest \
+  -t ghcr.io/myorg/myapp:${GIT_SHA} \
+  .
+```
+
+## Multi-Platform Builds and Push
+
+```bash
+# Create a multi-platform builder
+docker buildx create --name multiplatform --use
+
+# Build and push for linux/amd64 and linux/arm64
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --push \
+  -t ghcr.io/myorg/myapp:latest \
+  .
+
+# Inspect a multi-platform manifest
+docker manifest inspect ghcr.io/myorg/myapp:latest
+```
+
+## GitHub Actions Workflow Pattern
+
+```yaml
+# .github/workflows/docker-push.yml
+name: Build and Push
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+```
+
+## Verify Push
+
+```bash
+# Verify the image exists in the registry
+docker manifest inspect ghcr.io/myorg/myapp:latest
+
+# Pull to verify (in a clean environment)
+docker pull ghcr.io/myorg/myapp:latest
+docker run --rm ghcr.io/myorg/myapp:latest --version
+
+# List tags in a registry (ghcr.io via GitHub API)
+gh api /user/packages/container/myapp/versions --jq '.[].metadata.container.tags[]'
+```
+
+## Security Best Practices
+
+- Never embed credentials in Dockerfiles or image layers.
+- Use short-lived tokens (`GITHUB_TOKEN` in Actions, IAM roles in ECR) rather than long-lived passwords.
+- Sign images with `cosign` for supply chain security.
+- Scan images for vulnerabilities before pushing to production registries.
+- Use immutable tags (git SHA) for deployments; never rely solely on `latest`.

--- a/skills/ollama-ops/SKILL.md
+++ b/skills/ollama-ops/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: ollama-ops
+description: "Manage local LLM inference with Ollama: pull/run/list/serve models, Modelfile creation, API usage, model management. Trigger: when using Ollama, running local LLMs, ollama pull, ollama run, ollama serve, Modelfile, local model inference"
+version: 1
+argument-hint: "[pull|run|list|serve|create] [model-name]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Ollama Operations
+
+You are now operating in Ollama local LLM management mode.
+
+## Installation and Server
+
+```bash
+# macOS (via Homebrew)
+brew install ollama
+
+# Start the Ollama server (runs on port 11434 by default)
+ollama serve
+
+# Check if Ollama server is running
+curl -s http://localhost:11434/api/tags | jq '.models[].name'
+
+# Verify the server is healthy
+curl -s http://localhost:11434/ | jq .
+```
+
+## Model Management
+
+```bash
+# List all locally available models
+ollama list
+
+# Pull a model from the Ollama registry
+ollama pull llama3.2
+ollama pull qwen2.5:7b
+ollama pull mistral:latest
+ollama pull nomic-embed-text    # embedding model
+
+# Show model details (parameters, context length, etc.)
+ollama show llama3.2
+
+# Remove a model
+ollama rm llama3.2
+
+# Copy a model (create an alias)
+ollama cp llama3.2 my-llama
+```
+
+## Running Models
+
+```bash
+# Interactive chat session
+ollama run llama3.2
+
+# One-shot prompt (non-interactive)
+ollama run llama3.2 "Explain what a mutex is in one sentence."
+
+# Pipe input to model
+echo "Summarize: $(cat README.md)" | ollama run llama3.2
+
+# Run with system prompt
+ollama run llama3.2 "What is the capital of France?" --system "You are a geography expert."
+```
+
+## REST API Usage
+
+Ollama exposes an OpenAI-compatible API on `http://localhost:11434`.
+
+```bash
+# Generate a completion (Ollama native API)
+curl -s http://localhost:11434/api/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.2",
+    "prompt": "Why is the sky blue?",
+    "stream": false
+  }' | jq -r '.response'
+
+# Chat completion (OpenAI-compatible API)
+curl -s http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "llama3.2",
+    "messages": [
+      {"role": "user", "content": "Hello, what can you do?"}
+    ]
+  }' | jq -r '.choices[0].message.content'
+
+# Generate embeddings
+curl -s http://localhost:11434/api/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nomic-embed-text",
+    "input": "The quick brown fox jumps over the lazy dog"
+  }' | jq '.embeddings[0] | length'
+```
+
+## Modelfile: Custom Models
+
+```bash
+# Create a Modelfile to customize a base model
+cat > Modelfile <<'EOF'
+FROM llama3.2
+
+# Set the system prompt
+SYSTEM "You are a helpful Go programming assistant. Always provide working code examples."
+
+# Adjust parameters
+PARAMETER temperature 0.3
+PARAMETER top_p 0.9
+PARAMETER num_ctx 4096
+EOF
+
+# Build the custom model
+ollama create go-assistant -f Modelfile
+
+# Run the custom model
+ollama run go-assistant "How do I implement a context-aware HTTP handler in Go?"
+```
+
+## Modelfile Parameters
+
+```dockerfile
+# Modelfile reference
+FROM llama3.2:latest        # base model
+
+SYSTEM "Your system prompt here"
+
+# Model parameters
+PARAMETER temperature 0.7   # 0.0 (deterministic) to 1.0 (creative)
+PARAMETER top_k 40          # top-k sampling
+PARAMETER top_p 0.9         # nucleus sampling
+PARAMETER num_ctx 8192      # context window size (tokens)
+PARAMETER repeat_penalty 1.1
+PARAMETER seed 42           # for reproducible outputs (0 = random)
+
+# Add files to the model
+MESSAGE user "What can you help me with?"
+MESSAGE assistant "I can help you with Go programming, code reviews, and debugging."
+```
+
+## Using Ollama from Go
+
+```go
+// Using the OpenAI-compatible API from Go
+import "github.com/openai/openai-go"
+
+client := openai.NewClient(
+    option.WithBaseURL("http://localhost:11434/v1"),
+    option.WithAPIKey("ollama"), // any non-empty string
+)
+
+chat, err := client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+    Model: openai.F("llama3.2"),
+    Messages: openai.F([]openai.ChatCompletionMessageParamUnion{
+        openai.UserMessage("Explain Go interfaces."),
+    }),
+})
+```
+
+## Performance and Configuration
+
+```bash
+# Set GPU layers (for NVIDIA/AMD GPUs)
+OLLAMA_GPU_LAYERS=35 ollama serve
+
+# Set number of parallel requests
+OLLAMA_NUM_PARALLEL=4 ollama serve
+
+# Set max loaded models (default: 1)
+OLLAMA_MAX_LOADED_MODELS=2 ollama serve
+
+# Check GPU usage during inference
+nvidia-smi dmon -s u -d 1
+
+# Check memory usage
+ollama ps    # shows loaded models and VRAM usage
+```
+
+## Common Models Reference
+
+| Model | Size | Best For |
+|-------|------|---------|
+| `llama3.2:3b` | 2 GB | Fast responses, simple tasks |
+| `llama3.2:latest` | 4.7 GB | General purpose, good quality |
+| `qwen2.5:7b` | 4.7 GB | Code, reasoning |
+| `mistral:latest` | 4.1 GB | Instruction following |
+| `nomic-embed-text` | 274 MB | Text embeddings |
+| `mxbai-embed-large` | 669 MB | High-quality embeddings |
+
+## Troubleshooting
+
+```bash
+# Check if server is running
+curl -s http://localhost:11434/ || echo "Ollama server not running; run: ollama serve"
+
+# Check loaded models and memory
+ollama ps
+
+# Restart the Ollama service
+pkill ollama && ollama serve
+
+# Model download failed? Resume by re-running pull
+ollama pull llama3.2
+
+# Clear model cache (if disk full)
+ollama rm $(ollama list --json | jq -r '.[].name' | head -1)
+```

--- a/skills/railway-deploy/SKILL.md
+++ b/skills/railway-deploy/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: railway-deploy
+description: "Deploy applications to Railway: railway up, environment management, domains, secrets/environment variables, logs, service management. Trigger: when deploying to Railway, using railway up, Railway environment variables, Railway domains, Railway logs, Railway CLI"
+version: 1
+argument-hint: "[up|logs|status|env|domain]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Railway Deployment
+
+You are now operating in Railway deployment mode.
+
+## Installation and Authentication
+
+```bash
+# Install Railway CLI
+npm install -g @railway/cli
+
+# Login (opens browser)
+railway login
+
+# Verify authentication
+railway whoami
+```
+
+## Project Setup
+
+```bash
+# Link current directory to an existing Railway project
+railway link
+
+# Initialize a new Railway project
+railway init
+
+# Show current project info
+railway status
+```
+
+## Deploy
+
+```bash
+# Deploy from current directory (triggers a build + deploy)
+railway up
+
+# Deploy with verbose output
+railway up --verbose
+
+# Deploy detached (do not stream logs)
+railway up --detach
+
+# Deploy a specific service
+railway up --service my-service
+
+# Force a redeploy of the current image (no rebuild)
+railway redeploy
+```
+
+## Environment Variables and Secrets
+
+```bash
+# List all environment variables for current environment
+railway variables
+
+# Set an environment variable
+railway variables set DATABASE_URL="postgresql://..."
+railway variables set SECRET_KEY="$(openssl rand -hex 32)"
+
+# Set multiple variables at once
+railway variables set \
+  APP_ENV=production \
+  LOG_LEVEL=info \
+  PORT=8080
+
+# Delete an environment variable
+railway variables delete OLD_VAR
+
+# Import from a .env file
+railway variables import .env.production
+```
+
+## Environments
+
+Railway supports multiple environments (production, staging, etc.).
+
+```bash
+# List environments
+railway environment
+
+# Switch to a specific environment
+railway environment staging
+
+# Create a new environment
+# (done via Railway dashboard or CLI prompts)
+
+# Show the current environment
+railway status
+```
+
+## Domains and Networking
+
+```bash
+# Generate a Railway subdomain for the service
+railway domain
+
+# Add a custom domain
+railway domain add myapp.example.com
+
+# List all domains for the service
+railway domain list
+```
+
+## Logs
+
+```bash
+# Tail deployment logs
+railway logs
+
+# Stream logs in real time
+railway logs --tail
+
+# View logs for a specific deployment
+railway logs --deployment <deployment-id>
+
+# Filter logs by search term
+railway logs | grep ERROR
+```
+
+## Database Services
+
+Railway can provision databases alongside your app:
+
+```bash
+# After adding a Postgres plugin in the dashboard, the
+# DATABASE_URL variable is automatically injected.
+
+# Connect to Railway Postgres from CLI
+railway run psql $DATABASE_URL
+
+# Run a migration against Railway Postgres
+railway run goose -dir migrations postgres "$DATABASE_URL" up
+
+# Dump the Railway database
+railway run pg_dump "$DATABASE_URL" > backup.sql
+```
+
+## Running One-Off Commands
+
+```bash
+# Execute a command in the Railway environment (uses Railway env vars)
+railway run go test ./...
+railway run ./scripts/migrate.sh
+railway run bash -c "echo $DATABASE_URL"
+```
+
+## Service Management
+
+```bash
+# List all services in the project
+railway service
+
+# Show service info
+railway service --json
+
+# Restart a service
+railway service restart
+```
+
+## Monitoring Deployments
+
+```bash
+# Check deployment status
+railway status
+
+# List recent deployments
+railway deployments list 2>/dev/null || railway status
+
+# Verify the deployed commit
+railway status --json | jq '.deploymentStatus'
+```
+
+## CI/CD Integration
+
+```yaml
+# GitHub Actions example
+name: Deploy to Railway
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: railway up --detach
+```
+
+## Post-Deploy Verification
+
+```bash
+# Check the service is responding
+curl -s -o /dev/null -w "%{http_code}" https://myapp.up.railway.app/health
+
+# Verify the correct commit was deployed
+railway status --json | jq '.commitSha'
+git rev-parse HEAD
+
+# Monitor initial startup logs
+railway logs --tail | head -50
+```
+
+## Troubleshooting
+
+```bash
+# View build logs for a failed deployment
+railway logs --deployment <id>
+
+# Check environment variable is set
+railway run printenv APP_ENV
+
+# Validate the Railway config file
+cat railway.json 2>/dev/null || cat railway.toml 2>/dev/null
+
+# Force a fresh deployment (clear build cache)
+railway up --no-cache 2>/dev/null || railway up
+```
+
+## railway.json Configuration
+
+```json
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "startCommand": "./server",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 100,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}
+```
+
+## Safety Rules
+
+- Never commit `RAILWAY_TOKEN` to source control — use GitHub Secrets or environment-scoped variables.
+- Always verify deployed content after `railway up`; a success exit code does not guarantee the new code is live.
+- Use environment-specific secrets: production and staging should have separate `DATABASE_URL` values.

--- a/skills/skills_validation_56_57_73_76_test.go
+++ b/skills/skills_validation_56_57_73_76_test.go
@@ -1,0 +1,779 @@
+// Package skills_validation tests that the bundled SKILL.md files in this
+// directory parse correctly and satisfy required field constraints.
+//
+// Each SKILL.md file is loaded via the production Loader to ensure any future
+// loader changes are caught by these tests automatically.
+package skills_validation
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/skills"
+)
+
+// skillsDirNew returns the absolute path to the skills/ directory that contains
+// this test file. Using runtime.Caller makes the path independent of the
+// working directory from which `go test` is invoked.
+func skillsDirNew(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(file)
+}
+
+// loadAllSkillsNew uses the production Loader to discover all SKILL.md files
+// in the skills/ directory and returns them indexed by name.
+func loadAllSkillsNew(t *testing.T) map[string]skills.Skill {
+	t.Helper()
+	dir := skillsDirNew(t)
+	loader := skills.NewLoader(skills.LoaderConfig{GlobalDir: dir})
+	all, err := loader.Load()
+	if err != nil {
+		t.Fatalf("skills.Loader.Load() error: %v", err)
+	}
+	m := make(map[string]skills.Skill, len(all))
+	for _, s := range all {
+		m[s.Name] = s
+	}
+	return m
+}
+
+// --- Issue #56: Docker Skills ---
+
+func TestDockerBuildSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["docker-build"]
+	if !ok {
+		t.Fatal("docker-build skill not found; expected SKILL.md in skills/docker-build/")
+	}
+	if s.Name != "docker-build" {
+		t.Errorf("Name = %q, want %q", s.Name, "docker-build")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestDockerBuildSkill_HasBuildCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-build"]
+	if !strings.Contains(s.Body, "docker build") {
+		t.Error("docker-build body should include 'docker build' command")
+	}
+	if !strings.Contains(s.Body, "--build-arg") {
+		t.Error("docker-build body should document --build-arg flag")
+	}
+	if !strings.Contains(s.Body, "multi-stage") || !strings.Contains(s.Body, "Multi-Stage") ||
+		(!strings.Contains(s.Body, "Stage") && !strings.Contains(s.Body, "stage")) {
+		// flexible check: just ensure multi-stage is covered
+		if !strings.Contains(strings.ToLower(s.Body), "multi-stage") {
+			t.Error("docker-build body should document multi-stage builds")
+		}
+	}
+}
+
+func TestDockerBuildSkill_HasTaggingContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-build"]
+	if !strings.Contains(s.Body, "-t ") {
+		t.Error("docker-build body should document -t (tag) flag")
+	}
+	if !strings.Contains(s.Body, "latest") {
+		t.Error("docker-build body should document :latest tag convention")
+	}
+}
+
+func TestDockerBuildSkill_HasCachingContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-build"]
+	if !strings.Contains(s.Body, "--no-cache") {
+		t.Error("docker-build body should document --no-cache flag")
+	}
+}
+
+func TestDockerBuildSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-build"]
+	if len(s.Triggers) == 0 {
+		t.Error("docker-build should have at least one trigger phrase in description")
+	}
+}
+
+func TestDockerBuildSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-build"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("docker-build should declare allowed-tools")
+	}
+}
+
+func TestDockerComposeSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["docker-compose"]
+	if !ok {
+		t.Fatal("docker-compose skill not found; expected SKILL.md in skills/docker-compose/")
+	}
+	if s.Name != "docker-compose" {
+		t.Errorf("Name = %q, want %q", s.Name, "docker-compose")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestDockerComposeSkill_HasUpDownCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-compose"]
+	if !strings.Contains(s.Body, "docker compose up") {
+		t.Error("docker-compose body should include 'docker compose up'")
+	}
+	if !strings.Contains(s.Body, "docker compose down") {
+		t.Error("docker-compose body should include 'docker compose down'")
+	}
+}
+
+func TestDockerComposeSkill_HasLogsAndExec(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-compose"]
+	if !strings.Contains(s.Body, "docker compose logs") {
+		t.Error("docker-compose body should include 'docker compose logs'")
+	}
+	if !strings.Contains(s.Body, "docker compose exec") {
+		t.Error("docker-compose body should include 'docker compose exec'")
+	}
+}
+
+func TestDockerComposeSkill_HasNetworkingContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-compose"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "network") {
+		t.Error("docker-compose body should document networking")
+	}
+}
+
+func TestDockerComposeSkill_HasVolumesContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-compose"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "volume") {
+		t.Error("docker-compose body should document volumes")
+	}
+}
+
+func TestDockerPushSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["docker-push"]
+	if !ok {
+		t.Fatal("docker-push skill not found; expected SKILL.md in skills/docker-push/")
+	}
+	if s.Name != "docker-push" {
+		t.Errorf("Name = %q, want %q", s.Name, "docker-push")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestDockerPushSkill_HasRegistries(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-push"]
+	if !strings.Contains(s.Body, "DockerHub") && !strings.Contains(s.Body, "docker login") {
+		t.Error("docker-push body should cover DockerHub")
+	}
+	if !strings.Contains(s.Body, "ghcr.io") {
+		t.Error("docker-push body should cover GitHub Container Registry (ghcr.io)")
+	}
+	if !strings.Contains(s.Body, "ECR") {
+		t.Error("docker-push body should cover AWS ECR")
+	}
+}
+
+func TestDockerPushSkill_HasPushCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-push"]
+	if !strings.Contains(s.Body, "docker push") {
+		t.Error("docker-push body should include 'docker push' command")
+	}
+}
+
+func TestDockerPushSkill_HasTaggingConventions(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-push"]
+	if !strings.Contains(s.Body, "docker tag") {
+		t.Error("docker-push body should include 'docker tag' command")
+	}
+	if !strings.Contains(s.Body, "latest") {
+		t.Error("docker-push body should document :latest tag convention")
+	}
+}
+
+func TestDockerDebugSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["docker-debug"]
+	if !ok {
+		t.Fatal("docker-debug skill not found; expected SKILL.md in skills/docker-debug/")
+	}
+	if s.Name != "docker-debug" {
+		t.Errorf("Name = %q, want %q", s.Name, "docker-debug")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestDockerDebugSkill_HasLogsCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-debug"]
+	if !strings.Contains(s.Body, "docker logs") {
+		t.Error("docker-debug body should include 'docker logs' command")
+	}
+}
+
+func TestDockerDebugSkill_HasExecCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-debug"]
+	if !strings.Contains(s.Body, "docker exec") {
+		t.Error("docker-debug body should include 'docker exec' command")
+	}
+}
+
+func TestDockerDebugSkill_HasInspectCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-debug"]
+	if !strings.Contains(s.Body, "docker inspect") {
+		t.Error("docker-debug body should include 'docker inspect' command")
+	}
+}
+
+func TestDockerDebugSkill_HasStatsCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-debug"]
+	if !strings.Contains(s.Body, "docker stats") {
+		t.Error("docker-debug body should include 'docker stats' command")
+	}
+}
+
+func TestDockerDebugSkill_HasTroubleshootingPatterns(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["docker-debug"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "troubleshoot") && !strings.Contains(bodyLower, "crash") &&
+		!strings.Contains(bodyLower, "oom") && !strings.Contains(bodyLower, "exit") {
+		t.Error("docker-debug body should cover troubleshooting patterns (crashes, OOM, exit codes)")
+	}
+}
+
+// --- Issue #57: Railway Deployment Skill ---
+
+func TestRailwayDeploySkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["railway-deploy"]
+	if !ok {
+		t.Fatal("railway-deploy skill not found; expected SKILL.md in skills/railway-deploy/")
+	}
+	if s.Name != "railway-deploy" {
+		t.Errorf("Name = %q, want %q", s.Name, "railway-deploy")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestRailwayDeploySkill_HasDeployCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	if !strings.Contains(s.Body, "railway up") {
+		t.Error("railway-deploy body should include 'railway up' command")
+	}
+}
+
+func TestRailwayDeploySkill_HasEnvironmentManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	if !strings.Contains(s.Body, "railway variables") {
+		t.Error("railway-deploy body should include 'railway variables' for environment management")
+	}
+}
+
+func TestRailwayDeploySkill_HasDomainManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	if !strings.Contains(s.Body, "railway domain") {
+		t.Error("railway-deploy body should include 'railway domain' for domain management")
+	}
+}
+
+func TestRailwayDeploySkill_HasLogsCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	if !strings.Contains(s.Body, "railway logs") {
+		t.Error("railway-deploy body should include 'railway logs' command")
+	}
+}
+
+func TestRailwayDeploySkill_HasSecretsContent(t *testing.T) {
+	t.Parallel()
+	dir := skillsDirNew(t)
+	path := filepath.Join(dir, "railway-deploy", "SKILL.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading railway-deploy SKILL.md: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "RAILWAY_TOKEN") {
+		t.Error("railway-deploy SKILL.md should document RAILWAY_TOKEN for CI/CD authentication")
+	}
+}
+
+func TestRailwayDeploySkill_HasPostDeployVerification(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "verif") && !strings.Contains(bodyLower, "health") {
+		t.Error("railway-deploy body should include post-deploy verification patterns")
+	}
+}
+
+func TestRailwayDeploySkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["railway-deploy"]
+	if len(s.Triggers) == 0 {
+		t.Error("railway-deploy should have at least one trigger phrase in description")
+	}
+}
+
+// --- Issue #73: Terraform Skill ---
+
+func TestTerraformSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["terraform"]
+	if !ok {
+		t.Fatal("terraform skill not found; expected SKILL.md in skills/terraform/")
+	}
+	if s.Name != "terraform" {
+		t.Errorf("Name = %q, want %q", s.Name, "terraform")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestTerraformSkill_HasCoreWorkflow(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if !strings.Contains(s.Body, "terraform init") {
+		t.Error("terraform body should include 'terraform init'")
+	}
+	if !strings.Contains(s.Body, "terraform plan") {
+		t.Error("terraform body should include 'terraform plan'")
+	}
+	if !strings.Contains(s.Body, "terraform apply") {
+		t.Error("terraform body should include 'terraform apply'")
+	}
+	if !strings.Contains(s.Body, "terraform destroy") {
+		t.Error("terraform body should include 'terraform destroy'")
+	}
+}
+
+func TestTerraformSkill_HasStateManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if !strings.Contains(s.Body, "terraform state") {
+		t.Error("terraform body should include 'terraform state' commands")
+	}
+	if !strings.Contains(s.Body, "terraform state list") {
+		t.Error("terraform body should include 'terraform state list'")
+	}
+}
+
+func TestTerraformSkill_HasVariables(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if !strings.Contains(s.Body, "-var") {
+		t.Error("terraform body should document -var flag for variables")
+	}
+	if !strings.Contains(s.Body, "-var-file") {
+		t.Error("terraform body should document -var-file flag")
+	}
+}
+
+func TestTerraformSkill_HasWorkspaces(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if !strings.Contains(s.Body, "terraform workspace") {
+		t.Error("terraform body should document 'terraform workspace' commands")
+	}
+	if !strings.Contains(s.Body, "workspace new") {
+		t.Error("terraform body should document 'workspace new' command")
+	}
+}
+
+func TestTerraformSkill_HasModules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "module") {
+		t.Error("terraform body should document modules")
+	}
+}
+
+func TestTerraformSkill_HasRemoteBackend(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "backend") && !strings.Contains(bodyLower, "remote state") {
+		t.Error("terraform body should document remote state backend")
+	}
+}
+
+func TestTerraformSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if len(s.Triggers) == 0 {
+		t.Error("terraform should have at least one trigger phrase in description")
+	}
+}
+
+func TestTerraformSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["terraform"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("terraform should declare allowed-tools")
+	}
+}
+
+// --- Issue #76: AI/ML Skills ---
+
+func TestOllamaOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["ollama-ops"]
+	if !ok {
+		t.Fatal("ollama-ops skill not found; expected SKILL.md in skills/ollama-ops/")
+	}
+	if s.Name != "ollama-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "ollama-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestOllamaOpsSkill_HasModelManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if !strings.Contains(s.Body, "ollama pull") {
+		t.Error("ollama-ops body should include 'ollama pull' command")
+	}
+	if !strings.Contains(s.Body, "ollama list") {
+		t.Error("ollama-ops body should include 'ollama list' command")
+	}
+	if !strings.Contains(s.Body, "ollama rm") {
+		t.Error("ollama-ops body should include 'ollama rm' command")
+	}
+}
+
+func TestOllamaOpsSkill_HasRunCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if !strings.Contains(s.Body, "ollama run") {
+		t.Error("ollama-ops body should include 'ollama run' command")
+	}
+}
+
+func TestOllamaOpsSkill_HasServeCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if !strings.Contains(s.Body, "ollama serve") {
+		t.Error("ollama-ops body should include 'ollama serve' command")
+	}
+}
+
+func TestOllamaOpsSkill_HasModelfileContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if !strings.Contains(s.Body, "Modelfile") {
+		t.Error("ollama-ops body should document Modelfile creation")
+	}
+}
+
+func TestOllamaOpsSkill_HasAPIUsage(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if !strings.Contains(s.Body, "api/generate") && !strings.Contains(s.Body, "/v1/chat") {
+		t.Error("ollama-ops body should document the Ollama REST API")
+	}
+	if !strings.Contains(s.Body, "localhost:11434") {
+		t.Error("ollama-ops body should include the default Ollama server address")
+	}
+}
+
+func TestOllamaOpsSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["ollama-ops"]
+	if len(s.Triggers) == 0 {
+		t.Error("ollama-ops should have at least one trigger phrase in description")
+	}
+}
+
+func TestVectorDBSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["vector-db"]
+	if !ok {
+		t.Fatal("vector-db skill not found; expected SKILL.md in skills/vector-db/")
+	}
+	if s.Name != "vector-db" {
+		t.Errorf("Name = %q, want %q", s.Name, "vector-db")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body must not be empty")
+	}
+}
+
+func TestVectorDBSkill_HasChromaContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	if !strings.Contains(s.Body, "Chroma") && !strings.Contains(s.Body, "chroma") {
+		t.Error("vector-db body should cover Chroma vector database")
+	}
+}
+
+func TestVectorDBSkill_HasQdrantContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	if !strings.Contains(s.Body, "Qdrant") && !strings.Contains(s.Body, "qdrant") {
+		t.Error("vector-db body should cover Qdrant vector database")
+	}
+}
+
+func TestVectorDBSkill_HasEmbeddingsContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "embedding") {
+		t.Error("vector-db body should document embeddings")
+	}
+}
+
+func TestVectorDBSkill_HasSimilaritySearch(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "search") && !strings.Contains(bodyLower, "similarity") {
+		t.Error("vector-db body should document similarity search")
+	}
+}
+
+func TestVectorDBSkill_HasUpsertPattern(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "upsert") && !strings.Contains(bodyLower, "add") {
+		t.Error("vector-db body should document how to add/upsert vectors")
+	}
+}
+
+func TestVectorDBSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vector-db"]
+	if len(s.Triggers) == 0 {
+		t.Error("vector-db should have at least one trigger phrase in description")
+	}
+}
+
+// --- Cross-cutting validation for issues #56, #57, #73, #76 ---
+
+// TestNewSkillsHaveVersion ensures every new SKILL.md has version: 1.
+func TestNewSkillsHaveVersion(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"docker-build", "docker-compose", "docker-push", "docker-debug",
+		"railway-deploy",
+		"terraform",
+		"ollama-ops", "vector-db",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue // covered by individual parse tests
+		}
+		if s.Version != 1 {
+			t.Errorf("skill %q: Version = %d, want 1", name, s.Version)
+		}
+	}
+}
+
+// TestNewSkillsHaveAllowedTools ensures all new skills declare allowed-tools.
+func TestNewSkillsHaveAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"docker-build", "docker-compose", "docker-push", "docker-debug",
+		"railway-deploy",
+		"terraform",
+		"ollama-ops", "vector-db",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue // covered by individual parse tests
+		}
+		if len(s.AllowedTools) == 0 {
+			t.Errorf("skill %q: allowed-tools should be declared", name)
+		}
+	}
+}
+
+// TestNewSkillsExpectedCount validates all 8 skills for issues #56, #57, #73, #76
+// are present. This catches accidentally deleted or renamed skill directories.
+func TestNewSkillsExpectedCount(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	expected := []string{
+		// Issue #56: Docker Skills
+		"docker-build",
+		"docker-compose",
+		"docker-push",
+		"docker-debug",
+		// Issue #57: Railway Deployment
+		"railway-deploy",
+		// Issue #73: Terraform
+		"terraform",
+		// Issue #76: AI/ML Skills
+		"ollama-ops",
+		"vector-db",
+	}
+	for _, name := range expected {
+		if _, ok := all[name]; !ok {
+			t.Errorf("expected skill %q not found", name)
+		}
+	}
+}
+
+// TestNewSkillsDefaultToConversationContext ensures none of the new skills
+// accidentally use the fork context, which requires a runner.
+func TestNewSkillsDefaultToConversationContext(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"docker-build", "docker-compose", "docker-push", "docker-debug",
+		"railway-deploy",
+		"terraform",
+		"ollama-ops", "vector-db",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue
+		}
+		if s.Context == skills.ContextFork {
+			t.Errorf("skill %q uses context=fork; these skills should use conversation context", name)
+		}
+	}
+}

--- a/skills/terraform/SKILL.md
+++ b/skills/terraform/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: terraform
+description: "Manage infrastructure with Terraform: init, plan, apply, destroy, state management, variables, workspaces, modules. Trigger: when using Terraform, infrastructure as code, terraform plan, terraform apply, Terraform state, Terraform modules, IaC"
+version: 1
+argument-hint: "[init|plan|apply|destroy|state|workspace]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Terraform / Infrastructure-as-Code
+
+You are now operating in Terraform infrastructure management mode.
+
+## Installation
+
+```bash
+# macOS (via Homebrew)
+brew tap hashicorp/tap && brew install hashicorp/tap/terraform
+
+# Verify installation
+terraform version
+```
+
+## Core Workflow
+
+```bash
+# 1. Initialize — download providers and modules
+terraform init
+
+# 2. Format code (auto-fix indentation and style)
+terraform fmt -recursive
+
+# 3. Validate configuration
+terraform validate
+
+# 4. Preview changes
+terraform plan
+
+# 5. Apply changes (with confirmation prompt)
+terraform apply
+
+# 6. Apply without prompt (for CI/automation)
+terraform apply -auto-approve
+
+# 7. Destroy all resources
+terraform destroy
+```
+
+## Variables
+
+```bash
+# Define variables in variables.tf
+# variable "region" {
+#   type    = string
+#   default = "us-east-1"
+# }
+
+# Override variables on command line
+terraform plan -var="region=us-west-2"
+
+# Use a variable file (.tfvars)
+terraform plan -var-file="prod.tfvars"
+
+# Terraform auto-loads terraform.tfvars and *.auto.tfvars
+
+# Use environment variables (TF_VAR_ prefix)
+export TF_VAR_region="us-west-2"
+terraform plan
+```
+
+## Terraform Files
+
+```hcl
+# main.tf — core resources
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  backend "s3" {
+    bucket = "my-terraform-state"
+    key    = "prod/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "app" {
+  bucket = "my-app-assets-${var.environment}"
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.app.bucket
+}
+```
+
+## State Management
+
+```bash
+# List all resources in state
+terraform state list
+
+# Show details of a specific resource
+terraform state show aws_s3_bucket.app
+
+# Move a resource (rename in state)
+terraform state mv aws_s3_bucket.app aws_s3_bucket.assets
+
+# Remove a resource from state (does NOT destroy it)
+terraform state rm aws_s3_bucket.old
+
+# Import an existing resource into state
+terraform import aws_s3_bucket.app my-existing-bucket-name
+
+# Pull remote state to local (for inspection)
+terraform state pull > current.tfstate
+```
+
+## Remote State Backend (S3)
+
+```bash
+# Create S3 bucket for state (one-time setup)
+aws s3api create-bucket \
+  --bucket my-terraform-state \
+  --region us-east-1
+
+# Enable versioning (for state history)
+aws s3api put-bucket-versioning \
+  --bucket my-terraform-state \
+  --versioning-configuration Status=Enabled
+
+# Enable encryption
+aws s3api put-bucket-encryption \
+  --bucket my-terraform-state \
+  --server-side-encryption-configuration \
+    '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+```
+
+## Workspaces
+
+```bash
+# List workspaces
+terraform workspace list
+
+# Create and switch to a new workspace
+terraform workspace new staging
+
+# Switch between workspaces
+terraform workspace select production
+terraform workspace select staging
+
+# Show current workspace
+terraform workspace show
+
+# Use workspace name in resources
+# resource "aws_s3_bucket" "app" {
+#   bucket = "myapp-${terraform.workspace}"
+# }
+```
+
+## Modules
+
+```bash
+# Module usage in main.tf
+# module "vpc" {
+#   source  = "terraform-aws-modules/vpc/aws"
+#   version = "~> 5.0"
+#   name    = "my-vpc"
+#   cidr    = "10.0.0.0/16"
+# }
+
+# Download/update module sources
+terraform init -upgrade
+
+# List all module calls in config
+terraform providers
+```
+
+## Planning and Targeting
+
+```bash
+# Save plan to file (for apply in CI)
+terraform plan -out=tfplan
+terraform apply tfplan
+
+# Plan with detailed diff
+terraform plan -detailed-exitcode
+# Exit 0 = no changes, Exit 1 = error, Exit 2 = changes present
+
+# Apply only a specific resource
+terraform apply -target=aws_s3_bucket.app
+
+# Destroy only a specific resource
+terraform destroy -target=aws_s3_bucket.old
+
+# Refresh state from real infrastructure
+terraform refresh
+```
+
+## Outputs
+
+```bash
+# Show all outputs after apply
+terraform output
+
+# Show a specific output value
+terraform output bucket_name
+
+# Output as JSON
+terraform output -json
+```
+
+## Debugging
+
+```bash
+# Enable verbose logging
+TF_LOG=DEBUG terraform plan 2>&1 | head -100
+
+# Log to file
+TF_LOG=INFO TF_LOG_PATH=./terraform.log terraform apply
+
+# Show the dependency graph (requires graphviz)
+terraform graph | dot -Tsvg > graph.svg
+```
+
+## CI/CD Pattern
+
+```bash
+# Typical CI pipeline steps
+terraform init -input=false
+terraform validate
+terraform fmt -check -recursive        # fail if not formatted
+terraform plan -out=tfplan -input=false
+terraform apply -input=false tfplan
+```
+
+## Best Practices
+
+- Store state in a remote backend (S3 + DynamoDB for locking) — never commit `.tfstate` files.
+- Use workspaces or separate state files for production vs. staging.
+- Pin provider versions with `~>` constraints in `required_providers`.
+- Always run `terraform plan` and review output before `terraform apply`.
+- Use `terraform apply -target` with caution — it can leave state inconsistent.
+- Tag all resources with environment, owner, and `ManagedBy = "terraform"`.
+- Use `terraform fmt -recursive` in pre-commit hooks to keep code consistent.

--- a/skills/vector-db/SKILL.md
+++ b/skills/vector-db/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: vector-db
+description: "Work with vector databases for semantic search: Chroma, Qdrant, Weaviate. Embeddings, similarity search, collections, upsert, query patterns. Trigger: when using vector databases, semantic search, embeddings, Chroma, Qdrant, Weaviate, similarity search, RAG, vector search"
+version: 1
+argument-hint: "[chroma|qdrant|weaviate] [collection-name]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Vector Database Operations
+
+You are now operating in vector database management mode.
+
+## Chroma
+
+Chroma is an open-source embedding database. It can run locally (in-memory or persistent) or as a server.
+
+### Start Chroma Server
+
+```bash
+# Install Chroma CLI
+pip install chromadb
+
+# Start a persistent server
+chroma run --path ./chroma-data
+
+# Or with Docker
+docker run -d \
+  --name chroma \
+  -p 8000:8000 \
+  -v $(pwd)/chroma-data:/chroma/chroma \
+  chromadb/chroma:latest
+```
+
+### Chroma Python Usage
+
+```python
+import chromadb
+from chromadb.utils import embedding_functions
+
+# Connect to local server
+client = chromadb.HttpClient(host="localhost", port=8000)
+
+# Use Ollama embeddings (local)
+ef = embedding_functions.OllamaEmbeddingFunction(
+    url="http://localhost:11434/api/embeddings",
+    model_name="nomic-embed-text",
+)
+
+# Create or get a collection
+collection = client.get_or_create_collection(
+    name="documents",
+    embedding_function=ef,
+    metadata={"hnsw:space": "cosine"},
+)
+
+# Add documents
+collection.upsert(
+    ids=["doc1", "doc2", "doc3"],
+    documents=[
+        "Go is a statically typed compiled language.",
+        "Python is a dynamically typed interpreted language.",
+        "Rust focuses on memory safety and performance.",
+    ],
+    metadatas=[
+        {"source": "docs", "language": "go"},
+        {"source": "docs", "language": "python"},
+        {"source": "docs", "language": "rust"},
+    ],
+)
+
+# Query by semantic similarity
+results = collection.query(
+    query_texts=["compiled languages with type safety"],
+    n_results=2,
+)
+print(results["documents"])
+print(results["distances"])
+
+# Query with metadata filter
+results = collection.query(
+    query_texts=["memory management"],
+    n_results=1,
+    where={"language": {"$in": ["go", "rust"]}},
+)
+```
+
+## Qdrant
+
+Qdrant is a high-performance vector database written in Rust with a REST and gRPC API.
+
+### Start Qdrant Server
+
+```bash
+# Docker (persistent)
+docker run -d \
+  --name qdrant \
+  -p 6333:6333 \
+  -p 6334:6334 \
+  -v $(pwd)/qdrant-data:/qdrant/storage \
+  qdrant/qdrant:latest
+
+# Verify it's running
+curl -s http://localhost:6333/collections | jq .
+```
+
+### Qdrant REST API
+
+```bash
+# Create a collection
+curl -s -X PUT http://localhost:6333/collections/documents \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vectors": {
+      "size": 768,
+      "distance": "Cosine"
+    }
+  }' | jq .
+
+# Upsert points (vectors with payloads)
+curl -s -X PUT http://localhost:6333/collections/documents/points \
+  -H "Content-Type: application/json" \
+  -d '{
+    "points": [
+      {
+        "id": 1,
+        "vector": [0.1, 0.2, 0.3],
+        "payload": {"text": "Go language", "lang": "go"}
+      }
+    ]
+  }' | jq .
+
+# Search (semantic similarity)
+curl -s -X POST http://localhost:6333/collections/documents/points/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector": [0.1, 0.2, 0.3],
+    "limit": 5,
+    "with_payload": true
+  }' | jq .
+
+# Search with filter
+curl -s -X POST http://localhost:6333/collections/documents/points/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector": [0.1, 0.2, 0.3],
+    "limit": 5,
+    "filter": {
+      "must": [{"key": "lang", "match": {"value": "go"}}]
+    },
+    "with_payload": true
+  }' | jq .
+
+# List collections
+curl -s http://localhost:6333/collections | jq .
+
+# Collection info
+curl -s http://localhost:6333/collections/documents | jq .
+
+# Delete a collection
+curl -s -X DELETE http://localhost:6333/collections/documents | jq .
+```
+
+### Qdrant Go Client
+
+```go
+import (
+    "github.com/qdrant/go-client/qdrant"
+)
+
+client, err := qdrant.NewClient(&qdrant.Config{
+    Host: "localhost",
+    Port: 6334, // gRPC port
+})
+
+// Create collection
+client.CreateCollection(ctx, &qdrant.CreateCollection{
+    CollectionName: "documents",
+    VectorsConfig: qdrant.NewVectorsConfig(&qdrant.VectorParams{
+        Size:     768,
+        Distance: qdrant.Distance_Cosine,
+    }),
+})
+
+// Upsert points
+client.Upsert(ctx, &qdrant.UpsertPoints{
+    CollectionName: "documents",
+    Points: []*qdrant.PointStruct{
+        {
+            Id:      qdrant.NewIDNum(1),
+            Vectors: qdrant.NewVectors(0.1, 0.2, 0.3),
+            Payload: qdrant.NewValueMap(map[string]any{"text": "Go language"}),
+        },
+    },
+})
+
+// Search
+results, err := client.Query(ctx, &qdrant.QueryPoints{
+    CollectionName: "documents",
+    Query:          qdrant.NewQuery(0.1, 0.2, 0.3),
+    Limit:          qdrant.PtrOf(uint64(5)),
+    WithPayload:    qdrant.NewWithPayload(true),
+})
+```
+
+## Generating Embeddings (Ollama)
+
+```bash
+# Generate embedding via Ollama REST API
+curl -s http://localhost:11434/api/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "nomic-embed-text",
+    "input": "Go is a compiled language designed for simplicity and performance."
+  }' | jq '.embeddings[0] | length'   # should be 768 for nomic-embed-text
+```
+
+```python
+# Python: get embedding from Ollama
+import requests
+
+def embed(text: str, model: str = "nomic-embed-text") -> list[float]:
+    resp = requests.post(
+        "http://localhost:11434/api/embed",
+        json={"model": model, "input": text},
+    )
+    return resp.json()["embeddings"][0]
+```
+
+## RAG Pattern (Retrieval-Augmented Generation)
+
+```python
+# Full RAG pattern: embed query, search Chroma, generate with Ollama
+import chromadb, requests, json
+
+client = chromadb.HttpClient(host="localhost", port=8000)
+collection = client.get_collection("documents")
+
+def embed(text):
+    r = requests.post("http://localhost:11434/api/embed",
+                      json={"model": "nomic-embed-text", "input": text})
+    return r.json()["embeddings"][0]
+
+def rag_query(question: str, n_context: int = 3) -> str:
+    # 1. Embed the question
+    q_vec = embed(question)
+
+    # 2. Find similar documents
+    results = collection.query(query_embeddings=[q_vec], n_results=n_context)
+    context = "\n\n".join(results["documents"][0])
+
+    # 3. Generate answer using the retrieved context
+    prompt = f"Context:\n{context}\n\nQuestion: {question}\nAnswer:"
+    r = requests.post("http://localhost:11434/api/generate",
+                      json={"model": "llama3.2", "prompt": prompt, "stream": False})
+    return r.json()["response"]
+
+print(rag_query("What compiled languages prioritize type safety?"))
+```
+
+## Similarity Metrics
+
+| Metric | Use Case | Formula |
+|--------|----------|---------|
+| Cosine | Text similarity, NLP (most common) | cos(a, b) |
+| Dot Product | Retrieval when vectors are normalized | a · b |
+| Euclidean | Image similarity, dense features | ||a - b|| |
+
+## Best Practices
+
+- Normalize embeddings before storing (many models already do this).
+- Use the same model for indexing and querying — embedding spaces are model-specific.
+- Use metadata filtering to narrow search scope before vector similarity.
+- Persist Chroma/Qdrant data with mounted volumes in Docker.
+- For production, use Qdrant with replication or Weaviate clusters.
+- Store embedding model name in collection metadata to catch model mismatches.


### PR DESCRIPTION
## Summary
Adds 8 SKILL.md files across four issue tracks:

### Issue #56 — Docker Skills (4 skills)
- `skills/docker-build/SKILL.md` — multi-stage builds, build args, tagging conventions, cache optimization
- `skills/docker-push/SKILL.md` — push to DockerHub/ghcr.io/ECR, auth patterns, tagging
- `skills/docker-debug/SKILL.md` — `docker logs/exec/inspect/stats`, troubleshooting patterns
- `skills/docker-compose/SKILL.md` — `docker compose up/down/logs/exec`, networking, volumes

### Issue #57 — Railway Deployment (1 skill)
- `skills/railway-deploy/SKILL.md` — `railway up/deploy`, environment management, domains, secrets, logs

### Issue #73 — Terraform (1 skill)
- `skills/terraform/SKILL.md` — `terraform init/plan/apply/destroy`, state management, variables, workspaces, modules

### Issue #76 — AI/ML Skills (2 skills)
- `skills/ollama-ops/SKILL.md` — `ollama pull/run/list/serve`, Modelfile, API usage, model management
- `skills/vector-db/SKILL.md` — Chroma/Qdrant patterns, embeddings, similarity search

## Tests
- `skills/skills_validation_56_57_73_76_test.go` — regression tests for all 8 skills

## Test plan
- [x] All tests pass with `-race`

Closes #56
Closes #57
Closes #73
Closes #76