### PR TITLE
Add security, testing, and database skill files (Issues #83, #84, #85)

### DIFF
--- a/skills/cypress-testing/SKILL.md
+++ b/skills/cypress-testing/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: cypress-testing
+description: "Run end-to-end and component tests with Cypress: npx cypress open, npx cypress run, component testing, network intercepting, custom commands. Trigger: when using Cypress, cypress run, cypress open, e2e testing, component testing, cy.intercept, Cypress custom commands, browser testing"
+version: 1
+argument-hint: "[open|run] [--spec path] [--browser chrome]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Cypress Testing
+
+You are now operating in Cypress end-to-end and component testing mode.
+
+## Installation
+
+```bash
+# Install Cypress as a dev dependency
+npm install --save-dev cypress
+
+# Install with specific version
+npm install --save-dev cypress@13
+
+# Open Cypress for the first time (installs binaries, creates config)
+npx cypress open
+
+# Verify installation
+npx cypress verify
+
+# Check Cypress version
+npx cypress version
+```
+
+## Running Tests
+
+```bash
+# Open Cypress Test Runner (interactive GUI)
+npx cypress open
+
+# Run all tests headlessly (CI mode)
+npx cypress run
+
+# Run a specific test file
+npx cypress run --spec "cypress/e2e/login.cy.js"
+
+# Run multiple spec files with glob pattern
+npx cypress run --spec "cypress/e2e/auth/*.cy.js"
+
+# Run tests in a specific browser
+npx cypress run --browser chrome
+npx cypress run --browser firefox
+npx cypress run --browser edge
+npx cypress run --browser electron  # default headless
+
+# Run in headed mode (browser visible)
+npx cypress run --headed --browser chrome
+
+# Run component tests
+npx cypress run --component
+
+# Run e2e tests explicitly
+npx cypress run --e2e
+
+# Run with a specific base URL
+npx cypress run --config baseUrl=http://localhost:3000
+
+# Record results to Cypress Cloud
+npx cypress run --record --key $CYPRESS_RECORD_KEY
+
+# Run in parallel with Cypress Cloud
+npx cypress run --record --key $CYPRESS_RECORD_KEY --parallel
+```
+
+## Test File Structure
+
+```javascript
+// cypress/e2e/login.cy.js
+describe('Login', () => {
+  beforeEach(() => {
+    // Runs before each test
+    cy.visit('/login')
+  })
+
+  it('logs in with valid credentials', () => {
+    cy.get('[data-cy=email]').type('user@example.com')
+    cy.get('[data-cy=password]').type('password123')
+    cy.get('[data-cy=submit]').click()
+
+    cy.url().should('include', '/dashboard')
+    cy.get('[data-cy=welcome-message]').should('contain', 'Welcome')
+  })
+
+  it('shows error for invalid credentials', () => {
+    cy.get('[data-cy=email]').type('wrong@example.com')
+    cy.get('[data-cy=password]').type('wrongpassword')
+    cy.get('[data-cy=submit]').click()
+
+    cy.get('[data-cy=error-message]')
+      .should('be.visible')
+      .and('contain', 'Invalid credentials')
+  })
+})
+```
+
+## Component Testing
+
+```javascript
+// cypress/component/Button.cy.jsx
+import Button from '../../src/components/Button'
+
+describe('Button Component', () => {
+  it('renders with the correct label', () => {
+    cy.mount(<Button label="Click me" />)
+    cy.get('button').should('contain', 'Click me')
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClick = cy.stub().as('onClick')
+    cy.mount(<Button label="Click me" onClick={onClick} />)
+    cy.get('button').click()
+    cy.get('@onClick').should('have.been.calledOnce')
+  })
+
+  it('is disabled when disabled prop is true', () => {
+    cy.mount(<Button label="Submit" disabled />)
+    cy.get('button').should('be.disabled')
+  })
+})
+```
+
+## Network Intercepting
+
+```javascript
+// Intercept API calls and stub responses
+describe('User Profile', () => {
+  it('displays user data from API', () => {
+    // Intercept and stub the API call
+    cy.intercept('GET', '/api/user/profile', {
+      statusCode: 200,
+      body: {
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        role: 'admin'
+      }
+    }).as('getProfile')
+
+    cy.visit('/profile')
+    cy.wait('@getProfile')
+
+    cy.get('[data-cy=user-name]').should('contain', 'Jane Doe')
+    cy.get('[data-cy=user-role]').should('contain', 'admin')
+  })
+
+  it('handles API errors gracefully', () => {
+    cy.intercept('GET', '/api/user/profile', {
+      statusCode: 500,
+      body: { error: 'Internal Server Error' }
+    }).as('getProfileError')
+
+    cy.visit('/profile')
+    cy.wait('@getProfileError')
+
+    cy.get('[data-cy=error-banner]').should('be.visible')
+  })
+
+  it('intercepts POST requests', () => {
+    cy.intercept('POST', '/api/user/profile', (req) => {
+      // Assert request body
+      expect(req.body).to.have.property('name', 'John Updated')
+      req.reply({ statusCode: 200, body: { success: true } })
+    }).as('updateProfile')
+
+    cy.visit('/profile/edit')
+    cy.get('[data-cy=name-input]').clear().type('John Updated')
+    cy.get('[data-cy=save-button]').click()
+    cy.wait('@updateProfile')
+  })
+
+  it('intercepts with route matching', () => {
+    // Match by URL pattern
+    cy.intercept('GET', '/api/users/*').as('getUser')
+    cy.intercept('GET', { url: '/api/**', method: 'GET' }).as('anyGet')
+
+    // Intercept and modify the real response
+    cy.intercept('GET', '/api/config', (req) => {
+      req.continue((res) => {
+        res.body.featureFlag = true  // inject feature flag
+      })
+    })
+  })
+})
+```
+
+## Custom Commands
+
+```javascript
+// cypress/support/commands.js
+
+// Custom login command
+Cypress.Commands.add('login', (email, password) => {
+  cy.session([email, password], () => {
+    cy.visit('/login')
+    cy.get('[data-cy=email]').type(email)
+    cy.get('[data-cy=password]').type(password)
+    cy.get('[data-cy=submit]').click()
+    cy.url().should('include', '/dashboard')
+  })
+})
+
+// Custom API login (faster than UI login)
+Cypress.Commands.add('loginByApi', (email, password) => {
+  cy.request({
+    method: 'POST',
+    url: '/api/auth/login',
+    body: { email, password }
+  }).then((response) => {
+    window.localStorage.setItem('token', response.body.token)
+  })
+})
+
+// Custom command to check accessibility
+Cypress.Commands.add('checkA11y', (selector) => {
+  cy.injectAxe()
+  cy.checkA11y(selector)
+})
+
+// Custom drag-and-drop command
+Cypress.Commands.add('dragTo', { prevSubject: 'element' }, (subject, targetSelector) => {
+  cy.wrap(subject).trigger('mousedown', { button: 0 })
+  cy.get(targetSelector).trigger('mousemove').trigger('mouseup', { force: true })
+})
+
+// Usage in tests:
+// cy.login('user@example.com', 'password123')
+// cy.loginByApi('user@example.com', 'password123')
+// cy.get('.draggable').dragTo('.dropzone')
+```
+
+## Cypress Configuration
+
+```javascript
+// cypress.config.js
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    viewportWidth: 1280,
+    viewportHeight: 720,
+    defaultCommandTimeout: 10000,
+    requestTimeout: 10000,
+    responseTimeout: 30000,
+    video: true,
+    screenshotOnRunFailure: true,
+    experimentalStudio: true,  // record test actions
+
+    setupNodeEvents(on, config) {
+      // Register plugins
+      require('@cypress/code-coverage/task')(on, config)
+      return config
+    },
+
+    // Exclude patterns
+    excludeSpecPattern: ['**/examples/**', '**/__snapshots__/**'],
+
+    // Environment variables accessible in tests
+    env: {
+      apiUrl: 'http://localhost:8080/api',
+      username: 'testuser',
+    }
+  },
+
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'vite'
+    },
+    specPattern: 'src/**/*.cy.{js,jsx,ts,tsx}'
+  }
+})
+```
+
+## Common Assertions
+
+```javascript
+// Element assertions
+cy.get('.button').should('be.visible')
+cy.get('.button').should('not.exist')
+cy.get('.button').should('be.disabled')
+cy.get('.button').should('have.class', 'active')
+cy.get('.button').should('have.attr', 'href', '/home')
+cy.get('.input').should('have.value', 'expected text')
+cy.get('.list').should('have.length', 5)
+
+// Text assertions
+cy.get('h1').should('contain.text', 'Welcome')
+cy.get('p').invoke('text').should('match', /\d+ items/)
+
+// URL assertions
+cy.url().should('include', '/dashboard')
+cy.url().should('eq', 'http://localhost:3000/login')
+
+// Cookie and localStorage
+cy.getCookie('session').should('exist')
+cy.window().its('localStorage.token').should('exist')
+
+// Multiple assertions chained
+cy.get('[data-cy=user-card]')
+  .should('be.visible')
+  .and('contain', 'John Doe')
+  .and('not.have.class', 'loading')
+```
+
+## Fixtures and Test Data
+
+```javascript
+// cypress/fixtures/user.json
+// {
+//   "name": "Test User",
+//   "email": "test@example.com",
+//   "role": "admin"
+// }
+
+// Using fixtures in tests
+cy.fixture('user').then((user) => {
+  cy.get('[data-cy=name]').type(user.name)
+  cy.get('[data-cy=email]').type(user.email)
+})
+
+// Intercept with fixture
+cy.intercept('GET', '/api/user', { fixture: 'user.json' }).as('getUser')
+```
+
+## CI/CD Integration
+
+```bash
+# Install dependencies and run tests
+npm ci
+npx cypress run --browser chrome --headless
+
+# With environment variables
+CYPRESS_BASE_URL=https://staging.example.com \
+  CYPRESS_API_TOKEN=secret \
+  npx cypress run
+
+# Run with retries for flaky tests
+npx cypress run --config retries=2
+
+# Generate JUnit XML report for CI
+npx cypress run --reporter junit --reporter-options "mochaFile=results/test-[hash].xml"
+```
+
+```yaml
+# GitHub Actions
+- name: Run Cypress tests
+  uses: cypress-io/github-action@v6
+  with:
+    build: npm run build
+    start: npm start
+    browser: chrome
+    record: true
+  env:
+    CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Troubleshooting
+
+```bash
+# Clear Cypress cache
+npx cypress cache clear
+npx cypress cache prune  # remove old versions
+
+# Verify Cypress binary
+npx cypress verify
+
+# Run with debug output
+DEBUG=cypress:* npx cypress run
+
+# Common issues:
+# Tests timing out — increase defaultCommandTimeout in cypress.config.js
+# Flaky tests — use cy.intercept() to control network, add retries
+# Element not found — check selector, add cy.wait() or use .should('be.visible')
+# CORS errors — configure proxy in cypress.config.js or intercept requests
+# Login required — use cy.session() or loginByApi custom command
+```

--- a/skills/load-testing/SKILL.md
+++ b/skills/load-testing/SKILL.md
@@ -1,0 +1,456 @@
+---
+name: load-testing
+description: "Run load and performance tests with k6 or vegeta: test scripts, ramp-up patterns, threshold configuration, results analysis. Trigger: when using k6, vegeta, load testing, performance testing, stress testing, k6 run, vegeta attack, ramp-up, throughput testing, latency testing"
+version: 1
+argument-hint: "[k6 run|vegeta attack] [script.js|--rate=100] [--vus 50 --duration 30s]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Load Testing
+
+You are now operating in load and performance testing mode.
+
+## Tool Selection
+
+- **k6**: JavaScript-based, excellent for complex scenarios, great for APIs and web apps
+- **vegeta**: Go-based, simple CLI, ideal for constant-rate HTTP load testing
+
+## k6 — JavaScript Load Testing
+
+### Installation
+
+```bash
+# macOS (via Homebrew)
+brew install k6
+
+# Linux (Debian/Ubuntu)
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+
+# Via Docker
+docker run --rm grafana/k6 run - <script.js
+
+# Verify installation
+k6 version
+```
+
+### Basic k6 Script
+
+```javascript
+// script.js
+import http from 'k6/http'
+import { sleep, check } from 'k6'
+
+export const options = {
+  vus: 10,           // virtual users
+  duration: '30s',   // test duration
+}
+
+export default function () {
+  const res = http.get('http://localhost:8080/api/health')
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response time < 500ms': (r) => r.timings.duration < 500,
+  })
+
+  sleep(1)  // think time between requests
+}
+```
+
+```bash
+# Run the script
+k6 run script.js
+
+# Run with more virtual users
+k6 run --vus 50 --duration 60s script.js
+
+# Run with output to JSON
+k6 run --out json=results.json script.js
+```
+
+### Ramp-Up Patterns
+
+```javascript
+// Gradual ramp-up (recommended for production load tests)
+export const options = {
+  stages: [
+    { duration: '1m', target: 20 },   // ramp up to 20 VUs over 1 minute
+    { duration: '3m', target: 20 },   // hold at 20 VUs for 3 minutes
+    { duration: '1m', target: 50 },   // ramp up to 50 VUs
+    { duration: '3m', target: 50 },   // hold at 50 VUs
+    { duration: '1m', target: 0 },    // ramp down to 0
+  ],
+}
+
+// Spike test (sudden traffic burst)
+export const options = {
+  stages: [
+    { duration: '1m', target: 10 },   // warm up
+    { duration: '30s', target: 200 }, // spike to 200 VUs
+    { duration: '1m', target: 10 },   // recover
+    { duration: '1m', target: 0 },    // ramp down
+  ],
+}
+
+// Stress test (find breaking point)
+export const options = {
+  stages: [
+    { duration: '2m', target: 100 },
+    { duration: '2m', target: 200 },
+    { duration: '2m', target: 300 },
+    { duration: '2m', target: 400 },
+    { duration: '2m', target: 0 },
+  ],
+}
+
+// Soak test (extended duration at expected load)
+export const options = {
+  stages: [
+    { duration: '5m', target: 50 },   // ramp up
+    { duration: '4h', target: 50 },   // hold for 4 hours
+    { duration: '5m', target: 0 },    // ramp down
+  ],
+}
+```
+
+### Threshold Configuration
+
+```javascript
+// Define pass/fail criteria
+export const options = {
+  vus: 50,
+  duration: '2m',
+  thresholds: {
+    // 95th percentile response time must be below 500ms
+    http_req_duration: ['p(95)<500'],
+
+    // 99th percentile must be below 1 second
+    'http_req_duration{expected_response:true}': ['p(99)<1000'],
+
+    // Error rate must be below 1%
+    http_req_failed: ['rate<0.01'],
+
+    // Custom metric threshold
+    'checks{check:status is 200}': ['rate>0.99'],
+
+    // Multiple thresholds for same metric
+    http_req_duration: ['p(90)<300', 'p(95)<500', 'p(99)<1000'],
+  },
+}
+```
+
+### POST Requests and Authentication
+
+```javascript
+import http from 'k6/http'
+import { check, sleep } from 'k6'
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080'
+const API_TOKEN = __ENV.API_TOKEN
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 20 },
+    { duration: '1m', target: 20 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.05'],
+  },
+}
+
+export default function () {
+  const headers = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${API_TOKEN}`,
+  }
+
+  // POST request
+  const payload = JSON.stringify({
+    title: 'Test item',
+    description: 'Load test payload',
+  })
+
+  const createRes = http.post(`${BASE_URL}/api/items`, payload, { headers })
+  check(createRes, {
+    'item created': (r) => r.status === 201,
+    'has item id': (r) => r.json('id') !== undefined,
+  })
+
+  if (createRes.status === 201) {
+    const id = createRes.json('id')
+
+    // GET request with the created ID
+    const getRes = http.get(`${BASE_URL}/api/items/${id}`, { headers })
+    check(getRes, {
+      'item found': (r) => r.status === 200,
+    })
+  }
+
+  sleep(1)
+}
+```
+
+### Custom Metrics
+
+```javascript
+import { Trend, Counter, Rate, Gauge } from 'k6/metrics'
+
+const loginDuration = new Trend('login_duration')
+const loginErrors = new Counter('login_errors')
+const loginSuccessRate = new Rate('login_success')
+const activeUsers = new Gauge('active_users')
+
+export default function () {
+  const start = Date.now()
+
+  const res = http.post('/api/auth/login', { ... })
+
+  loginDuration.add(Date.now() - start)
+
+  if (res.status !== 200) {
+    loginErrors.add(1)
+    loginSuccessRate.add(false)
+  } else {
+    loginSuccessRate.add(true)
+  }
+
+  activeUsers.add(1)
+}
+```
+
+### Running k6
+
+```bash
+# Basic run
+k6 run script.js
+
+# With environment variables
+k6 run --env BASE_URL=https://staging.example.com --env API_TOKEN=$TOKEN script.js
+
+# With output to various sinks
+k6 run --out json=results.json script.js
+k6 run --out influxdb=http://localhost:8086/k6 script.js
+k6 run --out csv=results.csv script.js
+
+# Run with quiet mode (less output)
+k6 run --quiet script.js
+
+# Abort on first threshold breach
+k6 run --abort-on-fail script.js
+
+# Run with tags (for filtering results)
+k6 run --tag environment=staging script.js
+
+# List results summary
+k6 run script.js | tee load-test-results.txt
+```
+
+## vegeta — HTTP Load Testing Tool
+
+### Installation
+
+```bash
+# macOS (via Homebrew)
+brew install vegeta
+
+# Download binary from GitHub releases
+# https://github.com/tsenart/vegeta/releases
+
+# Verify installation
+vegeta -version
+```
+
+### Basic Usage
+
+```bash
+# Simple constant-rate attack
+echo "GET http://localhost:8080/api/health" | \
+  vegeta attack -rate=100 -duration=30s | \
+  vegeta report
+
+# Rate: 100 requests per second for 30 seconds
+
+# Attack with specific duration
+echo "GET http://localhost:8080/" | \
+  vegeta attack -rate=50 -duration=60s | \
+  tee results.bin | \
+  vegeta report
+```
+
+### vegeta Targets File
+
+```bash
+# targets.txt — define requests
+GET http://localhost:8080/api/health
+Authorization: Bearer mytoken
+
+GET http://localhost:8080/api/users
+
+POST http://localhost:8080/api/items
+Content-Type: application/json
+@body.json
+```
+
+```bash
+# body.json
+# {"title": "test", "description": "load test"}
+
+# Run with targets file
+vegeta attack -targets=targets.txt -rate=100 -duration=30s | \
+  vegeta report
+```
+
+### vegeta Output Formats
+
+```bash
+# Text report (default)
+vegeta attack -rate=100 -duration=30s -targets=targets.txt | \
+  vegeta report
+
+# JSON report
+vegeta attack -rate=100 -duration=30s -targets=targets.txt | \
+  vegeta report -type=json > report.json
+
+# Histogram report
+vegeta attack -rate=100 -duration=30s -targets=targets.txt | \
+  vegeta report -type=hdrplot > hdr.txt
+
+# Plot (generates HTML graph)
+vegeta attack -rate=100 -duration=30s -targets=targets.txt | \
+  vegeta plot > plot.html && open plot.html
+
+# Save results for later analysis
+vegeta attack -rate=100 -duration=30s -targets=targets.txt > results.bin
+vegeta report < results.bin
+vegeta plot < results.bin > plot.html
+```
+
+### vegeta Ramp-Up with Pacer
+
+```bash
+# Linear ramp-up from 10 to 100 rps over 30 seconds
+vegeta attack \
+  -rate=10 \
+  -duration=30s \
+  -targets=targets.txt | vegeta report
+
+# For ramp-up, generate a target file and use a script:
+# vegeta doesn't natively support ramp-up; use k6 for complex scenarios
+```
+
+### Analyzing Results
+
+```bash
+# Full text report
+vegeta report < results.bin
+
+# Example output:
+# Requests      [total, rate, throughput] 3000, 100.00, 99.50/s
+# Duration      [total, attack, wait]     30.005s, 30.000s, 4.567ms
+# Latencies     [min, mean, 50, 90, 95, 99, max] 1.2ms, 4.5ms, 3.1ms, 8.2ms, 12.1ms, 45.6ms, 234ms
+# Bytes In      [total, mean]             450000, 150.00
+# Bytes Out     [total, mean]             0, 0.00
+# Success       [ratio]                   99.80%
+# Status Codes  [code:count]              200:2994 500:6
+# Error Set:
+# 500 Internal Server Error
+
+# Parse JSON report for programmatic use
+vegeta report -type=json < results.bin | jq '{
+  requests: .requests,
+  success_ratio: .success,
+  latency_p95: .latencies.p95,
+  latency_p99: .latencies.p99,
+  status_codes: .status_codes
+}'
+```
+
+## CI/CD Integration
+
+```bash
+#!/bin/bash
+# load-test.sh — run in CI after deployment
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+PASS_P95_MS="${PASS_P95_MS:-500}"
+
+# Run k6 test
+k6 run \
+  --env BASE_URL="$BASE_URL" \
+  --env API_TOKEN="$API_TOKEN" \
+  --out json=results.json \
+  load-test.js
+
+# Check thresholds passed
+if [ $? -ne 0 ]; then
+  echo "Load test FAILED: thresholds not met"
+  exit 1
+fi
+
+echo "Load test PASSED"
+```
+
+```yaml
+# GitHub Actions
+- name: Run load tests
+  run: |
+    k6 run \
+      --env BASE_URL=${{ secrets.STAGING_URL }} \
+      --env API_TOKEN=${{ secrets.API_TOKEN }} \
+      load-test.js
+  if: github.ref == 'refs/heads/main'
+```
+
+## Interpreting Results
+
+### Key Metrics to Monitor
+
+| Metric | Target | Warning | Critical |
+|--------|--------|---------|----------|
+| p50 latency | <100ms | >200ms | >500ms |
+| p95 latency | <500ms | >1s | >2s |
+| p99 latency | <1s | >2s | >5s |
+| Error rate | <0.1% | >1% | >5% |
+| Throughput | >target RPS | <80% target | <50% target |
+
+```bash
+# Parse k6 JSON output for key metrics
+jq -r '
+  select(.type == "Point" and .metric == "http_req_duration") |
+  .data.tags.percentile as $p |
+  select($p == "p(95)") |
+  "\(.data.time) p95=\(.data.value)ms"
+' results.json | tail -20
+
+# Check if thresholds were met
+jq '.root_group.checks | to_entries[] | {name: .key, passes: .value.passes, fails: .value.fails}' results.json
+```
+
+## Troubleshooting
+
+```bash
+# k6: increase file descriptor limit for high VU counts
+ulimit -n 65535
+
+# k6: debug HTTP requests
+k6 run --http-debug=full script.js
+
+# vegeta: verbose output
+vegeta attack -rate=10 -duration=5s -targets=targets.txt 2>&1
+
+# Common issues:
+# Connection refused — ensure the target server is running
+# Too many open files — increase ulimit before testing
+# Results plateau — server is at capacity; this is expected behavior
+# High latency variance — network or GC pauses; run from same region as target
+```

--- a/skills/neon-branching/SKILL.md
+++ b/skills/neon-branching/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: neon-branching
+description: "Manage Neon serverless Postgres database branches: branch-per-PR workflow, neon branch create/delete, connection strings, reset branch from parent. Trigger: when using Neon database, neon branch create, neon branch delete, Neon branching, database branching, branch-per-PR, Neon Postgres"
+version: 1
+argument-hint: "[branch create|delete|list|get] [--name branch-name] [--project-id proj-id]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Neon Database Branching
+
+You are now operating in Neon serverless Postgres branching mode.
+
+## Installation and Setup
+
+```bash
+# Install Neon CLI
+npm install -g neonctl
+
+# macOS (via Homebrew)
+brew install neonctl
+
+# Authenticate with Neon (opens browser)
+neonctl auth
+
+# Authenticate with API key (CI/CD)
+neonctl auth --token $NEON_API_KEY
+
+# Verify authentication
+neonctl me
+
+# Set default project (avoids --project-id on every command)
+neonctl set-context --project-id <project-id>
+
+# List your projects
+neonctl projects list
+```
+
+## Branch Management
+
+```bash
+# List all branches in a project
+neonctl branches list
+neonctl branches list --project-id <project-id>
+
+# Get branch details
+neonctl branches get main
+neonctl branches get my-feature-branch
+
+# Create a branch from the default (main) branch
+neonctl branches create --name my-feature-branch
+
+# Create a branch from a specific parent branch
+neonctl branches create --name feature-db-v2 --parent staging
+
+# Create a branch from a specific point in time (point-in-time restore)
+neonctl branches create \
+  --name restore-to-yesterday \
+  --parent main \
+  --parent-timestamp 2024-01-15T10:00:00Z
+
+# Create a branch from a specific LSN (Log Sequence Number)
+neonctl branches create \
+  --name restore-to-lsn \
+  --parent main \
+  --parent-lsn 0/18B5F28
+
+# Delete a branch
+neonctl branches delete my-feature-branch
+
+# Rename a branch
+neonctl branches rename my-feature-branch --name my-renamed-branch
+
+# Set branch as primary (makes it the default branch)
+neonctl branches set-primary my-branch
+
+# Reset branch to match parent HEAD (discard all changes)
+neonctl branches reset my-feature-branch --parent
+```
+
+## Connection Strings
+
+```bash
+# Get connection string for a branch (uses default compute)
+neonctl connection-string my-feature-branch
+
+# Get connection string for the main branch
+neonctl connection-string main
+
+# Get connection string with specific role and database
+neonctl connection-string my-branch \
+  --role-name myuser \
+  --database-name mydb
+
+# Get pooled connection string (PgBouncer)
+neonctl connection-string my-branch --pooled
+
+# Output as environment variable format
+neonctl connection-string my-branch --output env
+
+# Store connection string in shell variable
+BRANCH_DB_URL=$(neonctl connection-string my-feature-branch)
+export DATABASE_URL="$BRANCH_DB_URL"
+
+# Output connection string components separately
+neonctl connection-string my-branch --output json | jq '{
+  host: .host,
+  port: .port,
+  database: .dbname,
+  user: .user,
+  password: .password
+}'
+```
+
+## Branch-per-PR Workflow
+
+This is the primary Neon use case: create a fresh database branch for each pull request, run migrations, test, then delete the branch when the PR closes.
+
+### Manual Workflow
+
+```bash
+# 1. Create branch when PR opens (use PR number as branch name)
+PR_NUMBER=42
+BRANCH_NAME="pr-${PR_NUMBER}"
+
+neonctl branches create --name "$BRANCH_NAME" --parent main
+
+# 2. Get connection string
+DB_URL=$(neonctl connection-string "$BRANCH_NAME")
+export DATABASE_URL="$DB_URL"
+
+# 3. Run migrations on the branch
+npm run db:migrate
+# or: goose up
+# or: flyway migrate
+
+# 4. Run integration tests
+npm test
+
+# 5. Delete branch when PR closes
+neonctl branches delete "$BRANCH_NAME"
+```
+
+### GitHub Actions Automation
+
+```yaml
+# .github/workflows/preview-db.yml
+name: Preview Database Branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  setup-db-branch:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neon CLI
+        run: npm install -g neonctl
+
+      - name: Create database branch
+        id: create-branch
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          BRANCH_NAME="pr-${{ github.event.number }}"
+
+          # Create branch (idempotent: delete if exists, then create)
+          neonctl branches delete "$BRANCH_NAME" 2>/dev/null || true
+          neonctl branches create \
+            --name "$BRANCH_NAME" \
+            --parent main \
+            --project-id "$PROJECT_ID"
+
+          # Get connection string
+          DB_URL=$(neonctl connection-string "$BRANCH_NAME" \
+            --project-id "$PROJECT_ID" \
+            --role-name neondb_owner \
+            --database-name neondb)
+
+          echo "db_url=$DB_URL" >> $GITHUB_OUTPUT
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url }}
+        run: npm run db:migrate
+
+      - name: Run tests
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url }}
+        run: npm test
+
+      - name: Comment PR with branch URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🗄️ Preview database branch: `${{ steps.create-branch.outputs.branch_name }}`'
+            })
+
+  cleanup-db-branch:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete database branch
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+        run: |
+          npm install -g neonctl
+          BRANCH_NAME="pr-${{ github.event.number }}"
+          neonctl branches delete "$BRANCH_NAME" \
+            --project-id "$PROJECT_ID" || true
+```
+
+### Vercel Integration Pattern
+
+```bash
+# In vercel.json or deployment scripts
+# Neon integrates with Vercel for automatic preview branch creation
+
+# Manual equivalent with Vercel CLI
+vercel env add DATABASE_URL preview "$(neonctl connection-string pr-42)"
+```
+
+## Compute Endpoints
+
+Each branch can have multiple compute endpoints. By default, endpoints use autosuspend.
+
+```bash
+# List endpoints for a branch
+neonctl endpoints list --branch my-feature-branch
+
+# Create an additional endpoint for a branch (e.g., read replica)
+neonctl endpoints create \
+  --branch my-feature-branch \
+  --type read_only
+
+# Get endpoint details
+neonctl endpoints get <endpoint-id>
+
+# Start a suspended endpoint
+neonctl endpoints start <endpoint-id>
+
+# Suspend an endpoint (saves compute costs)
+neonctl endpoints suspend <endpoint-id>
+
+# Delete an endpoint
+neonctl endpoints delete <endpoint-id>
+
+# Update compute size
+neonctl endpoints update <endpoint-id> --cu-min 0.25 --cu-max 2
+```
+
+## Database and Role Management
+
+```bash
+# List databases in a branch
+neonctl databases list --branch my-feature-branch
+
+# Create a database in a branch
+neonctl databases create mydb --branch my-feature-branch
+
+# Delete a database
+neonctl databases delete mydb --branch my-feature-branch
+
+# List roles
+neonctl roles list --branch my-feature-branch
+
+# Create a role
+neonctl roles create myuser --branch my-feature-branch
+
+# Get role password (for connection strings)
+neonctl roles get myuser --branch my-feature-branch
+```
+
+## Point-in-Time Restore
+
+```bash
+# Restore a branch to a specific timestamp
+# (Creates a new branch, doesn't modify existing)
+neonctl branches create \
+  --name restored-20240115 \
+  --parent main \
+  --parent-timestamp 2024-01-15T10:00:00Z
+
+# After restoring, swap connection strings in your app
+# or reset the production branch from the restored branch
+
+# Reset production from a restored point (DESTRUCTIVE)
+# This replaces production's data with the restored branch's data
+neonctl branches reset production --parent restored-20240115
+
+# Alternative: rename branches to swap
+neonctl branches rename production --name production-backup
+neonctl branches rename restored-20240115 --name production
+```
+
+## Using Neon via REST API
+
+```bash
+# Base URL
+NEON_API="https://console.neon.tech/api/v2"
+AUTH="Authorization: Bearer $NEON_API_KEY"
+
+# List branches
+curl -s -H "$AUTH" \
+  "$NEON_API/projects/$PROJECT_ID/branches" | jq '.branches[] | {id, name, created_at}'
+
+# Create a branch
+curl -s -X POST -H "$AUTH" -H "Content-Type: application/json" \
+  "$NEON_API/projects/$PROJECT_ID/branches" \
+  -d '{
+    "branch": {"name": "my-branch", "parent_id": "main-branch-id"},
+    "endpoints": [{"type": "read_write"}]
+  }' | jq .
+
+# Delete a branch
+curl -s -X DELETE -H "$AUTH" \
+  "$NEON_API/projects/$PROJECT_ID/branches/$BRANCH_ID"
+
+# Get connection URI
+curl -s -H "$AUTH" \
+  "$NEON_API/projects/$PROJECT_ID/connection_uri?branch_id=$BRANCH_ID&role_name=neondb_owner&database_name=neondb" | \
+  jq -r '.uri'
+```
+
+## Cost Management
+
+```bash
+# Autosuspend prevents charges when branch is idle
+# Branches suspend automatically after inactivity (default: 5 minutes)
+
+# Check current compute state
+neonctl endpoints list | jq '.endpoints[] | {id, current_state, autosuspend_duration_seconds}'
+
+# Branches share storage — only incremental changes cost extra
+# Delete unused PR branches promptly to avoid storage costs
+
+# Estimate branch storage
+neonctl branches get my-branch | jq '.branch.logical_size'
+
+# Check project usage/billing
+neonctl projects get $PROJECT_ID | jq '.project | {
+  data_storage_bytes_hour: .data_storage_bytes_hour,
+  compute_time_seconds: .compute_time_seconds
+}'
+```
+
+## Troubleshooting
+
+```bash
+# Verbose output for debugging
+neonctl --debug branches list
+
+# Check CLI version
+neonctl --version
+
+# Re-authenticate if token expired
+neonctl auth
+
+# Check project ID
+neonctl projects list | jq '.projects[] | {id, name}'
+
+# Common issues:
+# "Branch not found" — check name with: neonctl branches list
+# "Endpoint is starting" — branches may take 1-3s to start after autosuspend
+# "Too many connections" — use pooled connection string with --pooled flag
+# "Auth token expired" — run: neonctl auth
+# Connection timeout — check endpoint state: neonctl endpoints list
+```

--- a/skills/redis-ops/SKILL.md
+++ b/skills/redis-ops/SKILL.md
@@ -1,0 +1,476 @@
+---
+name: redis-ops
+description: "Operate Redis with redis-cli: key patterns, pub/sub, Lua scripting, memory analysis, cluster operations. Trigger: when using Redis, redis-cli, Redis keys, pub/sub messaging, Redis scripting, Redis cluster, Redis memory, KEYS pattern, SCAN, Redis streams"
+version: 1
+argument-hint: "[cli|monitor|info|cluster] [command] [args]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Redis Operations
+
+You are now operating in Redis management and operations mode.
+
+## Installation and Connection
+
+```bash
+# macOS (via Homebrew)
+brew install redis
+
+# Start Redis server
+redis-server
+
+# Start with config file
+redis-server /usr/local/etc/redis.conf
+
+# Start Redis in background
+redis-server --daemonize yes
+
+# Connect with redis-cli (local default)
+redis-cli
+
+# Connect to remote server
+redis-cli -h redis.example.com -p 6379
+
+# Connect with password
+redis-cli -h redis.example.com -p 6379 -a mypassword
+
+# Connect with TLS
+redis-cli --tls -h redis.example.com -p 6380
+
+# Check server connectivity
+redis-cli ping  # returns PONG
+
+# Check Redis version
+redis-cli info server | grep redis_version
+```
+
+## Basic Key Operations
+
+```bash
+# Set a key
+redis-cli SET mykey "hello world"
+redis-cli SET mykey "hello" EX 3600  # with TTL of 1 hour
+redis-cli SET mykey "hello" PX 60000 # with TTL of 60 seconds (ms)
+redis-cli SET mykey "hello" NX       # only set if not exists
+redis-cli SET mykey "hello" XX       # only set if exists
+
+# Get a key
+redis-cli GET mykey
+
+# Check if a key exists
+redis-cli EXISTS mykey  # returns 1 (exists) or 0 (not found)
+
+# Delete a key
+redis-cli DEL mykey
+redis-cli DEL key1 key2 key3  # delete multiple
+
+# Get remaining TTL
+redis-cli TTL mykey    # in seconds, -1 = no expiry, -2 = not found
+redis-cli PTTL mykey   # in milliseconds
+
+# Set TTL on an existing key
+redis-cli EXPIRE mykey 3600    # seconds
+redis-cli EXPIREAT mykey 1735689600  # Unix timestamp
+
+# Remove TTL (make persistent)
+redis-cli PERSIST mykey
+
+# Rename a key
+redis-cli RENAME oldkey newkey
+redis-cli RENAMENX oldkey newkey  # only if newkey doesn't exist
+
+# Get key type
+redis-cli TYPE mykey  # string, list, set, zset, hash, stream
+
+# Atomically get and set
+redis-cli GETSET mykey "newvalue"
+redis-cli GETDEL mykey  # get and delete
+```
+
+## Key Patterns and SCAN
+
+```bash
+# IMPORTANT: Never use KEYS in production — it blocks the server
+# Use SCAN instead for safe iteration
+
+# Scan through all keys (cursor-based, non-blocking)
+redis-cli SCAN 0
+
+# Scan with a pattern
+redis-cli SCAN 0 MATCH "user:*"
+redis-cli SCAN 0 MATCH "session:*" COUNT 100
+
+# Full scan loop in bash
+cursor=0
+while true; do
+  result=$(redis-cli SCAN $cursor MATCH "user:*" COUNT 100)
+  cursor=$(echo "$result" | head -1)
+  keys=$(echo "$result" | tail -n +2)
+  if [ -n "$keys" ]; then
+    echo "$keys"
+  fi
+  if [ "$cursor" = "0" ]; then break; fi
+done
+
+# Count keys matching a pattern (safe)
+redis-cli --scan --pattern "user:*" | wc -l
+
+# Find keys by type
+redis-cli --scan --pattern "*" | while read key; do
+  type=$(redis-cli TYPE "$key")
+  if [ "$type" = "hash" ]; then
+    echo "$key"
+  fi
+done
+
+# Delete all keys matching a pattern (use carefully)
+redis-cli --scan --pattern "session:*" | xargs redis-cli DEL
+
+# Use SCAN with HSCAN, SSCAN, ZSCAN for collection iteration
+redis-cli HSCAN myhash 0 MATCH "field*" COUNT 50
+redis-cli SSCAN myset 0 COUNT 100
+redis-cli ZSCAN myzset 0 MATCH "*" COUNT 100
+```
+
+## Data Structures
+
+```bash
+# --- Strings ---
+redis-cli INCR counter          # atomic increment
+redis-cli INCRBY counter 10
+redis-cli DECR counter
+redis-cli APPEND mykey " world" # append to string
+
+# --- Hashes ---
+redis-cli HSET user:1 name "Alice" email "alice@example.com" age 30
+redis-cli HGET user:1 name
+redis-cli HGETALL user:1         # get all fields
+redis-cli HMSET user:2 name "Bob" email "bob@example.com"
+redis-cli HMGET user:1 name email
+redis-cli HDEL user:1 age
+redis-cli HEXISTS user:1 name
+redis-cli HLEN user:1            # number of fields
+redis-cli HKEYS user:1           # all field names
+redis-cli HVALS user:1           # all values
+
+# --- Lists ---
+redis-cli LPUSH mylist a b c    # push left (c b a order)
+redis-cli RPUSH mylist d e f    # push right (a b c d e f)
+redis-cli LPOP mylist           # pop from left
+redis-cli RPOP mylist           # pop from right
+redis-cli LRANGE mylist 0 -1    # all elements
+redis-cli LRANGE mylist 0 9     # first 10 elements
+redis-cli LLEN mylist
+redis-cli LINDEX mylist 0       # element at index
+redis-cli LINSERT mylist BEFORE "b" "x"
+redis-cli BLPOP mylist 5        # blocking pop with 5s timeout
+
+# --- Sets ---
+redis-cli SADD myset a b c d
+redis-cli SREM myset a
+redis-cli SISMEMBER myset b     # check membership
+redis-cli SMEMBERS myset        # all members
+redis-cli SCARD myset           # cardinality
+redis-cli SUNION set1 set2      # union
+redis-cli SINTER set1 set2      # intersection
+redis-cli SDIFF set1 set2       # difference
+
+# --- Sorted Sets ---
+redis-cli ZADD leaderboard 100 "player1" 200 "player2" 150 "player3"
+redis-cli ZSCORE leaderboard "player1"
+redis-cli ZRANK leaderboard "player1"   # rank (0-based, lowest first)
+redis-cli ZREVRANK leaderboard "player1" # rank (highest first)
+redis-cli ZRANGE leaderboard 0 -1 WITHSCORES
+redis-cli ZREVRANGE leaderboard 0 9 WITHSCORES  # top 10
+redis-cli ZRANGEBYSCORE leaderboard 100 200 WITHSCORES
+redis-cli ZINCRBY leaderboard 50 "player1"
+redis-cli ZREM leaderboard "player1"
+redis-cli ZCARD leaderboard
+```
+
+## Pub/Sub Messaging
+
+```bash
+# Subscribe to a channel (blocks, waiting for messages)
+redis-cli SUBSCRIBE my-channel
+
+# Subscribe to multiple channels
+redis-cli SUBSCRIBE channel1 channel2 channel3
+
+# Subscribe with pattern matching
+redis-cli PSUBSCRIBE "user:*" "event:*"
+
+# Publish a message (from another terminal/connection)
+redis-cli PUBLISH my-channel "Hello, subscribers!"
+redis-cli PUBLISH user:123 '{"event":"login","timestamp":1700000000}'
+
+# List active subscriptions (from another connection)
+redis-cli PUBSUB CHANNELS        # all active channels
+redis-cli PUBSUB CHANNELS "user:*"  # channels matching pattern
+redis-cli PUBSUB NUMSUB channel1 channel2  # subscriber count per channel
+redis-cli PUBSUB NUMPAT          # number of pattern subscriptions
+```
+
+```bash
+# Pub/Sub in a script (subscriber)
+redis-cli SUBSCRIBE events &
+SUB_PID=$!
+
+# Publish messages
+redis-cli PUBLISH events "message1"
+redis-cli PUBLISH events "message2"
+
+# Stop subscriber
+kill $SUB_PID
+```
+
+## Lua Scripting
+
+```bash
+# Run a Lua script inline (EVAL)
+redis-cli EVAL "return 'hello'" 0
+
+# Script with key and argument access
+redis-cli EVAL "return redis.call('GET', KEYS[1])" 1 mykey
+
+# Atomic increment with expiry (set-if-not-exists pattern)
+redis-cli EVAL "
+  local current = redis.call('GET', KEYS[1])
+  if not current then
+    redis.call('SET', KEYS[1], ARGV[1])
+    redis.call('EXPIRE', KEYS[1], ARGV[2])
+    return 1
+  end
+  return 0
+" 1 my-lock-key "locked" 30
+
+# Load script and get SHA (for reuse)
+SHA=$(redis-cli SCRIPT LOAD "return redis.call('GET', KEYS[1])")
+redis-cli EVALSHA "$SHA" 1 mykey
+
+# Rate limiting Lua script
+redis-cli EVAL "
+  local key = KEYS[1]
+  local limit = tonumber(ARGV[1])
+  local window = tonumber(ARGV[2])
+  local current = redis.call('INCR', key)
+  if current == 1 then
+    redis.call('EXPIRE', key, window)
+  end
+  if current > limit then
+    return 0
+  end
+  return 1
+" 1 "ratelimit:user:123" 100 60
+
+# Flush all loaded scripts
+redis-cli SCRIPT FLUSH
+
+# Check if a script exists
+redis-cli SCRIPT EXISTS $SHA
+```
+
+## Memory Analysis
+
+```bash
+# Get memory usage stats
+redis-cli INFO memory
+
+# Key memory statistics:
+# used_memory: total allocated memory
+# used_memory_human: human-readable
+# used_memory_peak: peak memory usage
+# mem_fragmentation_ratio: >1.5 indicates fragmentation
+
+# Get memory usage of a specific key (in bytes)
+redis-cli MEMORY USAGE mykey
+redis-cli MEMORY USAGE myhash SAMPLES 5
+
+# Find largest keys (approximate)
+redis-cli --bigkeys
+
+# Analyze memory distribution
+redis-cli MEMORY DOCTOR  # get memory analysis
+
+# Memory usage by data type
+redis-cli INFO keyspace
+
+# Debug object memory (for individual keys)
+redis-cli DEBUG OBJECT mykey
+
+# Get LRU idle time for a key
+redis-cli OBJECT IDLETIME mykey
+
+# Get encoding used for a key
+redis-cli OBJECT ENCODING mykey
+
+# Purge expired keys immediately
+redis-cli DEBUG SLEEP 0
+```
+
+## Persistence and Configuration
+
+```bash
+# Check persistence config
+redis-cli CONFIG GET save
+redis-cli CONFIG GET appendonly
+
+# Trigger RDB snapshot
+redis-cli BGSAVE          # background save
+redis-cli SAVE            # synchronous save (blocks)
+redis-cli LASTSAVE        # timestamp of last save
+
+# Trigger AOF rewrite
+redis-cli BGREWRITEAOF
+
+# Flush all keys (DANGER: irreversible)
+redis-cli FLUSHDB          # flush current database
+redis-cli FLUSHDB ASYNC    # async flush
+redis-cli FLUSHALL         # flush all databases (VERY DANGEROUS)
+
+# Switch database (0-15 by default)
+redis-cli -n 1 GET mykey  # use database 1
+
+# Move key to another database
+redis-cli MOVE mykey 1
+
+# Config rewrite (persist current config)
+redis-cli CONFIG REWRITE
+```
+
+## Cluster Operations
+
+```bash
+# Check cluster info
+redis-cli CLUSTER INFO
+
+# Check cluster nodes
+redis-cli CLUSTER NODES
+
+# Check which node owns a key slot
+redis-cli -c CLUSTER KEYSLOT mykey  # returns slot number (0-16383)
+
+# Follow cluster redirects (use -c flag)
+redis-cli -c -h redis-cluster-node1 -p 7000 GET mykey
+
+# Get nodes for a slot
+redis-cli CLUSTER SLOTS
+
+# Reshard cluster (redistribute slots)
+redis-cli --cluster reshard redis-node1:7000
+
+# Add a node to cluster
+redis-cli --cluster add-node new-node:7006 existing-node:7000
+
+# Check cluster health
+redis-cli --cluster check redis-node1:7000
+
+# Rebalance cluster
+redis-cli --cluster rebalance redis-node1:7000
+```
+
+## Monitoring and Diagnostics
+
+```bash
+# Watch all commands in real-time (debug only, high overhead)
+redis-cli MONITOR
+
+# Get server stats
+redis-cli INFO
+redis-cli INFO server    # server info
+redis-cli INFO clients   # connected clients
+redis-cli INFO memory    # memory stats
+redis-cli INFO stats     # throughput stats
+redis-cli INFO replication  # master/replica info
+redis-cli INFO keyspace  # key counts per database
+
+# Get slow log (commands taking > slowlog-log-slower-than microseconds)
+redis-cli SLOWLOG GET 10  # last 10 slow commands
+redis-cli SLOWLOG LEN     # number of slow log entries
+redis-cli SLOWLOG RESET   # clear slow log
+
+# Get client list
+redis-cli CLIENT LIST
+
+# Kill a client connection
+redis-cli CLIENT KILL ID 123
+
+# Get command stats
+redis-cli INFO commandstats | grep -E "cmd_(get|set|hget):"
+
+# Latency monitoring
+redis-cli LATENCY LATEST
+redis-cli LATENCY HISTORY event-name
+redis-cli LATENCY RESET
+```
+
+## Common Patterns
+
+```bash
+# Cache-aside pattern check
+check_cache() {
+  local key="$1"
+  local value=$(redis-cli GET "$key")
+  if [ -n "$value" ]; then
+    echo "$value"
+  else
+    echo "CACHE_MISS"
+  fi
+}
+
+# Distributed lock (simple)
+acquire_lock() {
+  local key="lock:$1"
+  local ttl=30
+  redis-cli SET "$key" "1" NX EX "$ttl"  # returns OK or nil
+}
+
+release_lock() {
+  local key="lock:$1"
+  redis-cli DEL "$key"
+}
+
+# Session store pattern
+redis-cli HSET "session:abc123" \
+  user_id 42 \
+  username "alice" \
+  role "admin" \
+  created_at 1700000000
+redis-cli EXPIRE "session:abc123" 3600
+
+# Counter with sliding window rate limit
+redis-cli MULTI
+redis-cli INCR "ratelimit:user:42:$(date +%s)"
+redis-cli EXPIRE "ratelimit:user:42:$(date +%s)" 60
+redis-cli EXEC
+```
+
+## Troubleshooting
+
+```bash
+# Debug connection issues
+redis-cli -h redis.example.com ping
+
+# Check why a key doesn't exist
+redis-cli DEBUG SLEEP 0  # process pending expires
+redis-cli TTL mykey       # check if expired
+
+# Diagnose high memory usage
+redis-cli --bigkeys
+redis-cli MEMORY DOCTOR
+
+# Check replication lag
+redis-cli INFO replication | grep master_repl_offset
+redis-cli INFO replication | grep slave_repl_offset
+
+# Common issues:
+# "WRONGTYPE" error — key type mismatch; check TYPE before operating
+# High memory — scan for large keys with --bigkeys
+# Slow commands — check SLOWLOG; use SCAN instead of KEYS
+# Connection refused — check redis-server is running: redis-cli ping
+# Max clients reached — check CLIENT LIST, increase maxclients config
+```

--- a/skills/skills_validation_83_84_85_test.go
+++ b/skills/skills_validation_83_84_85_test.go
@@ -1,0 +1,790 @@
+// Package skills_validation tests that the bundled SKILL.md files in this
+// directory parse correctly and satisfy required field constraints.
+//
+// This file covers skills added in GitHub Issues #83 (Security), #84 (Testing),
+// and #85 (Database).
+package skills_validation
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/skills"
+)
+
+// skillsDir returns the absolute path to the skills/ directory that contains
+// this test file. Using runtime.Caller makes the path independent of the
+// working directory from which `go test` is invoked.
+func skillsDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(file)
+}
+
+// loadAllSkillsNew uses the production Loader to discover all SKILL.md files
+// in the skills/ directory and returns them indexed by name.
+func loadAllSkillsNew(t *testing.T) map[string]skills.Skill {
+	t.Helper()
+	dir := skillsDir(t)
+	loader := skills.NewLoader(skills.LoaderConfig{GlobalDir: dir})
+	all, err := loader.Load()
+	if err != nil {
+		t.Fatalf("skills.Loader.Load() error: %v", err)
+	}
+	m := make(map[string]skills.Skill, len(all))
+	for _, s := range all {
+		m[s.Name] = s
+	}
+	return m
+}
+
+// --- Issue #83: Security Skills ---
+
+func TestVaultOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["vault-ops"]
+	if !ok {
+		t.Fatal("vault-ops skill not found; expected SKILL.md in skills/vault-ops/")
+	}
+	if s.Name != "vault-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "vault-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestVaultOpsSkill_HasReadWriteCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if !strings.Contains(s.Body, "vault kv get") {
+		t.Error("vault-ops body should include 'vault kv get' command")
+	}
+	if !strings.Contains(s.Body, "vault kv put") {
+		t.Error("vault-ops body should include 'vault kv put' command")
+	}
+}
+
+func TestVaultOpsSkill_HasDynamicCredentials(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "dynamic") {
+		t.Error("vault-ops body should document dynamic credentials")
+	}
+	if !strings.Contains(s.Body, "vault read database/creds") {
+		t.Error("vault-ops body should show how to read dynamic database credentials")
+	}
+}
+
+func TestVaultOpsSkill_HasPolicyManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if !strings.Contains(s.Body, "vault policy") {
+		t.Error("vault-ops body should include 'vault policy' commands")
+	}
+	if !strings.Contains(s.Body, "vault policy write") {
+		t.Error("vault-ops body should include 'vault policy write' command")
+	}
+}
+
+func TestVaultOpsSkill_HasTokenRenewal(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if !strings.Contains(s.Body, "vault token renew") {
+		t.Error("vault-ops body should document token renewal")
+	}
+}
+
+func TestVaultOpsSkill_HasAuthMethods(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if !strings.Contains(s.Body, "vault login") {
+		t.Error("vault-ops body should document authentication with 'vault login'")
+	}
+}
+
+func TestVaultOpsSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if len(s.Triggers) == 0 {
+		t.Error("vault-ops should have at least one trigger phrase in description")
+	}
+}
+
+func TestVaultOpsSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["vault-ops"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("vault-ops should declare allowed-tools")
+	}
+}
+
+func TestSnykScanSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["snyk-scan"]
+	if !ok {
+		t.Fatal("snyk-scan skill not found; expected SKILL.md in skills/snyk-scan/")
+	}
+	if s.Name != "snyk-scan" {
+		t.Errorf("Name = %q, want %q", s.Name, "snyk-scan")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestSnykScanSkill_HasTestCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if !strings.Contains(s.Body, "snyk test") {
+		t.Error("snyk-scan body should include 'snyk test' command")
+	}
+}
+
+func TestSnykScanSkill_HasMonitorCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if !strings.Contains(s.Body, "snyk monitor") {
+		t.Error("snyk-scan body should include 'snyk monitor' command")
+	}
+}
+
+func TestSnykScanSkill_HasCodeTestCommand(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if !strings.Contains(s.Body, "snyk code test") {
+		t.Error("snyk-scan body should include 'snyk code test' for SAST scanning")
+	}
+}
+
+func TestSnykScanSkill_HasSeverityThresholds(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if !strings.Contains(s.Body, "--severity-threshold") {
+		t.Error("snyk-scan body should document --severity-threshold flag")
+	}
+}
+
+func TestSnykScanSkill_HasCIIntegration(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "github actions") && !strings.Contains(bodyLower, "ci") {
+		t.Error("snyk-scan body should document CI integration")
+	}
+}
+
+func TestSnykScanSkill_HasFixGuidance(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if !strings.Contains(s.Body, "snyk fix") {
+		t.Error("snyk-scan body should document 'snyk fix' command")
+	}
+}
+
+func TestSnykScanSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if len(s.Triggers) == 0 {
+		t.Error("snyk-scan should have at least one trigger phrase in description")
+	}
+}
+
+func TestSnykScanSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["snyk-scan"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("snyk-scan should declare allowed-tools")
+	}
+}
+
+func TestTrivyScanSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["trivy-scan"]
+	if !ok {
+		t.Fatal("trivy-scan skill not found; expected SKILL.md in skills/trivy-scan/")
+	}
+	if s.Name != "trivy-scan" {
+		t.Errorf("Name = %q, want %q", s.Name, "trivy-scan")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestTrivyScanSkill_HasImageScan(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "trivy image") {
+		t.Error("trivy-scan body should include 'trivy image' command")
+	}
+}
+
+func TestTrivyScanSkill_HasFsScan(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "trivy fs") {
+		t.Error("trivy-scan body should include 'trivy fs' command")
+	}
+}
+
+func TestTrivyScanSkill_HasRepoScan(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "trivy repo") {
+		t.Error("trivy-scan body should include 'trivy repo' command")
+	}
+}
+
+func TestTrivyScanSkill_HasSeverityFiltering(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "--severity") {
+		t.Error("trivy-scan body should document --severity filtering flag")
+	}
+	if !strings.Contains(s.Body, "HIGH,CRITICAL") {
+		t.Error("trivy-scan body should show HIGH,CRITICAL severity example")
+	}
+}
+
+func TestTrivyScanSkill_HasSARIFOutput(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "sarif") && !strings.Contains(s.Body, "SARIF") {
+		t.Error("trivy-scan body should document SARIF output format")
+	}
+}
+
+func TestTrivyScanSkill_HasCIIntegration(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if !strings.Contains(s.Body, "--exit-code 1") {
+		t.Error("trivy-scan body should document --exit-code 1 for CI integration")
+	}
+}
+
+func TestTrivyScanSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if len(s.Triggers) == 0 {
+		t.Error("trivy-scan should have at least one trigger phrase in description")
+	}
+}
+
+func TestTrivyScanSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["trivy-scan"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("trivy-scan should declare allowed-tools")
+	}
+}
+
+// --- Issue #84: Testing Skills ---
+
+func TestCypressTestingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["cypress-testing"]
+	if !ok {
+		t.Fatal("cypress-testing skill not found; expected SKILL.md in skills/cypress-testing/")
+	}
+	if s.Name != "cypress-testing" {
+		t.Errorf("Name = %q, want %q", s.Name, "cypress-testing")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestCypressTestingSkill_HasOpenAndRunCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	if !strings.Contains(s.Body, "cypress open") {
+		t.Error("cypress-testing body should include 'cypress open' command")
+	}
+	if !strings.Contains(s.Body, "cypress run") {
+		t.Error("cypress-testing body should include 'cypress run' command")
+	}
+}
+
+func TestCypressTestingSkill_HasComponentTesting(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "component") {
+		t.Error("cypress-testing body should document component testing")
+	}
+}
+
+func TestCypressTestingSkill_HasNetworkIntercepting(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	if !strings.Contains(s.Body, "cy.intercept") {
+		t.Error("cypress-testing body should document cy.intercept for network interception")
+	}
+}
+
+func TestCypressTestingSkill_HasCustomCommands(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	if !strings.Contains(s.Body, "Cypress.Commands.add") {
+		t.Error("cypress-testing body should document Cypress.Commands.add for custom commands")
+	}
+}
+
+func TestCypressTestingSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	if len(s.Triggers) == 0 {
+		t.Error("cypress-testing should have at least one trigger phrase in description")
+	}
+}
+
+func TestCypressTestingSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["cypress-testing"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("cypress-testing should declare allowed-tools")
+	}
+}
+
+func TestLoadTestingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["load-testing"]
+	if !ok {
+		t.Fatal("load-testing skill not found; expected SKILL.md in skills/load-testing/")
+	}
+	if s.Name != "load-testing" {
+		t.Errorf("Name = %q, want %q", s.Name, "load-testing")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestLoadTestingSkill_HasK6Content(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	if !strings.Contains(s.Body, "k6 run") {
+		t.Error("load-testing body should include 'k6 run' command")
+	}
+}
+
+func TestLoadTestingSkill_HasVegetaContent(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	if !strings.Contains(s.Body, "vegeta attack") {
+		t.Error("load-testing body should include 'vegeta attack' command")
+	}
+}
+
+func TestLoadTestingSkill_HasRampUpPatterns(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "ramp") {
+		t.Error("load-testing body should document ramp-up patterns")
+	}
+	if !strings.Contains(s.Body, "stages") {
+		t.Error("load-testing body should document k6 stages for ramp-up")
+	}
+}
+
+func TestLoadTestingSkill_HasThresholds(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	if !strings.Contains(s.Body, "thresholds") {
+		t.Error("load-testing body should document threshold configuration")
+	}
+}
+
+func TestLoadTestingSkill_HasResultsAnalysis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "p(95)") && !strings.Contains(bodyLower, "p95") {
+		t.Error("load-testing body should document p95 latency metric in results analysis")
+	}
+}
+
+func TestLoadTestingSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	if len(s.Triggers) == 0 {
+		t.Error("load-testing should have at least one trigger phrase in description")
+	}
+}
+
+func TestLoadTestingSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["load-testing"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("load-testing should declare allowed-tools")
+	}
+}
+
+// --- Issue #85: Database Skills ---
+
+func TestRedisOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["redis-ops"]
+	if !ok {
+		t.Fatal("redis-ops skill not found; expected SKILL.md in skills/redis-ops/")
+	}
+	if s.Name != "redis-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "redis-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestRedisOpsSkill_HasRedisCLI(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "redis-cli") {
+		t.Error("redis-ops body should include 'redis-cli' commands")
+	}
+}
+
+func TestRedisOpsSkill_HasKeyPatterns(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "SCAN") {
+		t.Error("redis-ops body should document SCAN for safe key iteration")
+	}
+}
+
+func TestRedisOpsSkill_HasPubSub(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "SUBSCRIBE") {
+		t.Error("redis-ops body should document SUBSCRIBE for pub/sub")
+	}
+	if !strings.Contains(s.Body, "PUBLISH") {
+		t.Error("redis-ops body should document PUBLISH for pub/sub")
+	}
+}
+
+func TestRedisOpsSkill_HasLuaScripting(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "EVAL") {
+		t.Error("redis-ops body should document EVAL for Lua scripting")
+	}
+}
+
+func TestRedisOpsSkill_HasMemoryAnalysis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "MEMORY USAGE") {
+		t.Error("redis-ops body should document MEMORY USAGE command")
+	}
+	if !strings.Contains(s.Body, "--bigkeys") {
+		t.Error("redis-ops body should document --bigkeys flag for memory analysis")
+	}
+}
+
+func TestRedisOpsSkill_HasClusterOperations(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if !strings.Contains(s.Body, "CLUSTER INFO") {
+		t.Error("redis-ops body should document CLUSTER INFO for cluster operations")
+	}
+}
+
+func TestRedisOpsSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if len(s.Triggers) == 0 {
+		t.Error("redis-ops should have at least one trigger phrase in description")
+	}
+}
+
+func TestRedisOpsSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["redis-ops"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("redis-ops should declare allowed-tools")
+	}
+}
+
+func TestNeonBranchingSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s, ok := all["neon-branching"]
+	if !ok {
+		t.Fatal("neon-branching skill not found; expected SKILL.md in skills/neon-branching/")
+	}
+	if s.Name != "neon-branching" {
+		t.Errorf("Name = %q, want %q", s.Name, "neon-branching")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestNeonBranchingSkill_HasBranchCreate(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	if !strings.Contains(s.Body, "neonctl branches create") {
+		t.Error("neon-branching body should include 'neonctl branches create' command")
+	}
+}
+
+func TestNeonBranchingSkill_HasBranchDelete(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	if !strings.Contains(s.Body, "neonctl branches delete") {
+		t.Error("neon-branching body should include 'neonctl branches delete' command")
+	}
+}
+
+func TestNeonBranchingSkill_HasConnectionStrings(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	if !strings.Contains(s.Body, "connection-string") {
+		t.Error("neon-branching body should document connection string retrieval")
+	}
+}
+
+func TestNeonBranchingSkill_HasBranchPerPR(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	bodyLower := strings.ToLower(s.Body)
+	if !strings.Contains(bodyLower, "branch-per-pr") && !strings.Contains(bodyLower, "pull request") {
+		t.Error("neon-branching body should document the branch-per-PR workflow")
+	}
+}
+
+func TestNeonBranchingSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	if len(s.Triggers) == 0 {
+		t.Error("neon-branching should have at least one trigger phrase in description")
+	}
+}
+
+func TestNeonBranchingSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	s := all["neon-branching"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("neon-branching should declare allowed-tools")
+	}
+}
+
+// --- Cross-cutting validation for issues #83, #84, #85 ---
+
+// TestIssue838485SkillsHaveVersion ensures every new SKILL.md has version: 1.
+func TestIssue838485SkillsHaveVersion(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		// Issue #83: Security
+		"vault-ops",
+		"snyk-scan",
+		"trivy-scan",
+		// Issue #84: Testing
+		"cypress-testing",
+		"load-testing",
+		// Issue #85: Database
+		"redis-ops",
+		"neon-branching",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue // covered by individual parse tests
+		}
+		if s.Version != 1 {
+			t.Errorf("skill %q: Version = %d, want 1", name, s.Version)
+		}
+	}
+}
+
+// TestIssue838485SkillsHaveAllowedTools ensures all new skills declare allowed-tools.
+func TestIssue838485SkillsHaveAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"vault-ops", "snyk-scan", "trivy-scan",
+		"cypress-testing", "load-testing",
+		"redis-ops", "neon-branching",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue // covered by individual parse tests
+		}
+		if len(s.AllowedTools) == 0 {
+			t.Errorf("skill %q: allowed-tools should be declared", name)
+		}
+	}
+}
+
+// TestIssue838485ExpectedCount validates all 7 skills for issues #83, #84, #85 are present.
+func TestIssue838485ExpectedCount(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	expected := []string{
+		// Issue #83: Security Skills
+		"vault-ops",
+		"snyk-scan",
+		"trivy-scan",
+		// Issue #84: Testing Skills
+		"cypress-testing",
+		"load-testing",
+		// Issue #85: Database Skills
+		"redis-ops",
+		"neon-branching",
+	}
+	for _, name := range expected {
+		if _, ok := all[name]; !ok {
+			t.Errorf("expected skill %q not found", name)
+		}
+	}
+}
+
+// TestIssue838485SkillsDefaultToConversationContext ensures none of the new skills
+// accidentally use the fork context, which requires a runner.
+func TestIssue838485SkillsDefaultToConversationContext(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"vault-ops", "snyk-scan", "trivy-scan",
+		"cypress-testing", "load-testing",
+		"redis-ops", "neon-branching",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue
+		}
+		if s.Context == "fork" {
+			t.Errorf("skill %q uses context=fork; these skills should use conversation context", name)
+		}
+	}
+}
+
+// TestIssue838485SkillsHaveTriggers ensures all new skills define trigger phrases.
+func TestIssue838485SkillsHaveTriggers(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkillsNew(t)
+	newSkills := []string{
+		"vault-ops", "snyk-scan", "trivy-scan",
+		"cypress-testing", "load-testing",
+		"redis-ops", "neon-branching",
+	}
+	for _, name := range newSkills {
+		s, ok := all[name]
+		if !ok {
+			continue
+		}
+		if len(s.Triggers) == 0 {
+			t.Errorf("skill %q: should have at least one trigger phrase in description", name)
+		}
+	}
+}

--- a/skills/snyk-scan/SKILL.md
+++ b/skills/snyk-scan/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: snyk-scan
+description: "Scan code and dependencies for vulnerabilities with Snyk: snyk test, snyk monitor, snyk code test, fix guidance, severity thresholds, CI integration. Trigger: when using Snyk, snyk test, snyk monitor, vulnerability scanning, dependency security, snyk code, SAST scanning, CVE scan"
+version: 1
+argument-hint: "[test|monitor|code|fix|ignore] [--severity-threshold=high]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Snyk Security Scanning
+
+You are now operating in Snyk vulnerability scanning mode.
+
+## Installation and Authentication
+
+```bash
+# Install Snyk CLI
+npm install -g snyk
+
+# macOS via Homebrew
+brew install snyk-cli
+
+# Authenticate with Snyk (opens browser)
+snyk auth
+
+# Authenticate with a token (CI/CD)
+snyk auth $SNYK_TOKEN
+export SNYK_TOKEN=your-api-token  # alternative method
+
+# Verify authentication
+snyk whoami
+```
+
+## Dependency Vulnerability Scanning
+
+```bash
+# Scan current project dependencies for vulnerabilities
+snyk test
+
+# Scan with JSON output (machine-readable)
+snyk test --json
+
+# Scan with SARIF output (for GitHub Code Scanning)
+snyk test --sarif
+
+# Save SARIF output to file
+snyk test --sarif-file-output=snyk-results.sarif
+
+# Scan a specific package.json or pom.xml
+snyk test --file=package.json
+snyk test --file=pom.xml
+
+# Scan all projects in a monorepo
+snyk test --all-projects
+
+# Scan with a severity threshold (only fail on high or critical)
+snyk test --severity-threshold=high
+
+# Severity thresholds: low, medium, high, critical
+snyk test --severity-threshold=critical
+
+# Show all vulnerabilities including low severity
+snyk test --severity-threshold=low
+
+# Skip dev dependencies (Node.js)
+snyk test --dev=false
+
+# Scan a Docker image for OS vulnerabilities
+snyk container test myapp:latest
+
+# Scan with a specific Docker file for more context
+snyk container test myapp:latest --file=Dockerfile
+```
+
+## Code Security Analysis (SAST)
+
+```bash
+# Scan source code for security issues (static analysis)
+snyk code test
+
+# Scan with JSON output
+snyk code test --json
+
+# Scan with SARIF output
+snyk code test --sarif
+
+# Save SARIF output to file
+snyk code test --sarif-file-output=snyk-code-results.sarif
+
+# Scan a specific directory
+snyk code test ./src
+
+# Filter by severity
+snyk code test --severity-threshold=high
+```
+
+## Infrastructure as Code Scanning
+
+```bash
+# Scan Terraform files for misconfigurations
+snyk iac test ./terraform/
+
+# Scan Kubernetes manifests
+snyk iac test ./k8s/
+
+# Scan CloudFormation templates
+snyk iac test ./cloudformation/
+
+# Scan with severity threshold
+snyk iac test --severity-threshold=high ./terraform/
+
+# Scan with SARIF output
+snyk iac test --sarif ./terraform/
+```
+
+## Continuous Monitoring
+
+```bash
+# Monitor a project (sends results to Snyk dashboard)
+snyk monitor
+
+# Monitor with a project name
+snyk monitor --project-name=myapp-production
+
+# Monitor all projects in a monorepo
+snyk monitor --all-projects
+
+# Monitor a Docker image
+snyk container monitor myapp:latest
+
+# Monitor with org specification
+snyk monitor --org=my-org-slug
+```
+
+## Fix and Remediation
+
+```bash
+# Automatically fix vulnerabilities by upgrading packages
+snyk fix
+
+# Fix in dry-run mode (show what would be fixed)
+snyk fix --dry-run
+
+# Fix with specific package manager
+snyk fix --unmanaged
+
+# View fix options for a vulnerability
+snyk test --json | jq '.vulnerabilities[] | {id, title, fixedIn}'
+
+# Upgrade a specific package to fix vulnerabilities
+# (Node.js example — Snyk will suggest the version)
+npm install lodash@4.17.21
+
+# Open Snyk web UI for a project's issues
+snyk open
+```
+
+## Ignore and Exceptions
+
+```bash
+# Ignore a specific vulnerability for 30 days with a reason
+snyk ignore --id=SNYK-JS-LODASH-567746 \
+  --reason="No current fix available" \
+  --expiry=2024-12-31
+
+# Ignore a vulnerability permanently
+snyk ignore --id=SNYK-JS-LODASH-567746 --reason="False positive"
+
+# Ignore vulnerabilities in a specific path
+snyk ignore --id=SNYK-JS-LODASH-567746 --path="lodash@4.17.15"
+
+# List ignored vulnerabilities
+cat .snyk  # Snyk stores ignores in .snyk file
+
+# Example .snyk file format
+cat > .snyk <<'EOF'
+version: v1.25.0
+ignore:
+  SNYK-JS-LODASH-567746:
+    - lodash@4.17.15:
+        reason: No fix available yet
+        expires: '2024-12-31T00:00:00.000Z'
+EOF
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/snyk.yml
+name: Snyk Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Snyk dependency scan
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high
+
+      - name: Run Snyk code scan
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: code test
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
+```
+
+### GitLab CI
+
+```yaml
+# .gitlab-ci.yml snippet
+snyk-scan:
+  image: node:18
+  script:
+    - npm install -g snyk
+    - snyk auth $SNYK_TOKEN
+    - snyk test --severity-threshold=high
+  variables:
+    SNYK_TOKEN: $SNYK_TOKEN
+```
+
+### Shell Script for CI
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Authenticate
+snyk auth "$SNYK_TOKEN"
+
+# Run dependency scan, fail on high+ severity
+if ! snyk test --severity-threshold=high --json > snyk-results.json 2>&1; then
+  echo "Snyk found high severity vulnerabilities:"
+  cat snyk-results.json | jq '.vulnerabilities[] | select(.severity == "high" or .severity == "critical") | {id, title, severity}'
+  exit 1
+fi
+
+# Run SAST scan
+if ! snyk code test --severity-threshold=high; then
+  echo "Snyk Code found high severity issues"
+  exit 1
+fi
+
+echo "All Snyk scans passed"
+```
+
+## Interpreting Results
+
+```bash
+# Parse JSON output to find critical vulnerabilities
+snyk test --json | jq '.vulnerabilities[] | select(.severity == "critical") | {
+  id: .id,
+  title: .title,
+  packageName: .packageName,
+  version: .version,
+  fixedIn: .fixedIn
+}'
+
+# Count vulnerabilities by severity
+snyk test --json | jq '
+  .vulnerabilities |
+  group_by(.severity) |
+  map({severity: .[0].severity, count: length}) |
+  .[]
+'
+
+# Get CVE IDs for all vulnerabilities
+snyk test --json | jq '.vulnerabilities[].identifiers.CVE[]?' 2>/dev/null
+
+# Check if any fixable vulnerabilities exist
+snyk test --json | jq '[.vulnerabilities[] | select(.isUpgradable == true)] | length'
+```
+
+## Troubleshooting
+
+```bash
+# Run with verbose output for debugging
+snyk test -d
+
+# Check Snyk CLI version
+snyk --version
+
+# Clear Snyk cache
+snyk config unset api
+
+# Test without internet (use cached data)
+snyk test --offline
+
+# Common issues:
+# "Authentication required" — run: snyk auth
+# "Could not detect package manager" — specify with: --file=package.json
+# "No supported target files detected" — check working directory
+# High false positive rate — use: snyk ignore or configure in .snyk file
+```

--- a/skills/trivy-scan/SKILL.md
+++ b/skills/trivy-scan/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: trivy-scan
+description: "Scan containers and filesystems for vulnerabilities with Trivy: trivy image, trivy fs, trivy repo, severity filtering, SARIF output, CI integration. Trigger: when using Trivy, trivy image, trivy fs, trivy scan, container vulnerability scan, trivy repo, CVE scanning, SBOM generation"
+version: 1
+argument-hint: "[image|fs|repo|config|sbom] [target] [--severity HIGH,CRITICAL]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# Trivy Security Scanner
+
+You are now operating in Trivy vulnerability scanning mode.
+
+## Installation
+
+```bash
+# macOS (via Homebrew)
+brew install trivy
+
+# Linux (Debian/Ubuntu)
+sudo apt-get install wget apt-transport-https gnupg lsb-release
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
+echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install trivy
+
+# Using Docker (no installation required)
+docker run --rm aquasec/trivy:latest image alpine:3.18
+
+# Verify installation
+trivy --version
+
+# Update vulnerability database
+trivy image --download-db-only
+```
+
+## Container Image Scanning
+
+```bash
+# Scan a Docker image
+trivy image nginx:latest
+
+# Scan a local image (built but not pushed)
+trivy image myapp:local
+
+# Scan with severity filtering
+trivy image --severity HIGH,CRITICAL nginx:latest
+
+# Severity levels: UNKNOWN, LOW, MEDIUM, HIGH, CRITICAL
+trivy image --severity CRITICAL nginx:latest
+
+# Scan and output as JSON
+trivy image --format json nginx:latest
+
+# Scan and output as SARIF (for GitHub Code Scanning)
+trivy image --format sarif --output trivy-results.sarif nginx:latest
+
+# Scan and output as table (default)
+trivy image --format table nginx:latest
+
+# Scan without showing unfixed vulnerabilities
+trivy image --ignore-unfixed nginx:latest
+
+# Combine: only show HIGH/CRITICAL that have fixes
+trivy image --severity HIGH,CRITICAL --ignore-unfixed nginx:latest
+
+# Scan a remote image from a private registry
+trivy image --username user --password pass myregistry.com/myapp:latest
+
+# Scan a tar archive
+docker save myapp:latest -o myapp.tar
+trivy image --input myapp.tar
+
+# Exit with non-zero code if vulnerabilities found (for CI)
+trivy image --exit-code 1 --severity HIGH,CRITICAL nginx:latest
+```
+
+## Filesystem Scanning
+
+```bash
+# Scan the current directory
+trivy fs .
+
+# Scan a specific directory
+trivy fs /path/to/project
+
+# Scan with severity filter
+trivy fs --severity HIGH,CRITICAL .
+
+# Scan and output as JSON
+trivy fs --format json . > trivy-fs-results.json
+
+# Scan package files only (no code analysis)
+trivy fs --scanners vuln .
+
+# Include secret detection
+trivy fs --scanners vuln,secret .
+
+# Include misconfig detection
+trivy fs --scanners vuln,secret,misconfig .
+
+# Scan and exit non-zero on findings
+trivy fs --exit-code 1 --severity HIGH,CRITICAL .
+```
+
+## Repository Scanning
+
+```bash
+# Scan a remote Git repository
+trivy repo https://github.com/myorg/myrepo
+
+# Scan with authentication (private repos)
+trivy repo --token $GITHUB_TOKEN https://github.com/myorg/private-repo
+
+# Scan a local repository
+trivy repo .
+
+# Scan specific branch
+trivy repo --branch main https://github.com/myorg/myrepo
+
+# Scan specific commit
+trivy repo --commit abc1234 https://github.com/myorg/myrepo
+```
+
+## Configuration/IaC Scanning
+
+```bash
+# Scan Terraform files for misconfigurations
+trivy config ./terraform/
+
+# Scan Kubernetes manifests
+trivy config ./k8s/
+
+# Scan Dockerfile
+trivy config ./Dockerfile
+
+# Scan Helm charts
+trivy config ./charts/
+
+# Scan CloudFormation templates
+trivy config ./cloudformation/
+
+# Scan with severity filtering
+trivy config --severity HIGH,CRITICAL ./terraform/
+
+# Show all checks including passed ones
+trivy config --show-suppressed ./terraform/
+```
+
+## SBOM (Software Bill of Materials)
+
+```bash
+# Generate SBOM in CycloneDX format
+trivy image --format cyclonedx --output sbom.json nginx:latest
+
+# Generate SBOM in SPDX format
+trivy image --format spdx-json --output sbom.spdx.json nginx:latest
+
+# Generate SBOM for filesystem
+trivy fs --format cyclonedx --output sbom.json .
+
+# Scan an existing SBOM for vulnerabilities
+trivy sbom ./sbom.json
+```
+
+## Severity Filtering and Thresholds
+
+```bash
+# Only report HIGH and CRITICAL vulnerabilities
+trivy image --severity HIGH,CRITICAL myapp:latest
+
+# Fail CI build if CRITICAL vulnerabilities found
+trivy image --exit-code 1 --severity CRITICAL myapp:latest
+
+# Fail CI build on any HIGH or CRITICAL
+trivy image --exit-code 1 --severity HIGH,CRITICAL myapp:latest
+
+# Show vulnerability counts by severity
+trivy image --format json myapp:latest | \
+  jq '.Results[].Vulnerabilities | group_by(.Severity) | map({severity: .[0].Severity, count: length})'
+
+# Ignore specific CVEs
+echo "CVE-2023-1234" > .trivyignore
+trivy image myapp:latest
+
+# .trivyignore format
+cat > .trivyignore <<'EOF'
+# Ignore CVEs with comments
+CVE-2023-1234
+CVE-2023-5678  # False positive confirmed
+EOF
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+# .github/workflows/trivy.yml
+name: Trivy Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t myapp:${{ github.sha }} .
+
+      - name: Run Trivy container scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: myapp:${{ github.sha }}
+          format: sarif
+          output: trivy-container.sarif
+          severity: HIGH,CRITICAL
+          exit-code: 1
+          ignore-unfixed: true
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: HIGH,CRITICAL
+
+      - name: Upload container SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-container.sarif
+
+      - name: Upload filesystem SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+```
+
+### Shell Script for CI Pipeline
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+IMAGE="myapp:${CI_COMMIT_SHA:-latest}"
+SEVERITY="HIGH,CRITICAL"
+EXIT_CODE=0
+
+echo "=== Scanning container image: $IMAGE ==="
+trivy image \
+  --severity "$SEVERITY" \
+  --ignore-unfixed \
+  --exit-code 1 \
+  --format sarif \
+  --output trivy-image.sarif \
+  "$IMAGE" || EXIT_CODE=$?
+
+echo "=== Scanning filesystem ==="
+trivy fs \
+  --severity "$SEVERITY" \
+  --scanners vuln,secret \
+  --exit-code 1 \
+  --format sarif \
+  --output trivy-fs.sarif \
+  . || EXIT_CODE=$?
+
+echo "=== Scanning IaC configurations ==="
+trivy config \
+  --severity "$SEVERITY" \
+  --exit-code 1 \
+  ./terraform/ ./k8s/ || EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "Trivy found vulnerabilities at severity $SEVERITY"
+  exit $EXIT_CODE
+fi
+
+echo "All Trivy scans passed"
+```
+
+### Makefile Integration
+
+```makefile
+TRIVY_SEVERITY ?= HIGH,CRITICAL
+IMAGE_NAME ?= myapp:latest
+
+.PHONY: scan-image scan-fs scan-config scan-all
+scan-image:
+	trivy image --severity $(TRIVY_SEVERITY) --ignore-unfixed $(IMAGE_NAME)
+
+scan-fs:
+	trivy fs --severity $(TRIVY_SEVERITY) --scanners vuln,secret .
+
+scan-config:
+	trivy config --severity $(TRIVY_SEVERITY) ./terraform/ ./k8s/
+
+scan-all: scan-image scan-fs scan-config
+```
+
+## Interpreting Results
+
+```bash
+# Parse JSON to find all CRITICAL vulnerabilities
+trivy image --format json myapp:latest | \
+  jq '.Results[].Vulnerabilities[] | select(.Severity == "CRITICAL") | {
+    VulnerabilityID: .VulnerabilityID,
+    PkgName: .PkgName,
+    InstalledVersion: .InstalledVersion,
+    FixedVersion: .FixedVersion,
+    Title: .Title
+  }'
+
+# Count vulnerabilities by severity across all results
+trivy image --format json myapp:latest | \
+  jq '[.Results[].Vulnerabilities[]?.Severity] | group_by(.) | map({severity: .[0], count: length})'
+
+# Find vulnerabilities with available fixes
+trivy image --format json myapp:latest | \
+  jq '.Results[].Vulnerabilities[] | select(.FixedVersion != "") | {
+    id: .VulnerabilityID,
+    pkg: .PkgName,
+    installed: .InstalledVersion,
+    fixedIn: .FixedVersion
+  }'
+```
+
+## Caching and Performance
+
+```bash
+# Cache directory (default: ~/.cache/trivy)
+# Set custom cache location
+TRIVY_CACHE_DIR=/tmp/trivy-cache trivy image myapp:latest
+
+# Download vulnerability database without scanning
+trivy image --download-db-only
+
+# Skip database update (use cached data)
+trivy image --skip-db-update myapp:latest
+
+# Use offline mode (no internet access)
+trivy image --offline-scan myapp:latest
+
+# Clear cache
+trivy image --clear-cache
+```
+
+## Troubleshooting
+
+```bash
+# Enable debug logging
+trivy image --debug myapp:latest
+
+# Check database update time
+trivy image --format json myapp:latest | jq '.SchemaVersion, .CreatedAt'
+
+# Scan without pulling (use local image only)
+trivy image --no-progress myapp:latest
+
+# Common issues:
+# "No such image" — build or pull the image first
+# "TOOMANYREQUESTS" — Docker Hub rate limit; use: docker login
+# Slow scan — pre-download DB with: trivy image --download-db-only
+# False positives — add CVE to .trivyignore file
+```

--- a/skills/vault-ops/SKILL.md
+++ b/skills/vault-ops/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: vault-ops
+description: "Manage HashiCorp Vault secrets: read/write secrets, dynamic credentials, policy management, token renewal, authentication methods. Trigger: when using HashiCorp Vault, vault read, vault write, Vault secrets, dynamic credentials, Vault policy, Vault token, Vault auth"
+version: 1
+argument-hint: "[read|write|list|policy|token|lease] [path]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - grep
+  - glob
+---
+# HashiCorp Vault Operations
+
+You are now operating in HashiCorp Vault secrets management mode.
+
+## Installation and Setup
+
+```bash
+# macOS (via Homebrew)
+brew tap hashicorp/tap
+brew install hashicorp/tap/vault
+
+# Verify installation
+vault version
+
+# Start a dev server (local development only — not for production)
+vault server -dev
+
+# Set environment variables for the dev server
+export VAULT_ADDR='http://127.0.0.1:8200'
+export VAULT_TOKEN='root'  # dev mode root token
+
+# Authenticate with a production Vault server
+export VAULT_ADDR='https://vault.example.com:8200'
+vault login -method=token  # prompts for token
+```
+
+## Authentication Methods
+
+```bash
+# Token authentication (most common)
+vault login <token>
+vault login -method=token token=<token>
+
+# AppRole authentication (CI/CD)
+vault write auth/approle/login \
+  role_id="$ROLE_ID" \
+  secret_id="$SECRET_ID"
+
+# AWS IAM authentication
+vault login -method=aws role=my-role
+
+# Kubernetes authentication (in-cluster)
+vault write auth/kubernetes/login \
+  role=my-role \
+  jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+
+# Check current token info
+vault token lookup
+vault token lookup -accessor <accessor>
+
+# Check authentication status
+vault auth list
+```
+
+## Reading and Writing Secrets
+
+```bash
+# KV v2 secrets engine (default path: secret/)
+# Write a secret
+vault kv put secret/myapp/config \
+  db_password="supersecret" \
+  api_key="abc123"
+
+# Read a secret
+vault kv get secret/myapp/config
+
+# Read a specific field
+vault kv get -field=db_password secret/myapp/config
+
+# List secrets at a path
+vault kv list secret/myapp
+
+# Delete a secret (creates a soft delete)
+vault kv delete secret/myapp/config
+
+# Destroy a specific version permanently
+vault kv destroy -versions=1,2 secret/myapp/config
+
+# Get secret metadata (versions, deletion status)
+vault kv metadata get secret/myapp/config
+
+# Read an older version
+vault kv get -version=2 secret/myapp/config
+
+# KV v1 secrets engine
+vault read kv/myapp/config
+vault write kv/myapp/config db_password="supersecret"
+```
+
+## Dynamic Credentials
+
+Dynamic credentials are short-lived credentials generated on demand by Vault.
+
+```bash
+# Database dynamic credentials (PostgreSQL example)
+# Read generates new temporary credentials
+vault read database/creds/my-role
+
+# Output:
+# Key                Value
+# ---                -----
+# lease_id           database/creds/my-role/abc123
+# lease_duration     1h
+# lease_renewable    true
+# password           A1a-xyz789
+# username           v-root-my-role-abc123
+
+# AWS dynamic credentials
+vault read aws/creds/my-role
+
+# Renew a lease before it expires
+vault lease renew database/creds/my-role/abc123
+
+# Revoke a lease immediately
+vault lease revoke database/creds/my-role/abc123
+
+# Revoke all leases under a prefix
+vault lease revoke -prefix database/creds/my-role
+```
+
+## Policy Management
+
+```bash
+# List existing policies
+vault policy list
+
+# Read a policy
+vault policy read default
+vault policy read my-app-policy
+
+# Write a policy from a file
+cat > my-app-policy.hcl <<'EOF'
+# Read secrets at specific path
+path "secret/data/myapp/*" {
+  capabilities = ["read", "list"]
+}
+
+# Allow reading dynamic database credentials
+path "database/creds/my-role" {
+  capabilities = ["read"]
+}
+
+# Allow token self-renewal
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+
+# Deny access to other paths
+path "secret/data/other/*" {
+  capabilities = ["deny"]
+}
+EOF
+
+vault policy write my-app-policy my-app-policy.hcl
+
+# Delete a policy
+vault policy delete my-app-policy
+
+# Format/validate a policy file
+vault policy fmt my-app-policy.hcl
+```
+
+## Token Management
+
+```bash
+# Create a token with a specific policy
+vault token create \
+  -policy="my-app-policy" \
+  -ttl="1h" \
+  -renewable=true \
+  -display-name="my-app"
+
+# Create a token with multiple policies
+vault token create \
+  -policy="my-app-policy" \
+  -policy="database-policy" \
+  -ttl="24h"
+
+# Renew your own token
+vault token renew
+
+# Renew a specific token
+vault token renew <token>
+
+# Renew with a new TTL increment
+vault token renew -increment=2h <token>
+
+# Revoke a token
+vault token revoke <token>
+
+# Revoke all child tokens recursively
+vault token revoke -mode=tree <token>
+
+# Look up token details
+vault token lookup <token>
+
+# Create an orphan token (no parent, won't be revoked when parent expires)
+vault token create -orphan -policy="my-app-policy"
+```
+
+## Secrets Engine Management
+
+```bash
+# List enabled secrets engines
+vault secrets list
+
+# Enable KV v2 secrets engine at a custom path
+vault secrets enable -path=apps kv-v2
+
+# Enable database secrets engine
+vault secrets enable database
+
+# Configure database connection (PostgreSQL)
+vault write database/config/my-postgres \
+  plugin_name="postgresql-database-plugin" \
+  allowed_roles="my-role" \
+  connection_url="postgresql://{{username}}:{{password}}@localhost:5432/mydb" \
+  username="vault-user" \
+  password="vault-password"
+
+# Create database role for dynamic credentials
+vault write database/roles/my-role \
+  db_name="my-postgres" \
+  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';" \
+  default_ttl="1h" \
+  max_ttl="24h"
+
+# Disable a secrets engine
+vault secrets disable apps/
+```
+
+## Environment Variable Injection
+
+```bash
+# Use vault agent for automatic secret injection
+# vault-agent.hcl
+cat > vault-agent.hcl <<'EOF'
+auto_auth {
+  method "approle" {
+    mount_path = "auth/approle"
+    config = {
+      role_id_file_path = "/etc/vault/role_id"
+      secret_id_file_path = "/etc/vault/secret_id"
+    }
+  }
+}
+
+template {
+  source = "/etc/vault/config.ctmpl"
+  destination = "/app/config.env"
+  command = "systemctl reload myapp"
+}
+EOF
+
+vault agent -config=vault-agent.hcl
+
+# Direct env injection with envconsul
+envconsul -vault-addr=$VAULT_ADDR -secret=secret/myapp/config myapp
+```
+
+## Audit and Compliance
+
+```bash
+# Enable audit logging to a file
+vault audit enable file file_path=/var/log/vault/audit.log
+
+# Enable audit logging to syslog
+vault audit enable syslog
+
+# List enabled audit devices
+vault audit list
+
+# Check Vault health/status
+vault status
+
+# Check Vault operator info (seal status, cluster)
+vault operator init       # initial setup
+vault operator unseal     # unseal after restart
+vault operator seal       # manually seal
+
+# Check HA status
+vault operator members
+```
+
+## Common Usage Patterns
+
+```bash
+# Read a secret and use it in a script
+DB_PASSWORD=$(vault kv get -field=db_password secret/myapp/config)
+export DATABASE_URL="postgres://app:${DB_PASSWORD}@localhost:5432/mydb"
+
+# Check if a secret exists before reading
+if vault kv get secret/myapp/config > /dev/null 2>&1; then
+  echo "Secret exists"
+else
+  echo "Secret not found"
+fi
+
+# Rotate a secret
+vault kv patch secret/myapp/config db_password="newpassword123"
+
+# Copy a secret from one path to another
+vault kv get -format=json secret/source/config | \
+  jq '.data.data' | \
+  vault kv put secret/dest/config -
+
+# List all secrets recursively (requires list capability)
+vault kv list -format=json secret/ | jq -r '.[]' | while read path; do
+  if [[ "$path" == */ ]]; then
+    vault kv list "secret/${path}"
+  fi
+done
+```
+
+## Troubleshooting
+
+```bash
+# Debug connection issues
+VAULT_LOG_LEVEL=debug vault status
+
+# Check token capabilities for a path
+vault token capabilities secret/data/myapp/config
+
+# Verify auth method configuration
+vault auth list -detailed
+
+# Check lease information
+vault list sys/leases/lookup/database/creds/
+
+# Unwrap a wrapped token
+vault unwrap <wrapping_token>
+
+# Common errors:
+# "permission denied" — check token policy with: vault token capabilities <path>
+# "no secret exists" — verify path, remember KV v2 uses 'secret/data/<path>'
+# "token has expired" — renew token or generate a new one
+```


### PR DESCRIPTION
## Summary
Adds 7 SKILL.md files across three issue tracks:

### Issue #83 — Security Skills (3 skills)
- `skills/vault-ops/SKILL.md` — HashiCorp Vault: kv get/put, dynamic credentials, policy management, token lifecycle, AppRole/AWS/K8s auth methods, audit logging
- `skills/snyk-scan/SKILL.md` — `snyk test/monitor/code test/iac test/fix`, severity thresholds, `.snyk` ignore file, CI integration (GitHub Actions, GitLab), SARIF output
- `skills/trivy-scan/SKILL.md` — `trivy image/fs/repo/config/sbom`, `--severity HIGH,CRITICAL`, `.trivyignore`, CI with `--exit-code 1`, JSON/SARIF output

### Issue #84 — Testing Skills (2 skills)
- `skills/cypress-testing/SKILL.md` — `npx cypress open/run`, component testing, `cy.intercept()`, custom commands, fixtures, `cypress.config.js`, CI patterns
- `skills/load-testing/SKILL.md` — k6 (ramp-up stages, thresholds, custom metrics) + vegeta (attack, report, plot, targets files)

### Issue #85 — Database Skills (2 skills)
- `skills/redis-ops/SKILL.md` — redis-cli, SCAN (safe vs KEYS), all data structures, pub/sub, Lua scripting, memory analysis, cluster ops
- `skills/neon-branching/SKILL.md` — `neonctl branches create/delete/list`, branch-per-PR workflow, GitHub Actions automation, point-in-time restore, REST API

## Tests
- `skills/skills_validation_83_84_85_test.go` — 62 tests (race-safe)

## Test plan
- [x] All 62 validation tests pass
- [x] `go test $(go list ./... | grep -v demo-cli) -race` passes

Closes #83
Closes #84
Closes #85