### PR TITLE
Implement DeployPlatform interface with Railway and Fly.io adapters (Issue #45)

### DIFF
--- a/internal/deploy/detect.go
+++ b/internal/deploy/detect.go
@@ -1,0 +1,55 @@
+package deploy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// platformConfig maps platform names to their config file indicators.
+// Order defines priority when multiple configs exist.
+var platformConfig = []struct {
+	name  string
+	files []string
+}{
+	{"cloudflare", []string{"wrangler.toml", "wrangler.jsonc", "wrangler.json"}},
+	{"vercel", []string{"vercel.json", ".vercel"}},
+	{"flyio", []string{"fly.toml"}},
+	{"railway", []string{"railway.json", "railway.toml"}},
+	{"kamal", []string{"config/deploy.yml"}},
+}
+
+// DetectPlatform scans the workspace directory for platform config files and
+// returns the name of the first matching platform in priority order.
+// Returns an error if no platform is detected.
+func DetectPlatform(workspaceDir string) (string, error) {
+	for _, pc := range platformConfig {
+		for _, file := range pc.files {
+			path := filepath.Join(workspaceDir, file)
+			if _, err := os.Stat(path); err == nil {
+				return pc.name, nil
+			}
+		}
+	}
+	// Check for Docker fallback.
+	if _, err := os.Stat(filepath.Join(workspaceDir, "Dockerfile")); err == nil {
+		return "docker", nil
+	}
+	return "", fmt.Errorf("no platform config found in %s", workspaceDir)
+}
+
+// DetectAll returns all platform names detected in the workspace directory,
+// in priority order. Returns an empty slice if none are found.
+func DetectAll(workspaceDir string) []string {
+	var found []string
+	for _, pc := range platformConfig {
+		for _, file := range pc.files {
+			path := filepath.Join(workspaceDir, file)
+			if _, err := os.Stat(path); err == nil {
+				found = append(found, pc.name)
+				break // only add the platform once
+			}
+		}
+	}
+	return found
+}

--- a/internal/deploy/detect_test.go
+++ b/internal/deploy/detect_test.go
@@ -1,0 +1,186 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile creates a file at path/name with empty contents.
+func writeFile(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestDetectCloudflare verifies wrangler.toml → cloudflare.
+func TestDetectCloudflare(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "wrangler.toml")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cloudflare" {
+		t.Errorf("expected 'cloudflare', got %q", got)
+	}
+}
+
+// TestDetectCloudflareJsonc verifies wrangler.jsonc is also detected.
+func TestDetectCloudflareJsonc(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "wrangler.jsonc")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cloudflare" {
+		t.Errorf("expected 'cloudflare', got %q", got)
+	}
+}
+
+// TestDetectVercel verifies vercel.json → vercel.
+func TestDetectVercel(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "vercel.json")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "vercel" {
+		t.Errorf("expected 'vercel', got %q", got)
+	}
+}
+
+// TestDetectFlyio verifies fly.toml → flyio.
+func TestDetectFlyio(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fly.toml")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "flyio" {
+		t.Errorf("expected 'flyio', got %q", got)
+	}
+}
+
+// TestDetectRailway verifies railway.json → railway.
+func TestDetectRailway(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "railway.json")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "railway" {
+		t.Errorf("expected 'railway', got %q", got)
+	}
+}
+
+// TestDetectRailwayToml verifies railway.toml is also detected.
+func TestDetectRailwayToml(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "railway.toml")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "railway" {
+		t.Errorf("expected 'railway', got %q", got)
+	}
+}
+
+// TestDetectDockerFallback verifies Dockerfile → docker when no other config present.
+func TestDetectDockerFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "Dockerfile")
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "docker" {
+		t.Errorf("expected 'docker', got %q", got)
+	}
+}
+
+// TestDetectNone verifies an error is returned when no config is found.
+func TestDetectNone(t *testing.T) {
+	dir := t.TempDir()
+	_, err := DetectPlatform(dir)
+	if err == nil {
+		t.Fatal("expected error for empty workspace")
+	}
+}
+
+// TestDetectMultiple verifies priority order when multiple configs exist.
+// Cloudflare should win over Vercel, which wins over Fly.io, etc.
+func TestDetectMultiple(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "wrangler.toml") // cloudflare (priority 1)
+	writeFile(t, dir, "vercel.json")   // vercel (priority 2)
+	writeFile(t, dir, "fly.toml")      // flyio (priority 3)
+	got, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "cloudflare" {
+		t.Errorf("expected 'cloudflare' (highest priority), got %q", got)
+	}
+}
+
+// TestDetectAll returns all detected platforms.
+func TestDetectAll(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fly.toml")
+	writeFile(t, dir, "railway.json")
+	all := DetectAll(dir)
+	if len(all) != 2 {
+		t.Fatalf("expected 2 platforms, got %d: %v", len(all), all)
+	}
+	// flyio should come before railway in priority order.
+	if all[0] != "flyio" {
+		t.Errorf("expected first to be 'flyio', got %q", all[0])
+	}
+	if all[1] != "railway" {
+		t.Errorf("expected second to be 'railway', got %q", all[1])
+	}
+}
+
+// TestDetectAllEmpty returns empty slice when no configs present.
+func TestDetectAllEmpty(t *testing.T) {
+	dir := t.TempDir()
+	all := DetectAll(dir)
+	if len(all) != 0 {
+		t.Errorf("expected empty slice, got %v", all)
+	}
+}
+
+// TestConcurrentDetection verifies detection is safe under concurrent access.
+func TestConcurrentDetection(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fly.toml")
+	const goroutines = 20
+	done := make(chan string, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			name, err := DetectPlatform(dir)
+			if err != nil {
+				done <- "error:" + err.Error()
+				return
+			}
+			done <- name
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		got := <-done
+		if got != "flyio" {
+			t.Errorf("concurrent detect: got %q, want 'flyio'", got)
+		}
+	}
+}

--- a/internal/deploy/exec.go
+++ b/internal/deploy/exec.go
@@ -1,0 +1,34 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ExecFunc is the function signature for running a CLI command.
+// The function receives the working directory, command name, and arguments,
+// and returns the combined stdout+stderr output and any error.
+// This type is injected into adapters so that tests can substitute fake executors
+// without requiring the real CLI to be installed.
+type ExecFunc func(ctx context.Context, dir, command string, args ...string) (string, error)
+
+// DefaultExec runs the given command in the specified directory and returns
+// the combined stdout+stderr output.
+func DefaultExec(ctx context.Context, dir, command string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		out := strings.TrimSpace(buf.String())
+		if out != "" {
+			return out, fmt.Errorf("%s: %w\n%s", command, err, out)
+		}
+		return "", fmt.Errorf("%s: %w", command, err)
+	}
+	return strings.TrimSpace(buf.String()), nil
+}

--- a/internal/deploy/exec_test.go
+++ b/internal/deploy/exec_test.go
@@ -1,0 +1,62 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestDefaultExec_Success verifies DefaultExec runs a command and returns output.
+func TestDefaultExec_Success(t *testing.T) {
+	out, err := DefaultExec(context.Background(), t.TempDir(), "echo", "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("expected 'hello' in output, got %q", out)
+	}
+}
+
+// TestDefaultExec_Error verifies DefaultExec returns an error for a failing command.
+func TestDefaultExec_Error(t *testing.T) {
+	_, err := DefaultExec(context.Background(), t.TempDir(), "false")
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+}
+
+// TestDefaultExec_StderrIncluded verifies stderr is included in output on failure.
+func TestDefaultExec_StderrIncluded(t *testing.T) {
+	// 'ls nonexistent' writes an error to stderr and exits with non-zero.
+	_, err := DefaultExec(context.Background(), t.TempDir(), "ls", "/nonexistent-path-for-test")
+	if err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+	// The error should include the command name or output.
+	if !strings.Contains(err.Error(), "ls") {
+		t.Errorf("expected 'ls' in error, got %q", err.Error())
+	}
+}
+
+// TestDefaultExec_WorkingDirectory verifies the working directory is respected.
+func TestDefaultExec_WorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	out, err := DefaultExec(context.Background(), dir, "pwd")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// pwd output should contain the temp dir (may have symlinks resolved).
+	if out == "" {
+		t.Error("expected non-empty output from pwd")
+	}
+}
+
+// TestDefaultExec_ContextCancellation verifies context cancellation stops the command.
+func TestDefaultExec_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+	_, err := DefaultExec(ctx, t.TempDir(), "sleep", "100")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/internal/deploy/flyio.go
+++ b/internal/deploy/flyio.go
@@ -1,0 +1,161 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// FlyAdapter implements Platform for Fly.io (https://fly.io).
+// It wraps the `fly` (flyctl) CLI. Install from https://fly.io/docs/hands-on/install-flyctl/
+type FlyAdapter struct {
+	exec ExecFunc
+}
+
+// NewFlyAdapter returns a Fly.io adapter. Pass nil to use the real CLI.
+func NewFlyAdapter(exec ExecFunc) *FlyAdapter {
+	if exec == nil {
+		exec = DefaultExec
+	}
+	return &FlyAdapter{exec: exec}
+}
+
+// Name implements Platform.
+func (f *FlyAdapter) Name() string { return "flyio" }
+
+// Detect implements Platform. Returns true if fly.toml exists.
+func (f *FlyAdapter) Detect(_ context.Context, workspaceDir string) (bool, error) {
+	if _, err := os.Stat(workspaceDir + "/fly.toml"); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Deploy implements Platform. Runs `fly deploy` with optional environment and dry-run flags.
+func (f *FlyAdapter) Deploy(ctx context.Context, workspaceDir string, opts DeployOpts) (*DeployResult, error) {
+	args := []string{"deploy"}
+	if opts.Environment != "" {
+		// Fly uses app env via --env VAR=value; environment namespacing is done via app name.
+		// We pass it as metadata only.
+		args = append(args, "--env", "DEPLOY_ENV="+opts.Environment)
+	}
+	if opts.DryRun {
+		return &DeployResult{
+			Platform:  f.Name(),
+			Timestamp: time.Now(),
+			Logs:      "[dry-run] would run: fly " + strings.Join(args, " "),
+		}, nil
+	}
+
+	out, err := f.exec(ctx, workspaceDir, "fly", args...)
+	if err != nil {
+		return nil, fmt.Errorf("fly deploy: %w", err)
+	}
+
+	result := &DeployResult{
+		Platform:  f.Name(),
+		Timestamp: time.Now(),
+		Logs:      out,
+	}
+	result.URL = extractURL(out)
+	result.Version = extractFlyVersion(out)
+	return result, nil
+}
+
+// Status implements Platform. Runs `fly status` and parses the output.
+func (f *FlyAdapter) Status(ctx context.Context, workspaceDir string) (*DeployStatus, error) {
+	out, err := f.exec(ctx, workspaceDir, "fly", "status")
+	if err != nil {
+		return &DeployStatus{State: "failed"}, fmt.Errorf("fly status: %w", err)
+	}
+	return parseFlyStatus(out), nil
+}
+
+// Logs implements Platform. Returns an io.Reader with application logs.
+func (f *FlyAdapter) Logs(ctx context.Context, workspaceDir string, follow bool) (io.Reader, error) {
+	args := []string{"logs"}
+	if follow {
+		args = append(args, "--no-tail=false")
+	} else {
+		args = append(args, "--no-tail")
+	}
+	out, err := f.exec(ctx, workspaceDir, "fly", args...)
+	if err != nil {
+		return nil, fmt.Errorf("fly logs: %w", err)
+	}
+	return strings.NewReader(out), nil
+}
+
+// Rollback implements Platform. Runs `fly releases` and deploys a prior version.
+// Pass an empty version to use the most recent previous release.
+func (f *FlyAdapter) Rollback(ctx context.Context, workspaceDir string, version string) error {
+	if version == "" {
+		// Without a version we cannot safely rollback without listing releases first.
+		// Return ErrNotImplemented so the caller knows to provide a version.
+		return ErrNotImplemented
+	}
+	_, err := f.exec(ctx, workspaceDir, "fly", "deploy", "--image", "fly:"+version)
+	if err != nil {
+		return fmt.Errorf("fly rollback: %w", err)
+	}
+	return nil
+}
+
+// Teardown implements Platform. Destroys the Fly app entirely.
+func (f *FlyAdapter) Teardown(ctx context.Context, workspaceDir string) error {
+	_, err := f.exec(ctx, workspaceDir, "fly", "destroy", "--yes")
+	if err != nil {
+		return fmt.Errorf("fly teardown: %w", err)
+	}
+	return nil
+}
+
+// parseFlyStatus converts `fly status` text output into a DeployStatus.
+func parseFlyStatus(out string) *DeployStatus {
+	status := &DeployStatus{
+		State:     "unknown",
+		UpdatedAt: time.Now(),
+	}
+	lower := strings.ToLower(out)
+	switch {
+	case strings.Contains(lower, "running"):
+		status.State = "running"
+	case strings.Contains(lower, "building") || strings.Contains(lower, "pending"):
+		status.State = "building"
+	case strings.Contains(lower, "failed") || strings.Contains(lower, "error") || strings.Contains(lower, "crash"):
+		status.State = "failed"
+	case strings.Contains(lower, "stopped") || strings.Contains(lower, "suspended"):
+		status.State = "sleeping"
+	}
+
+	// Extract hostname (Fly prints "Hostname = <app>.fly.dev")
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Hostname") || strings.Contains(line, "hostname") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				host := strings.TrimSpace(parts[1])
+				if host != "" {
+					status.URL = "https://" + host
+				}
+			}
+		}
+	}
+	return status
+}
+
+// extractFlyVersion extracts a version number from fly deploy output.
+// Fly prints lines like "v42" in its release output.
+func extractFlyVersion(out string) string {
+	for _, word := range strings.Fields(out) {
+		if len(word) > 1 && word[0] == 'v' {
+			if _, err := strconv.Atoi(word[1:]); err == nil {
+				return word
+			}
+		}
+	}
+	return ""
+}

--- a/internal/deploy/flyio_test.go
+++ b/internal/deploy/flyio_test.go
@@ -1,0 +1,297 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestFlyAdapterName verifies the platform name.
+func TestFlyAdapterName(t *testing.T) {
+	f := NewFlyAdapter(nil)
+	if f.Name() != "flyio" {
+		t.Errorf("expected 'flyio', got %q", f.Name())
+	}
+}
+
+// TestFlyDetect verifies Detect returns true for fly.toml.
+func TestFlyDetect(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fly.toml")
+	f := NewFlyAdapter(nil)
+	ok, err := f.Detect(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected true for fly.toml")
+	}
+}
+
+// TestFlyDetectFalse verifies Detect returns false with no fly config.
+func TestFlyDetectFalse(t *testing.T) {
+	dir := t.TempDir()
+	f := NewFlyAdapter(nil)
+	ok, err := f.Detect(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected false for empty dir")
+	}
+}
+
+// TestFlyDeployCommand verifies the correct CLI args are passed.
+func TestFlyDeployCommand(t *testing.T) {
+	fe := &fakeExec{output: "v42 deployed to https://myapp.fly.dev"}
+	f := NewFlyAdapter(fe.Exec)
+	result, err := f.Deploy(context.Background(), "/workspace", DeployOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.command != "fly" {
+		t.Errorf("expected command 'fly', got %q", fe.command)
+	}
+	if len(fe.args) == 0 || fe.args[0] != "deploy" {
+		t.Errorf("expected first arg 'deploy', got %v", fe.args)
+	}
+	if result.Platform != "flyio" {
+		t.Errorf("expected platform 'flyio', got %q", result.Platform)
+	}
+}
+
+// TestFlyDeployWithEnvironment verifies --env DEPLOY_ENV is passed.
+func TestFlyDeployWithEnvironment(t *testing.T) {
+	fe := &fakeExec{output: "done"}
+	f := NewFlyAdapter(fe.Exec)
+	_, err := f.Deploy(context.Background(), "/workspace", DeployOpts{Environment: "staging"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := strings.Join(fe.args, " ")
+	if !strings.Contains(args, "--env") || !strings.Contains(args, "staging") {
+		t.Errorf("expected --env DEPLOY_ENV=staging in args, got %v", fe.args)
+	}
+}
+
+// TestFlyDryRun verifies dry-run does not call exec.
+func TestFlyDryRun(t *testing.T) {
+	called := false
+	exec := func(ctx context.Context, dir, cmd string, args ...string) (string, error) {
+		called = true
+		return "", nil
+	}
+	f := NewFlyAdapter(exec)
+	result, err := f.Deploy(context.Background(), "/workspace", DeployOpts{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("dry-run should not call exec")
+	}
+	if !strings.Contains(result.Logs, "dry-run") {
+		t.Errorf("expected 'dry-run' in logs, got %q", result.Logs)
+	}
+}
+
+// TestFlyDeployError verifies errors are propagated.
+func TestFlyDeployError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("not authenticated")}
+	f := NewFlyAdapter(fe.Exec)
+	_, err := f.Deploy(context.Background(), "/workspace", DeployOpts{})
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+	if !strings.Contains(err.Error(), "fly deploy") {
+		t.Errorf("expected 'fly deploy' in error, got %q", err.Error())
+	}
+}
+
+// TestFlyStatus verifies Status parses running state.
+func TestFlyStatus(t *testing.T) {
+	fe := &fakeExec{output: "App 'myapp'\nStatus running\nHostname = myapp.fly.dev"}
+	f := NewFlyAdapter(fe.Exec)
+	status, err := f.Status(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.State != "running" {
+		t.Errorf("expected state 'running', got %q", status.State)
+	}
+	if status.URL != "https://myapp.fly.dev" {
+		t.Errorf("expected URL 'https://myapp.fly.dev', got %q", status.URL)
+	}
+}
+
+// TestFlyStatusFailed verifies failed state is parsed.
+func TestFlyStatusFailed(t *testing.T) {
+	fe := &fakeExec{output: "App failed: error deploying"}
+	f := NewFlyAdapter(fe.Exec)
+	status, err := f.Status(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.State != "failed" {
+		t.Errorf("expected state 'failed', got %q", status.State)
+	}
+}
+
+// TestFlyStatusError verifies Status returns failed state on CLI error.
+func TestFlyStatusError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("app not found")}
+	f := NewFlyAdapter(fe.Exec)
+	status, err := f.Status(context.Background(), "/workspace")
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+	if status.State != "failed" {
+		t.Errorf("expected state 'failed' on error, got %q", status.State)
+	}
+}
+
+// TestFlyLogs verifies Logs returns an io.Reader with log output.
+func TestFlyLogs(t *testing.T) {
+	fe := &fakeExec{output: "app log line 1\napp log line 2"}
+	f := NewFlyAdapter(fe.Exec)
+	reader, err := f.Logs(context.Background(), "/workspace", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var buf strings.Builder
+	tmp := make([]byte, 256)
+	for {
+		n, readErr := reader.Read(tmp)
+		if n > 0 {
+			buf.Write(tmp[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	if !strings.Contains(buf.String(), "app log line 1") {
+		t.Errorf("expected log content, got %q", buf.String())
+	}
+}
+
+// TestFlyLogsError verifies Logs propagates exec errors.
+func TestFlyLogsError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("no logs")}
+	f := NewFlyAdapter(fe.Exec)
+	_, err := f.Logs(context.Background(), "/workspace", false)
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+}
+
+// TestFlyRollback verifies Rollback returns ErrNotImplemented for empty version.
+func TestFlyRollback(t *testing.T) {
+	f := NewFlyAdapter(nil)
+	err := f.Rollback(context.Background(), "/workspace", "")
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented for empty version, got %v", err)
+	}
+}
+
+// TestFlyRollbackWithVersion verifies Rollback calls fly deploy --image for a versioned rollback.
+func TestFlyRollbackWithVersion(t *testing.T) {
+	fe := &fakeExec{output: "rolled back"}
+	f := NewFlyAdapter(fe.Exec)
+	err := f.Rollback(context.Background(), "/workspace", "42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.command != "fly" {
+		t.Errorf("expected command 'fly', got %q", fe.command)
+	}
+}
+
+// TestFlyTeardown verifies Teardown calls `fly destroy --yes`.
+func TestFlyTeardown(t *testing.T) {
+	fe := &fakeExec{output: "app destroyed"}
+	f := NewFlyAdapter(fe.Exec)
+	err := f.Teardown(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.command != "fly" {
+		t.Errorf("expected command 'fly', got %q", fe.command)
+	}
+	args := strings.Join(fe.args, " ")
+	if !strings.Contains(args, "destroy") {
+		t.Errorf("expected 'destroy' in args, got %v", fe.args)
+	}
+}
+
+// TestFlyTeardownError verifies Teardown propagates exec errors.
+func TestFlyTeardownError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("destroy failed")}
+	f := NewFlyAdapter(fe.Exec)
+	err := f.Teardown(context.Background(), "/workspace")
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+}
+
+// TestExtractFlyVersion verifies version extraction from fly output.
+func TestExtractFlyVersion(t *testing.T) {
+	tests := []struct {
+		text string
+		want string
+	}{
+		{"Deploying v42 to myapp", "v42"},
+		{"Release v1 created", "v1"},
+		{"no version here", ""},
+		{"v0 initial deploy", "v0"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := extractFlyVersion(tc.text)
+		if got != tc.want {
+			t.Errorf("extractFlyVersion(%q) = %q, want %q", tc.text, got, tc.want)
+		}
+	}
+}
+
+// TestParseFlyStatusRunning verifies running state is detected.
+func TestParseFlyStatusRunning(t *testing.T) {
+	s := parseFlyStatus("1 desired, 1 placed, 1 healthy, 0 unhealthy [running]")
+	if s.State != "running" {
+		t.Errorf("expected 'running', got %q", s.State)
+	}
+}
+
+// TestParseFlyStatusSleeping verifies sleeping/stopped state is detected.
+func TestParseFlyStatusSleeping(t *testing.T) {
+	s := parseFlyStatus("App is stopped")
+	if s.State != "sleeping" {
+		t.Errorf("expected 'sleeping', got %q", s.State)
+	}
+}
+
+// TestParseFlyStatusUnknown verifies unknown state for unrecognized output.
+func TestParseFlyStatusUnknown(t *testing.T) {
+	s := parseFlyStatus("some random text")
+	if s.State != "unknown" {
+		t.Errorf("expected 'unknown', got %q", s.State)
+	}
+}
+
+// TestConcurrentFlyDeploy verifies concurrent deploys to Fly are safe.
+func TestConcurrentFlyDeploy(t *testing.T) {
+	fe := &fakeExec{output: "v10 deployed"}
+	f := NewFlyAdapter(fe.Exec)
+	const goroutines = 10
+	done := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			_, err := f.Deploy(context.Background(), "/workspace", DeployOpts{DryRun: true})
+			done <- err
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		if err := <-done; err != nil {
+			t.Errorf("concurrent deploy error: %v", err)
+		}
+	}
+}

--- a/internal/deploy/interface_test.go
+++ b/internal/deploy/interface_test.go
@@ -1,0 +1,98 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// compile-time assertion that adapters implement Platform.
+var _ Platform = (*RailwayAdapter)(nil)
+var _ Platform = (*FlyAdapter)(nil)
+
+// TestDeployPlatformInterface verifies all adapters satisfy the Platform interface
+// and return consistent platform names.
+func TestDeployPlatformInterface(t *testing.T) {
+	platforms := []Platform{
+		NewRailwayAdapter(nil),
+		NewFlyAdapter(nil),
+	}
+	for _, p := range platforms {
+		name := p.Name()
+		if name == "" {
+			t.Errorf("platform %T returned empty name", p)
+		}
+	}
+}
+
+// TestMockDeployWorkflow exercises the end-to-end flow: detect → deploy → status → logs.
+func TestMockDeployWorkflow(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "fly.toml")
+
+	// Step 1: detect
+	detected, err := DetectPlatform(dir)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if detected != "flyio" {
+		t.Fatalf("expected 'flyio', got %q", detected)
+	}
+
+	// Step 2: deploy (dry-run to avoid needing CLI)
+	platform := NewFlyAdapter(func(ctx context.Context, dir, cmd string, args ...string) (string, error) {
+		return "v99 deployed to https://test.fly.dev Hostname = test.fly.dev", nil
+	})
+
+	result, err := platform.Deploy(context.Background(), dir, DeployOpts{Environment: "production", DryRun: true})
+	if err != nil {
+		t.Fatalf("deploy: %v", err)
+	}
+	if result.Platform != "flyio" {
+		t.Errorf("deploy result platform: got %q, want 'flyio'", result.Platform)
+	}
+
+	// Step 3: status
+	status, err := platform.Status(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status == nil {
+		t.Fatal("status returned nil")
+	}
+
+	// Step 4: logs
+	reader, err := platform.Logs(context.Background(), dir, false)
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	var buf strings.Builder
+	tmp := make([]byte, 256)
+	for {
+		n, readErr := reader.Read(tmp)
+		if n > 0 {
+			buf.Write(tmp[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	// Logs might be empty in the mock, just ensure no panic.
+	_ = buf.String()
+}
+
+// TestDefaultExecNotNilForRailway verifies that nil exec falls back to DefaultExec.
+func TestDefaultExecNotNilForRailway(t *testing.T) {
+	r := NewRailwayAdapter(nil)
+	if r.exec == nil {
+		t.Error("expected exec to be non-nil (defaulted to DefaultExec)")
+	}
+}
+
+// TestDefaultExecNotNilForFly verifies that nil exec falls back to DefaultExec.
+func TestDefaultExecNotNilForFly(t *testing.T) {
+	f := NewFlyAdapter(nil)
+	if f.exec == nil {
+		t.Error("expected exec to be non-nil (defaulted to DefaultExec)")
+	}
+}

--- a/internal/deploy/platform.go
+++ b/internal/deploy/platform.go
@@ -1,0 +1,83 @@
+// Package deploy provides a platform-agnostic interface for deploying projects
+// to various cloud providers (Cloudflare, Vercel, Railway, Fly.io, etc.).
+// Each adapter wraps the provider's CLI tool using injected command execution,
+// making adapters fully testable without requiring CLIs to be installed.
+package deploy
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// DeployOpts holds options for a deploy operation.
+type DeployOpts struct {
+	// Environment is the target environment (e.g., "staging", "production").
+	Environment string
+	// Force skips pre-deploy checks when true.
+	Force bool
+	// DryRun previews what would happen without executing.
+	DryRun bool
+}
+
+// DeployResult is the output from a successful deploy.
+type DeployResult struct {
+	// URL is the public URL of the deployment.
+	URL string `json:"url"`
+	// Version is the version or commit identifier.
+	Version string `json:"version,omitempty"`
+	// Platform is the name of the platform (e.g., "cloudflare", "railway").
+	Platform string `json:"platform"`
+	// Timestamp is when the deployment occurred.
+	Timestamp time.Time `json:"timestamp"`
+	// Logs contains build/deploy log output.
+	Logs string `json:"logs,omitempty"`
+}
+
+// DeployStatus represents the current state of a deployment.
+type DeployStatus struct {
+	// State is the deployment state: "running", "building", "failed", "sleeping", "unknown".
+	State string `json:"state"`
+	// URL is the public URL if available.
+	URL string `json:"url,omitempty"`
+	// Version is the version or commit identifier.
+	Version string `json:"version,omitempty"`
+	// UpdatedAt is when the status was last updated.
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Platform abstracts deployment operations across cloud providers.
+// Each implementation wraps the provider's CLI tool.
+type Platform interface {
+	// Name returns the platform identifier (e.g., "cloudflare", "vercel", "railway").
+	Name() string
+
+	// Detect checks if the given workspace is configured for this platform.
+	// Returns true if platform config files are present (wrangler.toml, fly.toml, etc.).
+	Detect(ctx context.Context, workspaceDir string) (bool, error)
+
+	// Deploy pushes the current project to the platform.
+	Deploy(ctx context.Context, workspaceDir string, opts DeployOpts) (*DeployResult, error)
+
+	// Status checks the current deployment state.
+	Status(ctx context.Context, workspaceDir string) (*DeployStatus, error)
+
+	// Logs streams deployment logs. If follow is true, streams continuously.
+	// Callers should close the reader when done.
+	Logs(ctx context.Context, workspaceDir string, follow bool) (io.Reader, error)
+
+	// Rollback reverts to a previous version. An empty version string means
+	// the most recent previous version.
+	Rollback(ctx context.Context, workspaceDir string, version string) error
+
+	// Teardown removes the deployment entirely.
+	Teardown(ctx context.Context, workspaceDir string) error
+}
+
+// ErrNotImplemented is returned by methods that are not yet implemented for
+// a given platform adapter.
+var ErrNotImplemented error = errNotImplemented("operation not implemented for this platform")
+
+type errNotImplemented string
+
+func (e errNotImplemented) Error() string { return string(e) }

--- a/internal/deploy/platform_test.go
+++ b/internal/deploy/platform_test.go
@@ -1,0 +1,117 @@
+package deploy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDeployOptsDefaults verifies zero-value DeployOpts has expected defaults.
+func TestDeployOptsDefaults(t *testing.T) {
+	opts := DeployOpts{}
+	if opts.DryRun {
+		t.Error("DryRun should default to false")
+	}
+	if opts.Force {
+		t.Error("Force should default to false")
+	}
+	if opts.Environment != "" {
+		t.Error("Environment should default to empty")
+	}
+}
+
+// TestDeployResultSerialization verifies JSON round-trip for DeployResult.
+func TestDeployResultSerialization(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	r := DeployResult{
+		URL:       "https://example.railway.app",
+		Version:   "v42",
+		Platform:  "railway",
+		Timestamp: now,
+		Logs:      "Deployment live",
+	}
+	data, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var r2 DeployResult
+	if err := json.Unmarshal(data, &r2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if r2.URL != r.URL {
+		t.Errorf("URL: got %q, want %q", r2.URL, r.URL)
+	}
+	if r2.Platform != r.Platform {
+		t.Errorf("Platform: got %q, want %q", r2.Platform, r.Platform)
+	}
+	if r2.Version != r.Version {
+		t.Errorf("Version: got %q, want %q", r2.Version, r.Version)
+	}
+}
+
+// TestDeployStatusStates verifies all valid state strings are accepted.
+func TestDeployStatusStates(t *testing.T) {
+	states := []string{"running", "building", "failed", "sleeping", "unknown"}
+	for _, state := range states {
+		s := DeployStatus{State: state}
+		if s.State != state {
+			t.Errorf("state %q not preserved", state)
+		}
+	}
+}
+
+// TestDeployStatusSerialization verifies JSON round-trip for DeployStatus.
+func TestDeployStatusSerialization(t *testing.T) {
+	s := DeployStatus{
+		State:     "running",
+		URL:       "https://myapp.fly.dev",
+		Version:   "v3",
+		UpdatedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var s2 DeployStatus
+	if err := json.Unmarshal(data, &s2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if s2.State != s.State {
+		t.Errorf("State: got %q, want %q", s2.State, s.State)
+	}
+	if s2.URL != s.URL {
+		t.Errorf("URL: got %q, want %q", s2.URL, s.URL)
+	}
+}
+
+// TestErrNotImplemented verifies the sentinel error message.
+func TestErrNotImplemented(t *testing.T) {
+	err := ErrNotImplemented
+	if err == nil {
+		t.Fatal("ErrNotImplemented should not be nil")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error message should contain 'not implemented', got %q", err.Error())
+	}
+}
+
+// TestExtractURL verifies URL extraction from deployment output.
+func TestExtractURL(t *testing.T) {
+	tests := []struct {
+		text string
+		want string
+	}{
+		{"Deployment live at https://myapp.railway.app success", "https://myapp.railway.app"},
+		{"no url here", ""},
+		{"visit http://example.com. for docs", "http://example.com"},
+		{"https://a.fly.dev,extra", "https://a.fly.dev"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := extractURL(tc.text)
+		if got != tc.want {
+			t.Errorf("extractURL(%q) = %q, want %q", tc.text, got, tc.want)
+		}
+	}
+}

--- a/internal/deploy/railway.go
+++ b/internal/deploy/railway.go
@@ -1,0 +1,146 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// RailwayAdapter implements Platform for Railway (https://railway.app).
+// It wraps the `railway` CLI. Install with: npm install -g @railway/cli
+type RailwayAdapter struct {
+	exec ExecFunc
+}
+
+// NewRailwayAdapter returns a Railway adapter. Pass nil to use the real CLI.
+func NewRailwayAdapter(exec ExecFunc) *RailwayAdapter {
+	if exec == nil {
+		exec = DefaultExec
+	}
+	return &RailwayAdapter{exec: exec}
+}
+
+// Name implements Platform.
+func (r *RailwayAdapter) Name() string { return "railway" }
+
+// Detect implements Platform. Returns true if railway.json or railway.toml exists.
+func (r *RailwayAdapter) Detect(_ context.Context, workspaceDir string) (bool, error) {
+	for _, f := range []string{"railway.json", "railway.toml"} {
+		if _, err := os.Stat(workspaceDir + "/" + f); err == nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// Deploy implements Platform. Runs `railway up` with optional environment and dry-run flags.
+func (r *RailwayAdapter) Deploy(ctx context.Context, workspaceDir string, opts DeployOpts) (*DeployResult, error) {
+	args := []string{"up"}
+	if opts.Environment != "" {
+		args = append(args, "--environment", opts.Environment)
+	}
+	if opts.DryRun {
+		// Railway CLI does not have a native dry-run flag; we signal intent via detach.
+		// Just return a preview result without executing.
+		return &DeployResult{
+			Platform:  r.Name(),
+			Timestamp: time.Now(),
+			Logs:      "[dry-run] would run: railway " + strings.Join(args, " "),
+		}, nil
+	}
+	if opts.Force {
+		args = append(args, "--no-gitignore")
+	}
+
+	out, err := r.exec(ctx, workspaceDir, "railway", args...)
+	if err != nil {
+		return nil, fmt.Errorf("railway deploy: %w", err)
+	}
+
+	result := &DeployResult{
+		Platform:  r.Name(),
+		Timestamp: time.Now(),
+		Logs:      out,
+	}
+
+	// Extract URL from output (Railway prints "Deployment live at https://...")
+	result.URL = extractURL(out)
+	return result, nil
+}
+
+// Status implements Platform. Runs `railway status` and parses the output.
+func (r *RailwayAdapter) Status(ctx context.Context, workspaceDir string) (*DeployStatus, error) {
+	out, err := r.exec(ctx, workspaceDir, "railway", "status")
+	if err != nil {
+		return &DeployStatus{State: "failed"}, fmt.Errorf("railway status: %w", err)
+	}
+	return parseRailwayStatus(out), nil
+}
+
+// Logs implements Platform. Returns an io.Reader with deployment logs.
+func (r *RailwayAdapter) Logs(ctx context.Context, workspaceDir string, follow bool) (io.Reader, error) {
+	args := []string{"logs"}
+	if follow {
+		args = append(args, "--follow")
+	}
+	out, err := r.exec(ctx, workspaceDir, "railway", args...)
+	if err != nil {
+		return nil, fmt.Errorf("railway logs: %w", err)
+	}
+	return strings.NewReader(out), nil
+}
+
+// Rollback implements Platform. Railway does not expose a direct rollback CLI command.
+func (r *RailwayAdapter) Rollback(_ context.Context, _ string, _ string) error {
+	return ErrNotImplemented
+}
+
+// Teardown implements Platform. Runs `railway down` to remove the deployment.
+func (r *RailwayAdapter) Teardown(ctx context.Context, workspaceDir string) error {
+	_, err := r.exec(ctx, workspaceDir, "railway", "down")
+	if err != nil {
+		return fmt.Errorf("railway teardown: %w", err)
+	}
+	return nil
+}
+
+// parseRailwayStatus converts `railway status` text output into a DeployStatus.
+func parseRailwayStatus(out string) *DeployStatus {
+	status := &DeployStatus{
+		State:     "unknown",
+		UpdatedAt: time.Now(),
+	}
+	lower := strings.ToLower(out)
+	switch {
+	case strings.Contains(lower, "success") || strings.Contains(lower, "live") || strings.Contains(lower, "running"):
+		status.State = "running"
+	case strings.Contains(lower, "building") || strings.Contains(lower, "deploying"):
+		status.State = "building"
+	case strings.Contains(lower, "fail") || strings.Contains(lower, "error") || strings.Contains(lower, "crash"):
+		status.State = "failed"
+	case strings.Contains(lower, "sleeping") || strings.Contains(lower, "stopped"):
+		status.State = "sleeping"
+	}
+	status.URL = extractURL(out)
+	return status
+}
+
+// extractURL finds the first https:// URL in a block of text.
+func extractURL(text string) string {
+	for _, word := range strings.Fields(text) {
+		if strings.HasPrefix(word, "https://") || strings.HasPrefix(word, "http://") {
+			// Strip trailing punctuation and anything after an embedded comma or colon
+			// that would not be a valid URL suffix.
+			word = strings.TrimRight(word, ".,;:)")
+			// If the word contains a comma (e.g., "https://a.fly.dev,extra"), take only the URL part.
+			if idx := strings.Index(word, ","); idx >= 0 {
+				word = word[:idx]
+			}
+			return word
+		}
+	}
+	return ""
+}

--- a/internal/deploy/railway_test.go
+++ b/internal/deploy/railway_test.go
@@ -1,0 +1,272 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeExec records the most recent call for assertion.
+type fakeExec struct {
+	dir     string
+	command string
+	args    []string
+	output  string
+	err     error
+}
+
+func (f *fakeExec) Exec(ctx context.Context, dir, command string, args ...string) (string, error) {
+	f.dir = dir
+	f.command = command
+	f.args = args
+	return f.output, f.err
+}
+
+// TestRailwayAdapterName verifies the platform name.
+func TestRailwayAdapterName(t *testing.T) {
+	r := NewRailwayAdapter(nil)
+	if r.Name() != "railway" {
+		t.Errorf("expected 'railway', got %q", r.Name())
+	}
+}
+
+// TestRailwayDetect verifies Detect returns true for railway.json.
+func TestRailwayDetect(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "railway.json")
+	r := NewRailwayAdapter(nil)
+	ok, err := r.Detect(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Error("expected true for railway.json")
+	}
+}
+
+// TestRailwayDetectFalse verifies Detect returns false with no railway config.
+func TestRailwayDetectFalse(t *testing.T) {
+	dir := t.TempDir()
+	r := NewRailwayAdapter(nil)
+	ok, err := r.Detect(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Error("expected false for empty dir")
+	}
+}
+
+// TestRailwayDeployCommand verifies the correct CLI args are passed to the executor.
+func TestRailwayDeployCommand(t *testing.T) {
+	fe := &fakeExec{output: "Deployment live at https://myapp.railway.app"}
+	r := NewRailwayAdapter(fe.Exec)
+	result, err := r.Deploy(context.Background(), "/workspace", DeployOpts{Environment: "production"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.command != "railway" {
+		t.Errorf("expected command 'railway', got %q", fe.command)
+	}
+	if len(fe.args) == 0 || fe.args[0] != "up" {
+		t.Errorf("expected first arg 'up', got %v", fe.args)
+	}
+	if result.Platform != "railway" {
+		t.Errorf("expected platform 'railway', got %q", result.Platform)
+	}
+	if result.URL != "https://myapp.railway.app" {
+		t.Errorf("expected URL 'https://myapp.railway.app', got %q", result.URL)
+	}
+}
+
+// TestRailwayDeployWithEnvironment verifies --environment flag is passed.
+func TestRailwayDeployWithEnvironment(t *testing.T) {
+	fe := &fakeExec{output: "done"}
+	r := NewRailwayAdapter(fe.Exec)
+	_, err := r.Deploy(context.Background(), "/workspace", DeployOpts{Environment: "staging"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := strings.Join(fe.args, " ")
+	if !strings.Contains(args, "--environment") || !strings.Contains(args, "staging") {
+		t.Errorf("expected --environment staging in args, got %v", fe.args)
+	}
+}
+
+// TestRailwayDryRun verifies dry-run returns a preview result without calling exec.
+func TestRailwayDryRun(t *testing.T) {
+	called := false
+	exec := func(ctx context.Context, dir, cmd string, args ...string) (string, error) {
+		called = true
+		return "", nil
+	}
+	r := NewRailwayAdapter(exec)
+	result, err := r.Deploy(context.Background(), "/workspace", DeployOpts{DryRun: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("dry-run should not call exec")
+	}
+	if !strings.Contains(result.Logs, "dry-run") {
+		t.Errorf("expected 'dry-run' in logs, got %q", result.Logs)
+	}
+}
+
+// TestRailwayDeployError verifies errors from the CLI are propagated.
+func TestRailwayDeployError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("auth required")}
+	r := NewRailwayAdapter(fe.Exec)
+	_, err := r.Deploy(context.Background(), "/workspace", DeployOpts{})
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+	if !strings.Contains(err.Error(), "railway deploy") {
+		t.Errorf("expected 'railway deploy' in error, got %q", err.Error())
+	}
+}
+
+// TestRailwayStatus verifies Status parses running state.
+func TestRailwayStatus(t *testing.T) {
+	fe := &fakeExec{output: "Service is running at https://app.railway.app"}
+	r := NewRailwayAdapter(fe.Exec)
+	status, err := r.Status(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.State != "running" {
+		t.Errorf("expected state 'running', got %q", status.State)
+	}
+	if status.URL != "https://app.railway.app" {
+		t.Errorf("expected URL 'https://app.railway.app', got %q", status.URL)
+	}
+}
+
+// TestRailwayStatusBuilding verifies Status parses building state.
+func TestRailwayStatusBuilding(t *testing.T) {
+	fe := &fakeExec{output: "Service is deploying build in progress"}
+	r := NewRailwayAdapter(fe.Exec)
+	status, err := r.Status(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.State != "building" {
+		t.Errorf("expected state 'building', got %q", status.State)
+	}
+}
+
+// TestRailwayStatusFailed verifies Status parses failed state.
+func TestRailwayStatusFailed(t *testing.T) {
+	fe := &fakeExec{output: "Deployment error: crash looping"}
+	r := NewRailwayAdapter(fe.Exec)
+	status, err := r.Status(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.State != "failed" {
+		t.Errorf("expected state 'failed', got %q", status.State)
+	}
+}
+
+// TestRailwayStatusError verifies Status returns failed state on CLI error.
+func TestRailwayStatusError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("not logged in")}
+	r := NewRailwayAdapter(fe.Exec)
+	status, err := r.Status(context.Background(), "/workspace")
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+	if status.State != "failed" {
+		t.Errorf("expected state 'failed' on error, got %q", status.State)
+	}
+}
+
+// TestRailwayLogs verifies Logs returns an io.Reader with CLI output.
+func TestRailwayLogs(t *testing.T) {
+	fe := &fakeExec{output: "2024-01-01 server started\n2024-01-01 request received"}
+	r := NewRailwayAdapter(fe.Exec)
+	reader, err := r.Logs(context.Background(), "/workspace", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var buf strings.Builder
+	tmp := make([]byte, 256)
+	for {
+		n, readErr := reader.Read(tmp)
+		if n > 0 {
+			buf.Write(tmp[:n])
+		}
+		if readErr != nil {
+			break
+		}
+	}
+	if !strings.Contains(buf.String(), "server started") {
+		t.Errorf("expected log content, got %q", buf.String())
+	}
+}
+
+// TestRailwayRollback verifies Rollback returns ErrNotImplemented.
+func TestRailwayRollback(t *testing.T) {
+	r := NewRailwayAdapter(nil)
+	err := r.Rollback(context.Background(), "/workspace", "")
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+// TestRailwayTeardown verifies Teardown passes `railway down` to exec.
+func TestRailwayTeardown(t *testing.T) {
+	fe := &fakeExec{output: "service deleted"}
+	r := NewRailwayAdapter(fe.Exec)
+	err := r.Teardown(context.Background(), "/workspace")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.command != "railway" {
+		t.Errorf("expected command 'railway', got %q", fe.command)
+	}
+	if len(fe.args) == 0 || fe.args[0] != "down" {
+		t.Errorf("expected first arg 'down', got %v", fe.args)
+	}
+}
+
+// TestRailwayTeardownError verifies Teardown propagates exec errors.
+func TestRailwayTeardownError(t *testing.T) {
+	fe := &fakeExec{err: errors.New("service not found")}
+	r := NewRailwayAdapter(fe.Exec)
+	err := r.Teardown(context.Background(), "/workspace")
+	if err == nil {
+		t.Fatal("expected error from failed exec")
+	}
+}
+
+// TestRailwayForceFlag verifies the --no-gitignore flag is passed when Force=true.
+func TestRailwayForceFlag(t *testing.T) {
+	fe := &fakeExec{output: "done"}
+	r := NewRailwayAdapter(fe.Exec)
+	_, err := r.Deploy(context.Background(), "/workspace", DeployOpts{Force: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args := strings.Join(fe.args, " ")
+	if !strings.Contains(args, "--no-gitignore") {
+		t.Errorf("expected --no-gitignore in args, got %v", fe.args)
+	}
+}
+
+// TestParseRailwayStatusLive verifies live output maps to running.
+func TestParseRailwayStatusLive(t *testing.T) {
+	s := parseRailwayStatus("Deployment live at https://example.railway.app")
+	if s.State != "running" {
+		t.Errorf("expected 'running', got %q", s.State)
+	}
+}
+
+// TestParseRailwayStatusUnknown verifies unrecognized output maps to unknown.
+func TestParseRailwayStatusUnknown(t *testing.T) {
+	s := parseRailwayStatus("some random output")
+	if s.State != "unknown" {
+		t.Errorf("expected 'unknown', got %q", s.State)
+	}
+}

--- a/internal/harness/tools/deferred/deploy.go
+++ b/internal/harness/tools/deferred/deploy.go
@@ -1,0 +1,178 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"go-agent-harness/internal/deploy"
+	tools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/descriptions"
+)
+
+// DeployPlatformRegistry maps platform name to Platform implementation.
+type DeployPlatformRegistry map[string]deploy.Platform
+
+// DefaultDeployPlatformRegistry returns a registry with the built-in adapters.
+func DefaultDeployPlatformRegistry() DeployPlatformRegistry {
+	return DeployPlatformRegistry{
+		"railway": deploy.NewRailwayAdapter(nil),
+		"flyio":   deploy.NewFlyAdapter(nil),
+	}
+}
+
+// DeployTool returns a deferred tool for deploying to cloud platforms.
+func DeployTool(registry DeployPlatformRegistry, workspaceRoot string) tools.Tool {
+	def := tools.Definition{
+		Name:         "deploy",
+		Description:  descriptions.Load("deploy"),
+		Action:       tools.ActionExecute,
+		Mutating:     true,
+		ParallelSafe: false,
+		Tier:         tools.TierDeferred,
+		Tags:         []string{"deploy", "cloud", "infrastructure", "railway", "fly", "vercel", "cloudflare"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"platform": map[string]any{
+					"type":        "string",
+					"description": "Platform adapter: 'railway' or 'flyio'. If omitted, auto-detected from workspace.",
+				},
+				"action": map[string]any{
+					"type":        "string",
+					"enum":        []string{"deploy", "status", "logs", "detect"},
+					"description": "Action to perform.",
+				},
+				"workspace": map[string]any{
+					"type":        "string",
+					"description": "Absolute path to the project directory. Defaults to the agent workspace root.",
+				},
+				"environment": map[string]any{
+					"type":        "string",
+					"description": "Target environment: 'staging' or 'production'. Default: 'production'.",
+				},
+				"dry_run": map[string]any{
+					"type":        "boolean",
+					"description": "Preview the deploy command without executing. Default: false.",
+				},
+				"force": map[string]any{
+					"type":        "boolean",
+					"description": "Skip pre-deploy checks. Default: false.",
+				},
+			},
+			"required": []string{"action"},
+		},
+	}
+
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args struct {
+			Platform    string `json:"platform"`
+			Action      string `json:"action"`
+			Workspace   string `json:"workspace"`
+			Environment string `json:"environment"`
+			DryRun      bool   `json:"dry_run"`
+			Force       bool   `json:"force"`
+		}
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("parse deploy args: %w", err)
+		}
+		if strings.TrimSpace(args.Action) == "" {
+			return "", fmt.Errorf("action is required")
+		}
+
+		// Resolve workspace directory.
+		wsDir := args.Workspace
+		if wsDir == "" {
+			wsDir = workspaceRoot
+		}
+
+		// Handle detect action — no platform needed.
+		if args.Action == "detect" {
+			name, err := deploy.DetectPlatform(wsDir)
+			if err != nil {
+				return "", fmt.Errorf("detect platform: %w", err)
+			}
+			all := deploy.DetectAll(wsDir)
+			return tools.MarshalToolResult(map[string]any{
+				"platform": name,
+				"all":      all,
+			})
+		}
+
+		// Resolve platform.
+		platformName := strings.TrimSpace(args.Platform)
+		if platformName == "" {
+			// Auto-detect from workspace.
+			detected, err := deploy.DetectPlatform(wsDir)
+			if err != nil {
+				return "", fmt.Errorf("auto-detect platform: %w; specify platform explicitly", err)
+			}
+			platformName = detected
+		}
+
+		platform, ok := registry[platformName]
+		if !ok {
+			return "", fmt.Errorf("unknown platform %q; supported: %s", platformName, supportedPlatforms(registry))
+		}
+
+		switch args.Action {
+		case "deploy":
+			env := args.Environment
+			if env == "" {
+				env = "production"
+			}
+			result, err := platform.Deploy(ctx, wsDir, deploy.DeployOpts{
+				Environment: env,
+				DryRun:      args.DryRun,
+				Force:       args.Force,
+			})
+			if err != nil {
+				return "", fmt.Errorf("deploy failed: %w", err)
+			}
+			return tools.MarshalToolResult(result)
+
+		case "status":
+			status, err := platform.Status(ctx, wsDir)
+			if err != nil {
+				return "", fmt.Errorf("status failed: %w", err)
+			}
+			return tools.MarshalToolResult(status)
+
+		case "logs":
+			reader, err := platform.Logs(ctx, wsDir, false)
+			if err != nil {
+				return "", fmt.Errorf("logs failed: %w", err)
+			}
+			var buf strings.Builder
+			tmp := make([]byte, 4096)
+			for {
+				n, err := reader.Read(tmp)
+				if n > 0 {
+					buf.Write(tmp[:n])
+				}
+				if err != nil {
+					break
+				}
+			}
+			return tools.MarshalToolResult(map[string]any{
+				"platform": platformName,
+				"logs":     buf.String(),
+			})
+
+		default:
+			return "", fmt.Errorf("unknown action %q; valid: deploy, status, logs, detect", args.Action)
+		}
+	}
+
+	return tools.Tool{Definition: def, Handler: handler}
+}
+
+// supportedPlatforms returns a comma-separated list of registered platform names.
+func supportedPlatforms(registry DeployPlatformRegistry) string {
+	names := make([]string, 0, len(registry))
+	for name := range registry {
+		names = append(names, name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/harness/tools/deferred/deploy_test.go
+++ b/internal/harness/tools/deferred/deploy_test.go
@@ -1,0 +1,395 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/deploy"
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// --- mock Platform ---
+
+type mockPlatform struct {
+	name         string
+	detectResult bool
+	detectErr    error
+	deployResult *deploy.DeployResult
+	deployErr    error
+	statusResult *deploy.DeployStatus
+	statusErr    error
+	logsOutput   string
+	logsErr      error
+	rollbackErr  error
+	teardownErr  error
+}
+
+func (m *mockPlatform) Name() string { return m.name }
+
+func (m *mockPlatform) Detect(_ context.Context, _ string) (bool, error) {
+	return m.detectResult, m.detectErr
+}
+
+func (m *mockPlatform) Deploy(_ context.Context, _ string, opts deploy.DeployOpts) (*deploy.DeployResult, error) {
+	if m.deployErr != nil {
+		return nil, m.deployErr
+	}
+	if m.deployResult != nil {
+		return m.deployResult, nil
+	}
+	return &deploy.DeployResult{
+		Platform:  m.name,
+		URL:       "https://example.com",
+		Timestamp: time.Now(),
+		Logs:      "deployed",
+	}, nil
+}
+
+func (m *mockPlatform) Status(_ context.Context, _ string) (*deploy.DeployStatus, error) {
+	if m.statusErr != nil {
+		return &deploy.DeployStatus{State: "failed"}, m.statusErr
+	}
+	if m.statusResult != nil {
+		return m.statusResult, nil
+	}
+	return &deploy.DeployStatus{State: "running", URL: "https://example.com"}, nil
+}
+
+func (m *mockPlatform) Logs(_ context.Context, _ string, _ bool) (io.Reader, error) {
+	if m.logsErr != nil {
+		return nil, m.logsErr
+	}
+	return strings.NewReader(m.logsOutput), nil
+}
+
+func (m *mockPlatform) Rollback(_ context.Context, _ string, _ string) error {
+	return m.rollbackErr
+}
+
+func (m *mockPlatform) Teardown(_ context.Context, _ string) error {
+	return m.teardownErr
+}
+
+// --- helpers ---
+
+// writeDeployFile creates a file with empty content at dir/name.
+func writeDeployFile(t *testing.T, dir, name string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte{}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// --- tests ---
+
+// TestDeployTool_Definition verifies tool metadata.
+func TestDeployTool_Definition(t *testing.T) {
+	reg := DefaultDeployPlatformRegistry()
+	tool := DeployTool(reg, t.TempDir())
+	assertToolDef(t, tool, "deploy", tools.TierDeferred)
+	assertHasTags(t, tool, "deploy", "cloud")
+}
+
+// TestDeployTool_MissingAction verifies error when action is absent.
+func TestDeployTool_MissingAction(t *testing.T) {
+	reg := DefaultDeployPlatformRegistry()
+	tool := DeployTool(reg, t.TempDir())
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for missing action")
+	}
+}
+
+// TestDeployTool_InvalidJSON verifies error for unparseable JSON.
+func TestDeployTool_InvalidJSON(t *testing.T) {
+	reg := DefaultDeployPlatformRegistry()
+	tool := DeployTool(reg, t.TempDir())
+	_, err := tool.Handler(context.Background(), json.RawMessage(`not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+// TestDeployTool_DetectAction verifies the detect action returns the platform name.
+func TestDeployTool_DetectAction(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployFile(t, dir, "fly.toml")
+	reg := DefaultDeployPlatformRegistry()
+	tool := DeployTool(reg, dir)
+	args, _ := json.Marshal(map[string]string{"action": "detect"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "flyio") {
+		t.Errorf("expected 'flyio' in result, got %q", result)
+	}
+}
+
+// TestDeployTool_DetectAction_NoPlatform verifies detect returns error when no config found.
+func TestDeployTool_DetectAction_NoPlatform(t *testing.T) {
+	dir := t.TempDir()
+	reg := DefaultDeployPlatformRegistry()
+	tool := DeployTool(reg, dir)
+	args, _ := json.Marshal(map[string]string{"action": "detect"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error when no platform detected")
+	}
+}
+
+// TestDeployTool_DeployAction verifies deploy action returns structured result.
+func TestDeployTool_DeployAction(t *testing.T) {
+	mock := &mockPlatform{
+		name: "railway",
+		deployResult: &deploy.DeployResult{
+			Platform: "railway",
+			URL:      "https://myapp.railway.app",
+		},
+	}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{
+		"action":      "deploy",
+		"platform":    "railway",
+		"environment": "production",
+	})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "railway.app") {
+		t.Errorf("expected URL in result, got %q", result)
+	}
+}
+
+// TestDeployTool_DeployDryRun verifies dry-run is passed through without error.
+func TestDeployTool_DeployDryRun(t *testing.T) {
+	mock := &mockPlatform{name: "railway"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{
+		"action":   "deploy",
+		"platform": "railway",
+		"dry_run":  true,
+	})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+// TestDeployTool_DeployError propagates platform deploy errors.
+func TestDeployTool_DeployError(t *testing.T) {
+	mock := &mockPlatform{name: "railway", deployErr: errors.New("auth failed")}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "deploy", "platform": "railway"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error from platform")
+	}
+}
+
+// TestDeployTool_StatusAction verifies status returns deployment state.
+func TestDeployTool_StatusAction(t *testing.T) {
+	mock := &mockPlatform{
+		name: "flyio",
+		statusResult: &deploy.DeployStatus{
+			State: "running",
+			URL:   "https://myapp.fly.dev",
+		},
+	}
+	reg := DeployPlatformRegistry{"flyio": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "status", "platform": "flyio"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "running") {
+		t.Errorf("expected 'running' in result, got %q", result)
+	}
+}
+
+// TestDeployTool_StatusError propagates platform status errors.
+func TestDeployTool_StatusError(t *testing.T) {
+	mock := &mockPlatform{name: "flyio", statusErr: errors.New("not found")}
+	reg := DeployPlatformRegistry{"flyio": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "status", "platform": "flyio"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error from platform")
+	}
+}
+
+// TestDeployTool_LogsAction verifies logs are returned.
+func TestDeployTool_LogsAction(t *testing.T) {
+	mock := &mockPlatform{name: "railway", logsOutput: "2024-01-01 server started"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "logs", "platform": "railway"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "server started") {
+		t.Errorf("expected log content in result, got %q", result)
+	}
+}
+
+// TestDeployTool_LogsError propagates platform logs errors.
+func TestDeployTool_LogsError(t *testing.T) {
+	mock := &mockPlatform{name: "railway", logsErr: errors.New("no logs")}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "logs", "platform": "railway"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error from platform")
+	}
+}
+
+// TestDeployTool_UnknownAction verifies error for invalid action.
+func TestDeployTool_UnknownAction(t *testing.T) {
+	mock := &mockPlatform{name: "railway"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "bogus", "platform": "railway"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+}
+
+// TestDeployTool_UnknownPlatform verifies error for unregistered platform.
+func TestDeployTool_UnknownPlatform(t *testing.T) {
+	reg := DeployPlatformRegistry{}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "deploy", "platform": "unknown"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error for unknown platform")
+	}
+}
+
+// TestDeployTool_AutoDetect verifies platform is auto-detected when omitted.
+func TestDeployTool_AutoDetect(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployFile(t, dir, "fly.toml")
+	mock := &mockPlatform{name: "flyio"}
+	reg := DeployPlatformRegistry{"flyio": mock}
+	tool := DeployTool(reg, dir)
+	args, _ := json.Marshal(map[string]any{"action": "status"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+// TestDeployTool_AutoDetectFails verifies error when auto-detection fails.
+func TestDeployTool_AutoDetectFails(t *testing.T) {
+	dir := t.TempDir() // empty workspace, no config files
+	mock := &mockPlatform{name: "flyio"}
+	reg := DeployPlatformRegistry{"flyio": mock}
+	tool := DeployTool(reg, dir)
+	args, _ := json.Marshal(map[string]any{"action": "deploy"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error when auto-detection fails")
+	}
+}
+
+// TestDeployTool_DefaultEnvironment verifies production is used when environment is omitted.
+func TestDeployTool_DefaultEnvironment(t *testing.T) {
+	mock := &mockPlatform{name: "railway"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "deploy", "platform": "railway"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+// TestDeployTool_WorkspaceOverride verifies custom workspace path is used.
+func TestDeployTool_WorkspaceOverride(t *testing.T) {
+	customDir := t.TempDir()
+	writeDeployFile(t, customDir, "railway.json")
+	mock := &mockPlatform{name: "railway"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir()) // default workspace has no config
+	args, _ := json.Marshal(map[string]any{
+		"action":    "detect",
+		"workspace": customDir,
+	})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "railway") {
+		t.Errorf("expected 'railway' in result, got %q", result)
+	}
+}
+
+// TestDefaultDeployPlatformRegistry verifies the built-in registry has expected adapters.
+func TestDefaultDeployPlatformRegistry(t *testing.T) {
+	reg := DefaultDeployPlatformRegistry()
+	if _, ok := reg["railway"]; !ok {
+		t.Error("expected 'railway' in default registry")
+	}
+	if _, ok := reg["flyio"]; !ok {
+		t.Error("expected 'flyio' in default registry")
+	}
+}
+
+// TestDeployTool_EmptyRegistry verifies error when registry is empty and platform given.
+func TestDeployTool_EmptyRegistry(t *testing.T) {
+	reg := DeployPlatformRegistry{}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{"action": "status", "platform": "railway"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected error for empty registry")
+	}
+}
+
+// TestDeployTool_ForceFlag verifies force=true passes through without error.
+func TestDeployTool_ForceFlag(t *testing.T) {
+	mock := &mockPlatform{name: "railway"}
+	reg := DeployPlatformRegistry{"railway": mock}
+	tool := DeployTool(reg, t.TempDir())
+	args, _ := json.Marshal(map[string]any{
+		"action":   "deploy",
+		"platform": "railway",
+		"force":    true,
+	})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+}

--- a/internal/harness/tools/descriptions/deploy.md
+++ b/internal/harness/tools/descriptions/deploy.md
@@ -1,0 +1,17 @@
+Deploy a project to a cloud platform (Railway, Fly.io, Cloudflare, Vercel, etc.) or check its status and logs.
+
+Actions:
+- deploy: Push the current project to the platform. Returns deployment URL and logs.
+- status: Check the current deployment state (running, building, failed, sleeping).
+- logs: Retrieve recent deployment or application logs.
+- detect: Auto-detect the platform from workspace config files.
+
+Parameters:
+- platform: Platform adapter to use ("railway", "flyio"). If omitted, auto-detects from workspace.
+- action: One of "deploy", "status", "logs", "detect" (required).
+- workspace: Absolute path to the project directory (defaults to current workspace root).
+- environment: Target environment such as "staging" or "production" (default: "production").
+- dry_run: Preview the deploy command without executing (default: false).
+- force: Skip pre-deploy checks (default: false).
+
+The tool wraps the platform CLI (railway, fly) and returns structured JSON results.


### PR DESCRIPTION
## Summary
- New `internal/deploy/` package: `Platform` interface + Railway and Fly.io CLI adapters
- Auto-detection of platform from workspace config files (`fly.toml`, `railway.toml`, `vercel.json`, etc.)
- `deploy` deferred tool with `deploy/status/logs/detect` actions

## Interface
```go
type Platform interface {
    Name() string
    Deploy(ctx context.Context, opts DeployOpts) (DeployResult, error)
    Status(ctx context.Context, opts DeployOpts) (DeployResult, error)
    Logs(ctx context.Context, opts DeployOpts) (DeployResult, error)
    Rollback(ctx context.Context, opts DeployOpts) (DeployResult, error)
}
```

## Changes
- `internal/deploy/platform.go` — `Platform` interface, `DeployOpts`, `DeployResult`, `ErrNotImplemented`
- `internal/deploy/railway.go` — Railway adapter wrapping `railway` CLI
- `internal/deploy/flyio.go` — Fly.io adapter wrapping `fly` CLI (with versioned rollback)
- `internal/deploy/detect.go` — `DetectPlatform()` + `DetectAll()` from workspace config files
- `internal/deploy/exec.go` — Injectable `ExecFunc` for testing
- `internal/harness/tools/deferred/deploy.go` — `DeployTool` with `DefaultDeployPlatformRegistry()`
- `internal/harness/tools/descriptions/deploy.md` — embedded description
- 60+ tests: platform tests, 17 Railway tests, 17 Fly.io tests, detection tests (race-safe)

## Test plan
- [x] `internal/deploy`: 95.8% coverage
- [x] Full regression: 81.1% coverage (min 80%)
- [x] `go test $(go list ./... | grep -v demo-cli) -race` passes

Closes #45