### PR TITLE
Add skill files for Cloudflare Workers, Vercel, Fly.io, and Kubernetes (issues #46, #48, #54, #71)

### DIFF
--- a/skills/cloudflare-workers/SKILL.md
+++ b/skills/cloudflare-workers/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: cloudflare-workers
+description: "Deploy and manage Cloudflare Workers, KV namespaces, D1 databases, R2 buckets, and Durable Objects via the wrangler CLI. Trigger: when deploying to Cloudflare, using wrangler, deploying Workers, managing KV namespaces, D1 databases, R2 buckets, Durable Objects, Cloudflare queues"
+version: 1
+argument-hint: "[deploy|dev|tail|kv|d1|r2|secret|rollback]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - edit
+  - glob
+  - grep
+---
+# Cloudflare Workers Deployment
+
+You are now operating in Cloudflare Workers deployment mode using the `wrangler` CLI.
+
+## Prerequisites
+
+```bash
+# Install wrangler
+npm install -g wrangler
+
+# Authenticate (one-time, interactive)
+wrangler login
+
+# Or use API token (preferred for CI/automation)
+export CLOUDFLARE_API_TOKEN="your-token-here"
+# Generate at: https://dash.cloudflare.com/profile/api-tokens
+# Required scopes: Workers Scripts:Edit, Workers KV Storage:Edit, D1:Edit, R2:Edit
+
+# Verify authentication
+wrangler whoami
+```
+
+## Project Structure
+
+```
+my-worker/
+├── wrangler.toml      # Configuration file
+├── src/
+│   └── index.ts       # Worker entrypoint
+└── package.json
+```
+
+### Minimal `wrangler.toml`
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# Optional: bind KV namespace
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "abc123def456"
+
+# Optional: bind D1 database
+[[d1_databases]]
+binding = "DB"
+database_name = "my-database"
+database_id = "abc123"
+
+# Optional: bind R2 bucket
+[[r2_buckets]]
+binding = "MY_BUCKET"
+bucket_name = "my-bucket"
+```
+
+## Local Development
+
+```bash
+# Start local dev server (uses local emulation)
+wrangler dev
+
+# Dev against real Cloudflare network (remote bindings)
+wrangler dev --remote
+
+# Specify port
+wrangler dev --port 8787
+
+# Enable live reload on save
+wrangler dev --watch
+```
+
+## Deployment
+
+```bash
+# Deploy to production
+wrangler deploy
+
+# Dry run (validate without deploying)
+wrangler deploy --dry-run
+
+# Deploy to a named environment (requires [env.staging] in wrangler.toml)
+wrangler deploy --env staging
+wrangler deploy --env production
+
+# Deploy and verify output
+wrangler deploy 2>&1 | tee deploy.log
+grep "Deployed" deploy.log
+```
+
+## Multi-Environment Configuration
+
+```toml
+# wrangler.toml
+
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[env.staging]
+name = "my-worker-staging"
+vars = { ENVIRONMENT = "staging" }
+
+[env.production]
+name = "my-worker-production"
+vars = { ENVIRONMENT = "production" }
+```
+
+## Monitoring: Live Log Tailing
+
+```bash
+# Tail logs in real-time
+wrangler tail
+
+# Always use --format json for parsing
+wrangler tail --format json
+
+# Tail a specific environment
+wrangler tail --env production --format json
+
+# Filter by status code (e.g., only errors)
+wrangler tail --status error
+
+# Filter by sampling rate (0.0 to 1.0)
+wrangler tail --sampling-rate 0.1
+```
+
+## Version Management and Rollback
+
+```bash
+# List deployed versions
+wrangler versions list
+wrangler versions list --json
+
+# View a specific version's details
+wrangler versions view <version-id>
+
+# Upload a new version without activating
+wrangler versions upload
+
+# Activate a specific version (gradual rollout)
+wrangler versions deploy <version-id>
+
+# Deploy with percentage traffic split
+wrangler versions deploy <version-id> --percentage 10
+
+# Rollback to previous version
+wrangler rollback
+```
+
+## Secrets Management
+
+```bash
+# Set a secret (prompts for value, never logged)
+wrangler secret put DATABASE_URL
+
+# Set a secret for a specific environment
+wrangler secret put DATABASE_URL --env production
+
+# List all secret names (values are never shown)
+wrangler secret list
+
+# Delete a secret
+wrangler secret delete DATABASE_URL
+```
+
+## KV Namespace Operations
+
+```bash
+# Create a KV namespace
+wrangler kv namespace create MY_NAMESPACE
+
+# List all namespaces
+wrangler kv namespace list
+
+# Write a key-value pair
+wrangler kv key put mykey "myvalue" --namespace-id <namespace-id>
+
+# Read a value
+wrangler kv key get mykey --namespace-id <namespace-id>
+
+# List keys with prefix
+wrangler kv key list --namespace-id <namespace-id> --prefix "user:"
+
+# Delete a key
+wrangler kv key delete mykey --namespace-id <namespace-id>
+
+# Bulk upload from JSON file
+wrangler kv bulk put data.json --namespace-id <namespace-id>
+```
+
+KV is eventually consistent (~60s). Best for: config, feature flags, cached reads.
+
+## D1 Database Operations
+
+```bash
+# Create a D1 database
+wrangler d1 create my-database
+
+# List all D1 databases
+wrangler d1 list
+
+# Execute SQL (local emulation)
+wrangler d1 execute my-database --command "SELECT * FROM users LIMIT 10;"
+
+# Execute SQL on production (always use --remote for production)
+wrangler d1 execute my-database --remote --command "SELECT COUNT(*) FROM users;"
+
+# Execute a SQL file
+wrangler d1 execute my-database --remote --file ./schema.sql
+
+# Apply migrations
+wrangler d1 migrations apply my-database --remote
+
+# Show migration status
+wrangler d1 migrations list my-database
+```
+
+D1 is strongly consistent SQLite. Best for: structured data, relational queries.
+
+## R2 Bucket Operations
+
+```bash
+# Create an R2 bucket
+wrangler r2 bucket create my-bucket
+
+# List all buckets
+wrangler r2 bucket list
+
+# Upload an object
+wrangler r2 object put my-bucket/path/to/file.txt --file ./local-file.txt
+
+# Download an object
+wrangler r2 object get my-bucket/path/to/file.txt --file ./downloaded.txt
+
+# Delete an object
+wrangler r2 object delete my-bucket/path/to/file.txt
+```
+
+R2 has zero egress fees. Best for: files, media, backups.
+
+## Queues Operations
+
+```bash
+# Create a queue
+wrangler queues create my-queue
+
+# List queues
+wrangler queues list
+
+# Send a message to a queue (for testing)
+wrangler queues send my-queue '{"event": "test", "data": {}}'
+```
+
+## Worker Deletion
+
+```bash
+# Delete a Worker (irreversible!)
+wrangler delete
+
+# Delete a specific environment's worker
+wrangler delete --env staging
+```
+
+## Deployment Patterns
+
+### Pattern 1: Standard Deploy and Verify
+
+```bash
+# 1. Deploy
+wrangler deploy --env production
+
+# 2. Tail logs to verify health (press Ctrl+C when satisfied)
+wrangler tail --env production --format json &
+TAIL_PID=$!
+
+# 3. Wait a few seconds for traffic
+sleep 10
+
+# 4. Stop tailing
+kill $TAIL_PID
+
+# 5. Report deployment URL (from deploy output)
+```
+
+### Pattern 2: Multi-Environment Pipeline
+
+```bash
+# 1. Deploy to staging first
+wrangler deploy --env staging
+
+# 2. Verify staging works
+curl -f https://my-worker-staging.workers.dev/health
+
+# 3. Deploy to production only if staging passes
+wrangler deploy --env production
+
+# 4. Verify production
+curl -f https://my-worker-production.workers.dev/health
+```
+
+### Pattern 3: Blue-Green with Traffic Splitting
+
+```bash
+# 1. Upload new version without activating
+wrangler versions upload
+
+# 2. Get the new version ID
+NEW_VERSION=$(wrangler versions list --json | jq -r '.[0].id')
+
+# 3. Route 10% of traffic to new version
+wrangler versions deploy "$NEW_VERSION" --percentage 10
+
+# 4. Monitor logs for errors
+wrangler tail --format json | jq 'select(.outcome == "exception")'
+
+# 5. Promote to 100% if healthy
+wrangler versions deploy "$NEW_VERSION" --percentage 100
+
+# OR rollback if problems found
+wrangler rollback
+```
+
+## Cloudflare Storage Binding Reference
+
+| Binding | Best For | Consistency | Notes |
+|---------|---------|-------------|-------|
+| KV | Config, feature flags, cached reads | Eventually (~60s) | $0.50/M reads, $5/M writes |
+| R2 | Files, media, backups | Strong | Zero egress, $0.015/GB-month |
+| D1 | Structured SQL data | Strong (SQLite) | $0.001/M reads |
+| Durable Objects | Real-time, WebSockets, per-entity state | Strong (single-threaded) | $0.15/M requests |
+| Queues | Background jobs, async processing | At-least-once | $0.40/M after 1M free |
+| Workers AI | LLM inference, embeddings | N/A | Per-token billing |
+
+## Free Tier Limits
+
+- 100,000 requests/day
+- 10ms CPU time per invocation
+- KV: 100k reads/day, 1k writes/day, 1 GB storage
+- D1: 5M rows read/day, 100k rows written/day, 5 GB storage
+- R2: 10 GB storage, 1M Class A ops, 10M Class B ops
+
+## Safety Rules
+
+- Never commit `CLOUDFLARE_API_TOKEN` to source control — use environment variables or `wrangler secret put`.
+- Always deploy to staging before production.
+- Always tail logs after deployment to verify no errors.
+- Use `--dry-run` to validate the deployment bundle before pushing to production.
+- Use `wrangler rollback` immediately if errors spike after deployment.
+- D1 migrations with `--remote` modify live production data — test locally first.

--- a/skills/fly-deploy/SKILL.md
+++ b/skills/fly-deploy/SKILL.md
@@ -1,0 +1,378 @@
+---
+name: fly-deploy
+description: "Deploy containers globally to Fly.io with multi-region support, managed Postgres, volumes, and Firecracker microVMs using the fly CLI. Trigger: when deploying to Fly.io, using flyctl, fly launch, fly deploy, managing Fly machines, Fly Postgres, multi-region deployment"
+version: 1
+argument-hint: "[launch|deploy|status|logs|ssh|scale|secrets|postgres]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - edit
+  - glob
+  - grep
+---
+# Fly.io Deployment
+
+You are now operating in Fly.io deployment mode using the `fly` CLI (flyctl).
+
+## Prerequisites
+
+```bash
+# Install flyctl
+# macOS
+brew install flyctl
+
+# Linux / macOS alternative
+curl -L https://fly.io/install.sh | sh
+
+# Authenticate
+fly auth login
+
+# Or use API token (preferred for CI/automation)
+export FLY_API_TOKEN="your-token-here"
+# Generate at: https://fly.io/user/personal_access_tokens
+
+# Verify authentication
+fly auth whoami
+```
+
+## Initializing a New App
+
+```bash
+# Launch a new app (detects Dockerfile, prompts for config)
+fly launch
+
+# Launch without interactive prompts
+fly launch --yes
+
+# Launch without deploying (generate fly.toml only)
+fly launch --no-deploy
+
+# Launch with a specific name and region
+fly launch --name my-app --region iad --yes
+
+# Launch and override org
+fly launch --org my-org --yes
+```
+
+## Application Configuration (`fly.toml`)
+
+```toml
+app = "my-app"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  ENVIRONMENT = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/health"
+    timeout = "5s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory_mb = 256
+```
+
+## Deploying
+
+```bash
+# Deploy current project
+fly deploy
+
+# Deploy with a specific strategy
+fly deploy --strategy rolling       # rolling update (default)
+fly deploy --strategy canary        # canary release
+fly deploy --strategy bluegreen     # blue-green deployment
+fly deploy --strategy immediate     # replace all at once
+
+# Deploy and wait for health checks to pass
+fly deploy --wait-timeout 120s
+
+# Build and deploy a specific Docker image
+fly deploy --image registry.fly.io/my-app:v1.2.3
+
+# Deploy to a specific region only
+fly deploy --regions iad
+
+# Verbose output for debugging
+fly deploy --verbose
+```
+
+## Checking Status
+
+```bash
+# App status (shows machines and their health)
+fly status
+
+# Status in JSON format (for parsing)
+fly status --json
+
+# List all machines
+fly machine list
+
+# Machine list in JSON
+fly machine list --json
+
+# Check a specific machine
+fly machine status <machine-id>
+
+# List all apps in the org
+fly apps list
+```
+
+## Viewing Logs
+
+```bash
+# Stream live logs
+fly logs
+
+# Logs in JSON format (for parsing/filtering)
+fly logs --json
+
+# Logs from a specific region
+fly logs --region iad
+
+# Logs from a specific machine
+fly logs --machine <machine-id>
+
+# Filter logs with grep
+fly logs | grep -i error
+
+# Parse structured JSON logs
+fly logs --json | jq 'select(.level == "error")'
+```
+
+## Scaling
+
+```bash
+# Scale to N machines (replicas)
+fly scale count 3
+
+# Scale per region
+fly scale count 2 --region iad
+fly scale count 1 --region lhr
+
+# Change VM size (shared CPU)
+fly scale vm shared-cpu-1x    # 256 MB RAM
+fly scale vm shared-cpu-2x    # 512 MB RAM
+fly scale vm shared-cpu-4x    # 1 GB RAM
+
+# Change VM size (dedicated CPU)
+fly scale vm performance-1x   # 2 GB RAM
+fly scale vm performance-2x   # 4 GB RAM
+
+# Show current VM count and sizes
+fly scale show
+```
+
+## Multi-Region Configuration
+
+```bash
+# Add regions to the app
+fly regions add ord lax ams
+
+# Remove a region
+fly regions remove lhr
+
+# List active regions
+fly regions list
+
+# Set the primary region
+fly regions set-primary iad
+
+# Deploy and distribute across regions
+fly scale count 2 --region ord
+fly scale count 2 --region lax
+fly deploy
+```
+
+## Secrets Management
+
+```bash
+# Set a secret (never logged or shown after set)
+fly secrets set DATABASE_URL="postgresql://..."
+
+# Set multiple secrets at once
+fly secrets set \
+  DATABASE_URL="postgresql://..." \
+  API_KEY="sk_live_..." \
+  JWT_SECRET="..."
+
+# List secret names (values are never shown)
+fly secrets list
+
+# Remove a secret
+fly secrets unset DATABASE_URL
+
+# Import secrets from a .env file
+fly secrets import < .env.production
+```
+
+## SSH Access
+
+```bash
+# Open an interactive shell in a running machine
+fly ssh console
+
+# Run a one-off command (non-interactive)
+fly ssh console -C "ls /app"
+
+# SSH to a specific machine
+fly ssh console --machine <machine-id>
+
+# SSH to a specific region
+fly ssh console --region lax
+
+# Copy files from a machine
+fly ssh sftp get /app/logs/app.log ./app.log
+```
+
+## Volumes (Persistent Storage)
+
+```bash
+# Create a volume in a region
+fly volumes create myapp_data --region iad --size 10
+
+# List volumes
+fly volumes list
+
+# Extend a volume (increase size)
+fly volumes extend <volume-id> --size 20
+
+# Show volume details
+fly volumes show <volume-id>
+
+# Attach volume in fly.toml
+# [[mounts]]
+#   source = "myapp_data"
+#   destination = "/data"
+```
+
+## Managed Postgres
+
+```bash
+# Create a managed Postgres cluster
+fly postgres create --name myapp-db --region iad
+
+# Create with specific plan
+fly postgres create --name myapp-db --region iad --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 10
+
+# Attach Postgres to an app (injects DATABASE_URL secret)
+fly postgres attach myapp-db --app my-app
+
+# Connect to Postgres with psql
+fly postgres connect -a myapp-db
+
+# View Postgres status
+fly postgres status -a myapp-db
+
+# List Postgres clusters
+fly postgres list
+
+# Failover (promote replica)
+fly postgres failover -a myapp-db
+
+# Detach Postgres from app
+fly postgres detach myapp-db --app my-app
+```
+
+## Deployment Patterns
+
+### Pattern 1: Single-Region Production Deploy
+
+```bash
+# 1. Launch or deploy
+fly deploy
+
+# 2. Verify status
+fly status --json | jq '.Machines[] | {id, state, region}'
+
+# 3. Check logs for errors
+fly logs 2>&1 | head -50
+
+# 4. Report app URL
+fly status | grep "Hostname:"
+```
+
+### Pattern 2: Multi-Region Deployment
+
+```bash
+# 1. Launch app
+fly launch --yes
+
+# 2. Add regions
+fly regions add ord lax ams
+
+# 3. Scale in each region
+fly scale count 2 --region ord
+fly scale count 2 --region lax
+fly scale count 1 --region ams
+
+# 4. Deploy globally
+fly deploy
+
+# 5. Verify all regions are healthy
+fly status --json | jq '.Machines[] | {region, state}'
+```
+
+### Pattern 3: App with Managed Postgres
+
+```bash
+# 1. Create Postgres cluster
+fly postgres create --name myapp-db --region iad
+
+# 2. Create the app
+fly launch --name myapp --region iad --no-deploy
+
+# 3. Attach Postgres (sets DATABASE_URL automatically)
+fly postgres attach myapp-db --app myapp
+
+# 4. Deploy (DATABASE_URL is available in the container)
+fly deploy
+
+# 5. Verify database connection
+fly ssh console -C "psql \$DATABASE_URL -c 'SELECT 1'"
+```
+
+## VM Sizing Reference
+
+| VM Size | CPUs | RAM | Price/Month |
+|---------|------|-----|-------------|
+| shared-cpu-1x | 1 shared | 256 MB | ~$1.94 |
+| shared-cpu-2x | 2 shared | 512 MB | ~$3.88 |
+| shared-cpu-4x | 4 shared | 1 GB | ~$7.76 |
+| performance-1x | 1 dedicated | 2 GB | ~$31 |
+| performance-2x | 2 dedicated | 4 GB | ~$62 |
+
+## Free Tier
+
+- 3 shared-cpu-1x VMs with 256 MB RAM
+- 3 GB persistent volume storage
+- 160 GB outbound data transfer
+- Shared IPv4, dedicated IPv6
+
+## Safety Rules
+
+- Never commit `FLY_API_TOKEN` to source control — use environment variables or CI secrets.
+- Use `fly secrets set` for sensitive values; never pass them via environment variables in `fly.toml`.
+- Test locally with Docker before deploying to Fly.io.
+- Use `fly deploy --strategy rolling` (default) to avoid downtime during updates.
+- Always check `fly status` after deployment to confirm machines are healthy.
+- SSH (`fly ssh console`) can be used for emergency debugging — avoid running destructive commands.
+- Volumes cannot be moved between regions — plan region placement before creating volumes.
+- Postgres `fly postgres failover` promotes a replica — only use in emergency, not routine maintenance.

--- a/skills/k8s-debug/SKILL.md
+++ b/skills/k8s-debug/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: k8s-debug
+description: "Debug Kubernetes issues: CrashLoopBackOff, OOMKilled, ImagePullBackOff, pending pods, networking, and resource limits using kubectl. Trigger: when debugging Kubernetes pods, troubleshooting CrashLoopBackOff, OOMKilled pods, ImagePullBackOff errors, pending Kubernetes pods, K8s networking issues"
+version: 1
+argument-hint: "[pod-name or issue: crashloop|oom|imagepull|pending|networking]"
+allowed-tools:
+  - bash
+  - read
+  - grep
+---
+# Kubernetes Debugging
+
+You are now operating in Kubernetes debugging mode.
+
+## Standard Debug Workflow
+
+When a pod is not working, follow these steps in order:
+
+```bash
+# Step 1: Identify the problem pod
+kubectl get pods -n <namespace>
+# Look for: CrashLoopBackOff, Error, Pending, OOMKilled, ImagePullBackOff
+
+# Step 2: Get detailed pod status and events
+kubectl describe pod <pod-name> -n <namespace>
+# Key sections: Conditions, Events, Last State
+
+# Step 3: View current container logs
+kubectl logs <pod-name> -n <namespace>
+
+# Step 4: View logs from previous (crashed) container
+kubectl logs <pod-name> -n <namespace> --previous
+
+# Step 5: If the container is running, exec in for inspection
+kubectl exec -it <pod-name> -n <namespace> -- sh
+
+# Step 6: Check resource usage
+kubectl top pod <pod-name> -n <namespace>
+
+# Step 7: Check cluster-level events
+kubectl get events -n <namespace> --sort-by='.lastTimestamp'
+```
+
+## CrashLoopBackOff
+
+The container starts, crashes, and Kubernetes keeps restarting it.
+
+```bash
+# Check the current container logs
+kubectl logs <pod-name> -n <namespace>
+
+# MOST IMPORTANT: Check logs from the previous (crashed) container
+kubectl logs <pod-name> -n <namespace> --previous
+
+# Get the exit code and reason
+kubectl describe pod <pod-name> -n <namespace> | grep -A5 "Last State:"
+# Look for: Exit Code, Reason (e.g., Error, OOMKilled)
+
+# Check the last restart reason in JSON
+kubectl get pod <pod-name> -n <namespace> -o json | \
+  jq '.status.containerStatuses[0] | {restartCount, lastState}'
+
+# Common causes and fixes:
+# - Exit code 1: Application error — check app logs above
+# - Exit code 137: OOMKilled — increase memory limits (see OOMKilled section)
+# - Exit code 126/127: Command not found or not executable — check container entrypoint
+# - Exit code 2: Misuse of shell builtins — check startup script
+```
+
+**Common Causes:**
+- Application crashes on startup (missing env var, bad config, connection failure)
+- Missing required secrets or ConfigMaps
+- Database connection failures
+- Incorrect entrypoint command in Dockerfile or pod spec
+
+**Resolution Steps:**
+1. Read the `--previous` logs first — they show why the container crashed
+2. Check environment variables are present: `kubectl exec ... -- env | grep MY_VAR`
+3. Verify secrets/configmaps exist: `kubectl get secret my-secret -n <namespace>`
+4. Test the database connection separately using port-forward
+
+## OOMKilled (Out of Memory)
+
+The Linux OOM killer terminated the container because it exceeded its memory limit.
+
+```bash
+# Check if a pod was OOMKilled
+kubectl describe pod <pod-name> -n <namespace> | grep -A3 "Last State:"
+# Look for: Reason: OOMKilled
+
+# Get current resource limits and usage
+kubectl describe pod <pod-name> -n <namespace> | grep -A6 "Limits:"
+
+# Check current memory usage (requires metrics-server)
+kubectl top pod <pod-name> -n <namespace>
+
+# Check all pods for OOMKilled status
+kubectl get pods -n <namespace> -o json | \
+  jq '.items[] | select(.status.containerStatuses[0].lastState.terminated.reason == "OOMKilled") | .metadata.name'
+
+# View memory usage across all pods
+kubectl top pods -n <namespace> --sort-by=memory
+```
+
+**Resolution:**
+
+```yaml
+# Increase memory limits in the deployment manifest
+resources:
+  requests:
+    memory: 256Mi    # minimum guaranteed
+  limits:
+    memory: 512Mi    # maximum allowed (increase this)
+```
+
+```bash
+# Apply the updated limits
+kubectl apply -f deployment.yaml
+kubectl rollout status deployment/my-app -n <namespace>
+```
+
+**If memory is legitimately high:**
+- Profile the application for memory leaks
+- Check for unbounded caches or connection pools
+- Consider using a larger node or VM class
+
+## ImagePullBackOff / ErrImagePull
+
+Kubernetes cannot pull the container image.
+
+```bash
+# Get the full error message
+kubectl describe pod <pod-name> -n <namespace> | grep -A10 "Events:"
+# Look for: Failed to pull image, unauthorized, not found
+
+# Common error patterns:
+# "not found" -> wrong image name or tag
+# "unauthorized" -> missing or invalid registry credentials
+# "connection refused" -> registry is unreachable
+
+# Check the image name in the pod spec
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[0].image}'
+
+# Check if the image tag exists in the registry
+docker manifest inspect myregistry/my-app:v2.0.0 2>&1
+```
+
+**Resolution — Wrong Image Name/Tag:**
+
+```bash
+# Fix the image tag in the deployment
+kubectl set image deployment/my-app \
+  my-container=myregistry/my-app:v1.0.0 \  # correct tag
+  -n <namespace>
+```
+
+**Resolution — Missing Registry Credentials:**
+
+```bash
+# Create a Docker registry secret
+kubectl create secret docker-registry regcred \
+  --docker-server=registry.example.com \
+  --docker-username=myuser \
+  --docker-password=mypass \
+  -n <namespace>
+
+# Add imagePullSecrets to the deployment manifest
+# spec:
+#   imagePullSecrets:
+#   - name: regcred
+
+kubectl apply -f deployment.yaml
+```
+
+**Resolution — Private Registry (ECR, GCR, ACR):**
+
+```bash
+# AWS ECR: refresh credentials (they expire every 12h)
+aws ecr get-login-password --region us-east-1 | \
+  kubectl create secret docker-registry ecr-cred \
+  --docker-server=<account>.dkr.ecr.us-east-1.amazonaws.com \
+  --docker-username=AWS \
+  --docker-password-stdin \
+  -n <namespace>
+```
+
+## Pending Pods
+
+Pods remain in `Pending` state, meaning Kubernetes cannot schedule them.
+
+```bash
+# Get the reason a pod is pending
+kubectl describe pod <pod-name> -n <namespace> | grep -A20 "Events:"
+
+# Common reasons:
+# "0/3 nodes are available: Insufficient cpu" -> not enough CPU
+# "0/3 nodes are available: Insufficient memory" -> not enough memory
+# "0/3 nodes are available: node(s) didn't match Pod's node affinity" -> affinity mismatch
+# "0/1 nodes are available: pod has unbound immediate PersistentVolumeClaims" -> PVC issue
+
+# Check node capacity and allocatable resources
+kubectl describe nodes | grep -A5 "Allocatable:"
+
+# Check how much is already allocated
+kubectl describe nodes | grep -A8 "Allocated resources:"
+
+# Check PVC status if pending due to storage
+kubectl get pvc -n <namespace>
+kubectl describe pvc <pvc-name> -n <namespace>
+```
+
+**Resolution — Insufficient Resources:**
+
+```yaml
+# Reduce resource requests in the deployment manifest
+resources:
+  requests:
+    cpu: 50m       # reduce from 500m
+    memory: 64Mi   # reduce from 512Mi
+```
+
+**Resolution — Node Affinity Mismatch:**
+
+```bash
+# Check node labels
+kubectl get nodes --show-labels
+
+# Remove or relax the affinity rule in the deployment manifest
+# spec:
+#   affinity:
+#     nodeAffinity:  <-- remove this if not needed
+```
+
+**Resolution — PVC Not Bound:**
+
+```bash
+# Check if a matching PersistentVolume exists
+kubectl get pv
+
+# Check storage class availability
+kubectl get storageclass
+
+# If using dynamic provisioning, verify the storage class is installed
+kubectl describe pvc <pvc-name> -n <namespace>
+```
+
+## Networking Issues
+
+```bash
+# Test DNS resolution from inside a pod
+kubectl exec <pod-name> -n <namespace> -- nslookup other-service
+kubectl exec <pod-name> -n <namespace> -- nslookup other-service.other-namespace.svc.cluster.local
+
+# Test connectivity to a service by DNS name
+kubectl exec <pod-name> -n <namespace> -- curl -s http://my-service/health
+
+# Test connectivity to a service by ClusterIP
+SVC_IP=$(kubectl get svc my-service -n <namespace> -o jsonpath='{.spec.clusterIP}')
+kubectl exec <pod-name> -n <namespace> -- curl -s http://$SVC_IP/health
+
+# Check that a service has endpoints (pods selected)
+kubectl get endpoints my-service -n <namespace>
+# If ENDPOINTS is "<none>", the service selector doesn't match any pods
+
+# Check service selector matches pod labels
+kubectl describe svc my-service -n <namespace> | grep Selector:
+kubectl get pods -n <namespace> --show-labels
+
+# Check NetworkPolicies that may be blocking traffic
+kubectl get networkpolicies -n <namespace>
+kubectl describe networkpolicy <policy-name> -n <namespace>
+
+# Run a debug pod with networking tools
+kubectl run debug-pod --image=nicolaka/netshoot --rm -it --restart=Never -n <namespace> -- sh
+# Inside: ping, curl, nslookup, traceroute, tcpdump are all available
+```
+
+## Config and Environment Issues
+
+```bash
+# Check all environment variables in a running pod
+kubectl exec <pod-name> -n <namespace> -- env | sort
+
+# Check if a specific environment variable is set
+kubectl exec <pod-name> -n <namespace> -- printenv MY_VAR
+
+# Verify a secret exists and has the right keys
+kubectl describe secret my-secret -n <namespace>
+# Shows keys but NOT values (by design)
+
+# Verify a ConfigMap and its contents
+kubectl get configmap my-config -n <namespace> -o yaml
+
+# Check if the pod mounts the correct secret/configmap
+kubectl describe pod <pod-name> -n <namespace> | grep -A10 "Mounts:"
+kubectl describe pod <pod-name> -n <namespace> | grep -A10 "Volumes:"
+```
+
+## Ephemeral Debug Containers
+
+For pods without a shell or debugging tools:
+
+```bash
+# Attach an ephemeral debug container to a running pod
+kubectl debug -it <pod-name> -n <namespace> \
+  --image=busybox \
+  --target=my-container
+
+# Use a richer debug image
+kubectl debug -it <pod-name> -n <namespace> \
+  --image=nicolaka/netshoot \
+  --target=my-container
+
+# Copy a pod and add a debug shell (useful for initContainer issues)
+kubectl debug <pod-name> -n <namespace> \
+  --copy-to=debug-pod \
+  --container=my-container \
+  --image=busybox \
+  -it -- sh
+```
+
+## Cluster-Level Diagnostics
+
+```bash
+# View all events across the cluster, sorted by time
+kubectl get events -A --sort-by='.lastTimestamp' | tail -30
+
+# View events for a specific namespace
+kubectl get events -n <namespace> --sort-by='.lastTimestamp'
+
+# Filter events by reason
+kubectl get events -n <namespace> --field-selector reason=OOMKilling
+kubectl get events -n <namespace> --field-selector reason=BackOff
+
+# Check node conditions
+kubectl get nodes
+# Look for: Ready, MemoryPressure, DiskPressure, PIDPressure
+
+# Describe a specific node
+kubectl describe node <node-name>
+
+# Check pod disruption budgets
+kubectl get pdb -n <namespace>
+```
+
+## Quick Diagnostic Summary
+
+```bash
+# One-liner to show problem pods across all namespaces
+kubectl get pods -A | grep -v Running | grep -v Completed | grep -v Terminating
+
+# Get restart counts for all pods
+kubectl get pods -n <namespace> -o json | \
+  jq '.items[] | {name: .metadata.name, restarts: .status.containerStatuses[0].restartCount}' | \
+  jq -s 'sort_by(.restarts) | reverse[]'
+
+# Show most recently failed events
+kubectl get events -n <namespace> \
+  --field-selector type=Warning \
+  --sort-by='.lastTimestamp' | tail -20
+```
+
+## Safety Rules
+
+- Never expose secret values in logs or `kubectl exec` output. Use `kubectl describe secret` to check key names only.
+- Use `kubectl exec` with caution in production — commands run directly on live containers.
+- Avoid `kubectl delete pod` in production unless you intend to force a restart (the deployment will recreate it).
+- `kubectl debug --copy-to` creates a new pod; clean it up with `kubectl delete pod debug-pod` when done.
+- Resource limit changes require a rolling restart — use `kubectl rollout status` to verify the restart completes.
+- `kubectl delete namespace` is irreversible and removes all resources — confirm the namespace name before running.

--- a/skills/kubectl-ops/SKILL.md
+++ b/skills/kubectl-ops/SKILL.md
@@ -1,0 +1,456 @@
+---
+name: kubectl-ops
+description: "Apply manifests, manage rollouts, scale deployments, configure services, and manage secrets on Kubernetes clusters using kubectl. Trigger: when deploying to Kubernetes, using kubectl, applying manifests, managing K8s deployments, scaling Kubernetes workloads, Kubernetes rollouts, kubectl port-forward"
+version: 1
+argument-hint: "[apply|get|rollout|scale|exec|port-forward|secrets]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - edit
+  - glob
+  - grep
+---
+# Kubernetes Operations
+
+You are now operating in Kubernetes operations mode using `kubectl`.
+
+## Prerequisites
+
+```bash
+# Install kubectl
+# macOS
+brew install kubectl
+
+# Linux
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# Verify version
+kubectl version --client
+
+# Verify cluster connection
+kubectl cluster-info
+```
+
+## Context and Namespace Management
+
+```bash
+# List all configured contexts (clusters)
+kubectl config get-contexts
+
+# Switch to a context
+kubectl config use-context my-cluster
+
+# Show current context
+kubectl config current-context
+
+# Set the default namespace for the current context
+kubectl config set-context --current --namespace=my-namespace
+
+# View full kubeconfig
+kubectl config view
+
+# Run a command in a specific namespace (override default)
+kubectl get pods -n my-namespace
+
+# Run a command against a specific context
+kubectl get pods --context=my-other-cluster
+```
+
+## Applying Manifests
+
+```bash
+# Apply a single manifest file
+kubectl apply -f deployment.yaml
+
+# Apply all manifests in a directory
+kubectl apply -f ./manifests/
+
+# Apply manifests recursively
+kubectl apply -f ./k8s/ -R
+
+# Apply from stdin
+cat deployment.yaml | kubectl apply -f -
+
+# Apply and wait for rollout to complete
+kubectl apply -f deployment.yaml
+kubectl rollout status deployment/my-app -n my-namespace
+
+# Dry-run to preview changes (no actual apply)
+kubectl apply -f deployment.yaml --dry-run=client
+
+# Show diff before applying
+kubectl diff -f deployment.yaml
+```
+
+## Viewing Resources
+
+```bash
+# List pods in current namespace
+kubectl get pods
+
+# List pods in a specific namespace
+kubectl get pods -n my-namespace
+
+# List pods in JSON format (for parsing)
+kubectl get pods -n my-namespace -o json
+
+# List pods with node assignment and IP
+kubectl get pods -n my-namespace -o wide
+
+# Watch pods in real-time
+kubectl get pods -n my-namespace --watch
+
+# List all resources of a type with labels
+kubectl get pods -l app=my-app -n my-namespace
+
+# List deployments
+kubectl get deployments -n my-namespace
+
+# List services
+kubectl get services -n my-namespace
+
+# List all resource types at once
+kubectl get all -n my-namespace
+
+# List across all namespaces
+kubectl get pods -A
+kubectl get deployments -A
+
+# Get a specific resource by name
+kubectl get pod my-pod-xyz -n my-namespace -o yaml
+
+# List persistent volume claims
+kubectl get pvc -n my-namespace
+```
+
+## Describing Resources (Detailed View)
+
+```bash
+# Describe a pod (shows events, conditions, mounts)
+kubectl describe pod <pod-name> -n my-namespace
+
+# Describe a deployment
+kubectl describe deployment my-app -n my-namespace
+
+# Describe a service
+kubectl describe service my-svc -n my-namespace
+
+# Describe a node
+kubectl describe node <node-name>
+```
+
+## Rollout Management
+
+```bash
+# Watch a rollout in progress
+kubectl rollout status deployment/my-app -n my-namespace
+
+# View rollout history
+kubectl rollout history deployment/my-app -n my-namespace
+
+# View a specific revision's details
+kubectl rollout history deployment/my-app -n my-namespace --revision=2
+
+# Rollback to the previous version
+kubectl rollout undo deployment/my-app -n my-namespace
+
+# Rollback to a specific revision
+kubectl rollout undo deployment/my-app -n my-namespace --to-revision=2
+
+# Pause a rolling update
+kubectl rollout pause deployment/my-app -n my-namespace
+
+# Resume a paused rollout
+kubectl rollout resume deployment/my-app -n my-namespace
+
+# Restart all pods in a deployment (rolling restart)
+kubectl rollout restart deployment/my-app -n my-namespace
+```
+
+## Scaling
+
+```bash
+# Scale a deployment to N replicas
+kubectl scale deployment/my-app --replicas=3 -n my-namespace
+
+# Scale a StatefulSet
+kubectl scale statefulset/my-db --replicas=3 -n my-namespace
+
+# Scale and wait for the operation to complete
+kubectl scale deployment/my-app --replicas=3 -n my-namespace
+kubectl rollout status deployment/my-app -n my-namespace
+
+# Auto-scale based on CPU utilization (HPA)
+kubectl autoscale deployment/my-app --min=2 --max=10 --cpu-percent=80 -n my-namespace
+
+# List HPAs
+kubectl get hpa -n my-namespace
+```
+
+## Updating Images
+
+```bash
+# Update a container image in a deployment
+kubectl set image deployment/my-app \
+  my-container=myregistry/my-app:v2.0.0 \
+  -n my-namespace
+
+# Update and watch the rollout
+kubectl set image deployment/my-app \
+  my-container=myregistry/my-app:v2.0.0 \
+  -n my-namespace && \
+kubectl rollout status deployment/my-app -n my-namespace
+```
+
+## Viewing Logs
+
+```bash
+# View logs from a pod
+kubectl logs <pod-name> -n my-namespace
+
+# Follow logs in real-time
+kubectl logs <pod-name> -n my-namespace -f
+
+# View logs from a specific container in a multi-container pod
+kubectl logs <pod-name> -c my-container -n my-namespace
+
+# View logs from the previously crashed container
+kubectl logs <pod-name> --previous -n my-namespace
+
+# View logs from all pods with a label selector
+kubectl logs -l app=my-app -n my-namespace --prefix
+
+# Tail the last N lines
+kubectl logs <pod-name> -n my-namespace --tail=100
+
+# View logs since a duration
+kubectl logs <pod-name> -n my-namespace --since=1h
+```
+
+## Executing Commands in Pods
+
+```bash
+# Open an interactive shell in a pod
+kubectl exec -it <pod-name> -n my-namespace -- sh
+
+# Open bash if available
+kubectl exec -it <pod-name> -n my-namespace -- bash
+
+# Run a one-off command (non-interactive)
+kubectl exec <pod-name> -n my-namespace -- ls /app
+
+# Exec in a specific container within a multi-container pod
+kubectl exec -it <pod-name> -c my-container -n my-namespace -- sh
+
+# Check environment variables in a pod
+kubectl exec <pod-name> -n my-namespace -- env | sort
+
+# Test connectivity from inside a pod
+kubectl exec <pod-name> -n my-namespace -- curl -s http://other-service/health
+```
+
+## Port Forwarding
+
+```bash
+# Forward a local port to a pod
+kubectl port-forward pod/<pod-name> 8080:80 -n my-namespace
+
+# Forward a local port to a service (load-balanced)
+kubectl port-forward svc/my-service 8080:80 -n my-namespace
+
+# Forward a local port to a deployment
+kubectl port-forward deployment/my-app 8080:80 -n my-namespace
+
+# Forward on all interfaces (accessible from other machines)
+kubectl port-forward svc/my-service 8080:80 -n my-namespace --address 0.0.0.0
+
+# Run in background (use with care — press Ctrl+C to stop)
+kubectl port-forward svc/my-service 8080:80 -n my-namespace &
+PORT_FORWARD_PID=$!
+# ... do work ...
+kill $PORT_FORWARD_PID
+```
+
+## Secrets Management
+
+```bash
+# Create a generic secret from literal values
+kubectl create secret generic my-secret \
+  --from-literal=DATABASE_URL="postgresql://..." \
+  --from-literal=API_KEY="sk_live_..." \
+  -n my-namespace
+
+# Create a secret from a file
+kubectl create secret generic my-secret \
+  --from-file=tls.crt=./cert.pem \
+  --from-file=tls.key=./key.pem \
+  -n my-namespace
+
+# Create a TLS secret
+kubectl create secret tls my-tls-secret \
+  --cert=./tls.crt \
+  --key=./tls.key \
+  -n my-namespace
+
+# Create a Docker registry secret
+kubectl create secret docker-registry regcred \
+  --docker-server=registry.example.com \
+  --docker-username=myuser \
+  --docker-password=mypass \
+  -n my-namespace
+
+# List secret names (never print values)
+kubectl get secrets -n my-namespace
+
+# View secret metadata without decoding values
+kubectl describe secret my-secret -n my-namespace
+
+# SAFE: decode a specific key for verification only
+kubectl get secret my-secret -n my-namespace \
+  -o jsonpath='{.data.DATABASE_URL}' | base64 --decode
+
+# Update a secret (apply new manifest)
+kubectl apply -f secret.yaml
+
+# Delete a secret
+kubectl delete secret my-secret -n my-namespace
+```
+
+## ConfigMaps
+
+```bash
+# Create a ConfigMap from literal values
+kubectl create configmap my-config \
+  --from-literal=LOG_LEVEL=info \
+  --from-literal=MAX_CONNECTIONS=100 \
+  -n my-namespace
+
+# Create a ConfigMap from a file
+kubectl create configmap app-config \
+  --from-file=config.yaml \
+  -n my-namespace
+
+# View ConfigMap contents
+kubectl get configmap my-config -n my-namespace -o yaml
+
+# Update a ConfigMap
+kubectl edit configmap my-config -n my-namespace
+```
+
+## Resource Monitoring
+
+```bash
+# Resource usage for all pods in a namespace
+kubectl top pods -n my-namespace
+
+# Resource usage for all nodes
+kubectl top nodes
+
+# Resource usage sorted by CPU
+kubectl top pods -n my-namespace --sort-by=cpu
+
+# Resource usage sorted by memory
+kubectl top pods -n my-namespace --sort-by=memory
+
+# Note: kubectl top requires metrics-server to be installed in the cluster
+```
+
+## Deleting Resources
+
+```bash
+# Delete a specific pod (will be recreated by the deployment controller)
+kubectl delete pod <pod-name> -n my-namespace
+
+# Delete a deployment (removes all pods managed by it)
+kubectl delete deployment my-app -n my-namespace
+
+# Delete using a manifest file
+kubectl delete -f deployment.yaml
+
+# Delete all resources matching a label
+kubectl delete pods -l app=my-app -n my-namespace
+
+# Delete a namespace (deletes all resources within it)
+kubectl delete namespace my-namespace
+```
+
+## Common Manifest Examples
+
+### Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app
+  namespace: my-namespace
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: my-app
+  template:
+    metadata:
+      labels:
+        app: my-app
+    spec:
+      containers:
+      - name: my-app
+        image: myregistry/my-app:v1.0.0
+        ports:
+        - containerPort: 8080
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: my-secret
+              key: DATABASE_URL
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+```
+
+### Service
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app
+  namespace: my-namespace
+spec:
+  selector:
+    app: my-app
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: ClusterIP
+```
+
+## Safety Rules
+
+- Always use `kubectl diff` before `kubectl apply` in production to preview changes.
+- Never print secret values to logs or stdout. Use `kubectl describe secret` to view metadata only.
+- Use `kubectl rollout undo` immediately if a deployment causes errors after apply.
+- Set resource `requests` and `limits` on all containers to prevent resource exhaustion.
+- Test manifest changes with `--dry-run=client` before applying to production.
+- Use namespaces to isolate environments (dev, staging, production) within a cluster.
+- Prefer `kubectl apply` over `kubectl create` for idempotent operations.

--- a/skills/skills_validation_46_48_54_71_test.go
+++ b/skills/skills_validation_46_48_54_71_test.go
@@ -1,0 +1,612 @@
+// Package skills_validation tests that the bundled SKILL.md files in this
+// directory parse correctly and satisfy required field constraints.
+//
+// This file covers skills added in GitHub Issues #46 (Cloudflare Workers),
+// #48 (Vercel), #54 (Fly.io), and #71 (Kubernetes).
+package skills_validation
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Issue #46: Cloudflare Workers Deployment Skill ---
+
+func TestCloudflareWorkersSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["cloudflare-workers"]
+	if !ok {
+		t.Fatal("cloudflare-workers skill not found; expected SKILL.md in skills/cloudflare-workers/")
+	}
+	if s.Name != "cloudflare-workers" {
+		t.Errorf("Name = %q, want %q", s.Name, "cloudflare-workers")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if len(s.Triggers) == 0 {
+		t.Error("cloudflare-workers should have at least one trigger phrase in description")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasWranglerDeploy(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "wrangler deploy") {
+		t.Error("cloudflare-workers body should include 'wrangler deploy' command")
+	}
+	if !strings.Contains(s.Body, "wrangler dev") {
+		t.Error("cloudflare-workers body should include 'wrangler dev' command")
+	}
+	if !strings.Contains(s.Body, "wrangler tail") {
+		t.Error("cloudflare-workers body should include 'wrangler tail' for log monitoring")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasRollback(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "wrangler rollback") {
+		t.Error("cloudflare-workers body should include 'wrangler rollback' command")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasStorageBindings(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "KV") {
+		t.Error("cloudflare-workers body should document KV namespace binding")
+	}
+	if !strings.Contains(s.Body, "R2") {
+		t.Error("cloudflare-workers body should document R2 bucket binding")
+	}
+	if !strings.Contains(s.Body, "D1") {
+		t.Error("cloudflare-workers body should document D1 database binding")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasSecretManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "wrangler secret put") {
+		t.Error("cloudflare-workers body should include 'wrangler secret put' command")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasMultiEnvironment(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "--env") {
+		t.Error("cloudflare-workers body should document --env flag for multi-environment deployments")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasSafetyRules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if !strings.Contains(s.Body, "Safety") {
+		t.Error("cloudflare-workers body should include safety rules section")
+	}
+}
+
+func TestCloudflareWorkersSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["cloudflare-workers"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("cloudflare-workers should declare allowed-tools")
+	}
+}
+
+// --- Issue #48: Vercel Deployment Skill ---
+
+func TestVercelDeploySkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["vercel-deploy"]
+	if !ok {
+		t.Fatal("vercel-deploy skill not found; expected SKILL.md in skills/vercel-deploy/")
+	}
+	if s.Name != "vercel-deploy" {
+		t.Errorf("Name = %q, want %q", s.Name, "vercel-deploy")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestVercelDeploySkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if len(s.Triggers) == 0 {
+		t.Error("vercel-deploy should have at least one trigger phrase in description")
+	}
+}
+
+func TestVercelDeploySkill_HasPreviewDeploy(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "vercel --yes") {
+		t.Error("vercel-deploy body should include 'vercel --yes' for non-interactive preview deploy")
+	}
+}
+
+func TestVercelDeploySkill_HasProductionDeploy(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "--prod") {
+		t.Error("vercel-deploy body should include --prod flag for production deployment")
+	}
+}
+
+func TestVercelDeploySkill_HasEnvManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "vercel env") {
+		t.Error("vercel-deploy body should include 'vercel env' commands")
+	}
+	if !strings.Contains(s.Body, "vercel env pull") {
+		t.Error("vercel-deploy body should include 'vercel env pull' for syncing env vars locally")
+	}
+}
+
+func TestVercelDeploySkill_HasLogs(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "vercel logs") {
+		t.Error("vercel-deploy body should include 'vercel logs' for deployment verification")
+	}
+}
+
+func TestVercelDeploySkill_HasDomainManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "vercel domains") {
+		t.Error("vercel-deploy body should include 'vercel domains' commands")
+	}
+}
+
+func TestVercelDeploySkill_HasSafetyRules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if !strings.Contains(s.Body, "Safety") {
+		t.Error("vercel-deploy body should include safety rules section")
+	}
+}
+
+func TestVercelDeploySkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["vercel-deploy"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("vercel-deploy should declare allowed-tools")
+	}
+}
+
+// --- Issue #54: Fly.io Deployment Skill ---
+
+func TestFlyDeploySkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["fly-deploy"]
+	if !ok {
+		t.Fatal("fly-deploy skill not found; expected SKILL.md in skills/fly-deploy/")
+	}
+	if s.Name != "fly-deploy" {
+		t.Errorf("Name = %q, want %q", s.Name, "fly-deploy")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestFlyDeploySkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if len(s.Triggers) == 0 {
+		t.Error("fly-deploy should have at least one trigger phrase in description")
+	}
+}
+
+func TestFlyDeploySkill_HasLaunchAndDeploy(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly launch") {
+		t.Error("fly-deploy body should include 'fly launch' command")
+	}
+	if !strings.Contains(s.Body, "fly deploy") {
+		t.Error("fly-deploy body should include 'fly deploy' command")
+	}
+}
+
+func TestFlyDeploySkill_HasStatusAndLogs(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly status") {
+		t.Error("fly-deploy body should include 'fly status' for health verification")
+	}
+	if !strings.Contains(s.Body, "fly logs") {
+		t.Error("fly-deploy body should include 'fly logs' command")
+	}
+}
+
+func TestFlyDeploySkill_HasScaling(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly scale") {
+		t.Error("fly-deploy body should include 'fly scale' commands")
+	}
+}
+
+func TestFlyDeploySkill_HasMultiRegion(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly regions") {
+		t.Error("fly-deploy body should include 'fly regions' commands for multi-region deployment")
+	}
+}
+
+func TestFlyDeploySkill_HasSecretManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly secrets set") {
+		t.Error("fly-deploy body should include 'fly secrets set' command")
+	}
+}
+
+func TestFlyDeploySkill_HasSSHAccess(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly ssh") {
+		t.Error("fly-deploy body should include 'fly ssh' for debugging access")
+	}
+}
+
+func TestFlyDeploySkill_HasManagedPostgres(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "fly postgres") {
+		t.Error("fly-deploy body should include 'fly postgres' commands")
+	}
+	if !strings.Contains(s.Body, "fly postgres attach") {
+		t.Error("fly-deploy body should include 'fly postgres attach' for connecting DB to app")
+	}
+}
+
+func TestFlyDeploySkill_HasSafetyRules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if !strings.Contains(s.Body, "Safety") {
+		t.Error("fly-deploy body should include safety rules section")
+	}
+}
+
+func TestFlyDeploySkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["fly-deploy"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("fly-deploy should declare allowed-tools")
+	}
+}
+
+// --- Issue #71: Kubernetes Operations Skill (kubectl-ops) ---
+
+func TestKubectlOpsSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["kubectl-ops"]
+	if !ok {
+		t.Fatal("kubectl-ops skill not found; expected SKILL.md in skills/kubectl-ops/")
+	}
+	if s.Name != "kubectl-ops" {
+		t.Errorf("Name = %q, want %q", s.Name, "kubectl-ops")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestKubectlOpsSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if len(s.Triggers) == 0 {
+		t.Error("kubectl-ops should have at least one trigger phrase in description")
+	}
+}
+
+func TestKubectlOpsSkill_HasApplyAndGet(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl apply") {
+		t.Error("kubectl-ops body should include 'kubectl apply' command")
+	}
+	if !strings.Contains(s.Body, "kubectl get") {
+		t.Error("kubectl-ops body should include 'kubectl get' command")
+	}
+}
+
+func TestKubectlOpsSkill_HasRollout(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl rollout status") {
+		t.Error("kubectl-ops body should include 'kubectl rollout status' command")
+	}
+	if !strings.Contains(s.Body, "kubectl rollout undo") {
+		t.Error("kubectl-ops body should include 'kubectl rollout undo' for rollbacks")
+	}
+}
+
+func TestKubectlOpsSkill_HasScaling(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl scale") {
+		t.Error("kubectl-ops body should include 'kubectl scale' command")
+	}
+}
+
+func TestKubectlOpsSkill_HasPortForward(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl port-forward") {
+		t.Error("kubectl-ops body should include 'kubectl port-forward' command")
+	}
+}
+
+func TestKubectlOpsSkill_HasSecretsManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl create secret") {
+		t.Error("kubectl-ops body should include 'kubectl create secret' command")
+	}
+}
+
+func TestKubectlOpsSkill_HasContextManagement(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "kubectl config use-context") {
+		t.Error("kubectl-ops body should include context switching command")
+	}
+}
+
+func TestKubectlOpsSkill_HasSafetyRules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if !strings.Contains(s.Body, "Safety") {
+		t.Error("kubectl-ops body should include safety rules section")
+	}
+}
+
+func TestKubectlOpsSkill_SecretsNeverLogged(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	// Must warn about not exposing secret values
+	if !strings.Contains(s.Body, "never") && !strings.Contains(s.Body, "Never") {
+		t.Error("kubectl-ops body should warn about never exposing secret values")
+	}
+}
+
+func TestKubectlOpsSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["kubectl-ops"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("kubectl-ops should declare allowed-tools")
+	}
+}
+
+// --- Issue #71: Kubernetes Debugging Skill (k8s-debug) ---
+
+func TestK8sDebugSkill_Parses(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s, ok := all["k8s-debug"]
+	if !ok {
+		t.Fatal("k8s-debug skill not found; expected SKILL.md in skills/k8s-debug/")
+	}
+	if s.Name != "k8s-debug" {
+		t.Errorf("Name = %q, want %q", s.Name, "k8s-debug")
+	}
+	if s.Description == "" {
+		t.Error("Description must not be empty")
+	}
+	if s.Version != 1 {
+		t.Errorf("Version = %d, want 1", s.Version)
+	}
+	if s.Body == "" {
+		t.Error("Body (markdown content) must not be empty")
+	}
+}
+
+func TestK8sDebugSkill_HasTrigger(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if len(s.Triggers) == 0 {
+		t.Error("k8s-debug should have at least one trigger phrase in description")
+	}
+}
+
+func TestK8sDebugSkill_HasCrashLoopDiagnosis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "CrashLoopBackOff") {
+		t.Error("k8s-debug body should cover CrashLoopBackOff diagnosis")
+	}
+	if !strings.Contains(s.Body, "--previous") {
+		t.Error("k8s-debug body should use kubectl logs --previous for crash diagnosis")
+	}
+}
+
+func TestK8sDebugSkill_HasOOMKilledDiagnosis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "OOMKilled") {
+		t.Error("k8s-debug body should cover OOMKilled diagnosis")
+	}
+}
+
+func TestK8sDebugSkill_HasImagePullDiagnosis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "ImagePullBackOff") {
+		t.Error("k8s-debug body should cover ImagePullBackOff diagnosis")
+	}
+}
+
+func TestK8sDebugSkill_HasPendingPodDiagnosis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "Pending") {
+		t.Error("k8s-debug body should cover Pending pod diagnosis")
+	}
+}
+
+func TestK8sDebugSkill_HasNetworkingDiagnosis(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "nslookup") || !strings.Contains(s.Body, "curl") {
+		t.Error("k8s-debug body should include networking diagnosis with nslookup or curl")
+	}
+}
+
+func TestK8sDebugSkill_HasDebugWorkflow(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "kubectl describe pod") {
+		t.Error("k8s-debug body should include 'kubectl describe pod' in debug workflow")
+	}
+	if !strings.Contains(s.Body, "kubectl logs") {
+		t.Error("k8s-debug body should include 'kubectl logs' in debug workflow")
+	}
+}
+
+func TestK8sDebugSkill_HasEventInspection(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "kubectl get events") {
+		t.Error("k8s-debug body should include 'kubectl get events' for cluster-level diagnostics")
+	}
+}
+
+func TestK8sDebugSkill_HasSafetyRules(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if !strings.Contains(s.Body, "Safety") {
+		t.Error("k8s-debug body should include safety rules section")
+	}
+}
+
+func TestK8sDebugSkill_SecretsNeverExposed(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	// Must warn about not exposing secret values
+	if !strings.Contains(s.Body, "never") && !strings.Contains(s.Body, "Never") {
+		t.Error("k8s-debug body should warn about never exposing secret values")
+	}
+}
+
+func TestK8sDebugSkill_HasAllowedTools(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	s := all["k8s-debug"]
+	if len(s.AllowedTools) == 0 {
+		t.Error("k8s-debug should declare allowed-tools")
+	}
+}
+
+// --- Cross-cutting: Issues #46, #48, #54, #71 ---
+
+// TestExpectedSkillsForIssues46_48_54_71 validates that all 5 new skills
+// for issues #46, #48, #54, and #71 are present.
+func TestExpectedSkillsForIssues46_48_54_71(t *testing.T) {
+	t.Parallel()
+	all := loadAllSkills(t)
+	expected := []string{
+		// Issue #46: Cloudflare Workers
+		"cloudflare-workers",
+		// Issue #48: Vercel Deployment
+		"vercel-deploy",
+		// Issue #54: Fly.io Deployment
+		"fly-deploy",
+		// Issue #71: Kubernetes Operations
+		"kubectl-ops",
+		"k8s-debug",
+	}
+	for _, name := range expected {
+		if _, ok := all[name]; !ok {
+			t.Errorf("expected skill %q not found (required for issues #46/#48/#54/#71)", name)
+		}
+	}
+}

--- a/skills/vercel-deploy/SKILL.md
+++ b/skills/vercel-deploy/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: vercel-deploy
+description: "Deploy frontend apps, Next.js projects, and serverless functions to Vercel with preview URLs and production deployments. Trigger: when deploying to Vercel, using vercel CLI, deploying Next.js, creating preview deployments, managing Vercel environments, adding Vercel domains"
+version: 1
+argument-hint: "[deploy|--prod|env|logs|domains|inspect]"
+allowed-tools:
+  - bash
+  - read
+  - write
+  - edit
+  - glob
+  - grep
+---
+# Vercel Deployment
+
+You are now operating in Vercel deployment mode using the `vercel` CLI.
+
+## Prerequisites
+
+```bash
+# Install Vercel CLI
+npm install -g vercel
+
+# Authenticate (one-time, interactive browser flow)
+vercel login
+
+# Or use API token (preferred for CI/automation)
+export VERCEL_TOKEN="your-token-here"
+# Generate at: https://vercel.com/account/tokens
+
+# Verify authentication
+vercel whoami
+```
+
+## Linking a Project
+
+```bash
+# Link current directory to a Vercel project (interactive)
+vercel link
+
+# Link to a specific team/org project
+vercel link --scope my-team --project my-project
+
+# Pull project settings and env vars locally
+vercel env pull .env.local
+```
+
+## Preview Deployments
+
+Preview deployments create a unique URL for review before production.
+
+```bash
+# Deploy to preview (default behavior)
+vercel
+
+# Skip interactive prompts (use project defaults)
+vercel --yes
+
+# Deploy a specific directory
+vercel ./dist --yes
+
+# Deploy and output only the URL
+vercel --yes 2>/dev/null | tail -1
+```
+
+## Production Deployments
+
+```bash
+# Deploy to production
+vercel --prod --yes
+
+# Deploy with confirmation of the production URL
+vercel --prod --yes 2>&1 | grep "Production:"
+
+# Deploy a specific branch by pointing to the directory
+vercel --prod --yes --archive=tgz
+```
+
+## Deployment Inspection
+
+```bash
+# List recent deployments
+vercel ls
+
+# List deployments with JSON output for parsing
+vercel ls --json
+
+# Inspect a specific deployment by URL
+vercel inspect https://my-app-abc123.vercel.app
+
+# Get deployment details including build logs URL
+vercel inspect <deployment-url> --json
+```
+
+## Viewing Logs
+
+```bash
+# View logs for the latest production deployment
+vercel logs <deployment-url>
+
+# Follow logs in real-time
+vercel logs <deployment-url> --follow
+
+# View logs for a specific deployment
+vercel logs https://my-app-abc123.vercel.app --follow
+
+# Filter log output
+vercel logs <url> --follow 2>&1 | grep -i error
+```
+
+## Environment Variable Management
+
+```bash
+# Add an environment variable interactively
+vercel env add DATABASE_URL
+
+# Add env var to a specific target environment
+vercel env add DATABASE_URL production
+vercel env add DATABASE_URL preview
+vercel env add DATABASE_URL development
+
+# Add env var with a value (pipe input to avoid interactive prompt)
+echo "postgresql://..." | vercel env add DATABASE_URL production
+
+# List all environment variables (values are hidden)
+vercel env ls
+
+# Remove an environment variable
+vercel env rm DATABASE_URL production
+
+# Pull all env vars to a local file
+vercel env pull .env.local
+vercel env pull .env.production --environment production
+```
+
+## Domain Management
+
+```bash
+# List all domains for the account
+vercel domains ls
+
+# Add a custom domain to a project
+vercel domains add my-app.example.com
+
+# Add a domain to a specific project
+vercel domains add my-app.example.com --project my-project
+
+# Inspect domain configuration (DNS, cert status)
+vercel domains inspect my-app.example.com
+
+# Remove a domain
+vercel domains rm my-app.example.com
+```
+
+## Removing Deployments
+
+```bash
+# Remove a deployment by URL
+vercel rm https://my-app-abc123.vercel.app
+
+# Remove all deployments of a project (keep latest)
+vercel rm my-project --safe
+
+# Force remove without confirmation
+vercel rm my-project --yes
+```
+
+## Deployment Patterns
+
+### Pattern 1: Preview Deploy for Code Review
+
+```bash
+# 1. Deploy preview
+PREVIEW_URL=$(vercel --yes 2>/dev/null | tail -1)
+echo "Preview URL: $PREVIEW_URL"
+
+# 2. Run smoke test against preview
+curl -f "$PREVIEW_URL/api/health" || echo "Health check failed"
+
+# 3. Share preview URL for review
+echo "Share this URL for review: $PREVIEW_URL"
+```
+
+### Pattern 2: Production Deployment with Verification
+
+```bash
+# 1. Deploy to production
+vercel --prod --yes
+
+# 2. Get the production URL
+PROD_URL=$(vercel ls --json | jq -r '.[0].url' | head -1)
+
+# 3. Verify the deployment is live
+curl -f "https://$PROD_URL" || echo "Production check failed"
+
+# 4. Check that new content is live (not stale cache)
+curl -s "https://$PROD_URL/api/version" | jq '.version'
+
+# 5. View logs to confirm no errors
+vercel logs "https://$PROD_URL" --follow &
+LOGS_PID=$!
+sleep 15
+kill $LOGS_PID
+```
+
+### Pattern 3: Feature Branch Preview
+
+```bash
+# 1. Checkout feature branch
+git checkout feature/my-feature
+
+# 2. Deploy preview
+PREVIEW_URL=$(vercel --yes 2>/dev/null | tail -1)
+
+# 3. Output URL for CI comment or review
+echo "Feature preview: $PREVIEW_URL"
+```
+
+## Vercel Project Configuration (`vercel.json`)
+
+```json
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm ci",
+  "framework": "nextjs",
+  "regions": ["iad1", "sfo1"],
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/$1" }
+  ],
+  "headers": [
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
+}
+```
+
+## Parsing Deployment Output
+
+```bash
+# Get preview URL from deployment
+vercel --yes 2>&1 | grep -E "https://.*vercel\.app"
+
+# Get production URL
+vercel --prod --yes 2>&1 | grep "Production:"
+
+# Parse deployment list JSON
+vercel ls --json | jq '.[0] | {url, state, created}'
+
+# Check if deployment is ready
+vercel ls --json | jq '.[] | select(.state == "READY") | .url' | head -1
+```
+
+## Vercel Pricing Reference
+
+| Plan | Cost | Bandwidth | Features |
+|------|------|-----------|---------|
+| Hobby | Free | 100 GB | 1 user, personal projects |
+| Pro | $20/member/month | 1 TB | Teams, analytics, preview protection |
+| Enterprise | Custom | Custom | SSO, audit logs, SLA |
+
+## Safety Rules
+
+- Never commit `VERCEL_TOKEN` to source control — use environment variables or CI secrets.
+- Always deploy to preview first; verify the preview URL before promoting to production.
+- Use `vercel env pull` to sync environment variables locally; never hardcode secrets.
+- Verify new content is live after production deploy — Vercel CDN may serve stale cache briefly.
+- Use `vercel logs --follow` immediately after production deployment to catch startup errors.
+- Domain changes can take up to 48 hours for DNS propagation — plan accordingly.


### PR DESCRIPTION
Implements 5 SKILL.md files covering:
- Issue #46: cloudflare-workers (Wrangler CLI deployment)
- Issue #48: vercel-deploy (Vercel CLI deployment)
- Issue #54: fly-deploy (Fly.io deployment)
- Issue #71: k8s-debug and kubectl-ops (Kubernetes operations)

Each skill uses YAML frontmatter with name, description, version,
allowed-tools, and argument-hint. Tests in a separate file
(skills_validation_46_48_54_71_test.go) validate parse correctness,
required fields, and content completeness.

Closes #46
Closes #48
Closes #54
Closes #71