### PR TITLE
Fix search q-param on list endpoint and auto-generate compact summary

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1817,6 +1817,33 @@ func (r *Runner) GetConversationStore() ConversationStore {
 	return r.config.ConversationStore
 }
 
+// SummarizeMessages makes a single LLM call to summarize the given messages.
+// Returns a summary string suitable for use as a compact summary.
+func (r *Runner) SummarizeMessages(ctx context.Context, messages []Message) (string, error) {
+	if r.provider == nil {
+		return "", fmt.Errorf("provider not configured")
+	}
+	model := r.config.DefaultModel
+	if model == "" {
+		model = "gpt-4.1-mini"
+	}
+	req := CompletionRequest{
+		Model: model,
+		Messages: append(append([]Message(nil), messages...), Message{
+			Role:    "user",
+			Content: "Please provide a concise summary of this conversation so far, suitable for use as context in a continuation. Include key facts, decisions, and outputs. Be concise.",
+		}),
+	}
+	result, err := r.provider.Complete(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(result.Content) == "" {
+		return "", fmt.Errorf("empty summary from provider")
+	}
+	return result.Content, nil
+}
+
 func (r *Runner) observeMemory(runID string, step int, messages []Message) {
 	if r.config.MemoryManager == nil || r.config.MemoryManager.Mode() == om.ModeOff {
 		return

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -474,8 +474,22 @@ func (s *Server) handleCompactConversation(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if strings.TrimSpace(req.Summary) == "" {
-		writeError(w, http.StatusBadRequest, "invalid_request", "summary is required")
-		return
+		// Auto-generate summary via LLM when none provided.
+		msgs, err := store.LoadMessages(r.Context(), convID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+			return
+		}
+		if len(msgs) == 0 {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+			return
+		}
+		generated, err := s.runner.SummarizeMessages(r.Context(), msgs)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("auto-summary failed: %s", err.Error()))
+			return
+		}
+		req.Summary = generated
 	}
 	if req.KeepFromStep < 0 {
 		writeError(w, http.StatusBadRequest, "invalid_request", "keep_from_step must be >= 0")
@@ -523,6 +537,11 @@ func (s *Server) handleCompactConversation(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleListConversations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	// Delegate to search handler when ?q= is present.
+	if q := r.URL.Query().Get("q"); q != "" {
+		s.handleSearchConversations(w, r)
 		return
 	}
 	store := s.runner.GetConversationStore()

--- a/internal/server/http_compact_test.go
+++ b/internal/server/http_compact_test.go
@@ -147,18 +147,24 @@ func TestCompactConversationEndpoint_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestCompactConversationEndpoint_EmptySummary verifies that an empty summary
+// triggers auto-generation rather than a 400 error. When the conversation does
+// not exist in the store, auto-generation short-circuits with a 404 (no
+// messages to summarize).
 func TestCompactConversationEndpoint_EmptySummary(t *testing.T) {
 	t.Parallel()
 
 	store := newTestSQLiteStore(t)
 	runner := harness.NewRunner(
-		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		&staticProvider{result: harness.CompletionResult{Content: "auto-summary"}},
 		harness.NewRegistry(),
 		harness.RunnerConfig{ConversationStore: store},
 	)
 	ts := httptest.NewServer(New(runner))
 	defer ts.Close()
 
+	// Conversation "any-conv" does not exist — auto-generation loads 0 messages
+	// and returns 404 instead of a 400 for empty summary.
 	body := bytes.NewBufferString(`{"keep_from_step":2,"summary":""}`)
 	res, err := http.Post(ts.URL+"/v1/conversations/any-conv/compact", "application/json", body)
 	if err != nil {
@@ -166,8 +172,8 @@ func TestCompactConversationEndpoint_EmptySummary(t *testing.T) {
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusBadRequest {
-		t.Errorf("expected 400 for empty summary, got %d", res.StatusCode)
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 (conv not found during auto-summary), got %d", res.StatusCode)
 	}
 }
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -1567,3 +1567,285 @@ func TestHandleListConversationsNoFilter(t *testing.T) {
 			fstore.capturedFilter.Workspace, fstore.capturedFilter.TenantID)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Fix 1: GET /v1/conversations/?q= delegates to search handler
+// ---------------------------------------------------------------------------
+
+func TestListConversations_QParam_DelegatesToSearch(t *testing.T) {
+	t.Parallel()
+
+	store := &mockConversationStore{
+		searchResults: []harness.MessageSearchResult{
+			{ConversationID: "conv-found", Role: "user", Snippet: "hello <b>world</b>"},
+		},
+	}
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{ConversationStore: store},
+	)
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/v1/conversations/?q=hello")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, body)
+	}
+
+	var payload struct {
+		Results []harness.MessageSearchResult `json:"results"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(payload.Results) != 1 {
+		t.Fatalf("expected 1 search result, got %d", len(payload.Results))
+	}
+	if payload.Results[0].ConversationID != "conv-found" {
+		t.Errorf("unexpected conversation_id: %s", payload.Results[0].ConversationID)
+	}
+	if store.searchedQuery != "hello" {
+		t.Errorf("expected searchedQuery=hello, got %q", store.searchedQuery)
+	}
+}
+
+func TestListConversations_QParam_NoStore(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{},
+	)
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/v1/conversations/?q=hello")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer res.Body.Close()
+
+	// Without a store, search returns 501 Not Implemented.
+	if res.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", res.StatusCode)
+	}
+}
+
+func TestListConversations_NoQParam_StillLists(t *testing.T) {
+	t.Parallel()
+
+	store := &mockConversationStore{
+		conversations: []harness.Conversation{
+			{ID: "conv-a"},
+			{ID: "conv-b"},
+		},
+	}
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{ConversationStore: store},
+	)
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/v1/conversations/")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, body)
+	}
+
+	var payload struct {
+		Conversations []harness.Conversation `json:"conversations"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Conversations) != 2 {
+		t.Errorf("expected 2 conversations, got %d", len(payload.Conversations))
+	}
+	// search should NOT have been called
+	if store.searchedQuery != "" {
+		t.Errorf("expected no search call, but got searchedQuery=%q", store.searchedQuery)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fix 2: POST /v1/conversations/{id}/compact auto-generates summary
+// ---------------------------------------------------------------------------
+
+// summarizingProvider captures the messages it receives and returns a canned summary.
+type summarizingProvider struct {
+	mu              sync.Mutex
+	capturedRequest harness.CompletionRequest
+	summary         string
+}
+
+func (p *summarizingProvider) Complete(_ context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.capturedRequest = req
+	return harness.CompletionResult{Content: p.summary}, nil
+}
+
+func TestCompactConversation_AutoGenerateSummary(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	msgs := []harness.Message{
+		{Role: "user", Content: "What is the capital of France?"},
+		{Role: "assistant", Content: "Paris."},
+		{Role: "user", Content: "And Germany?"},
+		{Role: "assistant", Content: "Berlin."},
+	}
+	if err := store.SaveConversation(ctx, "conv-auto-summary", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	prov := &summarizingProvider{summary: "Auto-generated: capitals discussed, Paris and Berlin."}
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		ConversationStore: store,
+		DefaultModel:      "test-model",
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	// POST with no summary field — should auto-generate.
+	body := bytes.NewBufferString(`{"keep_from_step":4}`)
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-auto-summary/compact", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST compact: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, b)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["compacted"] != true {
+		t.Errorf("expected compacted=true, got %v", resp["compacted"])
+	}
+
+	// Verify the summary message in the store is the auto-generated one.
+	loaded, err := store.LoadMessages(ctx, "conv-auto-summary")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) == 0 {
+		t.Fatal("expected messages after compact")
+	}
+	if !loaded[0].IsCompactSummary {
+		t.Error("first message should be marked as compact summary")
+	}
+	if loaded[0].Content != "Auto-generated: capitals discussed, Paris and Berlin." {
+		t.Errorf("unexpected summary content: %q", loaded[0].Content)
+	}
+
+	// Verify the provider was called with the conversation messages plus a summarize prompt.
+	prov.mu.Lock()
+	captured := prov.capturedRequest
+	prov.mu.Unlock()
+
+	if captured.Model != "test-model" {
+		t.Errorf("expected model=test-model, got %q", captured.Model)
+	}
+	// The last message in the request should be the summarize prompt.
+	if len(captured.Messages) == 0 {
+		t.Fatal("expected messages in captured request")
+	}
+	last := captured.Messages[len(captured.Messages)-1]
+	if last.Role != "user" {
+		t.Errorf("expected last message role=user, got %q", last.Role)
+	}
+	if !strings.Contains(last.Content, "summary") {
+		t.Errorf("expected summarize prompt in last message, got %q", last.Content)
+	}
+}
+
+func TestCompactConversation_AutoGenerateSummary_NoProvider(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	msgs := []harness.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "world"},
+	}
+	if err := store.SaveConversation(ctx, "conv-no-provider", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	// Use a provider that errors to simulate unavailability.
+	errProv := &errorOnSummarizeProvider{}
+	runner := harness.NewRunner(errProv, harness.NewRegistry(), harness.RunnerConfig{
+		ConversationStore: store,
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	body := bytes.NewBufferString(`{"keep_from_step":2}`)
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-no-provider/compact", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST compact: %v", err)
+	}
+	defer res.Body.Close()
+
+	// When auto-summary fails, we expect a 500.
+	if res.StatusCode != http.StatusInternalServerError {
+		b, _ := io.ReadAll(res.Body)
+		t.Errorf("expected 500 when provider errors, got %d: %s", res.StatusCode, b)
+	}
+}
+
+// errorOnSummarizeProvider always returns an error from Complete.
+type errorOnSummarizeProvider struct{}
+
+func (e *errorOnSummarizeProvider) Complete(_ context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+	return harness.CompletionResult{}, fmt.Errorf("provider unavailable")
+}
+
+func TestCompactConversation_AutoGenerateSummary_ConvNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{ConversationStore: store},
+	)
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	// No summary, conversation does not exist.
+	body := bytes.NewBufferString(`{"keep_from_step":0}`)
+	res, err := http.Post(ts.URL+"/v1/conversations/does-not-exist/compact", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST compact: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotFound {
+		b, _ := io.ReadAll(res.Body)
+		t.Errorf("expected 404 for missing conversation, got %d: %s", res.StatusCode, b)
+	}
+}


### PR DESCRIPTION
## Changes

- **Fix 1**: \`GET /v1/conversations/?q=\` now delegates to the search handler when the \`q\` param is present, making the list endpoint a superset of search. Previously the param was silently ignored.

- **Fix 2**: \`POST /v1/conversations/{id}/compact\` now auto-generates a summary via a single LLM call (\`Runner.SummarizeMessages\`) when the \`summary\` field is omitted or empty. Previously this returned a 400 error. When no messages exist for the conversation, it returns 404. When the provider errors, it returns 500.

## Implementation

- Added \`Runner.SummarizeMessages(ctx, messages)\` to \`internal/harness/runner.go\` — makes a single non-streaming LLM completion with a concise summarize prompt appended to the conversation messages
- Added q-param delegation in \`handleListConversations\` in \`internal/server/http.go\`
- Updated \`handleCompactConversation\` in \`internal/server/http.go\` to auto-generate when summary is empty
- Updated \`TestCompactConversationEndpoint_EmptySummary\` to reflect the new behavior (404 instead of 400 when conversation not found during auto-generation)

## Testing
- \`TestListConversations_QParam_DelegatesToSearch\` — verifies list with \`?q=\` returns search results
- \`TestListConversations_QParam_NoStore\` — verifies 501 when no store is configured
- \`TestListConversations_NoQParam_StillLists\` — verifies ordinary list still works when no \`?q=\`
- \`TestCompactConversation_AutoGenerateSummary\` — verifies auto-generation uses provider output as summary
- \`TestCompactConversation_AutoGenerateSummary_NoProvider\` — verifies 500 when provider errors
- \`TestCompactConversation_AutoGenerateSummary_ConvNotFound\` — verifies 404 when conversation missing
- All packages pass \`go test ./internal/... ./cmd/... -race -count=1\`