### PR TITLE
feat(#135): structured reflection with supersession and contradiction detection

### DIFF
--- a/internal/observationalmemory/manager.go
+++ b/internal/observationalmemory/manager.go
@@ -267,6 +267,8 @@ func (m *service) Observe(ctx context.Context, req ObserveRequest) (ObserveResul
 				rec.ActiveReflection = reflection
 				rec.ActiveReflectionTokens = m.estimator.EstimateTextTokens(reflection)
 				rec.LastReflectedObservationSeq = lastChunk.Seq
+				parsed := ParseStructuredReflection(reflection)
+				rec.StructuredReflection = &parsed
 				rec.StateVersion++
 				rec.UpdatedAt = m.now().UTC()
 				reflected = true
@@ -312,10 +314,33 @@ func (m *service) Snippet(ctx context.Context, key ScopeKey) (string, Status, er
 		limit = DefaultConfig().SnippetMaxTokens
 	}
 	used := 0
-	sections := make([]string, 0, 2)
-	if rec.ActiveReflection != "" {
-		sections = append(sections, "Reflection:\n"+strings.TrimSpace(rec.ActiveReflection))
-		used += rec.ActiveReflectionTokens
+	sections := make([]string, 0, 4)
+
+	// Re-parse StructuredReflection from the raw string if it was not loaded
+	// from a persistent store (the SQLite store only persists active_reflection).
+	// This ensures Snippet() always has access to the parsed structured form.
+	if rec.StructuredReflection == nil && strings.TrimSpace(rec.ActiveReflection) != "" {
+		parsed := ParseStructuredReflection(strings.TrimSpace(rec.ActiveReflection))
+		rec.StructuredReflection = &parsed
+	}
+
+	// Build the reflection section. For structured reflections we use the
+	// Summary text; for legacy reflections we use the raw string.
+	reflectionText := strings.TrimSpace(rec.ActiveReflection)
+	if rec.StructuredReflection != nil && rec.StructuredReflection.SchemaVersion == 1 {
+		reflectionText = strings.TrimSpace(rec.StructuredReflection.Summary)
+	}
+	if reflectionText != "" {
+		sections = append(sections, "Reflection:\n"+reflectionText)
+		used += m.estimator.EstimateTextTokens(reflectionText)
+	}
+
+	// Build a set of superseded sequence numbers for fast lookup.
+	supersededSeqs := map[int64]bool{}
+	if rec.StructuredReflection != nil {
+		for _, sup := range rec.StructuredReflection.Supersessions {
+			supersededSeqs[sup.OlderSeq] = true
+		}
 	}
 
 	// Compute importance-weighted score with recency decay for each chunk.
@@ -323,6 +348,7 @@ func (m *service) Snippet(ctx context.Context, key ScopeKey) (string, Status, er
 	// where recencyWeight = 1.0 / (1.0 + float64(ageSteps))
 	// and ageSteps = len(observations) - 1 - index (0 = newest).
 	// Unscored chunks (Importance == 0.0) are treated as Importance=0.5.
+	// Phase 5: Superseded chunks have their effective importance clamped to 0.1.
 	type scoredChunk struct {
 		chunk ObservationChunk
 		score float64
@@ -333,6 +359,10 @@ func (m *service) Snippet(ctx context.Context, key ScopeKey) (string, Status, er
 		imp := chunk.Importance
 		if imp == 0.0 {
 			imp = 0.5
+		}
+		// Demote superseded chunks so they are deprioritised in the token budget.
+		if supersededSeqs[chunk.Seq] {
+			imp = 0.1
 		}
 		ageSteps := float64(n - 1 - i)
 		recencyWeight := 1.0 / (1.0 + ageSteps)
@@ -357,6 +387,35 @@ func (m *service) Snippet(ctx context.Context, key ScopeKey) (string, Status, er
 		}
 		sections = append(sections, strings.TrimSpace(b.String()))
 	}
+
+	// Phase 4: Surface supersessions and contradictions as warning sections.
+	if rec.StructuredReflection != nil && rec.StructuredReflection.SchemaVersion == 1 {
+		if len(rec.StructuredReflection.Supersessions) > 0 {
+			var b strings.Builder
+			b.WriteString("⚠️ Preference changes (most recent wins):\n")
+			for _, sup := range rec.StructuredReflection.Supersessions {
+				if sup.Reason != "" {
+					b.WriteString(fmt.Sprintf("- %s [step %d]\n", sup.Reason, sup.NewerSeq))
+				} else {
+					b.WriteString(fmt.Sprintf("- observation [%d] supersedes [%d]\n", sup.NewerSeq, sup.OlderSeq))
+				}
+			}
+			sections = append(sections, strings.TrimSpace(b.String()))
+		}
+		if len(rec.StructuredReflection.Contradictions) > 0 {
+			var b strings.Builder
+			b.WriteString("⚠️ Unresolved contradictions:\n")
+			for _, con := range rec.StructuredReflection.Contradictions {
+				if con.Detail != "" {
+					b.WriteString(fmt.Sprintf("- %s (step %d) vs (step %d) — confirm which applies\n", con.Detail, con.SeqA, con.SeqB))
+				} else {
+					b.WriteString(fmt.Sprintf("- observations [%d] and [%d] conflict\n", con.SeqA, con.SeqB))
+				}
+			}
+			sections = append(sections, strings.TrimSpace(b.String()))
+		}
+	}
+
 	if len(sections) == 0 {
 		return "", status, nil
 	}
@@ -388,6 +447,8 @@ func (m *service) ReflectNow(ctx context.Context, key ScopeKey, runID, toolCallI
 		rec.ActiveReflection = reflection
 		rec.ActiveReflectionTokens = m.estimator.EstimateTextTokens(reflection)
 		rec.LastReflectedObservationSeq = int64(len(rec.ActiveObservations))
+		parsed := ParseStructuredReflection(reflection)
+		rec.StructuredReflection = &parsed
 		rec.StateVersion++
 		rec.UpdatedAt = m.now().UTC()
 		return m.insertMarker(ctx, Marker{

--- a/internal/observationalmemory/manager_test.go
+++ b/internal/observationalmemory/manager_test.go
@@ -489,3 +489,317 @@ func TestMergeConfig(t *testing.T) {
 		t.Fatalf("expected reflect_threshold_tokens 45, got %d", merged.ReflectThresholdTokens)
 	}
 }
+
+// TestLegacyReflectionParsesWithoutError verifies that a legacy plain-text
+// reflection (no SUMMARY: header) is parsed gracefully as SchemaVersion=0
+// and does not cause any errors or panics in Snippet().
+func TestLegacyReflectionParsesWithoutError(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Reflector returns legacy plain text (no SUMMARY: header).
+	legacyReflection := "User prefers concise updates. Never auto-commit."
+	svc, err := NewService(ServiceOptions{
+		Mode:        ModeLocalCoordinator,
+		Store:       store,
+		Coordinator: NewLocalCoordinator(),
+		Observer:    ModelObserver{Model: modelStub{out: "IMPORTANCE:0.7\nUser prefers concise updates."}},
+		Reflector:   ModelReflector{Model: modelStub{out: legacyReflection}},
+		Estimator:   RuneTokenEstimator{},
+		DefaultConfig: Config{
+			ObserveMinTokens:       1,
+			SnippetMaxTokens:       500,
+			ReflectThresholdTokens: 2,
+		},
+		DefaultEnabled: true,
+		Now:            time.Now,
+	})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	scope := ScopeKey{TenantID: "t", ConversationID: "c", AgentID: "a"}
+	result, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r1",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Keep responses concise."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if !result.Reflected {
+		t.Fatalf("expected reflection to be triggered")
+	}
+
+	snippet, _, err := svc.Snippet(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("snippet: %v", err)
+	}
+	if !strings.Contains(snippet, "<observational-memory>") {
+		t.Fatalf("expected snippet tags, got: %q", snippet)
+	}
+	// Legacy reflection text should appear in the snippet.
+	if !strings.Contains(snippet, "User prefers concise updates") && !strings.Contains(snippet, "Never auto-commit") {
+		t.Fatalf("expected legacy reflection text in snippet, got: %q", snippet)
+	}
+	// No warning sections should appear for a legacy (SchemaVersion=0) reflection.
+	if strings.Contains(snippet, "Preference changes") || strings.Contains(snippet, "contradictions") {
+		t.Fatalf("unexpected warning sections in legacy snippet: %q", snippet)
+	}
+}
+
+// TestSupersededChunkIsDemotedInSnippet verifies that a chunk identified as
+// superseded by the structured reflection is demoted in Snippet() selection.
+// When both chunks would normally have equal importance, the superseded one
+// gets a lower effective importance (0.1), so the non-superseded chunk wins
+// when the token budget allows only one.
+func TestSupersededChunkIsDemotedInSnippet(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observerCalls := 0
+	obs := observerFunc(func(_ context.Context, _ ScopeKey, _ Config, _ []TranscriptMessage, _ []ObservationChunk, _ string) (string, error) {
+		observerCalls++
+		if observerCalls == 1 {
+			// Old preference chunk: ~11 tokens via RuneTokenEstimator (44 chars/4).
+			return "IMPORTANCE:0.8\nUse tabs.", nil
+		}
+		// New preference chunk: ~11 tokens.
+		return "IMPORTANCE:0.8\nUse spaces.", nil
+	})
+
+	// Reflector returns structured output indicating seq:1 is superseded by seq:2.
+	// The summary is short to leave room in the token budget for one observation.
+	structuredReflection := "SUMMARY:\nSpaces now.\n\nSUPERSESSIONS:\n- [seq:2] replaces [seq:1]: user changed from tabs to spaces\n\nCONTRADICTIONS:\n"
+
+	// Budget: summary "Spaces now." is ~3 tokens. Two chunks ("Use tabs." and
+	// "Use spaces.") are each ~3 tokens. The supersession warning adds tokens.
+	// We set SnippetMaxTokens to allow the summary + one chunk but not two, so
+	// demotion of seq:1 determines which chunk survives.
+	svc, err := NewService(ServiceOptions{
+		Mode:        ModeLocalCoordinator,
+		Store:       store,
+		Coordinator: NewLocalCoordinator(),
+		Observer:    obs,
+		Reflector:   ModelReflector{Model: modelStub{out: structuredReflection}},
+		Estimator:   RuneTokenEstimator{},
+		DefaultConfig: Config{
+			ObserveMinTokens:       1,
+			SnippetMaxTokens:       7, // fits summary (~3) + one 3-token chunk, not two
+			ReflectThresholdTokens: 2,
+		},
+		DefaultEnabled: true,
+		Now:            time.Now,
+	})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	scope := ScopeKey{TenantID: "t", ConversationID: "c", AgentID: "a"}
+
+	// First observe: produces chunk seq=1 (old preference: "Use tabs.").
+	if _, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r1",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Use tabs for indentation."},
+		},
+	}); err != nil {
+		t.Fatalf("observe 1: %v", err)
+	}
+
+	// Second observe: produces chunk seq=2 (new preference: "Use spaces.") and triggers reflection.
+	result, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r2",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Use tabs for indentation."},
+			{Index: 1, Role: "user", Content: "Actually, use spaces instead."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("observe 2: %v", err)
+	}
+	if !result.Reflected {
+		t.Fatalf("expected reflection to be triggered on second observe")
+	}
+
+	snippet, _, err := svc.Snippet(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("snippet: %v", err)
+	}
+
+	// The supersession warning must appear.
+	if !strings.Contains(snippet, "Preference changes") {
+		t.Fatalf("expected supersession warning in snippet, got: %q", snippet)
+	}
+
+	// The superseded chunk (seq:1, "Use tabs.") must NOT appear in observations
+	// when both chunks cannot fit — demotion must deprioritise it.
+	if strings.Contains(snippet, "Use tabs") {
+		t.Fatalf("expected superseded chunk (tabs) to be excluded from tight-budget snippet, got: %q", snippet)
+	}
+}
+
+// TestContradictionAppearsAsWarningInSnippet verifies that contradictions
+// detected by the structured reflection appear as a warning section in Snippet().
+func TestContradictionAppearsAsWarningInSnippet(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	observerCalls := 0
+	obs := observerFunc(func(_ context.Context, _ ScopeKey, _ Config, _ []TranscriptMessage, _ []ObservationChunk, _ string) (string, error) {
+		observerCalls++
+		if observerCalls == 1 {
+			return "IMPORTANCE:0.7\nRetry count should be 3.", nil
+		}
+		return "IMPORTANCE:0.7\nRetry count should be 5.", nil
+	})
+
+	// Reflector returns structured output with a contradiction between seq:1 and seq:2.
+	structuredReflection := "SUMMARY:\nConflicting guidance on retry count.\n\nSUPERSESSIONS:\n\nCONTRADICTIONS:\n- [seq:1] vs [seq:2]: conflicting retry count (3 vs 5)\n"
+
+	svc, err := NewService(ServiceOptions{
+		Mode:        ModeLocalCoordinator,
+		Store:       store,
+		Coordinator: NewLocalCoordinator(),
+		Observer:    obs,
+		Reflector:   ModelReflector{Model: modelStub{out: structuredReflection}},
+		Estimator:   RuneTokenEstimator{},
+		DefaultConfig: Config{
+			ObserveMinTokens:       1,
+			SnippetMaxTokens:       500,
+			ReflectThresholdTokens: 2,
+		},
+		DefaultEnabled: true,
+		Now:            time.Now,
+	})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	scope := ScopeKey{TenantID: "t", ConversationID: "c", AgentID: "a"}
+
+	if _, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r1",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Retry count is 3."},
+		},
+	}); err != nil {
+		t.Fatalf("observe 1: %v", err)
+	}
+
+	result, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r2",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Retry count is 3."},
+			{Index: 1, Role: "user", Content: "Actually retry count should be 5."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("observe 2: %v", err)
+	}
+	if !result.Reflected {
+		t.Fatalf("expected reflection to be triggered")
+	}
+
+	snippet, _, err := svc.Snippet(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("snippet: %v", err)
+	}
+
+	if !strings.Contains(snippet, "contradictions") && !strings.Contains(snippet, "Unresolved") {
+		t.Fatalf("expected contradiction warning in snippet, got: %q", snippet)
+	}
+	if !strings.Contains(snippet, "retry") && !strings.Contains(snippet, "conflicting") {
+		t.Fatalf("expected contradiction detail in snippet, got: %q", snippet)
+	}
+}
+
+// TestStructuredReflectionNoSupersessionsNoContradictions verifies that a
+// structured reflection with empty SUPERSESSIONS and CONTRADICTIONS sections
+// works normally without producing spurious warning blocks in Snippet().
+func TestStructuredReflectionNoSupersessionsNoContradictions(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "state.db"))
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cleanReflection := "SUMMARY:\nUser wants concise responses and prefers Go idioms.\n\nSUPERSESSIONS:\n\nCONTRADICTIONS:\n"
+
+	svc, err := NewService(ServiceOptions{
+		Mode:        ModeLocalCoordinator,
+		Store:       store,
+		Coordinator: NewLocalCoordinator(),
+		Observer:    ModelObserver{Model: modelStub{out: "IMPORTANCE:0.8\nUser wants concise responses."}},
+		Reflector:   ModelReflector{Model: modelStub{out: cleanReflection}},
+		Estimator:   RuneTokenEstimator{},
+		DefaultConfig: Config{
+			ObserveMinTokens:       1,
+			SnippetMaxTokens:       500,
+			ReflectThresholdTokens: 2,
+		},
+		DefaultEnabled: true,
+		Now:            time.Now,
+	})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	scope := ScopeKey{TenantID: "t", ConversationID: "c", AgentID: "a"}
+	result, err := svc.Observe(context.Background(), ObserveRequest{
+		Scope: scope,
+		RunID: "r1",
+		Messages: []TranscriptMessage{
+			{Index: 0, Role: "user", Content: "Keep responses concise."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if !result.Reflected {
+		t.Fatalf("expected reflection to be triggered")
+	}
+
+	snippet, _, err := svc.Snippet(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("snippet: %v", err)
+	}
+	if !strings.Contains(snippet, "<observational-memory>") {
+		t.Fatalf("expected snippet tags, got: %q", snippet)
+	}
+	// Should show the summary from the structured reflection.
+	if !strings.Contains(snippet, "concise responses") && !strings.Contains(snippet, "Go idioms") {
+		t.Fatalf("expected summary content in snippet, got: %q", snippet)
+	}
+	// No warning sections should appear.
+	if strings.Contains(snippet, "Preference changes") || strings.Contains(snippet, "Unresolved") {
+		t.Fatalf("unexpected warning sections in clean-reflection snippet: %q", snippet)
+	}
+}

--- a/internal/observationalmemory/prompt_templates.go
+++ b/internal/observationalmemory/prompt_templates.go
@@ -60,8 +60,16 @@ func buildObservationPrompt(scope ScopeKey, cfg Config, unobserved []TranscriptM
 func buildReflectionPrompt(scope ScopeKey, cfg Config, observations []ObservationChunk, existingReflection string) []PromptMessage {
 	var b strings.Builder
 	b.WriteString("You are compressing observational memory for long-lived agent performance.\n")
-	b.WriteString("Create a compact reflection that preserves durable decisions, constraints, and preferences.\n")
-	b.WriteString("Return plain text only.\n\n")
+	b.WriteString("Create a compact, structured reflection that preserves durable decisions, constraints, and preferences.\n")
+	b.WriteString("Also identify any observations that supersede or contradict each other.\n\n")
+	b.WriteString("Respond using EXACTLY this format (all three sections are required):\n\n")
+	b.WriteString("SUMMARY:\n<compressed prose summary of all observations>\n\n")
+	b.WriteString("SUPERSESSIONS:\n")
+	b.WriteString("- [seq:N] replaces [seq:M]: <reason why N supersedes M>\n")
+	b.WriteString("(Use this section when a newer observation replaces an older one. Leave empty if none.)\n\n")
+	b.WriteString("CONTRADICTIONS:\n")
+	b.WriteString("- [seq:N] vs [seq:M]: <description of the conflicting claims>\n")
+	b.WriteString("(Use this section when two observations conflict and neither clearly wins. Leave empty if none.)\n\n")
 	b.WriteString("Scope:\n")
 	b.WriteString(fmt.Sprintf("- tenant_id: %s\n- conversation_id: %s\n- agent_id: %s\n\n", scope.TenantID, scope.ConversationID, scope.AgentID))
 	b.WriteString(fmt.Sprintf("Reflection threshold tokens: %d\n\n", cfg.ReflectThresholdTokens))
@@ -70,12 +78,12 @@ func buildReflectionPrompt(scope ScopeKey, cfg Config, observations []Observatio
 		b.WriteString(existingReflection)
 		b.WriteString("\n\n")
 	}
-	b.WriteString("Observation chunks:\n")
+	b.WriteString("Observation chunks (use [seq:N] notation to reference them):\n")
 	for _, obs := range observations {
-		b.WriteString(fmt.Sprintf("- [%d] %s\n", obs.Seq, strings.TrimSpace(obs.Content)))
+		b.WriteString(fmt.Sprintf("- [seq:%d] %s\n", obs.Seq, strings.TrimSpace(obs.Content)))
 	}
 	return []PromptMessage{
-		{Role: "system", Content: "Produce a compressed reflection for future prompts."},
+		{Role: "system", Content: "Produce a structured compressed reflection with SUMMARY, SUPERSESSIONS, and CONTRADICTIONS sections."},
 		{Role: "user", Content: b.String()},
 	}
 }

--- a/internal/observationalmemory/structured_reflection.go
+++ b/internal/observationalmemory/structured_reflection.go
@@ -1,0 +1,209 @@
+package observationalmemory
+
+import (
+	"strconv"
+	"strings"
+)
+
+// StructuredReflection holds the parsed output of a structured reflection prompt.
+// SchemaVersion==1 means the reflection was produced with the structured prompt
+// (SUMMARY / SUPERSESSIONS / CONTRADICTIONS sections). SchemaVersion==0 means
+// legacy plain-text — the entire raw string is stored in Summary.
+type StructuredReflection struct {
+	Summary        string         `json:"summary"`
+	Supersessions  []Supersession `json:"supersessions,omitempty"`
+	Contradictions []Contradiction `json:"contradictions,omitempty"`
+	SchemaVersion  int            `json:"schema_version"`
+}
+
+// Supersession records that a newer observation replaces an older one.
+type Supersession struct {
+	NewerSeq int64  `json:"newer_seq"`
+	OlderSeq int64  `json:"older_seq"`
+	Reason   string `json:"reason"`
+}
+
+// Contradiction records two observations that are in conflict.
+type Contradiction struct {
+	SeqA   int64  `json:"seq_a"`
+	SeqB   int64  `json:"seq_b"`
+	Detail string `json:"detail"`
+}
+
+// ParseStructuredReflection parses the raw LLM output from a structured
+// reflection prompt. If the output contains a "SUMMARY:" header it is treated
+// as SchemaVersion=1 and all three sections are parsed. Otherwise the entire
+// text is treated as the Summary with SchemaVersion=0 (legacy plain text).
+func ParseStructuredReflection(raw string) StructuredReflection {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return StructuredReflection{SchemaVersion: 0}
+	}
+
+	// Detect structured format by looking for a SUMMARY: header.
+	if !strings.Contains(raw, "SUMMARY:") {
+		// Legacy plain-text reflection.
+		return StructuredReflection{
+			Summary:       raw,
+			SchemaVersion: 0,
+		}
+	}
+
+	sr := StructuredReflection{SchemaVersion: 1}
+
+	// Split into labelled sections. We recognise the three section headers.
+	// Everything between SUMMARY: and the next header (or end) is the summary.
+	// SUPERSESSIONS: lines follow the format:
+	//   - [seq:N] replaces [seq:M]: reason text
+	// CONTRADICTIONS: lines follow the format:
+	//   - [seq:N] vs [seq:M]: detail text
+
+	type section struct {
+		name    string
+		content strings.Builder
+	}
+
+	sections := []string{"SUMMARY:", "SUPERSESSIONS:", "CONTRADICTIONS:"}
+	sectionContent := map[string]*strings.Builder{}
+	for _, s := range sections {
+		var b strings.Builder
+		sectionContent[s] = &b
+	}
+
+	currentSection := ""
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		matched := false
+		for _, sec := range sections {
+			if strings.HasPrefix(trimmed, sec) {
+				currentSection = sec
+				// Capture anything on the same line after the header.
+				remainder := strings.TrimSpace(strings.TrimPrefix(trimmed, sec))
+				if remainder != "" {
+					sectionContent[sec].WriteString(remainder)
+					sectionContent[sec].WriteByte('\n')
+				}
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		if currentSection != "" {
+			sectionContent[currentSection].WriteString(line)
+			sectionContent[currentSection].WriteByte('\n')
+		}
+	}
+
+	sr.Summary = strings.TrimSpace(sectionContent["SUMMARY:"].String())
+	sr.Supersessions = parseSupersessions(sectionContent["SUPERSESSIONS:"].String())
+	sr.Contradictions = parseContradictions(sectionContent["CONTRADICTIONS:"].String())
+
+	return sr
+}
+
+// parseSupersessions parses lines of the form:
+//
+//	- [seq:N] replaces [seq:M]: reason
+func parseSupersessions(block string) []Supersession {
+	var out []Supersession
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Remove leading "- " bullet if present.
+		line = strings.TrimPrefix(line, "- ")
+		line = strings.TrimSpace(line)
+
+		// Expected: [seq:N] replaces [seq:M]: reason
+		newerSeq, rest, ok := extractSeqBracket(line)
+		if !ok {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		// Expect "replaces"
+		if !strings.HasPrefix(strings.ToLower(rest), "replaces") {
+			continue
+		}
+		rest = strings.TrimSpace(rest[len("replaces"):])
+		olderSeq, rest, ok := extractSeqBracket(rest)
+		if !ok {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		// Strip optional leading colon.
+		rest = strings.TrimPrefix(rest, ":")
+		reason := strings.TrimSpace(rest)
+		out = append(out, Supersession{
+			NewerSeq: newerSeq,
+			OlderSeq: olderSeq,
+			Reason:   reason,
+		})
+	}
+	return out
+}
+
+// parseContradictions parses lines of the form:
+//
+//	- [seq:N] vs [seq:M]: detail
+func parseContradictions(block string) []Contradiction {
+	var out []Contradiction
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Remove leading "- " bullet if present.
+		line = strings.TrimPrefix(line, "- ")
+		line = strings.TrimSpace(line)
+
+		// Expected: [seq:N] vs [seq:M]: detail
+		seqA, rest, ok := extractSeqBracket(line)
+		if !ok {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		// Expect "vs"
+		lower := strings.ToLower(rest)
+		if !strings.HasPrefix(lower, "vs") {
+			continue
+		}
+		rest = strings.TrimSpace(rest[len("vs"):])
+		seqB, rest, ok := extractSeqBracket(rest)
+		if !ok {
+			continue
+		}
+		rest = strings.TrimSpace(rest)
+		// Strip optional leading colon.
+		rest = strings.TrimPrefix(rest, ":")
+		detail := strings.TrimSpace(rest)
+		out = append(out, Contradiction{
+			SeqA:   seqA,
+			SeqB:   seqB,
+			Detail: detail,
+		})
+	}
+	return out
+}
+
+// extractSeqBracket extracts [seq:N] from the start of s, returning the
+// parsed integer, the remaining string after the bracket, and whether it
+// succeeded.
+func extractSeqBracket(s string) (int64, string, bool) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "[seq:") {
+		return 0, s, false
+	}
+	end := strings.IndexByte(s, ']')
+	if end == -1 {
+		return 0, s, false
+	}
+	inner := s[len("[seq:"):end]
+	n, err := strconv.ParseInt(strings.TrimSpace(inner), 10, 64)
+	if err != nil {
+		return 0, s, false
+	}
+	return n, s[end+1:], true
+}

--- a/internal/observationalmemory/structured_reflection_test.go
+++ b/internal/observationalmemory/structured_reflection_test.go
@@ -1,0 +1,213 @@
+package observationalmemory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseStructuredReflectionLegacyPlainText(t *testing.T) {
+	t.Parallel()
+
+	raw := "User prefers short responses. Never auto-commit."
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 0 {
+		t.Fatalf("expected SchemaVersion 0 for legacy, got %d", sr.SchemaVersion)
+	}
+	if sr.Summary != raw {
+		t.Fatalf("expected full text as summary, got %q", sr.Summary)
+	}
+	if len(sr.Supersessions) != 0 {
+		t.Fatalf("expected no supersessions, got %d", len(sr.Supersessions))
+	}
+	if len(sr.Contradictions) != 0 {
+		t.Fatalf("expected no contradictions, got %d", len(sr.Contradictions))
+	}
+}
+
+func TestParseStructuredReflectionEmpty(t *testing.T) {
+	t.Parallel()
+
+	sr := ParseStructuredReflection("")
+	if sr.SchemaVersion != 0 {
+		t.Fatalf("expected SchemaVersion 0 for empty, got %d", sr.SchemaVersion)
+	}
+	if sr.Summary != "" {
+		t.Fatalf("expected empty summary, got %q", sr.Summary)
+	}
+}
+
+func TestParseStructuredReflectionFullStructured(t *testing.T) {
+	t.Parallel()
+
+	raw := `SUMMARY:
+User changed indentation preference from tabs to spaces. Auth method changed to bearer token.
+
+SUPERSESSIONS:
+- [seq:5] replaces [seq:2]: user changed from tabs to spaces
+- [seq:8] replaces [seq:1]: auth method changed to bearer token
+
+CONTRADICTIONS:
+- [seq:3] vs [seq:7]: conflicting constraints on retry count (3 vs 5)
+`
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion 1, got %d", sr.SchemaVersion)
+	}
+	if sr.Summary == "" {
+		t.Fatalf("expected non-empty summary")
+	}
+	if !containsString(sr.Summary, "tabs to spaces") && !containsString(sr.Summary, "bearer token") {
+		t.Fatalf("unexpected summary content: %q", sr.Summary)
+	}
+
+	if len(sr.Supersessions) != 2 {
+		t.Fatalf("expected 2 supersessions, got %d: %+v", len(sr.Supersessions), sr.Supersessions)
+	}
+	if sr.Supersessions[0].NewerSeq != 5 || sr.Supersessions[0].OlderSeq != 2 {
+		t.Fatalf("unexpected first supersession: %+v", sr.Supersessions[0])
+	}
+	if sr.Supersessions[0].Reason == "" {
+		t.Fatalf("expected non-empty reason for first supersession")
+	}
+	if sr.Supersessions[1].NewerSeq != 8 || sr.Supersessions[1].OlderSeq != 1 {
+		t.Fatalf("unexpected second supersession: %+v", sr.Supersessions[1])
+	}
+
+	if len(sr.Contradictions) != 1 {
+		t.Fatalf("expected 1 contradiction, got %d: %+v", len(sr.Contradictions), sr.Contradictions)
+	}
+	if sr.Contradictions[0].SeqA != 3 || sr.Contradictions[0].SeqB != 7 {
+		t.Fatalf("unexpected contradiction: %+v", sr.Contradictions[0])
+	}
+	if sr.Contradictions[0].Detail == "" {
+		t.Fatalf("expected non-empty detail for contradiction")
+	}
+}
+
+func TestParseStructuredReflectionNoSupersessionsNoContradictions(t *testing.T) {
+	t.Parallel()
+
+	raw := `SUMMARY:
+User wants concise responses and prefers Go idioms.
+
+SUPERSESSIONS:
+
+CONTRADICTIONS:
+`
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion 1, got %d", sr.SchemaVersion)
+	}
+	if sr.Summary == "" {
+		t.Fatalf("expected non-empty summary")
+	}
+	if len(sr.Supersessions) != 0 {
+		t.Fatalf("expected no supersessions, got %d", len(sr.Supersessions))
+	}
+	if len(sr.Contradictions) != 0 {
+		t.Fatalf("expected no contradictions, got %d", len(sr.Contradictions))
+	}
+}
+
+func TestParseStructuredReflectionOnlySupersessions(t *testing.T) {
+	t.Parallel()
+
+	raw := `SUMMARY:
+Auth method changed.
+
+SUPERSESSIONS:
+- [seq:3] replaces [seq:1]: bearer token replaced API key
+
+CONTRADICTIONS:
+`
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion 1, got %d", sr.SchemaVersion)
+	}
+	if len(sr.Supersessions) != 1 {
+		t.Fatalf("expected 1 supersession, got %d", len(sr.Supersessions))
+	}
+	if sr.Supersessions[0].NewerSeq != 3 || sr.Supersessions[0].OlderSeq != 1 {
+		t.Fatalf("unexpected supersession seqs: %+v", sr.Supersessions[0])
+	}
+	if len(sr.Contradictions) != 0 {
+		t.Fatalf("expected no contradictions, got %d", len(sr.Contradictions))
+	}
+}
+
+func TestParseStructuredReflectionOnlyContradictions(t *testing.T) {
+	t.Parallel()
+
+	raw := `SUMMARY:
+Conflicting retry count guidance.
+
+SUPERSESSIONS:
+
+CONTRADICTIONS:
+- [seq:2] vs [seq:4]: conflicting retry count (3 vs 5)
+- [seq:6] vs [seq:9]: conflicting timeout value (30s vs 60s)
+`
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion 1, got %d", sr.SchemaVersion)
+	}
+	if len(sr.Contradictions) != 2 {
+		t.Fatalf("expected 2 contradictions, got %d", len(sr.Contradictions))
+	}
+	if sr.Contradictions[0].SeqA != 2 || sr.Contradictions[0].SeqB != 4 {
+		t.Fatalf("unexpected first contradiction: %+v", sr.Contradictions[0])
+	}
+	if sr.Contradictions[1].SeqA != 6 || sr.Contradictions[1].SeqB != 9 {
+		t.Fatalf("unexpected second contradiction: %+v", sr.Contradictions[1])
+	}
+	if len(sr.Supersessions) != 0 {
+		t.Fatalf("expected no supersessions, got %d", len(sr.Supersessions))
+	}
+}
+
+func TestParseStructuredReflectionMalformedLines(t *testing.T) {
+	t.Parallel()
+
+	// Lines that don't match the expected format should be silently ignored.
+	raw := `SUMMARY:
+Some summary.
+
+SUPERSESSIONS:
+- invalid line without seq brackets
+- [seq:abc] replaces [seq:2]: non-numeric seq should be ignored
+- [seq:3] replaces [seq:1]: valid line
+
+CONTRADICTIONS:
+- bad format
+- [seq:5] vs [seq:7]: valid contradiction
+`
+	sr := ParseStructuredReflection(raw)
+
+	if sr.SchemaVersion != 1 {
+		t.Fatalf("expected SchemaVersion 1, got %d", sr.SchemaVersion)
+	}
+	// Only the valid supersession line should be parsed.
+	if len(sr.Supersessions) != 1 {
+		t.Fatalf("expected 1 valid supersession, got %d: %+v", len(sr.Supersessions), sr.Supersessions)
+	}
+	if sr.Supersessions[0].NewerSeq != 3 || sr.Supersessions[0].OlderSeq != 1 {
+		t.Fatalf("unexpected supersession: %+v", sr.Supersessions[0])
+	}
+	// Only the valid contradiction line should be parsed.
+	if len(sr.Contradictions) != 1 {
+		t.Fatalf("expected 1 valid contradiction, got %d: %+v", len(sr.Contradictions), sr.Contradictions)
+	}
+	if sr.Contradictions[0].SeqA != 5 || sr.Contradictions[0].SeqB != 7 {
+		t.Fatalf("unexpected contradiction: %+v", sr.Contradictions[0])
+	}
+}
+
+// containsString is a helper to check if a string contains a substring.
+func containsString(s, sub string) bool {
+	return strings.Contains(s, sub)
+}

--- a/internal/observationalmemory/types.go
+++ b/internal/observationalmemory/types.go
@@ -46,19 +46,20 @@ type ObservationChunk struct {
 }
 
 type Record struct {
-	MemoryID                    string             `json:"memory_id"`
-	Scope                       ScopeKey           `json:"scope"`
-	Enabled                     bool               `json:"enabled"`
-	StateVersion                int64              `json:"state_version"`
-	LastObservedMessageIndex    int64              `json:"last_observed_message_index"`
-	ActiveObservations          []ObservationChunk `json:"active_observations"`
-	ActiveObservationTokens     int                `json:"active_observation_tokens"`
-	ActiveReflection            string             `json:"active_reflection"`
-	ActiveReflectionTokens      int                `json:"active_reflection_tokens"`
-	LastReflectedObservationSeq int64              `json:"last_reflected_observation_seq"`
-	Config                      Config             `json:"config"`
-	CreatedAt                   time.Time          `json:"created_at"`
-	UpdatedAt                   time.Time          `json:"updated_at"`
+	MemoryID                    string               `json:"memory_id"`
+	Scope                       ScopeKey             `json:"scope"`
+	Enabled                     bool                 `json:"enabled"`
+	StateVersion                int64                `json:"state_version"`
+	LastObservedMessageIndex    int64                `json:"last_observed_message_index"`
+	ActiveObservations          []ObservationChunk   `json:"active_observations"`
+	ActiveObservationTokens     int                  `json:"active_observation_tokens"`
+	ActiveReflection            string               `json:"active_reflection"`
+	ActiveReflectionTokens      int                  `json:"active_reflection_tokens"`
+	LastReflectedObservationSeq int64                `json:"last_reflected_observation_seq"`
+	StructuredReflection        *StructuredReflection `json:"structured_reflection,omitempty"`
+	Config                      Config               `json:"config"`
+	CreatedAt                   time.Time            `json:"created_at"`
+	UpdatedAt                   time.Time            `json:"updated_at"`
 }
 
 type Status struct {


### PR DESCRIPTION
## Summary
- Update reflection prompt to produce structured SUMMARY/SUPERSESSIONS/CONTRADICTIONS output
- Add `StructuredReflection` type with `ParseStructuredReflection()` parser — graceful fallback for legacy plain text (SchemaVersion=0)
- Add `StructuredReflection *StructuredReflection` field to `Record` (pointer, omitempty for backward compat with existing SQLite stores)
- Parse structured reflection in `Observe()` and `ReflectNow()` and store on Record; re-parse lazily in `Snippet()` for records loaded from SQLite (no schema migration required)
- Surface supersessions as `⚠️ Preference changes (most recent wins)` and contradictions as `⚠️ Unresolved contradictions` in `Snippet()` output
- Demote superseded chunks to effective importance 0.1 in importance-weighted `Snippet()` selection, freeing token budget for current observations

## Test plan
- [x] Legacy plain-text reflection parses without error (SchemaVersion=0, no warning sections in Snippet)
- [x] Superseded chunk is demoted in Snippet() importance-weighted selection
- [x] Contradictions appear as warnings in Snippet() output
- [x] Structured reflection with no supersessions/contradictions works normally (no spurious warning sections)
- [x] Malformed lines in SUPERSESSIONS/CONTRADICTIONS are silently ignored
- [x] All existing tests pass with race detector

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)