### PR TITLE
feat(#183): add WorktreeWorkspace implementation (git worktree-based)

### DIFF
--- a/internal/workspace/local.go
+++ b/internal/workspace/local.go
@@ -1,0 +1,95 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+)
+
+// LocalWorkspace is a directory-based workspace implementation.
+// It creates a subdirectory under a base path and uses an externally-running
+// harnessd instance (no process management). Suitable for development and
+// single-agent use.
+type LocalWorkspace struct {
+	harnessURL string
+	basePath   string
+	id         string
+	path       string // set after Provision
+}
+
+// NewLocal returns a new LocalWorkspace configured with the given harnessURL
+// and basePath. Either value may be overridden at Provision time via opts.
+func NewLocal(harnessURL, basePath string) *LocalWorkspace {
+	return &LocalWorkspace{
+		harnessURL: harnessURL,
+		basePath:   basePath,
+	}
+}
+
+// Provision creates the workspace directory at <basePath>/<id>.
+// The basePath is taken from opts.BaseDir (if non-empty) or the value set at
+// construction time or os.TempDir() as a last resort.
+// The harnessURL is taken from opts.Env["HARNESS_URL"] (if non-empty) or the
+// value set at construction time or defaultHarnessURL.
+// It returns ErrInvalidID if opts.ID is empty.
+func (w *LocalWorkspace) Provision(_ context.Context, opts Options) error {
+	if opts.ID == "" {
+		return ErrInvalidID
+	}
+
+	// Resolve harnessURL: opts env > constructor value > default.
+	if url, ok := opts.Env["HARNESS_URL"]; ok && url != "" {
+		w.harnessURL = url
+	} else if w.harnessURL == "" {
+		w.harnessURL = defaultHarnessURL
+	}
+
+	// Resolve basePath: opts.BaseDir > constructor value > os.TempDir().
+	if opts.BaseDir != "" {
+		w.basePath = opts.BaseDir
+	} else if w.basePath == "" {
+		w.basePath = os.TempDir()
+	}
+
+	w.id = opts.ID
+	w.path = filepath.Join(w.basePath, w.id)
+
+	if err := os.MkdirAll(w.path, 0o755); err != nil {
+		return err
+	}
+	return nil
+}
+
+// HarnessURL returns the HTTP endpoint of the harnessd instance.
+// Returns the default URL if Provision has not been called yet and no URL was
+// set at construction time.
+func (w *LocalWorkspace) HarnessURL() string {
+	if w.harnessURL == "" {
+		return defaultHarnessURL
+	}
+	return w.harnessURL
+}
+
+// WorkspacePath returns the filesystem path of the workspace root.
+// Returns an empty string if Provision has not been called.
+func (w *LocalWorkspace) WorkspacePath() string {
+	return w.path
+}
+
+// Destroy removes the workspace directory. It is a no-op (returns nil) if the
+// workspace has not been provisioned.
+func (w *LocalWorkspace) Destroy(_ context.Context) error {
+	if w.path == "" {
+		return nil
+	}
+	return os.RemoveAll(w.path)
+}
+
+func init() {
+	// Ignore the error — the default registry panics on duplicate registration
+	// only in tests that share the default registry. In normal usage this runs
+	// exactly once.
+	_ = Register("local", func() Workspace {
+		return &LocalWorkspace{}
+	})
+}

--- a/internal/workspace/local_test.go
+++ b/internal/workspace/local_test.go
@@ -1,0 +1,221 @@
+package workspace_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go-agent-harness/internal/workspace"
+)
+
+// Compile-time interface compliance check.
+var _ workspace.Workspace = (*workspace.LocalWorkspace)(nil)
+
+// TestLocalWorkspace_ImplementsWorkspace is the runtime counterpart to the
+// compile-time check above.
+func TestLocalWorkspace_ImplementsWorkspace(t *testing.T) {
+	var _ workspace.Workspace = (*workspace.LocalWorkspace)(nil)
+}
+
+func TestLocalWorkspace_Provision(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("http://localhost:8080", base)
+
+	opts := workspace.Options{ID: "test-provision"}
+	if err := ws.Provision(context.Background(), opts); err != nil {
+		t.Fatalf("Provision: unexpected error: %v", err)
+	}
+
+	want := filepath.Join(base, "test-provision")
+	if got := ws.WorkspacePath(); got != want {
+		t.Errorf("WorkspacePath = %q, want %q", got, want)
+	}
+
+	// Directory must exist.
+	if _, err := os.Stat(want); os.IsNotExist(err) {
+		t.Errorf("directory %q was not created", want)
+	}
+}
+
+func TestLocalWorkspace_Provision_EmptyID(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("http://localhost:8080", base)
+
+	err := ws.Provision(context.Background(), workspace.Options{ID: ""})
+	if err == nil {
+		t.Fatal("Provision with empty ID: expected error, got nil")
+	}
+}
+
+func TestLocalWorkspace_HarnessURL_Default(t *testing.T) {
+	// Zero-value LocalWorkspace (as returned by the factory) should return the
+	// default URL even before Provision is called.
+	ws := workspace.NewLocal("", "")
+	if got := ws.HarnessURL(); got != "http://localhost:8080" {
+		t.Errorf("HarnessURL (pre-provision, no URL set) = %q, want %q", got, "http://localhost:8080")
+	}
+}
+
+func TestLocalWorkspace_HarnessURL_FromEnv(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("", base)
+
+	opts := workspace.Options{
+		ID:  "env-url-test",
+		Env: map[string]string{"HARNESS_URL": "http://custom-harness:9090"},
+	}
+	if err := ws.Provision(context.Background(), opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	if got := ws.HarnessURL(); got != "http://custom-harness:9090" {
+		t.Errorf("HarnessURL = %q, want %q", got, "http://custom-harness:9090")
+	}
+}
+
+func TestLocalWorkspace_WorkspacePath_BeforeProvision(t *testing.T) {
+	ws := workspace.NewLocal("http://localhost:8080", t.TempDir())
+	if got := ws.WorkspacePath(); got != "" {
+		t.Errorf("WorkspacePath before Provision = %q, want empty string", got)
+	}
+}
+
+func TestLocalWorkspace_WorkspacePath_AfterProvision(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("http://localhost:8080", base)
+
+	id := "ws-after-provision"
+	if err := ws.Provision(context.Background(), workspace.Options{ID: id}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	want := filepath.Join(base, id)
+	if got := ws.WorkspacePath(); got != want {
+		t.Errorf("WorkspacePath = %q, want %q", got, want)
+	}
+}
+
+func TestLocalWorkspace_Destroy(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("http://localhost:8080", base)
+
+	id := "destroy-test"
+	if err := ws.Provision(context.Background(), workspace.Options{ID: id}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	dir := ws.WorkspacePath()
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		t.Fatalf("directory %q does not exist after Provision", dir)
+	}
+
+	if err := ws.Destroy(context.Background()); err != nil {
+		t.Fatalf("Destroy: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("directory %q still exists after Destroy", dir)
+	}
+}
+
+func TestLocalWorkspace_Destroy_NotProvisioned(t *testing.T) {
+	ws := workspace.NewLocal("http://localhost:8080", t.TempDir())
+	if err := ws.Destroy(context.Background()); err != nil {
+		t.Errorf("Destroy (not provisioned): expected nil error, got %v", err)
+	}
+}
+
+func TestLocalWorkspace_FullLifecycle(t *testing.T) {
+	base := t.TempDir()
+	ws := workspace.NewLocal("http://harness:8080", base)
+
+	// Before Provision.
+	if got := ws.WorkspacePath(); got != "" {
+		t.Errorf("pre-provision WorkspacePath = %q, want empty", got)
+	}
+
+	opts := workspace.Options{ID: "lifecycle-test"}
+	if err := ws.Provision(context.Background(), opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// After Provision.
+	wantPath := filepath.Join(base, "lifecycle-test")
+	if got := ws.WorkspacePath(); got != wantPath {
+		t.Errorf("WorkspacePath = %q, want %q", got, wantPath)
+	}
+	if got := ws.HarnessURL(); got != "http://harness:8080" {
+		t.Errorf("HarnessURL = %q, want %q", got, "http://harness:8080")
+	}
+
+	// Write a file inside to confirm it's a real directory.
+	marker := filepath.Join(wantPath, "marker.txt")
+	if err := os.WriteFile(marker, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Destroy cleans everything up.
+	if err := ws.Destroy(context.Background()); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+		t.Errorf("directory %q still exists after Destroy", wantPath)
+	}
+}
+
+func TestLocalWorkspace_BaseDir_Default(t *testing.T) {
+	// When NewLocal is given an empty basePath and opts.BaseDir is also empty,
+	// it should fall back to os.TempDir().
+	ws := workspace.NewLocal("", "")
+
+	id := "base-default-test"
+	if err := ws.Provision(context.Background(), workspace.Options{ID: id}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Destroy(context.Background()) })
+
+	want := filepath.Join(os.TempDir(), id)
+	if got := ws.WorkspacePath(); got != want {
+		t.Errorf("WorkspacePath = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); os.IsNotExist(err) {
+		t.Errorf("directory %q was not created", want)
+	}
+}
+
+func TestLocalWorkspace_CustomBaseDir(t *testing.T) {
+	customBase := t.TempDir()
+	ws := workspace.NewLocal("http://localhost:8080", "")
+
+	opts := workspace.Options{
+		ID:      "custom-base",
+		BaseDir: customBase,
+	}
+	if err := ws.Provision(context.Background(), opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	want := filepath.Join(customBase, "custom-base")
+	if got := ws.WorkspacePath(); got != want {
+		t.Errorf("WorkspacePath = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); os.IsNotExist(err) {
+		t.Errorf("directory %q was not created", want)
+	}
+}
+
+// TestLocalWorkspace_RegisteredInDefaultRegistry verifies the init() function
+// registered "local" in the package-level default registry.
+func TestLocalWorkspace_RegisteredInDefaultRegistry(t *testing.T) {
+	found := false
+	for _, n := range workspace.List() {
+		if n == "local" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error(`"local" is not registered in the default workspace registry`)
+	}
+}

--- a/internal/workspace/worktree.go
+++ b/internal/workspace/worktree.go
@@ -1,0 +1,162 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const defaultHarnessURL = "http://localhost:8080"
+
+// sanitizeBranchRe matches any character that is not alphanumeric, dot, underscore, or hyphen.
+var sanitizeBranchRe = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+// sanitizeBranch replaces all characters not in [A-Za-z0-9._-] with '-'.
+// If the result is empty, it returns "workspace".
+func sanitizeBranch(id string) string {
+	result := sanitizeBranchRe.ReplaceAllString(id, "-")
+	if result == "" {
+		return "workspace"
+	}
+	return result
+}
+
+// WorktreeWorkspace implements Workspace using git worktrees.
+// Each workspace gets its own branch checked out in a separate directory,
+// enabling parallel work on the same repo without conflicts.
+type WorktreeWorkspace struct {
+	harnessURL string
+	repoPath   string // path to the git repo
+	id         string
+	branch     string // sanitized branch name, set after Provision
+	path       string // worktree path, set after Provision
+}
+
+// NewWorktree creates a new unprovisioned WorktreeWorkspace.
+// harnessURL is the HTTP endpoint of the harnessd instance; if empty, the
+// default "http://localhost:8080" is used. repoPath is the path to the git
+// repository; if empty it will be derived from opts.BaseDir during Provision.
+func NewWorktree(harnessURL, repoPath string) *WorktreeWorkspace {
+	if harnessURL == "" {
+		harnessURL = defaultHarnessURL
+	}
+	return &WorktreeWorkspace{
+		harnessURL: harnessURL,
+		repoPath:   repoPath,
+	}
+}
+
+// Provision sets up the git worktree for this workspace.
+// It creates a new branch derived from opts.ID and checks it out into a
+// subdirectory under <repoPath>/worktrees/.
+func (w *WorktreeWorkspace) Provision(ctx context.Context, opts Options) error {
+	if opts.ID == "" {
+		return ErrInvalidID
+	}
+
+	w.id = opts.ID
+
+	// Resolve harnessURL from environment if provided.
+	if u, ok := opts.Env["HARNESS_URL"]; ok && u != "" {
+		w.harnessURL = u
+	}
+	if w.harnessURL == "" {
+		w.harnessURL = defaultHarnessURL
+	}
+
+	// Resolve repoPath: prefer opts.BaseDir, fall back to existing repoPath.
+	if opts.BaseDir != "" {
+		w.repoPath = opts.BaseDir
+	}
+	if w.repoPath == "" {
+		return fmt.Errorf("workspace: repoPath must be set (via opts.BaseDir or NewWorktree)")
+	}
+
+	// Compute branch and worktree path.
+	sanitized := sanitizeBranch(opts.ID)
+	w.branch = "workspace-" + sanitized
+	w.path = filepath.Join(w.repoPath, "worktrees", sanitized)
+
+	// Containment check: prevent path traversal attacks.
+	// filepath.Join cleans the path, so ".." in the ID gets collapsed.
+	// We verify the resolved path still sits under repoPath.
+	absRepo, err := filepath.Abs(w.repoPath)
+	if err != nil {
+		return fmt.Errorf("workspace: resolving repoPath: %w", err)
+	}
+	absPath, err := filepath.Abs(w.path)
+	if err != nil {
+		return fmt.Errorf("workspace: resolving worktree path: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absRepo+string(filepath.Separator)) {
+		return fmt.Errorf("workspace: worktree path %q escapes repository root %q", absPath, absRepo)
+	}
+
+	// Create the worktree.
+	cmd := exec.CommandContext(ctx, "git", "-C", w.repoPath, "worktree", "add", w.path, "-b", w.branch)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("workspace: git worktree add: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
+// HarnessURL returns the HTTP endpoint of the harnessd instance for this workspace.
+func (w *WorktreeWorkspace) HarnessURL() string {
+	if w.harnessURL == "" {
+		return defaultHarnessURL
+	}
+	return w.harnessURL
+}
+
+// WorkspacePath returns the filesystem path of the worktree root.
+// Returns an empty string if Provision has not been called.
+func (w *WorktreeWorkspace) WorkspacePath() string {
+	return w.path
+}
+
+// Destroy tears down the git worktree and deletes the associated branch.
+// If the workspace has not been provisioned (path is empty), Destroy is a no-op.
+// Errors from "not found" conditions (already removed worktrees/branches) are
+// silently ignored.
+func (w *WorktreeWorkspace) Destroy(ctx context.Context) error {
+	if w.path == "" {
+		return nil
+	}
+
+	// Remove the worktree directory.
+	rmCmd := exec.CommandContext(ctx, "git", "-C", w.repoPath, "worktree", "remove", "--force", w.path)
+	if out, err := rmCmd.CombinedOutput(); err != nil {
+		msg := strings.ToLower(strings.TrimSpace(string(out)))
+		// Ignore errors if the worktree is already gone.
+		if !strings.Contains(msg, "is not a working tree") &&
+			!strings.Contains(msg, "no such file") &&
+			!strings.Contains(msg, "does not exist") {
+			return fmt.Errorf("workspace: git worktree remove: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	// Delete the branch.
+	branchCmd := exec.CommandContext(ctx, "git", "-C", w.repoPath, "branch", "-D", w.branch)
+	if out, err := branchCmd.CombinedOutput(); err != nil {
+		msg := strings.ToLower(strings.TrimSpace(string(out)))
+		// Ignore errors if the branch is already gone.
+		if !strings.Contains(msg, "not found") &&
+			!strings.Contains(msg, "error: branch") {
+			return fmt.Errorf("workspace: git branch -D: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	// Register the "worktree" implementation in the package-level default registry.
+	// Any error here means a duplicate registration, which is a programming error.
+	_ = Register("worktree", func() Workspace {
+		return &WorktreeWorkspace{}
+	})
+}

--- a/internal/workspace/worktree_test.go
+++ b/internal/workspace/worktree_test.go
@@ -1,0 +1,334 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// runGit is a test helper that runs a git command in the given directory and
+// fatals if the command fails.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+// initTestRepo creates a temporary directory, initialises a git repository with
+// an initial commit, and returns the directory path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "test@test.com")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	// Create an initial commit so that HEAD exists (required for worktrees).
+	readmePath := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("test"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "init")
+
+	return dir
+}
+
+// --------------------------------------------------------------------------
+// TestSanitizeBranch
+// --------------------------------------------------------------------------
+
+func TestSanitizeBranch(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "normal alphanumeric",
+			input: "issue-42",
+			want:  "issue-42",
+		},
+		{
+			name:  "dots and underscores preserved",
+			input: "v1.2_feature",
+			want:  "v1.2_feature",
+		},
+		{
+			name:  "slashes replaced",
+			input: "feature/my-branch",
+			want:  "feature-my-branch",
+		},
+		{
+			name:  "spaces replaced",
+			input: "hello world",
+			want:  "hello-world",
+		},
+		{
+			name:  "special chars replaced",
+			input: "foo@bar#baz!qux",
+			want:  "foo-bar-baz-qux",
+		},
+		{
+			name:  "empty input returns workspace",
+			input: "",
+			want:  "workspace",
+		},
+		{
+			name:  "all invalid chars returns workspace",
+			input: "!!!@@@",
+			want:  "------",
+		},
+		{
+			name:  "uppercase preserved",
+			input: "MyFeature",
+			want:  "MyFeature",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeBranch(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeBranch(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_Provision
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_Provision(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree(defaultHarnessURL, repo)
+	opts := Options{ID: "issue-183"}
+
+	if err := ws.Provision(ctx, opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Destroy(ctx) })
+
+	// Verify the worktree directory was created.
+	if _, err := os.Stat(ws.WorkspacePath()); err != nil {
+		t.Errorf("worktree directory not found: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_Provision_EmptyID
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_Provision_EmptyID(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree(defaultHarnessURL, repo)
+	err := ws.Provision(ctx, Options{ID: ""})
+	if err == nil {
+		t.Fatal("Provision with empty ID: expected error, got nil")
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_WorkspacePath_BeforeProvision
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_WorkspacePath_BeforeProvision(t *testing.T) {
+	ws := NewWorktree(defaultHarnessURL, "/some/repo")
+	if got := ws.WorkspacePath(); got != "" {
+		t.Errorf("WorkspacePath before Provision = %q, want empty string", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_WorkspacePath_AfterProvision
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_WorkspacePath_AfterProvision(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree(defaultHarnessURL, repo)
+	opts := Options{ID: "issue-183"}
+
+	if err := ws.Provision(ctx, opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Destroy(ctx) })
+
+	got := ws.WorkspacePath()
+	want := filepath.Join(repo, "worktrees", "issue-183")
+	if got != want {
+		t.Errorf("WorkspacePath = %q, want %q", got, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_HarnessURL_Default
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_HarnessURL_Default(t *testing.T) {
+	ws := &WorktreeWorkspace{}
+	if got := ws.HarnessURL(); got != defaultHarnessURL {
+		t.Errorf("HarnessURL = %q, want %q", got, defaultHarnessURL)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_HarnessURL_FromEnv
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_HarnessURL_FromEnv(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree("", repo)
+	opts := Options{
+		ID: "issue-183-env",
+		Env: map[string]string{
+			"HARNESS_URL": "http://harness.example.com:9000",
+		},
+	}
+
+	if err := ws.Provision(ctx, opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+	t.Cleanup(func() { _ = ws.Destroy(ctx) })
+
+	want := "http://harness.example.com:9000"
+	if got := ws.HarnessURL(); got != want {
+		t.Errorf("HarnessURL = %q, want %q", got, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_Destroy
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_Destroy(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree(defaultHarnessURL, repo)
+	opts := Options{ID: "issue-destroy"}
+
+	if err := ws.Provision(ctx, opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	worktreePath := ws.WorkspacePath()
+
+	// Confirm directory exists before destroy.
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree path missing before Destroy: %v", err)
+	}
+
+	if err := ws.Destroy(ctx); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	// Directory should be gone after destroy.
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Errorf("worktree directory still exists after Destroy: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_Destroy_NotProvisioned
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_Destroy_NotProvisioned(t *testing.T) {
+	ws := &WorktreeWorkspace{}
+	// Destroy on an unprovisioned workspace must be a no-op.
+	if err := ws.Destroy(context.Background()); err != nil {
+		t.Errorf("Destroy on unprovisioned workspace: got %v, want nil", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_FullLifecycle
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_FullLifecycle(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	ws := NewWorktree(defaultHarnessURL, repo)
+	opts := Options{ID: "lifecycle-test"}
+
+	// Provision.
+	if err := ws.Provision(ctx, opts); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	worktreePath := ws.WorkspacePath()
+
+	// Verify the worktree directory exists.
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree directory not found after Provision: %v", err)
+	}
+
+	// Destroy.
+	if err := ws.Destroy(ctx); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	// Verify the worktree directory is gone.
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Errorf("worktree directory still exists after Destroy: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_ImplementsWorkspace
+// --------------------------------------------------------------------------
+
+// Compile-time interface compliance check.
+var _ Workspace = (*WorktreeWorkspace)(nil)
+
+func TestWorktreeWorkspace_ImplementsWorkspace(t *testing.T) {
+	var ws Workspace = &WorktreeWorkspace{}
+	_ = ws // use the variable to silence the linter
+}
+
+// --------------------------------------------------------------------------
+// TestWorktreeWorkspace_PathContainment
+// --------------------------------------------------------------------------
+
+func TestWorktreeWorkspace_PathContainment(t *testing.T) {
+	repo := initTestRepo(t)
+	ctx := context.Background()
+
+	// An ID with path traversal characters that might escape the repo root.
+	// After sanitization, "../../evil" becomes "..-..-evil", which stays within the repo.
+	// We test that even IDs that look traversal-like are contained after sanitisation.
+	ws := NewWorktree(defaultHarnessURL, repo)
+	opts := Options{ID: "../../evil"}
+
+	if err := ws.Provision(ctx, opts); err != nil {
+		// This is also acceptable — if the git command fails for an unusual path,
+		// that's fine, but it must not have escaped the repo root.
+		t.Logf("Provision returned error (acceptable): %v", err)
+		return
+	}
+	t.Cleanup(func() { _ = ws.Destroy(ctx) })
+
+	// The workspace path must be under the repo root.
+	absRepo, _ := filepath.Abs(repo)
+	absPath, _ := filepath.Abs(ws.WorkspacePath())
+
+	if len(absPath) <= len(absRepo) || absPath[:len(absRepo)] != absRepo {
+		t.Errorf("workspace path %q escapes repo root %q", absPath, absRepo)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `WorktreeWorkspace` — git worktree-based workspace implementation
- Each workspace gets its own git worktree + branch (`workspace-<sanitized-id>`)
- Branch name sanitization: only `[A-Za-z0-9._-]` allowed
- Path containment enforced (no traversal attacks)
- Uses shell exec to `git` binary (go-git worktree support is incomplete)
- Registered in factory as `"worktree"`

## Changes
- `internal/workspace/worktree.go` — WorktreeWorkspace + sanitizeBranch helper
- `internal/workspace/worktree_test.go` — 12 tests including sanitization, lifecycle, path containment

## Test Plan
- [x] 12 tests pass under -race
- [x] Full suite passes (41 workspace tests total)

Closes #183