### PR TITLE
feat(#186): add PoolWorkspace with pre-provisioned pool and background replenishment

### DIFF
--- a/internal/workspace/pool.go
+++ b/internal/workspace/pool.go
@@ -1,0 +1,239 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// poolEntry holds a pre-provisioned workspace and its availability state.
+type poolEntry struct {
+	ws    Workspace
+	id    string
+	inUse bool
+}
+
+// Pool maintains a set of pre-provisioned workspaces ready for immediate use.
+// The background goroutine keeps the pool at target size, replacing destroyed
+// or returned entries as needed.
+//
+// Pool is safe for concurrent use by multiple goroutines.
+type Pool struct {
+	mu         sync.Mutex
+	entries    []*poolEntry
+	factory    Factory  // creates new Workspace instances
+	baseOpts   Options  // base Options used for provisioning; ID is overridden per entry
+	targetSize int
+	idCounter  int
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	ready      chan struct{} // closed once pool reaches target size for the first time
+	readyOnce  sync.Once
+}
+
+// NewPool creates a Pool that maintains targetSize pre-provisioned workspaces.
+// factory is called to create new Workspace instances.
+// baseOpts provides BaseDir and other config; ID is auto-generated per entry.
+//
+// The pool starts a background goroutine to maintain the target size. Call
+// Close to stop the background goroutine and destroy all workspaces.
+func NewPool(factory Factory, baseOpts Options, targetSize int) *Pool {
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Pool{
+		factory:    factory,
+		baseOpts:   baseOpts,
+		targetSize: targetSize,
+		ctx:        ctx,
+		cancel:     cancel,
+		ready:      make(chan struct{}),
+	}
+	p.wg.Add(1)
+	go p.maintainLoop()
+	return p
+}
+
+// Get leases an available workspace from the pool, blocking until one is
+// available or ctx is done. Returns the leased Workspace and its pool ID.
+// The caller must call Return(id) when done to release the workspace back to
+// the pool.
+func (p *Pool) Get(ctx context.Context) (Workspace, string, error) {
+	// Wait for the pool to reach target size at least once.
+	select {
+	case <-p.ready:
+	case <-ctx.Done():
+		return nil, "", ctx.Err()
+	case <-p.ctx.Done():
+		return nil, "", fmt.Errorf("workspace: pool closed")
+	}
+
+	for {
+		p.mu.Lock()
+		for _, e := range p.entries {
+			if !e.inUse && e.ws != nil {
+				e.inUse = true
+				ws := e.ws
+				id := e.id
+				p.mu.Unlock()
+				return ws, id, nil
+			}
+		}
+		p.mu.Unlock()
+
+		// No available entry; wait a short interval and retry.
+		select {
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		case <-p.ctx.Done():
+			return nil, "", fmt.Errorf("workspace: pool closed")
+		case <-time.After(100 * time.Millisecond):
+			// retry
+		}
+	}
+}
+
+// Return releases a leased workspace back to the pool.
+// The workspace is marked for reset (Destroy + re-Provision) by setting its ws
+// field to nil; the background goroutine will reprovision it.
+// Calling Return with an unknown or already-returned id is a no-op.
+func (p *Pool) Return(id string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, e := range p.entries {
+		if e.id == id && e.inUse {
+			// Destroy the underlying workspace to reset its state.
+			// We do this under the lock with a background context because
+			// Destroy is typically fast for local workspaces and avoids
+			// holding the workspace in a dirty state.
+			if e.ws != nil {
+				ws := e.ws
+				// Destroy asynchronously to avoid holding the lock.
+				go func() {
+					_ = ws.Destroy(context.Background())
+				}()
+			}
+			e.ws = nil
+			e.inUse = false
+			return
+		}
+	}
+}
+
+// Close shuts down the pool, stopping the background goroutine and destroying
+// all workspaces (both available and in-use).
+func (p *Pool) Close() {
+	p.cancel()
+	p.wg.Wait()
+
+	p.mu.Lock()
+	entries := p.entries
+	p.entries = nil
+	p.mu.Unlock()
+
+	for _, e := range entries {
+		if e.ws != nil {
+			_ = e.ws.Destroy(context.Background())
+		}
+	}
+}
+
+// Len returns the number of available (not in-use) entries currently in the pool.
+func (p *Pool) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, e := range p.entries {
+		if !e.inUse && e.ws != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// Ready returns a channel that is closed once the pool has reached its target
+// size for the first time.
+func (p *Pool) Ready() <-chan struct{} {
+	return p.ready
+}
+
+func (p *Pool) maintainLoop() {
+	defer p.wg.Done()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Attempt an immediate fill before waiting for the first tick.
+	p.fillPool()
+
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			p.fillPool()
+		}
+	}
+}
+
+// fillPool provisions workspaces until the pool reaches targetSize.
+// Entries with a nil ws (returned or failed) are reprovisioned.
+func (p *Pool) fillPool() {
+	p.mu.Lock()
+	// Ensure we have enough entry slots.
+	for len(p.entries) < p.targetSize {
+		p.idCounter++
+		p.entries = append(p.entries, &poolEntry{id: fmt.Sprintf("pool-%d", p.idCounter)})
+	}
+
+	// Collect entries that need provisioning.
+	var toProvision []*poolEntry
+	for _, e := range p.entries {
+		if e.ws == nil && !e.inUse {
+			toProvision = append(toProvision, e)
+		}
+	}
+	p.mu.Unlock()
+
+	provisioned := 0
+	for _, e := range toProvision {
+		// Stop provisioning if pool has been closed.
+		if p.ctx.Err() != nil {
+			break
+		}
+
+		ws := p.factory()
+		opts := p.baseOpts
+		opts.ID = e.id
+		if err := ws.Provision(p.ctx, opts); err != nil {
+			// Provisioning failed; maintainLoop will retry on next tick.
+			continue
+		}
+
+		p.mu.Lock()
+		// Only assign if the entry is still unprovisioned (not taken during provisioning).
+		if e.ws == nil && !e.inUse {
+			e.ws = ws
+			provisioned++
+		} else {
+			// Entry was claimed or reprovisioned elsewhere; discard this one.
+			p.mu.Unlock()
+			_ = ws.Destroy(context.Background())
+			continue
+		}
+		p.mu.Unlock()
+	}
+
+	// Signal readiness once we have at least targetSize live workspaces.
+	p.mu.Lock()
+	live := 0
+	for _, e := range p.entries {
+		if e.ws != nil {
+			live++
+		}
+	}
+	p.mu.Unlock()
+
+	if live >= p.targetSize {
+		p.readyOnce.Do(func() { close(p.ready) })
+	}
+}

--- a/internal/workspace/pool_test.go
+++ b/internal/workspace/pool_test.go
@@ -1,0 +1,380 @@
+package workspace_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/workspace"
+)
+
+// Compile-time interface compliance check.
+var _ workspace.Workspace = (*workspace.PoolWorkspace)(nil)
+
+// makeLocalFactory returns a Factory that creates LocalWorkspace instances
+// backed by the given base directory.
+func makeLocalFactory(harnessURL, baseDir string) workspace.Factory {
+	return func() workspace.Workspace {
+		return workspace.NewLocal(harnessURL, baseDir)
+	}
+}
+
+// waitReady blocks until the pool's Ready channel is closed or ctx is done.
+func waitReady(t *testing.T, pool *workspace.Pool, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-pool.Ready():
+	case <-ctx.Done():
+		t.Fatal("pool did not reach target size in time")
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_GetAndReturn
+// --------------------------------------------------------------------------
+
+func TestPool_GetAndReturn(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 2)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	ws, id, err := pool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: unexpected error: %v", err)
+	}
+	if ws == nil {
+		t.Fatal("Get: returned nil workspace")
+	}
+	if id == "" {
+		t.Fatal("Get: returned empty id")
+	}
+
+	pool.Return(id)
+}
+
+// --------------------------------------------------------------------------
+// TestPool_TargetSize
+// --------------------------------------------------------------------------
+
+func TestPool_TargetSize(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 3)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	if got := pool.Len(); got != 3 {
+		t.Errorf("pool.Len() = %d, want 3", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_Concurrent
+// --------------------------------------------------------------------------
+
+func TestPool_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 5)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ws, id, err := pool.Get(ctx)
+			if err != nil {
+				// Context might have expired; tolerate this.
+				return
+			}
+			_ = ws
+			// Simulate some work.
+			time.Sleep(10 * time.Millisecond)
+			pool.Return(id)
+		}()
+	}
+	wg.Wait()
+}
+
+// --------------------------------------------------------------------------
+// TestPool_GetContextCancelled
+// --------------------------------------------------------------------------
+
+func TestPool_GetContextCancelled(t *testing.T) {
+	dir := t.TempDir()
+	// Use targetSize=0 to ensure no entries are ever available.
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 0)
+	defer pool.Close()
+
+	// pool with size 0 never closes its ready channel, so we bypass that wait
+	// by using a context that is already cancelled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already done
+
+	_, _, err := pool.Get(ctx)
+	if err == nil {
+		t.Error("Get: expected error for cancelled context, got nil")
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_GetAfterClose
+// --------------------------------------------------------------------------
+
+func TestPool_GetAfterClose(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 2)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	pool.Close()
+
+	_, _, err := pool.Get(context.Background())
+	if err == nil {
+		t.Error("Get after Close: expected error, got nil")
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_ReturnAndReplenish
+// --------------------------------------------------------------------------
+
+// TestPool_ReturnAndReplenish verifies that after returning a workspace the
+// pool's background goroutine eventually replenishes the slot.
+func TestPool_ReturnAndReplenish(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 2)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	// Drain all entries.
+	_, id1, err := pool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get 1: %v", err)
+	}
+	_, id2, err := pool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get 2: %v", err)
+	}
+
+	if pool.Len() != 0 {
+		t.Errorf("expected 0 available after draining, got %d", pool.Len())
+	}
+
+	// Return one; the pool should eventually replenish back to 2.
+	pool.Return(id1)
+	pool.Return(id2)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if pool.Len() == 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if pool.Len() != 2 {
+		t.Errorf("pool did not replenish to target size; Len() = %d", pool.Len())
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_ReturnUnknownID
+// --------------------------------------------------------------------------
+
+func TestPool_ReturnUnknownID(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 1)
+	defer pool.Close()
+
+	// Returning an unknown ID must not panic.
+	pool.Return("nonexistent-id")
+}
+
+// --------------------------------------------------------------------------
+// TestPool_LenReflectsLeases
+// --------------------------------------------------------------------------
+
+func TestPool_LenReflectsLeases(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 3)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	if pool.Len() != 3 {
+		t.Fatalf("initial Len = %d, want 3", pool.Len())
+	}
+
+	_, id, err := pool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if pool.Len() != 2 {
+		t.Errorf("Len after 1 lease = %d, want 2", pool.Len())
+	}
+
+	pool.Return(id)
+}
+
+// --------------------------------------------------------------------------
+// TestPoolWorkspace_ImplementsWorkspace
+// --------------------------------------------------------------------------
+
+func TestPoolWorkspace_ImplementsWorkspace(t *testing.T) {
+	var _ workspace.Workspace = (*workspace.PoolWorkspace)(nil)
+}
+
+// --------------------------------------------------------------------------
+// TestPoolWorkspace_BeforeProvision
+// --------------------------------------------------------------------------
+
+func TestPoolWorkspace_BeforeProvision(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 1)
+	defer pool.Close()
+
+	pw := workspace.NewPoolWorkspace(pool)
+	if got := pw.HarnessURL(); got != "" {
+		t.Errorf("HarnessURL before Provision = %q, want empty", got)
+	}
+	if got := pw.WorkspacePath(); got != "" {
+		t.Errorf("WorkspacePath before Provision = %q, want empty", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPoolWorkspace_FullLifecycle
+// --------------------------------------------------------------------------
+
+func TestPoolWorkspace_FullLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 2)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	pw := workspace.NewPoolWorkspace(pool)
+	// Provision leases from the pool (blocks until ready).
+	if err := pw.Provision(ctx, workspace.Options{ID: "ignored"}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	if got := pw.HarnessURL(); got == "" {
+		t.Error("expected non-empty HarnessURL after Provision")
+	}
+	if got := pw.WorkspacePath(); got == "" {
+		t.Error("expected non-empty WorkspacePath after Provision")
+	}
+
+	// Destroy returns the workspace to the pool.
+	if err := pw.Destroy(ctx); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+
+	if got := pw.HarnessURL(); got != "" {
+		t.Errorf("HarnessURL after Destroy = %q, want empty", got)
+	}
+	if got := pw.WorkspacePath(); got != "" {
+		t.Errorf("WorkspacePath after Destroy = %q, want empty", got)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPoolWorkspace_Destroy_NotProvisioned
+// --------------------------------------------------------------------------
+
+func TestPoolWorkspace_Destroy_NotProvisioned(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 1)
+	defer pool.Close()
+
+	pw := workspace.NewPoolWorkspace(pool)
+	if err := pw.Destroy(context.Background()); err != nil {
+		t.Errorf("Destroy on unprovisioned PoolWorkspace: expected nil, got %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPoolWorkspace_Destroy_NilPool
+// --------------------------------------------------------------------------
+
+func TestPoolWorkspace_Destroy_NilPool(t *testing.T) {
+	// Calling Destroy with a nil pool must not panic.
+	pw := workspace.NewPoolWorkspace(nil)
+	if err := pw.Destroy(context.Background()); err != nil {
+		t.Errorf("Destroy with nil pool: expected nil, got %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPool_ConcurrentGetReturn_Race
+// --------------------------------------------------------------------------
+
+// TestPool_ConcurrentGetReturn_Race exercises concurrent Get/Return pairs
+// under the race detector to catch data races.
+func TestPool_ConcurrentGetReturn_Race(t *testing.T) {
+	dir := t.TempDir()
+	factory := makeLocalFactory("http://localhost:8080", dir)
+	pool := workspace.NewPool(factory, workspace.Options{BaseDir: dir}, 4)
+	defer pool.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	waitReady(t, pool, ctx)
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 3; j++ {
+				ws, id, err := pool.Get(ctx)
+				if err != nil {
+					return
+				}
+				_ = ws
+				time.Sleep(5 * time.Millisecond)
+				pool.Return(id)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/workspace/pool_workspace.go
+++ b/internal/workspace/pool_workspace.go
@@ -1,0 +1,66 @@
+package workspace
+
+import "context"
+
+// PoolWorkspace implements Workspace using a pre-provisioned workspace leased
+// from a Pool. Provision leases a workspace from the pool (blocking until one
+// is available or ctx is done). Destroy returns the workspace to the pool for
+// reuse rather than destroying the underlying resource.
+//
+// Note: PoolWorkspace is not registered in the default factory via init()
+// because it requires a configured Pool instance. Callers construct it
+// directly via NewPoolWorkspace and call Provision to lease from the pool.
+type PoolWorkspace struct {
+	pool *Pool
+	ws   Workspace
+	id   string
+}
+
+// NewPoolWorkspace creates a PoolWorkspace backed by the given pool.
+// Provision must be called before HarnessURL or WorkspacePath are valid.
+func NewPoolWorkspace(pool *Pool) *PoolWorkspace {
+	return &PoolWorkspace{pool: pool}
+}
+
+// Provision leases a workspace from the pool, blocking until one is available
+// or ctx is done. opts.ID is ignored; the pool manages workspace IDs.
+func (w *PoolWorkspace) Provision(ctx context.Context, _ Options) error {
+	ws, id, err := w.pool.Get(ctx)
+	if err != nil {
+		return err
+	}
+	w.ws = ws
+	w.id = id
+	return nil
+}
+
+// HarnessURL returns the harness URL of the leased workspace.
+// Returns an empty string if Provision has not been called.
+func (w *PoolWorkspace) HarnessURL() string {
+	if w.ws == nil {
+		return ""
+	}
+	return w.ws.HarnessURL()
+}
+
+// WorkspacePath returns the filesystem path of the leased workspace root.
+// Returns an empty string if Provision has not been called.
+func (w *PoolWorkspace) WorkspacePath() string {
+	if w.ws == nil {
+		return ""
+	}
+	return w.ws.WorkspacePath()
+}
+
+// Destroy returns the leased workspace to the pool for reuse.
+// It does not destroy the underlying workspace resource.
+// It is safe to call Destroy on an un-provisioned PoolWorkspace (no-op).
+func (w *PoolWorkspace) Destroy(_ context.Context) error {
+	if w.ws == nil || w.pool == nil {
+		return nil
+	}
+	w.pool.Return(w.id)
+	w.ws = nil
+	w.id = ""
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `Pool` — manages N pre-provisioned warm workspaces; background goroutine maintains target size
- Adds `PoolWorkspace` — wraps a leased workspace from Pool, implements Workspace interface
- `Get()` blocks until a workspace is available or context is cancelled
- `Return()` triggers async reset; background goroutine reprovisions the slot
- `Close()` gracefully shuts down pool and destroys all workspaces
- Not registered in default factory (requires configured Pool instance)

## Changes
- `internal/workspace/pool.go` — Pool with maintainLoop goroutine
- `internal/workspace/pool_workspace.go` — PoolWorkspace wrapping Pool
- `internal/workspace/pool_test.go` — 14 tests including concurrency under -race

## Test Plan
- [x] 71 workspace tests pass under -race (10s suite)
- [x] Full suite (27 packages) passes
- [x] 20 goroutines × concurrent Get/Return under race detector

Closes #186