### PR TITLE
feat(#187): add symphd daemon scaffold with HTTP API and config

### DIFF
--- a/cmd/symphd/main.go
+++ b/cmd/symphd/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go-agent-harness/internal/symphd"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "symphd: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	configPath := flag.String("config", "", "path to YAML config file")
+	addrOverride := flag.String("addr", "", "override listen address (e.g. :8888)")
+	flag.Parse()
+
+	var cfg *symphd.Config
+	var err error
+	if *configPath != "" {
+		cfg, err = symphd.Load(*configPath)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+	} else {
+		cfg = symphd.DefaultConfig()
+	}
+
+	if *addrOverride != "" {
+		cfg.Addr = *addrOverride
+	}
+
+	orch := symphd.NewOrchestrator(cfg)
+	handler := symphd.NewHandler(orch)
+
+	srv := &http.Server{
+		Addr:    cfg.Addr,
+		Handler: handler,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := orch.Start(ctx); err != nil {
+		return fmt.Errorf("orchestrator start: %w", err)
+	}
+
+	serverErr := make(chan error, 1)
+	go func() {
+		log.Printf("symphd listening on %s", cfg.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErr <- err
+		}
+	}()
+
+	select {
+	case err := <-serverErr:
+		return err
+	case <-ctx.Done():
+	}
+
+	log.Println("shutting down gracefully...")
+	shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutCtx); err != nil {
+		return fmt.Errorf("http shutdown: %w", err)
+	}
+	if err := orch.Shutdown(shutCtx); err != nil {
+		return fmt.Errorf("orchestrator shutdown: %w", err)
+	}
+
+	log.Println("symphd stopped")
+	return nil
+}

--- a/internal/symphd/config.go
+++ b/internal/symphd/config.go
@@ -1,0 +1,61 @@
+package symphd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds the runtime configuration for symphd.
+type Config struct {
+	Addr                string `yaml:"addr"`
+	WorkspaceType       string `yaml:"workspace_type"`
+	MaxConcurrentAgents int    `yaml:"max_concurrent_agents"`
+	PollIntervalMs      int    `yaml:"poll_interval_ms"`
+	HarnessURL          string `yaml:"harness_url"`
+	BaseDir             string `yaml:"base_dir"`
+}
+
+// Load reads and parses a YAML config file, applying defaults to unset fields.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("symphd: read config %q: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("symphd: parse config: %w", err)
+	}
+	cfg.applyDefaults()
+	return &cfg, nil
+}
+
+// DefaultConfig returns a Config with all defaults applied.
+func DefaultConfig() *Config {
+	cfg := &Config{}
+	cfg.applyDefaults()
+	return cfg
+}
+
+func (c *Config) applyDefaults() {
+	if c.Addr == "" {
+		c.Addr = ":8888"
+	}
+	if c.WorkspaceType == "" {
+		c.WorkspaceType = "local"
+	}
+	if c.MaxConcurrentAgents == 0 {
+		c.MaxConcurrentAgents = 10
+	}
+	if c.PollIntervalMs == 0 {
+		c.PollIntervalMs = 5000
+	}
+	if c.HarnessURL == "" {
+		c.HarnessURL = "http://localhost:8080"
+	}
+	if c.BaseDir == "" {
+		c.BaseDir = filepath.Join(os.TempDir(), "symphd")
+	}
+}

--- a/internal/symphd/config_test.go
+++ b/internal/symphd/config_test.go
@@ -1,0 +1,137 @@
+package symphd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoad_ValidYAML(t *testing.T) {
+	dir := t.TempDir()
+	content := `
+addr: ":9999"
+workspace_type: "worktree"
+max_concurrent_agents: 5
+poll_interval_ms: 2000
+harness_url: "http://localhost:9090"
+base_dir: "/tmp/test"
+`
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Addr != ":9999" {
+		t.Errorf("Addr = %q", cfg.Addr)
+	}
+	if cfg.WorkspaceType != "worktree" {
+		t.Errorf("WorkspaceType = %q", cfg.WorkspaceType)
+	}
+	if cfg.MaxConcurrentAgents != 5 {
+		t.Errorf("MaxConcurrentAgents = %d", cfg.MaxConcurrentAgents)
+	}
+	if cfg.PollIntervalMs != 2000 {
+		t.Errorf("PollIntervalMs = %d", cfg.PollIntervalMs)
+	}
+	if cfg.HarnessURL != "http://localhost:9090" {
+		t.Errorf("HarnessURL = %q", cfg.HarnessURL)
+	}
+	if cfg.BaseDir != "/tmp/test" {
+		t.Errorf("BaseDir = %q", cfg.BaseDir)
+	}
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Addr != ":8888" {
+		t.Errorf("default Addr = %q", cfg.Addr)
+	}
+	if cfg.WorkspaceType != "local" {
+		t.Errorf("default WorkspaceType = %q", cfg.WorkspaceType)
+	}
+	if cfg.MaxConcurrentAgents != 10 {
+		t.Errorf("default MaxConcurrentAgents = %d", cfg.MaxConcurrentAgents)
+	}
+	if cfg.PollIntervalMs != 5000 {
+		t.Errorf("default PollIntervalMs = %d", cfg.PollIntervalMs)
+	}
+	if cfg.HarnessURL != "http://localhost:8080" {
+		t.Errorf("default HarnessURL = %q", cfg.HarnessURL)
+	}
+	if cfg.BaseDir == "" {
+		t.Error("default BaseDir should not be empty")
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	if err := os.WriteFile(path, []byte("addr: [bad yaml\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(path)
+	if err == nil {
+		t.Error("expected error for malformed YAML")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Addr != ":8888" {
+		t.Errorf("Addr = %q", cfg.Addr)
+	}
+	if cfg.MaxConcurrentAgents != 10 {
+		t.Errorf("MaxConcurrentAgents = %d", cfg.MaxConcurrentAgents)
+	}
+}
+
+func TestLoad_PartialConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "partial.yaml")
+	if err := os.WriteFile(path, []byte("addr: \":7777\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Addr != ":7777" {
+		t.Errorf("Addr = %q", cfg.Addr)
+	}
+	// Unset fields should get defaults
+	if cfg.WorkspaceType != "local" {
+		t.Errorf("WorkspaceType = %q", cfg.WorkspaceType)
+	}
+	if cfg.HarnessURL != "http://localhost:8080" {
+		t.Errorf("HarnessURL = %q", cfg.HarnessURL)
+	}
+}
+
+func TestLoad_ErrorContainsPath(t *testing.T) {
+	_, err := Load("/no/such/file.yaml")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "/no/such/file.yaml") {
+		t.Errorf("error should contain path, got: %v", err)
+	}
+}

--- a/internal/symphd/http.go
+++ b/internal/symphd/http.go
@@ -1,0 +1,49 @@
+package symphd
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// NewHandler returns an http.Handler for the symphd API.
+func NewHandler(o *Orchestrator) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/state", handleState(o))
+	mux.HandleFunc("GET /api/v1/issues", handleIssues(o))
+	mux.HandleFunc("POST /api/v1/refresh", handleRefresh(o))
+	return mux
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func handleState(o *Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "ok",
+			"state":  o.State(),
+		})
+	}
+}
+
+func handleIssues(o *Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status": "ok",
+			"issues": []any{},
+		})
+	}
+}
+
+func handleRefresh(o *Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Stub: real logic in #188
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":  "ok",
+			"message": "refresh queued",
+		})
+	}
+}

--- a/internal/symphd/http_test.go
+++ b/internal/symphd/http_test.go
@@ -1,0 +1,90 @@
+package symphd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleState(t *testing.T) {
+	o := NewOrchestrator(DefaultConfig())
+	h := NewHandler(o)
+
+	req := httptest.NewRequest("GET", "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("status = %v", resp["status"])
+	}
+	if resp["state"] == nil {
+		t.Error("state is nil")
+	}
+}
+
+func TestHandleIssues(t *testing.T) {
+	o := NewOrchestrator(DefaultConfig())
+	h := NewHandler(o)
+
+	req := httptest.NewRequest("GET", "/api/v1/issues", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("status = %v", resp["status"])
+	}
+	if resp["issues"] == nil {
+		t.Error("issues is nil")
+	}
+}
+
+func TestHandleRefresh(t *testing.T) {
+	o := NewOrchestrator(DefaultConfig())
+	h := NewHandler(o)
+
+	req := httptest.NewRequest("POST", "/api/v1/refresh", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["status"] != "ok" {
+		t.Errorf("status = %v", resp["status"])
+	}
+	if !strings.Contains(resp["message"].(string), "refresh") {
+		t.Errorf("message = %v", resp["message"])
+	}
+}
+
+func TestHandler_ContentType(t *testing.T) {
+	o := NewOrchestrator(DefaultConfig())
+	h := NewHandler(o)
+	req := httptest.NewRequest("GET", "/api/v1/state", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q", ct)
+	}
+}

--- a/internal/symphd/orchestrator.go
+++ b/internal/symphd/orchestrator.go
@@ -1,0 +1,50 @@
+package symphd
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Orchestrator coordinates agent dispatch across workspaces.
+// This is a stub — real logic is added in issues #188-#190.
+type Orchestrator struct {
+	config    *Config
+	startedAt time.Time
+	mu        sync.RWMutex
+	agents    int
+}
+
+// NewOrchestrator creates a new Orchestrator with the given config.
+func NewOrchestrator(cfg *Config) *Orchestrator {
+	return &Orchestrator{
+		config:    cfg,
+		startedAt: time.Now(),
+	}
+}
+
+// State returns a snapshot of the orchestrator's current state.
+func (o *Orchestrator) State() map[string]any {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return map[string]any{
+		"version":       "0.1.0",
+		"running_since": o.startedAt.UTC().Format(time.RFC3339),
+		"agent_count":   o.agents,
+		"config": map[string]any{
+			"workspace_type":        o.config.WorkspaceType,
+			"max_concurrent_agents": o.config.MaxConcurrentAgents,
+		},
+	}
+}
+
+// Start begins orchestration. Currently a no-op stub.
+func (o *Orchestrator) Start(ctx context.Context) error {
+	// Real logic added in #188 (tracker), #189 (dispatcher), #190 (retry)
+	return nil
+}
+
+// Shutdown gracefully stops the orchestrator.
+func (o *Orchestrator) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/internal/symphd/orchestrator_test.go
+++ b/internal/symphd/orchestrator_test.go
@@ -1,0 +1,80 @@
+package symphd
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewOrchestrator(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	if o == nil {
+		t.Fatal("NewOrchestrator returned nil")
+	}
+	if o.config != cfg {
+		t.Error("config not set")
+	}
+	if o.startedAt.IsZero() {
+		t.Error("startedAt not set")
+	}
+}
+
+func TestOrchestrator_State(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	state := o.State()
+	if state["version"] != "0.1.0" {
+		t.Errorf("version = %v", state["version"])
+	}
+	if _, ok := state["running_since"]; !ok {
+		t.Error("running_since missing")
+	}
+	if state["agent_count"] != 0 {
+		t.Errorf("agent_count = %v", state["agent_count"])
+	}
+}
+
+func TestOrchestrator_State_RunningTimeIncreases(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	s1 := o.State()
+	time.Sleep(10 * time.Millisecond)
+	s2 := o.State()
+	// running_since should be the same (fixed at start)
+	if s1["running_since"] != s2["running_since"] {
+		t.Error("running_since changed between calls")
+	}
+}
+
+func TestOrchestrator_Start(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	if err := o.Start(context.Background()); err != nil {
+		t.Errorf("Start returned error: %v", err)
+	}
+}
+
+func TestOrchestrator_Shutdown(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	if err := o.Shutdown(context.Background()); err != nil {
+		t.Errorf("Shutdown returned error: %v", err)
+	}
+}
+
+func TestOrchestrator_Concurrent_State(t *testing.T) {
+	cfg := DefaultConfig()
+	o := NewOrchestrator(cfg)
+	// Concurrent reads should not race
+	done := make(chan struct{})
+	for i := 0; i < 20; i++ {
+		go func() {
+			_ = o.State()
+			done <- struct{}{}
+		}()
+	}
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `cmd/symphd/` — long-running orchestration daemon binary
- Adds `internal/symphd/` package with Config, Orchestrator (stub), and HTTP handler
- YAML config with defaults (addr :8888, workspace_type local, max 10 agents)
- Three HTTP API stubs: `GET /api/v1/state`, `GET /api/v1/issues`, `POST /api/v1/refresh`
- Graceful shutdown on SIGINT/SIGTERM (10s drain timeout)
- Unblocks #188 (tracker), #189 (dispatcher), #190 (retry), #191 (workflow config)

## Changes
- `internal/symphd/config.go` + `config_test.go` — YAML config loading
- `internal/symphd/orchestrator.go` + `orchestrator_test.go` — stub orchestrator
- `internal/symphd/http.go` + `http_test.go` — HTTP handler
- `cmd/symphd/main.go` — entry point with signal handling

## Test Plan
- [x] 17 tests pass under -race
- [x] Full suite passes
- [x] `go build ./cmd/symphd/` succeeds

Closes #187