### PR TITLE
feat(#188): add GitHub issue tracker client with claim state machine

### DIFF
--- a/internal/symphd/config.go
+++ b/internal/symphd/config.go
@@ -16,6 +16,12 @@ type Config struct {
 	PollIntervalMs      int    `yaml:"poll_interval_ms"`
 	HarnessURL          string `yaml:"harness_url"`
 	BaseDir             string `yaml:"base_dir"`
+
+	// GitHub issue tracker fields.
+	GitHubOwner string `yaml:"github_owner"`
+	GitHubRepo  string `yaml:"github_repo"`
+	TrackLabel  string `yaml:"track_label"`  // default: "symphd"
+	GitHubToken string `yaml:"github_token"` // falls back to GITHUB_TOKEN env var
 }
 
 // Load reads and parses a YAML config file, applying defaults to unset fields.
@@ -57,5 +63,11 @@ func (c *Config) applyDefaults() {
 	}
 	if c.BaseDir == "" {
 		c.BaseDir = filepath.Join(os.TempDir(), "symphd")
+	}
+	if c.TrackLabel == "" {
+		c.TrackLabel = "symphd"
+	}
+	if c.GitHubToken == "" {
+		c.GitHubToken = os.Getenv("GITHUB_TOKEN")
 	}
 }

--- a/internal/symphd/http.go
+++ b/internal/symphd/http.go
@@ -33,14 +33,20 @@ func handleIssues(o *Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"status": "ok",
-			"issues": []any{},
+			"issues": o.Issues(),
 		})
 	}
 }
 
 func handleRefresh(o *Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Stub: real logic in #188
+		if err := o.Refresh(r.Context()); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]any{
+				"status":  "error",
+				"message": err.Error(),
+			})
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{
 			"status":  "ok",
 			"message": "refresh queued",

--- a/internal/symphd/orchestrator.go
+++ b/internal/symphd/orchestrator.go
@@ -7,20 +7,33 @@ import (
 )
 
 // Orchestrator coordinates agent dispatch across workspaces.
-// This is a stub — real logic is added in issues #188-#190.
 type Orchestrator struct {
 	config    *Config
 	startedAt time.Time
 	mu        sync.RWMutex
 	agents    int
+	tracker   Tracker
 }
 
 // NewOrchestrator creates a new Orchestrator with the given config.
+// If the config has GitHubOwner and GitHubRepo set, a GitHubTracker is
+// initialised automatically.
 func NewOrchestrator(cfg *Config) *Orchestrator {
-	return &Orchestrator{
+	o := &Orchestrator{
 		config:    cfg,
 		startedAt: time.Now(),
 	}
+	if cfg.GitHubOwner != "" && cfg.GitHubRepo != "" {
+		o.tracker = NewGitHubTracker(cfg.GitHubOwner, cfg.GitHubRepo, cfg.TrackLabel, cfg.GitHubToken)
+	}
+	return o
+}
+
+// SetTracker replaces the tracker (useful for testing).
+func (o *Orchestrator) SetTracker(t Tracker) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.tracker = t
 }
 
 // State returns a snapshot of the orchestrator's current state.
@@ -38,9 +51,34 @@ func (o *Orchestrator) State() map[string]any {
 	}
 }
 
+// Issues returns all tracked issues, or an empty slice if no tracker is set.
+func (o *Orchestrator) Issues() []*TrackedIssue {
+	o.mu.RLock()
+	tr := o.tracker
+	o.mu.RUnlock()
+
+	if tr == nil {
+		return []*TrackedIssue{}
+	}
+	return tr.Issues()
+}
+
+// Refresh polls the tracker for new issues. It is a no-op when no tracker is
+// configured.
+func (o *Orchestrator) Refresh(ctx context.Context) error {
+	o.mu.RLock()
+	tr := o.tracker
+	o.mu.RUnlock()
+
+	if tr == nil {
+		return nil
+	}
+	return tr.Poll(ctx)
+}
+
 // Start begins orchestration. Currently a no-op stub.
 func (o *Orchestrator) Start(ctx context.Context) error {
-	// Real logic added in #188 (tracker), #189 (dispatcher), #190 (retry)
+	// Real logic added in #189 (dispatcher), #190 (retry)
 	return nil
 }
 

--- a/internal/symphd/tracker.go
+++ b/internal/symphd/tracker.go
@@ -1,0 +1,242 @@
+package symphd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ClaimState represents the lifecycle state of a tracked issue.
+type ClaimState string
+
+const (
+	ClaimStateUnclaimed ClaimState = "unclaimed"
+	ClaimStateClaimed   ClaimState = "claimed"
+	ClaimStateRunning   ClaimState = "running"
+	ClaimStateDone      ClaimState = "done"
+	ClaimStateFailed    ClaimState = "failed"
+)
+
+// TrackedIssue holds the GitHub issue data plus symphd claim state.
+type TrackedIssue struct {
+	Number      int
+	Title       string
+	Body        string
+	Labels      []string
+	ClaimState  ClaimState
+	ClaimedAt   time.Time
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Attempts    int
+}
+
+// Tracker is the interface for managing GitHub issue claim state.
+type Tracker interface {
+	// Poll fetches open issues from GitHub and updates internal state.
+	Poll(ctx context.Context) error
+	// Candidates returns issues in ClaimStateClaimed, sorted by number ASC.
+	Candidates() []*TrackedIssue
+	// Claim marks an issue as claimed (Unclaimed → Claimed).
+	Claim(number int) error
+	// Start marks an issue as running (Claimed → Running).
+	Start(number int) error
+	// Complete marks an issue as done (Running → Done).
+	Complete(number int) error
+	// Fail marks an issue as failed (Running → Failed).
+	Fail(number int, reason string) error
+	// Issues returns all tracked issues.
+	Issues() []*TrackedIssue
+}
+
+// githubIssueResponse is the JSON shape returned by the GitHub Issues API.
+type githubIssueResponse struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+}
+
+// GitHubTracker polls GitHub Issues and manages the claim state machine.
+type GitHubTracker struct {
+	mu      sync.RWMutex
+	owner   string
+	repo    string
+	label   string
+	token   string
+	issues  map[int]*TrackedIssue
+	client  *http.Client
+	baseURL string // overridable for testing
+}
+
+// NewGitHubTracker creates a new GitHubTracker.
+func NewGitHubTracker(owner, repo, label, token string) *GitHubTracker {
+	return &GitHubTracker{
+		owner:   owner,
+		repo:    repo,
+		label:   label,
+		token:   token,
+		issues:  make(map[int]*TrackedIssue),
+		client:  &http.Client{Timeout: 30 * time.Second},
+		baseURL: "https://api.github.com",
+	}
+}
+
+// Poll fetches open issues with the configured label from GitHub and adds
+// any new ones as Unclaimed. Issues already tracked retain their state.
+func (t *GitHubTracker) Poll(ctx context.Context) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/issues?state=open&labels=%s&per_page=100",
+		t.baseURL, t.owner, t.repo, t.label)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("tracker: build request: %w", err)
+	}
+	if t.token != "" {
+		req.Header.Set("Authorization", "Bearer "+t.token)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("tracker: fetch issues: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("tracker: GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var raw []githubIssueResponse
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return fmt.Errorf("tracker: decode response: %w", err)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, item := range raw {
+		if _, exists := t.issues[item.Number]; exists {
+			// Already tracked — preserve existing claim state.
+			continue
+		}
+		labels := make([]string, len(item.Labels))
+		for i, l := range item.Labels {
+			labels[i] = l.Name
+		}
+		t.issues[item.Number] = &TrackedIssue{
+			Number:     item.Number,
+			Title:      item.Title,
+			Body:       item.Body,
+			Labels:     labels,
+			ClaimState: ClaimStateUnclaimed,
+		}
+	}
+	return nil
+}
+
+// Candidates returns all issues currently in ClaimStateClaimed, sorted by
+// issue number ascending.
+func (t *GitHubTracker) Candidates() []*TrackedIssue {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	var out []*TrackedIssue
+	for _, issue := range t.issues {
+		if issue.ClaimState == ClaimStateClaimed {
+			copy := *issue
+			out = append(out, &copy)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Number < out[j].Number
+	})
+	return out
+}
+
+// Claim transitions an issue from Unclaimed → Claimed.
+func (t *GitHubTracker) Claim(number int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	issue, ok := t.issues[number]
+	if !ok {
+		return fmt.Errorf("tracker: issue #%d not tracked", number)
+	}
+	if issue.ClaimState != ClaimStateUnclaimed {
+		return fmt.Errorf("tracker: issue #%d is %s, cannot claim", number, issue.ClaimState)
+	}
+	issue.ClaimState = ClaimStateClaimed
+	issue.ClaimedAt = time.Now()
+	issue.Attempts++
+	return nil
+}
+
+// Start transitions an issue from Claimed → Running.
+func (t *GitHubTracker) Start(number int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	issue, ok := t.issues[number]
+	if !ok {
+		return fmt.Errorf("tracker: issue #%d not tracked", number)
+	}
+	if issue.ClaimState != ClaimStateClaimed {
+		return fmt.Errorf("tracker: issue #%d is %s, cannot start (must be claimed first)", number, issue.ClaimState)
+	}
+	issue.ClaimState = ClaimStateRunning
+	issue.StartedAt = time.Now()
+	return nil
+}
+
+// Complete transitions an issue from Running → Done.
+func (t *GitHubTracker) Complete(number int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	issue, ok := t.issues[number]
+	if !ok {
+		return fmt.Errorf("tracker: issue #%d not tracked", number)
+	}
+	if issue.ClaimState != ClaimStateRunning {
+		return fmt.Errorf("tracker: issue #%d is %s, cannot complete (must be running)", number, issue.ClaimState)
+	}
+	issue.ClaimState = ClaimStateDone
+	issue.CompletedAt = time.Now()
+	return nil
+}
+
+// Fail transitions an issue from Running → Failed.
+func (t *GitHubTracker) Fail(number int, reason string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	issue, ok := t.issues[number]
+	if !ok {
+		return fmt.Errorf("tracker: issue #%d not tracked", number)
+	}
+	if issue.ClaimState != ClaimStateRunning {
+		return fmt.Errorf("tracker: issue #%d is %s, cannot fail (must be running): %s", number, issue.ClaimState, reason)
+	}
+	issue.ClaimState = ClaimStateFailed
+	issue.CompletedAt = time.Now()
+	return nil
+}
+
+// Issues returns a snapshot of all tracked issues.
+func (t *GitHubTracker) Issues() []*TrackedIssue {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	out := make([]*TrackedIssue, 0, len(t.issues))
+	for _, issue := range t.issues {
+		copy := *issue
+		out = append(out, &copy)
+	}
+	return out
+}

--- a/internal/symphd/tracker_test.go
+++ b/internal/symphd/tracker_test.go
@@ -1,0 +1,452 @@
+package symphd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newMockGitHubServer returns an httptest.Server that serves the given issues
+// as a JSON array, mimicking the GitHub Issues API response format.
+func newMockGitHubServer(t *testing.T, issues []map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(issues); err != nil {
+			t.Errorf("mock server encode: %v", err)
+		}
+	}))
+}
+
+// newTrackerWithServer creates a GitHubTracker pointed at the mock server URL.
+func newTrackerWithServer(srv *httptest.Server) *GitHubTracker {
+	tr := NewGitHubTracker("owner", "repo", "symphd", "test-token")
+	tr.baseURL = srv.URL
+	return tr
+}
+
+func issueFixture(number int, title string) map[string]any {
+	return map[string]any{
+		"number": number,
+		"title":  title,
+		"body":   "body text",
+		"labels": []map[string]any{
+			{"name": "symphd"},
+		},
+	}
+}
+
+// TestGitHubTracker_Poll_FetchesIssues verifies that Poll adds new issues with
+// ClaimStateUnclaimed.
+func TestGitHubTracker_Poll_FetchesIssues(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{
+		issueFixture(1, "Issue One"),
+		issueFixture(2, "Issue Two"),
+	})
+	defer srv.Close()
+
+	tr := newTrackerWithServer(srv)
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll error: %v", err)
+	}
+
+	issues := tr.Issues()
+	if len(issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+
+	// Build map for assertion independence of order.
+	byNum := make(map[int]*TrackedIssue)
+	for _, iss := range issues {
+		byNum[iss.Number] = iss
+	}
+
+	for _, num := range []int{1, 2} {
+		iss, ok := byNum[num]
+		if !ok {
+			t.Errorf("issue #%d not found", num)
+			continue
+		}
+		if iss.ClaimState != ClaimStateUnclaimed {
+			t.Errorf("issue #%d state = %s, want unclaimed", num, iss.ClaimState)
+		}
+		if len(iss.Labels) == 0 {
+			t.Errorf("issue #%d has no labels", num)
+		}
+	}
+}
+
+// TestGitHubTracker_Poll_EmptyResponse verifies that an empty list doesn't panic.
+func TestGitHubTracker_Poll_EmptyResponse(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{})
+	defer srv.Close()
+
+	tr := newTrackerWithServer(srv)
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll error: %v", err)
+	}
+	if got := len(tr.Issues()); got != 0 {
+		t.Errorf("expected 0 issues, got %d", got)
+	}
+}
+
+// TestGitHubTracker_Poll_Idempotent verifies that polling the same issues
+// twice doesn't reset their claim state.
+func TestGitHubTracker_Poll_Idempotent(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{
+		issueFixture(10, "Repeated Issue"),
+	})
+	defer srv.Close()
+
+	tr := newTrackerWithServer(srv)
+
+	// First poll — issue arrives as unclaimed.
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll 1 error: %v", err)
+	}
+	if err := tr.Claim(10); err != nil {
+		t.Fatalf("Claim error: %v", err)
+	}
+
+	// Second poll — issue is already tracked; state must not reset.
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatalf("Poll 2 error: %v", err)
+	}
+
+	issues := tr.Issues()
+	if len(issues) != 1 {
+		t.Fatalf("expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].ClaimState != ClaimStateClaimed {
+		t.Errorf("state = %s after second Poll, want claimed", issues[0].ClaimState)
+	}
+}
+
+// TestGitHubTracker_Claim_ValidTransition checks Unclaimed → Claimed.
+func TestGitHubTracker_Claim_ValidTransition(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	before := time.Now()
+	if err := tr.Claim(5); err != nil {
+		t.Fatalf("Claim error: %v", err)
+	}
+	after := time.Now()
+
+	issues := tr.Issues()
+	if len(issues) != 1 {
+		t.Fatal("missing issue")
+	}
+	iss := issues[0]
+	if iss.ClaimState != ClaimStateClaimed {
+		t.Errorf("state = %s, want claimed", iss.ClaimState)
+	}
+	if iss.ClaimedAt.Before(before) || iss.ClaimedAt.After(after) {
+		t.Errorf("ClaimedAt %v not in range [%v, %v]", iss.ClaimedAt, before, after)
+	}
+	if iss.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", iss.Attempts)
+	}
+}
+
+// TestGitHubTracker_Claim_AlreadyClaimed verifies that claiming a claimed
+// issue returns an error.
+func TestGitHubTracker_Claim_AlreadyClaimed(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(5); err == nil {
+		t.Error("expected error claiming already-claimed issue")
+	}
+}
+
+// TestGitHubTracker_Start_ValidTransition checks Claimed → Running.
+func TestGitHubTracker_Start_ValidTransition(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Start(5); err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+
+	issues := tr.Issues()
+	if issues[0].ClaimState != ClaimStateRunning {
+		t.Errorf("state = %s, want running", issues[0].ClaimState)
+	}
+	if issues[0].StartedAt.IsZero() {
+		t.Error("StartedAt not set")
+	}
+}
+
+// TestGitHubTracker_Complete_ValidTransition checks Running → Done.
+func TestGitHubTracker_Complete_ValidTransition(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Start(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Complete(5); err != nil {
+		t.Fatalf("Complete error: %v", err)
+	}
+
+	issues := tr.Issues()
+	if issues[0].ClaimState != ClaimStateDone {
+		t.Errorf("state = %s, want done", issues[0].ClaimState)
+	}
+	if issues[0].CompletedAt.IsZero() {
+		t.Error("CompletedAt not set")
+	}
+}
+
+// TestGitHubTracker_Fail_ValidTransition checks Running → Failed.
+func TestGitHubTracker_Fail_ValidTransition(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Start(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Fail(5, "timed out"); err != nil {
+		t.Fatalf("Fail error: %v", err)
+	}
+
+	issues := tr.Issues()
+	if issues[0].ClaimState != ClaimStateFailed {
+		t.Errorf("state = %s, want failed", issues[0].ClaimState)
+	}
+	if issues[0].CompletedAt.IsZero() {
+		t.Error("CompletedAt not set after Fail")
+	}
+}
+
+// TestGitHubTracker_InvalidTransition verifies that skipping states returns errors.
+func TestGitHubTracker_InvalidTransition(t *testing.T) {
+	srv := newMockGitHubServer(t, []map[string]any{issueFixture(5, "T")})
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unclaimed → Running (invalid: must claim first)
+	if err := tr.Start(5); err == nil {
+		t.Error("expected error starting unclaimed issue")
+	}
+
+	// Unclaimed → Done (invalid)
+	if err := tr.Complete(5); err == nil {
+		t.Error("expected error completing unclaimed issue")
+	}
+
+	// Unclaimed → Failed (invalid)
+	if err := tr.Fail(5, "reason"); err == nil {
+		t.Error("expected error failing unclaimed issue")
+	}
+
+	// Now claim it; try Complete without Start
+	if err := tr.Claim(5); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Complete(5); err == nil {
+		t.Error("expected error completing claimed (not running) issue")
+	}
+}
+
+// TestGitHubTracker_Candidates_Sorted checks that Candidates returns only
+// claimed issues, sorted by number ascending.
+func TestGitHubTracker_Candidates_Sorted(t *testing.T) {
+	fixtures := []map[string]any{
+		issueFixture(30, "C"),
+		issueFixture(10, "A"),
+		issueFixture(20, "B"),
+	}
+	srv := newMockGitHubServer(t, fixtures)
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claim 10 and 30 but not 20.
+	if err := tr.Claim(10); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Claim(30); err != nil {
+		t.Fatal(err)
+	}
+
+	cands := tr.Candidates()
+	if len(cands) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(cands))
+	}
+
+	// Verify sorted order.
+	if !sort.SliceIsSorted(cands, func(i, j int) bool { return cands[i].Number < cands[j].Number }) {
+		t.Error("candidates not sorted by number ASC")
+	}
+	if cands[0].Number != 10 || cands[1].Number != 30 {
+		t.Errorf("wrong order: %d, %d", cands[0].Number, cands[1].Number)
+	}
+}
+
+// TestGitHubTracker_Issues_ReturnsAll verifies that Issues returns all tracked
+// issues regardless of state.
+func TestGitHubTracker_Issues_ReturnsAll(t *testing.T) {
+	fixtures := []map[string]any{
+		issueFixture(1, "A"),
+		issueFixture(2, "B"),
+		issueFixture(3, "C"),
+	}
+	srv := newMockGitHubServer(t, fixtures)
+	defer srv.Close()
+	tr := newTrackerWithServer(srv)
+
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// Advance #1 through all the way to Done.
+	if err := tr.Claim(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Start(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Complete(1); err != nil {
+		t.Fatal(err)
+	}
+	// Advance #2 to Failed.
+	if err := tr.Claim(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Start(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := tr.Fail(2, "error"); err != nil {
+		t.Fatal(err)
+	}
+
+	all := tr.Issues()
+	if len(all) != 3 {
+		t.Fatalf("expected 3 issues, got %d", len(all))
+	}
+}
+
+// TestGitHubTracker_Claim_UnknownIssue verifies the error for unknown issue.
+func TestGitHubTracker_Claim_UnknownIssue(t *testing.T) {
+	tr := NewGitHubTracker("owner", "repo", "symphd", "token")
+	if err := tr.Claim(999); err == nil {
+		t.Error("expected error for unknown issue")
+	}
+}
+
+// TestGitHubTracker_Poll_HTTPError verifies that a non-200 status is surfaced.
+func TestGitHubTracker_Poll_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	tr := NewGitHubTracker("owner", "repo", "symphd", "bad-token")
+	tr.baseURL = srv.URL
+
+	if err := tr.Poll(context.Background()); err == nil {
+		t.Error("expected error for 403 response")
+	}
+}
+
+// TestGitHubTracker_Concurrent exercises Poll, Claim, and Start concurrently
+// under the race detector.
+func TestGitHubTracker_Concurrent(t *testing.T) {
+	fixtures := make([]map[string]any, 20)
+	for i := range fixtures {
+		fixtures[i] = issueFixture(i+1, "issue")
+	}
+	srv := newMockGitHubServer(t, fixtures)
+	defer srv.Close()
+
+	tr := newTrackerWithServer(srv)
+	if err := tr.Poll(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent polls.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tr.Poll(context.Background())
+		}()
+	}
+
+	// Concurrent claims (only first succeeds per issue).
+	for i := 1; i <= 20; i++ {
+		wg.Add(1)
+		num := i
+		go func() {
+			defer wg.Done()
+			_ = tr.Claim(num)
+		}()
+	}
+
+	// Concurrent Issues reads.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tr.Issues()
+		}()
+	}
+
+	// Concurrent Candidates reads.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = tr.Candidates()
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- `GitHubTracker` polls GitHub Issues API (no new dependencies — pure net/http)
- Claim state machine: Unclaimed → Claimed → Running → Done/Failed
- `Tracker` interface with `Poll`, `Claim`, `Start`, `Complete`, `Fail`, `Candidates`, `Issues`
- `baseURL` overridable for testing with `httptest.Server`
- Config extended with `github_owner`, `github_repo`, `track_label`, `github_token`
- Orchestrator wired to tracker; HTTP `/api/v1/issues` and `/api/v1/refresh` now use real data

## Test Plan
- [x] 14 tests, 31 test cases pass under -race
- [x] Full suite (29 packages) passes
- [x] Concurrent Poll/Claim/Start under race detector

Closes #188