### PR TITLE
feat(#189): add dispatcher with workspace provision, harness dispatch, and stall detection

### DIFF
--- a/internal/symphd/dispatcher.go
+++ b/internal/symphd/dispatcher.go
@@ -1,0 +1,363 @@
+package symphd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go-agent-harness/internal/workspace"
+)
+
+// HarnessClient is the interface for interacting with a harnessd instance.
+// Implementations may use HTTP or be mocked for testing.
+type HarnessClient interface {
+	// StartRun posts a prompt to harnessd and returns a run ID.
+	StartRun(ctx context.Context, prompt string, workspacePath string) (string, error)
+	// RunStatus returns the current status of a run: "running", "completed", "failed", or "queued".
+	RunStatus(ctx context.Context, runID string) (string, error)
+}
+
+// DispatchConfig holds dispatcher settings.
+type DispatchConfig struct {
+	// MaxConcurrent is the maximum number of parallel agent runs.
+	MaxConcurrent int
+	// StallTimeout is the time with no status change before a run is declared stalled.
+	// Defaults to 5 minutes if zero.
+	StallTimeout time.Duration
+	// HarnessURL is the base URL of the harnessd instance.
+	HarnessURL string
+	// PollInterval controls how often RunStatus is polled.
+	// Defaults to 5 seconds if zero.
+	PollInterval time.Duration
+}
+
+// RunResult holds the outcome of a dispatched run.
+type RunResult struct {
+	IssueNumber int
+	Success     bool
+	Error       error
+	Duration    time.Duration
+}
+
+// Dispatcher orchestrates workspace provisioning and harness dispatch.
+// It claims issues from the tracker, provisions a workspace per issue, starts
+// a harness run, monitors progress, detects stalls, and marks issues complete
+// or failed.
+type Dispatcher struct {
+	config    DispatchConfig
+	workspace workspace.Workspace
+	tracker   Tracker
+	client    HarnessClient
+
+	sem     chan struct{} // semaphore limiting MaxConcurrent concurrent runs
+	results chan RunResult
+
+	mu      sync.Mutex
+	running map[int]context.CancelFunc // issue number → cancel func
+}
+
+// NewDispatcher creates a new Dispatcher.
+func NewDispatcher(cfg DispatchConfig, ws workspace.Workspace, tracker Tracker, client HarnessClient) *Dispatcher {
+	if cfg.StallTimeout <= 0 {
+		cfg.StallTimeout = 5 * time.Minute
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 5 * time.Second
+	}
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
+	return &Dispatcher{
+		config:    cfg,
+		workspace: ws,
+		tracker:   tracker,
+		client:    client,
+		sem:       make(chan struct{}, maxConcurrent),
+		results:   make(chan RunResult, 64),
+		running:   make(map[int]context.CancelFunc),
+	}
+}
+
+// Results returns the channel on which completed RunResults are published.
+// The caller should drain this channel to avoid blocking dispatched goroutines.
+func (d *Dispatcher) Results() <-chan RunResult {
+	return d.results
+}
+
+// Dispatch provisions a workspace and starts a harness run for the given issue.
+// It calls tracker.Start() immediately, then workspace.Provision(), then
+// client.StartRun(). Progress is polled at PollInterval; if StallTimeout elapses
+// with no terminal status, the run is cancelled and marked failed.
+// On completion, tracker.Complete() or tracker.Fail() is called and a RunResult
+// is sent to the Results channel.
+//
+// Dispatch acquires a semaphore slot before launching the goroutine, so callers
+// can call Dispatch sequentially and rely on backpressure from MaxConcurrent.
+func (d *Dispatcher) Dispatch(ctx context.Context, issue *TrackedIssue) error {
+	// Transition tracker state: Claimed → Running.
+	if err := d.tracker.Start(issue.Number); err != nil {
+		return fmt.Errorf("dispatcher: start issue #%d: %w", issue.Number, err)
+	}
+
+	// Acquire a semaphore slot (blocks until a slot is free or ctx is done).
+	select {
+	case d.sem <- struct{}{}:
+	case <-ctx.Done():
+		_ = d.tracker.Fail(issue.Number, "context cancelled before semaphore acquired")
+		return ctx.Err()
+	}
+
+	// Create a per-run cancellable context derived from the parent.
+	runCtx, cancel := context.WithCancel(ctx)
+
+	d.mu.Lock()
+	d.running[issue.Number] = cancel
+	d.mu.Unlock()
+
+	go func() {
+		defer func() {
+			cancel()
+			<-d.sem // release slot
+			d.mu.Lock()
+			delete(d.running, issue.Number)
+			d.mu.Unlock()
+		}()
+
+		start := time.Now()
+		result := d.runIssue(runCtx, issue)
+		result.Duration = time.Since(start)
+		d.results <- result
+	}()
+
+	return nil
+}
+
+// Shutdown cancels all in-flight dispatches and waits for them to drain.
+func (d *Dispatcher) Shutdown(ctx context.Context) {
+	d.mu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(d.running))
+	for _, cancel := range d.running {
+		cancels = append(cancels, cancel)
+	}
+	d.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+
+	// Drain the semaphore: wait until all slots are free.
+	// Each running goroutine releases a slot when it exits.
+	for i := 0; i < cap(d.sem); i++ {
+		select {
+		case d.sem <- struct{}{}:
+			// slot acquired means it was free
+		case <-ctx.Done():
+			return
+		}
+	}
+	// Release the slots we just acquired.
+	for i := 0; i < cap(d.sem); i++ {
+		<-d.sem
+	}
+}
+
+// runIssue is the core per-issue dispatch logic executed in a goroutine.
+func (d *Dispatcher) runIssue(ctx context.Context, issue *TrackedIssue) RunResult {
+	result := RunResult{IssueNumber: issue.Number}
+
+	// Provision workspace.
+	opts := workspace.Options{
+		ID:      fmt.Sprintf("issue-%d", issue.Number),
+		BaseDir: "", // caller may configure via workspace implementation
+	}
+	if err := d.workspace.Provision(ctx, opts); err != nil {
+		reason := fmt.Sprintf("workspace provision failed: %v", err)
+		_ = d.tracker.Fail(issue.Number, reason)
+		result.Error = fmt.Errorf("dispatcher: %s", reason)
+		return result
+	}
+
+	workspacePath := d.workspace.WorkspacePath()
+
+	// Build prompt from issue content.
+	prompt := buildPrompt(issue)
+
+	// Start run on harnessd.
+	runID, err := d.client.StartRun(ctx, prompt, workspacePath)
+	if err != nil {
+		reason := fmt.Sprintf("harness start failed: %v", err)
+		_ = d.tracker.Fail(issue.Number, reason)
+		result.Error = fmt.Errorf("dispatcher: %s", reason)
+		return result
+	}
+
+	// Poll for completion with stall detection.
+	// The stall deadline is set once at dispatch time and NOT reset while the
+	// run keeps returning "running" or "queued". A constant non-terminal status
+	// IS the stall condition — the deadline only resets on a genuine status
+	// transition (e.g. queued → running), not on repeated identical statuses.
+	ticker := time.NewTicker(d.config.PollInterval)
+	defer ticker.Stop()
+
+	stallTimer := time.NewTimer(d.config.StallTimeout)
+	defer stallTimer.Stop()
+
+	lastStatus := ""
+
+	for {
+		select {
+		case <-ctx.Done():
+			reason := "context cancelled"
+			_ = d.tracker.Fail(issue.Number, reason)
+			result.Error = fmt.Errorf("dispatcher: %s", reason)
+			return result
+
+		case <-stallTimer.C:
+			reason := fmt.Sprintf("stall timeout (%v) exceeded for run %s", d.config.StallTimeout, runID)
+			_ = d.tracker.Fail(issue.Number, reason)
+			result.Error = fmt.Errorf("dispatcher: %s", reason)
+			return result
+
+		case <-ticker.C:
+			status, err := d.client.RunStatus(ctx, runID)
+			if err != nil {
+				// Transient error — keep polling.
+				continue
+			}
+
+			// Reset the stall timer when we see a genuine status transition.
+			if status != lastStatus {
+				lastStatus = status
+				if !stallTimer.Stop() {
+					select {
+					case <-stallTimer.C:
+					default:
+					}
+				}
+				stallTimer.Reset(d.config.StallTimeout)
+			}
+
+			switch status {
+			case "completed":
+				if err := d.tracker.Complete(issue.Number); err != nil {
+					result.Error = fmt.Errorf("dispatcher: complete tracker: %w", err)
+					return result
+				}
+				result.Success = true
+				return result
+
+			case "failed":
+				reason := fmt.Sprintf("harness run %s reported failed", runID)
+				_ = d.tracker.Fail(issue.Number, reason)
+				result.Error = fmt.Errorf("dispatcher: %s", reason)
+				return result
+
+			case "running", "queued":
+				// Still in progress — stall timer handles timeout.
+
+			default:
+				// Unknown status — keep polling until stall timeout.
+			}
+		}
+	}
+}
+
+// buildPrompt constructs the agent prompt for an issue.
+func buildPrompt(issue *TrackedIssue) string {
+	return fmt.Sprintf("Implement GitHub issue #%d: %s\n\n%s", issue.Number, issue.Title, issue.Body)
+}
+
+// HTTPHarnessClient implements HarnessClient using real HTTP calls to harnessd.
+type HTTPHarnessClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+// NewHTTPHarnessClient creates an HTTPHarnessClient pointing at the given base URL.
+func NewHTTPHarnessClient(baseURL string) *HTTPHarnessClient {
+	return &HTTPHarnessClient{
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// startRunRequest is the JSON body for POST /v1/runs.
+type startRunRequest struct {
+	Prompt    string `json:"prompt"`
+	Workspace string `json:"workspace,omitempty"`
+}
+
+// startRunResponse is the JSON body returned by POST /v1/runs.
+type startRunResponse struct {
+	RunID  string `json:"run_id"`
+	Status string `json:"status"`
+}
+
+// runStatusResponse is the JSON body returned by GET /v1/runs/{id}.
+type runStatusResponse struct {
+	Status string `json:"status"`
+}
+
+// StartRun posts a new run to POST /v1/runs and returns the run ID.
+func (c *HTTPHarnessClient) StartRun(ctx context.Context, prompt string, workspacePath string) (string, error) {
+	body := startRunRequest{Prompt: prompt, Workspace: workspacePath}
+	data, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("harness client: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/runs", bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("harness client: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("harness client: post /v1/runs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return "", fmt.Errorf("harness client: /v1/runs returned status %d", resp.StatusCode)
+	}
+
+	var out startRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("harness client: decode response: %w", err)
+	}
+	if out.RunID == "" {
+		return "", fmt.Errorf("harness client: empty run_id in response")
+	}
+	return out.RunID, nil
+}
+
+// RunStatus queries GET /v1/runs/{id} and returns the status string.
+func (c *HTTPHarnessClient) RunStatus(ctx context.Context, runID string) (string, error) {
+	url := fmt.Sprintf("%s/v1/runs/%s", c.baseURL, runID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("harness client: build request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("harness client: get /v1/runs/%s: %w", runID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("harness client: /v1/runs/%s returned status %d", runID, resp.StatusCode)
+	}
+
+	var out runStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("harness client: decode response: %w", err)
+	}
+	return out.Status, nil
+}

--- a/internal/symphd/dispatcher_test.go
+++ b/internal/symphd/dispatcher_test.go
@@ -1,0 +1,687 @@
+package symphd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/workspace"
+)
+
+// ---------------------------------------------------------------------------
+// Mock workspace
+// ---------------------------------------------------------------------------
+
+type mockWorkspace struct {
+	mu          sync.Mutex
+	provisioned bool
+	destroyed   bool
+	provideErr  error
+	path        string
+	harnessURL  string
+}
+
+func (m *mockWorkspace) Provision(_ context.Context, _ workspace.Options) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.provideErr != nil {
+		return m.provideErr
+	}
+	m.provisioned = true
+	return nil
+}
+
+func (m *mockWorkspace) HarnessURL() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.harnessURL
+}
+
+func (m *mockWorkspace) WorkspacePath() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.path
+}
+
+func (m *mockWorkspace) Destroy(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.destroyed = true
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Mock harness client
+// ---------------------------------------------------------------------------
+
+type mockHarnessClient struct {
+	startFunc  func(ctx context.Context, prompt, path string) (string, error)
+	statusFunc func(ctx context.Context, runID string) (string, error)
+}
+
+func (m *mockHarnessClient) StartRun(ctx context.Context, prompt, path string) (string, error) {
+	return m.startFunc(ctx, prompt, path)
+}
+
+func (m *mockHarnessClient) RunStatus(ctx context.Context, runID string) (string, error) {
+	return m.statusFunc(ctx, runID)
+}
+
+// ---------------------------------------------------------------------------
+// Mock tracker
+// ---------------------------------------------------------------------------
+
+type mockTracker struct {
+	mu       sync.Mutex
+	issues   map[int]*TrackedIssue
+	started  []int
+	complete []int
+	failed   []int
+}
+
+func newMockTracker(issues ...*TrackedIssue) *mockTracker {
+	m := &mockTracker{issues: make(map[int]*TrackedIssue)}
+	for _, issue := range issues {
+		m.issues[issue.Number] = issue
+	}
+	return m
+}
+
+func (m *mockTracker) Poll(_ context.Context) error { return nil }
+
+func (m *mockTracker) Candidates() []*TrackedIssue {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*TrackedIssue
+	for _, i := range m.issues {
+		if i.ClaimState == ClaimStateClaimed {
+			cp := *i
+			out = append(out, &cp)
+		}
+	}
+	return out
+}
+
+func (m *mockTracker) Claim(number int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	i, ok := m.issues[number]
+	if !ok {
+		return fmt.Errorf("not found: %d", number)
+	}
+	i.ClaimState = ClaimStateClaimed
+	return nil
+}
+
+func (m *mockTracker) Start(number int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	i, ok := m.issues[number]
+	if !ok {
+		return fmt.Errorf("not found: %d", number)
+	}
+	if i.ClaimState != ClaimStateClaimed {
+		return fmt.Errorf("issue #%d is %s, cannot start", number, i.ClaimState)
+	}
+	i.ClaimState = ClaimStateRunning
+	m.started = append(m.started, number)
+	return nil
+}
+
+func (m *mockTracker) Complete(number int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	i, ok := m.issues[number]
+	if !ok {
+		return fmt.Errorf("not found: %d", number)
+	}
+	if i.ClaimState != ClaimStateRunning {
+		return fmt.Errorf("issue #%d is %s, cannot complete", number, i.ClaimState)
+	}
+	i.ClaimState = ClaimStateDone
+	m.complete = append(m.complete, number)
+	return nil
+}
+
+func (m *mockTracker) Fail(number int, reason string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	i, ok := m.issues[number]
+	if !ok {
+		return fmt.Errorf("not found: %d", number)
+	}
+	if i.ClaimState != ClaimStateRunning {
+		return fmt.Errorf("issue #%d is %s, cannot fail: %s", number, i.ClaimState, reason)
+	}
+	i.ClaimState = ClaimStateFailed
+	m.failed = append(m.failed, number)
+	return nil
+}
+
+func (m *mockTracker) Issues() []*TrackedIssue {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*TrackedIssue, 0, len(m.issues))
+	for _, i := range m.issues {
+		cp := *i
+		out = append(out, &cp)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func claimedIssue(n int) *TrackedIssue {
+	return &TrackedIssue{
+		Number:     n,
+		Title:      fmt.Sprintf("Issue %d", n),
+		Body:       fmt.Sprintf("Body for issue %d", n),
+		ClaimState: ClaimStateClaimed,
+	}
+}
+
+func fastDispatchConfig() DispatchConfig {
+	return DispatchConfig{
+		MaxConcurrent: 2,
+		StallTimeout:  200 * time.Millisecond,
+		HarnessURL:    "http://localhost:8080",
+		PollInterval:  10 * time.Millisecond,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestNewDispatcher verifies constructor sets fields correctly.
+func TestNewDispatcher(t *testing.T) {
+	ws := &mockWorkspace{}
+	tr := newMockTracker()
+	cl := &mockHarnessClient{}
+	cfg := DispatchConfig{MaxConcurrent: 3, StallTimeout: time.Minute, HarnessURL: "http://example.com"}
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	if d == nil {
+		t.Fatal("NewDispatcher returned nil")
+	}
+	if cap(d.sem) != 3 {
+		t.Errorf("semaphore capacity = %d, want 3", cap(d.sem))
+	}
+	if d.config.StallTimeout != time.Minute {
+		t.Errorf("StallTimeout = %v, want 1m", d.config.StallTimeout)
+	}
+	if d.results == nil {
+		t.Error("results channel is nil")
+	}
+	if d.running == nil {
+		t.Error("running map is nil")
+	}
+}
+
+// TestNewDispatcher_Defaults verifies zero-value fields receive sensible defaults.
+func TestNewDispatcher_Defaults(t *testing.T) {
+	ws := &mockWorkspace{}
+	tr := newMockTracker()
+	cl := &mockHarnessClient{}
+	d := NewDispatcher(DispatchConfig{}, ws, tr, cl)
+
+	if d.config.StallTimeout != 5*time.Minute {
+		t.Errorf("default StallTimeout = %v, want 5m", d.config.StallTimeout)
+	}
+	if d.config.PollInterval != 5*time.Second {
+		t.Errorf("default PollInterval = %v, want 5s", d.config.PollInterval)
+	}
+	if cap(d.sem) != 1 {
+		t.Errorf("default semaphore capacity = %d, want 1", cap(d.sem))
+	}
+}
+
+// TestDispatcher_Dispatch_Success verifies a happy-path dispatch:
+// workspace provisioned, run started, polled to "completed", tracker updated.
+func TestDispatcher_Dispatch_Success(t *testing.T) {
+	issue := claimedIssue(42)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{path: "/tmp/ws-42"}
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, prompt, path string) (string, error) {
+			if path != "/tmp/ws-42" {
+				return "", fmt.Errorf("unexpected workspace path: %q", path)
+			}
+			return "run-42", nil
+		},
+		statusFunc: func(_ context.Context, runID string) (string, error) {
+			return "completed", nil
+		},
+	}
+
+	cfg := fastDispatchConfig()
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+	if err := d.Dispatch(ctx, issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	result := <-d.Results()
+
+	if !result.Success {
+		t.Errorf("expected Success=true, got error: %v", result.Error)
+	}
+	if result.IssueNumber != 42 {
+		t.Errorf("IssueNumber = %d, want 42", result.IssueNumber)
+	}
+	if result.Duration <= 0 {
+		t.Error("Duration should be positive")
+	}
+
+	// Verify workspace was provisioned.
+	if !ws.provisioned {
+		t.Error("workspace was not provisioned")
+	}
+
+	// Verify tracker transitions.
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.started) != 1 || tr.started[0] != 42 {
+		t.Errorf("tracker.started = %v, want [42]", tr.started)
+	}
+	if len(tr.complete) != 1 || tr.complete[0] != 42 {
+		t.Errorf("tracker.complete = %v, want [42]", tr.complete)
+	}
+	if len(tr.failed) != 0 {
+		t.Errorf("tracker.failed = %v, want []", tr.failed)
+	}
+}
+
+// TestDispatcher_Dispatch_HarnessError verifies that a StartRun failure
+// calls tracker.Fail and returns an error result.
+func TestDispatcher_Dispatch_HarnessError(t *testing.T) {
+	issue := claimedIssue(10)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{path: "/tmp/ws-10"}
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "", errors.New("connection refused")
+		},
+		statusFunc: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("should not be called")
+		},
+	}
+
+	cfg := fastDispatchConfig()
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+	if err := d.Dispatch(ctx, issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	result := <-d.Results()
+
+	if result.Success {
+		t.Error("expected Success=false")
+	}
+	if result.Error == nil {
+		t.Error("expected non-nil error")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.failed) != 1 || tr.failed[0] != 10 {
+		t.Errorf("tracker.failed = %v, want [10]", tr.failed)
+	}
+	if len(tr.complete) != 0 {
+		t.Errorf("tracker.complete = %v, want []", tr.complete)
+	}
+}
+
+// TestDispatcher_Dispatch_WorkspaceProvisionError verifies that a workspace
+// provision failure calls tracker.Fail.
+func TestDispatcher_Dispatch_WorkspaceProvisionError(t *testing.T) {
+	issue := claimedIssue(7)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{provideErr: errors.New("disk full")}
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "", errors.New("should not be called")
+		},
+		statusFunc: func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("should not be called")
+		},
+	}
+
+	cfg := fastDispatchConfig()
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+	if err := d.Dispatch(ctx, issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	result := <-d.Results()
+
+	if result.Success {
+		t.Error("expected Success=false")
+	}
+	if result.Error == nil {
+		t.Error("expected non-nil error")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.failed) != 1 || tr.failed[0] != 7 {
+		t.Errorf("tracker.failed = %v, want [7]", tr.failed)
+	}
+}
+
+// TestDispatcher_Dispatch_Concurrency dispatches 3 issues with MaxConcurrent=2
+// and verifies that at most 2 run simultaneously.
+func TestDispatcher_Dispatch_Concurrency(t *testing.T) {
+	const numIssues = 3
+	issues := make([]*TrackedIssue, numIssues)
+	for i := range issues {
+		issues[i] = claimedIssue(100 + i)
+	}
+
+	tr := newMockTracker(issues...)
+
+	ws := &mockWorkspace{path: "/tmp/ws"}
+
+	var (
+		mu         sync.Mutex
+		concurrent int
+		maxSeen    int
+	)
+
+	gate := make(chan struct{})
+	var started atomic.Int32
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "run-x", nil
+		},
+		statusFunc: func(_ context.Context, runID string) (string, error) {
+			// Increment concurrent counter and track maximum.
+			mu.Lock()
+			concurrent++
+			if concurrent > maxSeen {
+				maxSeen = concurrent
+			}
+			mu.Unlock()
+
+			// Signal that this goroutine is active.
+			started.Add(1)
+
+			// Block until gate is released.
+			<-gate
+
+			mu.Lock()
+			concurrent--
+			mu.Unlock()
+			return "completed", nil
+		},
+	}
+
+	cfg := DispatchConfig{
+		MaxConcurrent: 2,
+		StallTimeout:  5 * time.Second,
+		HarnessURL:    "http://localhost:8080",
+		PollInterval:  5 * time.Millisecond,
+	}
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+
+	// Dispatch all issues. Since MaxConcurrent=2 and the status func blocks,
+	// the third Dispatch call should block until a slot is free.
+	errCh := make(chan error, numIssues)
+	var wg sync.WaitGroup
+	for _, issue := range issues {
+		wg.Add(1)
+		go func(i *TrackedIssue) {
+			defer wg.Done()
+			errCh <- d.Dispatch(ctx, i)
+		}(issue)
+	}
+
+	// Wait until at least 2 goroutines have entered status polling.
+	deadline := time.Now().Add(2 * time.Second)
+	for started.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Release all gates.
+	close(gate)
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Errorf("Dispatch returned error: %v", err)
+		}
+	}
+
+	// Drain results.
+	for i := 0; i < numIssues; i++ {
+		<-d.Results()
+	}
+
+	if maxSeen > 2 {
+		t.Errorf("maximum concurrent runs = %d, want <= 2", maxSeen)
+	}
+}
+
+// TestDispatcher_Dispatch_ContextCancel verifies that cancelling the context
+// during a run causes the run to be cleaned up and marked failed.
+func TestDispatcher_Dispatch_ContextCancel(t *testing.T) {
+	issue := claimedIssue(99)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{path: "/tmp/ws-99"}
+
+	started := make(chan struct{})
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "run-99", nil
+		},
+		statusFunc: func(ctx context.Context, _ string) (string, error) {
+			// Signal that polling has started.
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			// Block until context is cancelled.
+			<-ctx.Done()
+			return "", ctx.Err()
+		},
+	}
+
+	cfg := fastDispatchConfig()
+	ctx, cancel := context.WithCancel(context.Background())
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	if err := d.Dispatch(ctx, issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	// Wait until status polling has begun, then cancel.
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("status polling never started")
+	}
+	cancel()
+
+	result := <-d.Results()
+	if result.Success {
+		t.Error("expected Success=false after context cancel")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.failed) != 1 || tr.failed[0] != 99 {
+		t.Errorf("tracker.failed = %v, want [99]", tr.failed)
+	}
+}
+
+// TestDispatcher_Stall verifies that when RunStatus keeps returning "running"
+// past StallTimeout, the issue is marked failed.
+func TestDispatcher_Stall(t *testing.T) {
+	issue := claimedIssue(55)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{path: "/tmp/ws-55"}
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "run-55", nil
+		},
+		statusFunc: func(_ context.Context, _ string) (string, error) {
+			// Always return "running" — simulates a stalled run.
+			return "running", nil
+		},
+	}
+
+	cfg := DispatchConfig{
+		MaxConcurrent: 1,
+		StallTimeout:  50 * time.Millisecond, // very short for tests
+		HarnessURL:    "http://localhost:8080",
+		PollInterval:  5 * time.Millisecond,
+	}
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+	if err := d.Dispatch(ctx, issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	result := <-d.Results()
+	if result.Success {
+		t.Error("expected Success=false for stalled run")
+	}
+	if result.Error == nil {
+		t.Error("expected non-nil error for stalled run")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.failed) != 1 || tr.failed[0] != 55 {
+		t.Errorf("tracker.failed = %v, want [55]", tr.failed)
+	}
+}
+
+// TestDispatcher_Shutdown cancels all in-flight dispatches.
+func TestDispatcher_Shutdown(t *testing.T) {
+	const numIssues = 3
+	issues := make([]*TrackedIssue, numIssues)
+	for i := range issues {
+		issues[i] = claimedIssue(200 + i)
+	}
+	tr := newMockTracker(issues...)
+	ws := &mockWorkspace{path: "/tmp/ws"}
+
+	block := make(chan struct{})
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "run-x", nil
+		},
+		statusFunc: func(ctx context.Context, _ string) (string, error) {
+			select {
+			case <-block:
+				return "completed", nil
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		},
+	}
+
+	cfg := DispatchConfig{
+		MaxConcurrent: numIssues,
+		StallTimeout:  5 * time.Second,
+		HarnessURL:    "http://localhost:8080",
+		PollInterval:  5 * time.Millisecond,
+	}
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	ctx := context.Background()
+	for _, issue := range issues {
+		if err := d.Dispatch(ctx, issue); err != nil {
+			t.Fatalf("Dispatch returned error: %v", err)
+		}
+	}
+
+	// Give goroutines a moment to start.
+	time.Sleep(30 * time.Millisecond)
+
+	// Shutdown should cancel all in-flight runs.
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer shutdownCancel()
+	d.Shutdown(shutdownCtx)
+
+	// After shutdown, all running entries should be cleared.
+	d.mu.Lock()
+	runningCount := len(d.running)
+	d.mu.Unlock()
+	if runningCount != 0 {
+		t.Errorf("running map has %d entries after Shutdown, want 0", runningCount)
+	}
+}
+
+// TestDispatcher_Results_Channel verifies that Results() always returns the same channel.
+func TestDispatcher_Results_Channel(t *testing.T) {
+	d := NewDispatcher(fastDispatchConfig(), &mockWorkspace{}, newMockTracker(), &mockHarnessClient{})
+	c1 := d.Results()
+	c2 := d.Results()
+	if c1 != c2 {
+		t.Error("Results() should return the same channel on every call")
+	}
+}
+
+// TestDispatcher_Dispatch_FailedRunStatus verifies that a "failed" status from
+// harnessd causes the issue to be marked failed.
+func TestDispatcher_Dispatch_FailedRunStatus(t *testing.T) {
+	issue := claimedIssue(77)
+	tr := newMockTracker(issue)
+	ws := &mockWorkspace{path: "/tmp/ws-77"}
+
+	cl := &mockHarnessClient{
+		startFunc: func(_ context.Context, _, _ string) (string, error) {
+			return "run-77", nil
+		},
+		statusFunc: func(_ context.Context, _ string) (string, error) {
+			return "failed", nil
+		},
+	}
+
+	cfg := fastDispatchConfig()
+	d := NewDispatcher(cfg, ws, tr, cl)
+
+	if err := d.Dispatch(context.Background(), issue); err != nil {
+		t.Fatalf("Dispatch returned error: %v", err)
+	}
+
+	result := <-d.Results()
+	if result.Success {
+		t.Error("expected Success=false for failed run status")
+	}
+	if result.Error == nil {
+		t.Error("expected non-nil error")
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if len(tr.failed) != 1 || tr.failed[0] != 77 {
+		t.Errorf("tracker.failed = %v, want [77]", tr.failed)
+	}
+	if len(tr.complete) != 0 {
+		t.Errorf("tracker.complete = %v, want []", tr.complete)
+	}
+}

--- a/internal/symphd/orchestrator.go
+++ b/internal/symphd/orchestrator.go
@@ -8,11 +8,12 @@ import (
 
 // Orchestrator coordinates agent dispatch across workspaces.
 type Orchestrator struct {
-	config    *Config
-	startedAt time.Time
-	mu        sync.RWMutex
-	agents    int
-	tracker   Tracker
+	config     *Config
+	startedAt  time.Time
+	mu         sync.RWMutex
+	agents     int
+	tracker    Tracker
+	dispatcher *Dispatcher
 }
 
 // NewOrchestrator creates a new Orchestrator with the given config.
@@ -34,6 +35,13 @@ func (o *Orchestrator) SetTracker(t Tracker) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.tracker = t
+}
+
+// SetDispatcher replaces the dispatcher (useful for testing).
+func (o *Orchestrator) SetDispatcher(d *Dispatcher) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.dispatcher = d
 }
 
 // State returns a snapshot of the orchestrator's current state.
@@ -76,13 +84,76 @@ func (o *Orchestrator) Refresh(ctx context.Context) error {
 	return tr.Poll(ctx)
 }
 
-// Start begins orchestration. Currently a no-op stub.
+// Start begins orchestration. It runs a polling loop that claims unclaimed
+// issues from the tracker and dispatches them via the Dispatcher. If no
+// dispatcher is configured, Start returns immediately.
 func (o *Orchestrator) Start(ctx context.Context) error {
-	// Real logic added in #189 (dispatcher), #190 (retry)
-	return nil
+	o.mu.RLock()
+	d := o.dispatcher
+	tr := o.tracker
+	o.mu.RUnlock()
+
+	if d == nil || tr == nil {
+		// No dispatcher or tracker configured; nothing to do.
+		return nil
+	}
+
+	pollInterval := time.Duration(o.config.PollIntervalMs) * time.Millisecond
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	// Drain results in a background goroutine so the semaphore is never blocked
+	// by an unread results channel.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-d.Results():
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+			// Claim all unclaimed issues, then dispatch claimed candidates.
+			for _, issue := range tr.Issues() {
+				if issue.ClaimState == ClaimStateUnclaimed {
+					_ = tr.Claim(issue.Number)
+				}
+			}
+			for _, candidate := range tr.Candidates() {
+				if err := d.Dispatch(ctx, candidate); err != nil {
+					if ctx.Err() != nil {
+						return nil
+					}
+					// Log dispatch errors but keep looping.
+					continue
+				}
+			}
+		}
+	}
 }
 
-// Shutdown gracefully stops the orchestrator.
+// Shutdown gracefully stops the orchestrator and any in-flight dispatches.
 func (o *Orchestrator) Shutdown(ctx context.Context) error {
+	o.mu.RLock()
+	d := o.dispatcher
+	o.mu.RUnlock()
+
+	if d != nil {
+		d.Shutdown(ctx)
+	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `Dispatcher` provisions workspaces and dispatches harness runs per issue
- `HarnessClient` interface + `HTTPHarnessClient` for real API calls (mockable in tests)
- Semaphore limits `MaxConcurrent` parallel agents
- Per-run stall detection: if `RunStatus` stays "running" past `StallTimeout`, run is cancelled and marked failed
- `Shutdown` cancels all in-flight dispatches gracefully
- Orchestrator `Start()` runs polling loop: claim → dispatch → drain results

## Changes
- `internal/symphd/dispatcher.go` — Dispatcher, HarnessClient, HTTPHarnessClient
- `internal/symphd/dispatcher_test.go` — 10 tests including concurrency and stall detection
- `internal/symphd/orchestrator.go` — wired dispatch loop in Start()

## Test Plan
- [x] 59 symphd tests pass under -race
- [x] Full suite passes
- [x] Concurrency test verifies ≤ MaxConcurrent simultaneous agents
- [x] Stall test verifies failure after timeout

Closes #189