### PR TITLE
feat(#190): add retry policy with exponential backoff and dead letter queue

### DIFF
--- a/internal/symphd/config.go
+++ b/internal/symphd/config.go
@@ -22,6 +22,11 @@ type Config struct {
 	GitHubRepo  string `yaml:"github_repo"`
 	TrackLabel  string `yaml:"track_label"`  // default: "symphd"
 	GitHubToken string `yaml:"github_token"` // falls back to GITHUB_TOKEN env var
+
+	// Retry / backoff configuration.
+	RetryMaxAttempts int `yaml:"retry_max_attempts"` // default: 5
+	RetryBaseDelayMs int `yaml:"retry_base_delay_ms"` // default: 10000
+	RetryMaxDelayMs  int `yaml:"retry_max_delay_ms"`  // default: 300000
 }
 
 // Load reads and parses a YAML config file, applying defaults to unset fields.
@@ -69,5 +74,14 @@ func (c *Config) applyDefaults() {
 	}
 	if c.GitHubToken == "" {
 		c.GitHubToken = os.Getenv("GITHUB_TOKEN")
+	}
+	if c.RetryMaxAttempts == 0 {
+		c.RetryMaxAttempts = 5
+	}
+	if c.RetryBaseDelayMs == 0 {
+		c.RetryBaseDelayMs = 10000
+	}
+	if c.RetryMaxDelayMs == 0 {
+		c.RetryMaxDelayMs = 300000
 	}
 }

--- a/internal/symphd/http.go
+++ b/internal/symphd/http.go
@@ -11,6 +11,7 @@ func NewHandler(o *Orchestrator) http.Handler {
 	mux.HandleFunc("GET /api/v1/state", handleState(o))
 	mux.HandleFunc("GET /api/v1/issues", handleIssues(o))
 	mux.HandleFunc("POST /api/v1/refresh", handleRefresh(o))
+	mux.HandleFunc("GET /api/v1/dead-letters", handleDeadLetters(o))
 	return mux
 }
 
@@ -50,6 +51,19 @@ func handleRefresh(o *Orchestrator) http.HandlerFunc {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"status":  "ok",
 			"message": "refresh queued",
+		})
+	}
+}
+
+func handleDeadLetters(o *Orchestrator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		items := o.DeadLetters()
+		if items == nil {
+			items = []*DeadLetter{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":       "ok",
+			"dead_letters": items,
 		})
 	}
 }

--- a/internal/symphd/orchestrator.go
+++ b/internal/symphd/orchestrator.go
@@ -8,11 +8,13 @@ import (
 
 // Orchestrator coordinates agent dispatch across workspaces.
 type Orchestrator struct {
-	config    *Config
-	startedAt time.Time
-	mu        sync.RWMutex
-	agents    int
-	tracker   Tracker
+	config      *Config
+	startedAt   time.Time
+	mu          sync.RWMutex
+	agents      int
+	tracker     Tracker
+	retryPolicy RetryPolicy
+	deadLetters *DeadLetterQueue
 }
 
 // NewOrchestrator creates a new Orchestrator with the given config.
@@ -22,6 +24,12 @@ func NewOrchestrator(cfg *Config) *Orchestrator {
 	o := &Orchestrator{
 		config:    cfg,
 		startedAt: time.Now(),
+		retryPolicy: RetryPolicy{
+			MaxAttempts: cfg.RetryMaxAttempts,
+			BaseDelayMs: cfg.RetryBaseDelayMs,
+			MaxDelayMs:  cfg.RetryMaxDelayMs,
+		},
+		deadLetters: NewDeadLetterQueue(),
 	}
 	if cfg.GitHubOwner != "" && cfg.GitHubRepo != "" {
 		o.tracker = NewGitHubTracker(cfg.GitHubOwner, cfg.GitHubRepo, cfg.TrackLabel, cfg.GitHubToken)
@@ -74,6 +82,31 @@ func (o *Orchestrator) Refresh(ctx context.Context) error {
 		return nil
 	}
 	return tr.Poll(ctx)
+}
+
+// DeadLetters returns the current dead letter queue items.
+func (o *Orchestrator) DeadLetters() []*DeadLetter {
+	return o.deadLetters.Items()
+}
+
+// RetryFailed checks a failed issue and either resets it for another attempt
+// or moves it to the dead letter queue. Returns true if the issue was retried,
+// false if it was dead-lettered.
+func (o *Orchestrator) RetryFailed(issue *TrackedIssue, lastErr string) bool {
+	o.mu.RLock()
+	tr := o.tracker
+	policy := o.retryPolicy
+	dlq := o.deadLetters
+	o.mu.RUnlock()
+
+	if policy.ShouldRetry(issue.Attempts) {
+		if tr != nil {
+			_ = tr.Reset(issue.Number)
+		}
+		return true
+	}
+	dlq.Add(issue, lastErr)
+	return false
 }
 
 // Start begins orchestration. Currently a no-op stub.

--- a/internal/symphd/retry.go
+++ b/internal/symphd/retry.go
@@ -1,0 +1,105 @@
+package symphd
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// RetryPolicy defines the retry behavior for failed runs.
+type RetryPolicy struct {
+	MaxAttempts int // default: 5
+	BaseDelayMs int // base delay in ms: 10000 (10s)
+	MaxDelayMs  int // max delay cap: 300000 (5min)
+}
+
+// DefaultRetryPolicy returns sensible defaults.
+func DefaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxAttempts: 5,
+		BaseDelayMs: 10000,
+		MaxDelayMs:  300000,
+	}
+}
+
+// ShouldRetry returns true if the issue should be retried given its attempt count.
+func (p RetryPolicy) ShouldRetry(attempts int) bool {
+	return attempts < p.MaxAttempts
+}
+
+// BackoffDelay returns the delay before the next retry attempt.
+// attempt is 1-indexed (first retry = attempt 1).
+// Formula: min(BaseDelayMs * 2^(attempt-1), MaxDelayMs)
+func (p RetryPolicy) BackoffDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		attempt = 1
+	}
+	delayMs := p.BaseDelayMs
+	for i := 1; i < attempt; i++ {
+		delayMs *= 2
+		if delayMs > p.MaxDelayMs {
+			delayMs = p.MaxDelayMs
+			break
+		}
+	}
+	if delayMs > p.MaxDelayMs {
+		delayMs = p.MaxDelayMs
+	}
+	return time.Duration(delayMs) * time.Millisecond
+}
+
+// DeadLetter represents an issue that has exhausted all retries.
+type DeadLetter struct {
+	IssueNumber int
+	Title       string
+	Attempts    int
+	LastError   string
+	ExhaustedAt time.Time
+}
+
+// DeadLetterQueue holds issues that have exhausted retries.
+type DeadLetterQueue struct {
+	mu    sync.RWMutex
+	items []*DeadLetter
+}
+
+// NewDeadLetterQueue creates a new empty DeadLetterQueue.
+func NewDeadLetterQueue() *DeadLetterQueue {
+	return &DeadLetterQueue{}
+}
+
+// Add appends a dead letter entry for the given issue.
+func (q *DeadLetterQueue) Add(issue *TrackedIssue, lastErr string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.items = append(q.items, &DeadLetter{
+		IssueNumber: issue.Number,
+		Title:       issue.Title,
+		Attempts:    issue.Attempts,
+		LastError:   lastErr,
+		ExhaustedAt: time.Now(),
+	})
+}
+
+// Items returns a copy of all dead letter entries, sorted by ExhaustedAt ascending.
+func (q *DeadLetterQueue) Items() []*DeadLetter {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	out := make([]*DeadLetter, len(q.items))
+	for i, item := range q.items {
+		copy := *item
+		out[i] = &copy
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ExhaustedAt.Before(out[j].ExhaustedAt)
+	})
+	return out
+}
+
+// Len returns the number of dead letter entries.
+func (q *DeadLetterQueue) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.items)
+}

--- a/internal/symphd/retry_test.go
+++ b/internal/symphd/retry_test.go
@@ -1,0 +1,306 @@
+package symphd
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// RetryPolicy tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultRetryPolicy(t *testing.T) {
+	p := DefaultRetryPolicy()
+	if p.MaxAttempts != 5 {
+		t.Errorf("MaxAttempts: want 5, got %d", p.MaxAttempts)
+	}
+	if p.BaseDelayMs != 10000 {
+		t.Errorf("BaseDelayMs: want 10000, got %d", p.BaseDelayMs)
+	}
+	if p.MaxDelayMs != 300000 {
+		t.Errorf("MaxDelayMs: want 300000, got %d", p.MaxDelayMs)
+	}
+}
+
+func TestRetryPolicy_ShouldRetry_BelowMax(t *testing.T) {
+	p := DefaultRetryPolicy() // MaxAttempts = 5
+	for attempts := 0; attempts < 5; attempts++ {
+		if !p.ShouldRetry(attempts) {
+			t.Errorf("ShouldRetry(%d): want true, got false", attempts)
+		}
+	}
+}
+
+func TestRetryPolicy_ShouldRetry_AtMax(t *testing.T) {
+	p := DefaultRetryPolicy()
+	if p.ShouldRetry(p.MaxAttempts) {
+		t.Errorf("ShouldRetry(%d): want false, got true", p.MaxAttempts)
+	}
+}
+
+func TestRetryPolicy_ShouldRetry_AboveMax(t *testing.T) {
+	p := DefaultRetryPolicy()
+	if p.ShouldRetry(p.MaxAttempts + 10) {
+		t.Errorf("ShouldRetry(%d): want false, got true", p.MaxAttempts+10)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_Attempt1(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(1)
+	want := 10 * time.Second
+	if got != want {
+		t.Errorf("BackoffDelay(1): want %v, got %v", want, got)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_Attempt2(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(2)
+	want := 20 * time.Second
+	if got != want {
+		t.Errorf("BackoffDelay(2): want %v, got %v", want, got)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_Attempt3(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(3)
+	want := 40 * time.Second
+	if got != want {
+		t.Errorf("BackoffDelay(3): want %v, got %v", want, got)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_LargeAttempt(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(100)
+	want := time.Duration(p.MaxDelayMs) * time.Millisecond
+	if got != want {
+		t.Errorf("BackoffDelay(100): want %v (cap), got %v", want, got)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_ZeroAttempt(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(0)
+	want := 10 * time.Second // treated as attempt 1
+	if got != want {
+		t.Errorf("BackoffDelay(0): want %v (treated as 1), got %v", want, got)
+	}
+}
+
+func TestRetryPolicy_BackoffDelay_NegativeAttempt(t *testing.T) {
+	p := DefaultRetryPolicy()
+	got := p.BackoffDelay(-5)
+	want := 10 * time.Second // treated as attempt 1
+	if got != want {
+		t.Errorf("BackoffDelay(-5): want %v (treated as 1), got %v", want, got)
+	}
+}
+
+// TestRetryPolicy_BackoffDelay_ExactFormula verifies the formula
+// min(10000 * 2^(attempt-1), MaxDelayMs) for attempts 1–5.
+func TestRetryPolicy_BackoffDelay_ExactFormula(t *testing.T) {
+	p := RetryPolicy{
+		MaxAttempts: 5,
+		BaseDelayMs: 10000,
+		MaxDelayMs:  300000,
+	}
+
+	cases := []struct {
+		attempt int
+		wantMs  int
+	}{
+		{1, 10000},  // 10000 * 2^0 = 10000
+		{2, 20000},  // 10000 * 2^1 = 20000
+		{3, 40000},  // 10000 * 2^2 = 40000
+		{4, 80000},  // 10000 * 2^3 = 80000
+		{5, 160000}, // 10000 * 2^4 = 160000
+	}
+	for _, tc := range cases {
+		got := p.BackoffDelay(tc.attempt)
+		want := time.Duration(tc.wantMs) * time.Millisecond
+		if got != want {
+			t.Errorf("BackoffDelay(%d): want %v, got %v", tc.attempt, want, got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeadLetterQueue tests
+// ---------------------------------------------------------------------------
+
+func TestDeadLetterQueue_Add(t *testing.T) {
+	q := NewDeadLetterQueue()
+	issue := &TrackedIssue{Number: 42, Title: "fix bug", Attempts: 5}
+	q.Add(issue, "run timed out")
+
+	if q.Len() != 1 {
+		t.Fatalf("Len: want 1, got %d", q.Len())
+	}
+	items := q.Items()
+	if len(items) != 1 {
+		t.Fatalf("Items len: want 1, got %d", len(items))
+	}
+	dl := items[0]
+	if dl.IssueNumber != 42 {
+		t.Errorf("IssueNumber: want 42, got %d", dl.IssueNumber)
+	}
+	if dl.Title != "fix bug" {
+		t.Errorf("Title: want %q, got %q", "fix bug", dl.Title)
+	}
+	if dl.Attempts != 5 {
+		t.Errorf("Attempts: want 5, got %d", dl.Attempts)
+	}
+	if dl.LastError != "run timed out" {
+		t.Errorf("LastError: want %q, got %q", "run timed out", dl.LastError)
+	}
+	if dl.ExhaustedAt.IsZero() {
+		t.Error("ExhaustedAt should not be zero")
+	}
+}
+
+func TestDeadLetterQueue_Items_ReturnsAll(t *testing.T) {
+	q := NewDeadLetterQueue()
+	for i := 1; i <= 3; i++ {
+		q.Add(&TrackedIssue{Number: i, Title: "issue", Attempts: 5}, "err")
+	}
+	items := q.Items()
+	if len(items) != 3 {
+		t.Fatalf("Items len: want 3, got %d", len(items))
+	}
+}
+
+func TestDeadLetterQueue_Items_ReturnsCopy(t *testing.T) {
+	q := NewDeadLetterQueue()
+	q.Add(&TrackedIssue{Number: 1, Title: "original", Attempts: 5}, "err")
+
+	items := q.Items()
+	items[0].Title = "mutated"
+
+	// Internal state must not be affected.
+	items2 := q.Items()
+	if items2[0].Title == "mutated" {
+		t.Error("Items() returned a reference to internal state; mutations affected the queue")
+	}
+}
+
+func TestDeadLetterQueue_Len(t *testing.T) {
+	q := NewDeadLetterQueue()
+	if q.Len() != 0 {
+		t.Errorf("Len (empty): want 0, got %d", q.Len())
+	}
+	q.Add(&TrackedIssue{Number: 1, Title: "a", Attempts: 5}, "e")
+	q.Add(&TrackedIssue{Number: 2, Title: "b", Attempts: 5}, "e")
+	if q.Len() != 2 {
+		t.Errorf("Len (after 2 adds): want 2, got %d", q.Len())
+	}
+}
+
+func TestDeadLetterQueue_Concurrent(t *testing.T) {
+	q := NewDeadLetterQueue()
+	var wg sync.WaitGroup
+	const goroutines = 50
+
+	// Concurrent adds.
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			q.Add(&TrackedIssue{Number: n, Title: "issue", Attempts: 5}, "err")
+		}(i)
+	}
+
+	// Concurrent reads.
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = q.Items()
+			_ = q.Len()
+		}()
+	}
+
+	wg.Wait()
+	if q.Len() != goroutines {
+		t.Errorf("Len after concurrent adds: want %d, got %d", goroutines, q.Len())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tracker.Reset tests
+// ---------------------------------------------------------------------------
+
+func TestTracker_Reset_FromFailed(t *testing.T) {
+	tr := newTestTracker()
+	tr.addIssue(1, "fix-me", ClaimStateRunning)
+
+	if err := tr.Fail(1, "boom"); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	if err := tr.Reset(1); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	issues := tr.Issues()
+	if len(issues) != 1 {
+		t.Fatalf("Issues len: want 1, got %d", len(issues))
+	}
+	got := issues[0]
+	if got.ClaimState != ClaimStateUnclaimed {
+		t.Errorf("ClaimState: want unclaimed, got %s", got.ClaimState)
+	}
+	if got.Attempts != 2 {
+		// Started at 1 (set in addIssue), Reset increments to 2.
+		t.Errorf("Attempts: want 2, got %d", got.Attempts)
+	}
+}
+
+func TestTracker_Reset_NotFailed_Error(t *testing.T) {
+	tr := newTestTracker()
+	tr.addIssue(2, "other", ClaimStateRunning)
+
+	err := tr.Reset(2) // still running — must fail
+	if err == nil {
+		t.Error("Reset on Running issue: want error, got nil")
+	}
+}
+
+func TestTracker_Reset_Unknown_Error(t *testing.T) {
+	tr := newTestTracker()
+	err := tr.Reset(999)
+	if err == nil {
+		t.Error("Reset on unknown issue: want error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers for tracker tests
+// ---------------------------------------------------------------------------
+
+// testTracker is a thin wrapper around GitHubTracker that exposes addIssue for
+// test setup.
+type testTracker struct {
+	*GitHubTracker
+}
+
+func newTestTracker() *testTracker {
+	return &testTracker{
+		GitHubTracker: &GitHubTracker{
+			issues: make(map[int]*TrackedIssue),
+		},
+	}
+}
+
+func (tt *testTracker) addIssue(number int, title string, state ClaimState) {
+	tt.mu.Lock()
+	defer tt.mu.Unlock()
+	tt.issues[number] = &TrackedIssue{
+		Number:     number,
+		Title:      title,
+		ClaimState: state,
+		Attempts:   1,
+	}
+}

--- a/internal/symphd/tracker.go
+++ b/internal/symphd/tracker.go
@@ -48,6 +48,9 @@ type Tracker interface {
 	Complete(number int) error
 	// Fail marks an issue as failed (Running → Failed).
 	Fail(number int, reason string) error
+	// Reset moves a Failed issue back to Unclaimed and increments Attempts.
+	// Returns an error if the issue is not in Failed state.
+	Reset(number int) error
 	// Issues returns all tracked issues.
 	Issues() []*TrackedIssue
 }
@@ -225,6 +228,25 @@ func (t *GitHubTracker) Fail(number int, reason string) error {
 	}
 	issue.ClaimState = ClaimStateFailed
 	issue.CompletedAt = time.Now()
+	return nil
+}
+
+// Reset moves a Failed issue back to Unclaimed and increments Attempts.
+// Returns an error if the issue is not in Failed state.
+func (t *GitHubTracker) Reset(number int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	issue, ok := t.issues[number]
+	if !ok {
+		return fmt.Errorf("tracker: issue #%d not tracked", number)
+	}
+	if issue.ClaimState != ClaimStateFailed {
+		return fmt.Errorf("tracker: issue #%d is %s, cannot reset (must be failed)", number, issue.ClaimState)
+	}
+	issue.ClaimState = ClaimStateUnclaimed
+	issue.Attempts++
+	issue.CompletedAt = time.Time{}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `RetryPolicy` with `ShouldRetry(attempts)` and `BackoffDelay(attempt)` — formula: `min(BaseDelayMs * 2^(attempt-1), MaxDelayMs)`
- Default: 5 attempts, 10s base, 5min cap
- `DeadLetterQueue` — concurrent-safe store for exhausted-retry issues
- `Tracker.Reset(number)` — Failed → Unclaimed, increments Attempts
- Config extended with `retry_max_attempts`, `retry_base_delay_ms`, `retry_max_delay_ms`
- Orchestrator holds RetryPolicy + DeadLetterQueue, exposes `RetryFailed()` and `DeadLetters()`
- New `GET /api/v1/dead-letters` endpoint

## Test Plan
- [x] 67 symphd tests pass under -race
- [x] Full suite (28 packages) passes
- [x] Backoff formula verified against Symphony spec

Closes #190