### PR TITLE
fix(#232): CompactRun no longer overwritten by stale execute() messages

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -992,6 +992,21 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		}
 		r.mu.Unlock()
 
+		// Re-read messages from state at the start of each step so CompactRun()
+		// results from the inter-step window take effect before building the next
+		// LLM context (#232). messagesForStep holds compactMu only for the brief
+		// slice copy — it never holds compactMu while calling setMessages, so
+		// there is no lock-order inversion.
+		{
+			r.mu.RLock()
+			st, ok := r.runs[runID]
+			r.mu.RUnlock()
+			if !ok {
+				return
+			}
+			messages = r.messagesForStep(st)
+		}
+
 		stepStartTime := time.Now()
 		r.emit(runID, EventRunStepStarted, map[string]any{
 			"step":          step,
@@ -1314,18 +1329,19 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			return
 		}
 
-		// Hold compactMu across the re-read -> append -> setMessages sequence
-		// so CompactRun() cannot interleave between our read and write-back (#232).
+		// Re-read messages from state so that any concurrent CompactRun()
+		// results take effect before we append the LLM response (#232).
+		// messagesForStep holds compactMu only for the brief slice copy and
+		// releases it before returning, so there is no lock-order inversion.
 		r.mu.RLock()
 		stepState, stepOk := r.runs[runID]
 		r.mu.RUnlock()
 		if !stepOk {
 			return
 		}
+		messages = r.messagesForStep(stepState)
 
 		if len(result.ToolCalls) == 0 {
-			stepState.compactMu.Lock()
-			messages = copyMessages(stepState.messages)
 			if result.Content != "" {
 				messages = append(messages, Message{
 					Role:      "assistant",
@@ -1334,7 +1350,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 				})
 			}
 			r.setMessages(runID, messages)
-			stepState.compactMu.Unlock()
 			if result.Content != "" {
 				r.snapshotRecordMessage(runID, "assistant", result.Content)
 				r.emit(runID, EventAssistantMessage, map[string]any{"content": result.Content})
@@ -1350,8 +1365,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			return
 		}
 
-		stepState.compactMu.Lock()
-		messages = copyMessages(stepState.messages)
 		messages = append(messages, Message{
 			Role:      "assistant",
 			Content:   result.Content,
@@ -1359,7 +1372,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			Reasoning: capturedReasoning,
 		})
 		r.setMessages(runID, messages)
-		stepState.compactMu.Unlock()
 		r.snapshotRecordMessage(runID, "assistant", result.Content)
 
 		// Forensics Part 1: emit tool.decision event when tracing is enabled.
@@ -1460,7 +1472,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					"skill":   constraintSkillName,
 					"reason":  "not_in_allowed_tools",
 				})
-				stepState.compactMu.Lock()
 				messages = append(messages, Message{
 					Role:       "tool",
 					Name:       call.Name,
@@ -1468,7 +1479,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					Content:    toolOutput,
 				})
 				r.setMessages(runID, messages)
-				stepState.compactMu.Unlock()
 				continue
 			}
 
@@ -1491,7 +1501,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			// Apply pre-tool-use hooks; may deny execution or modify args.
 			callArgs := json.RawMessage(call.Arguments)
 			if denied, denialOutput := r.applyPreToolUseHooks(context.Background(), runID, call, &callArgs); denied {
-				stepState.compactMu.Lock()
 				messages = append(messages, Message{
 					Role:       "tool",
 					Name:       call.Name,
@@ -1499,7 +1508,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					Content:    denialOutput,
 				})
 				r.setMessages(runID, messages)
-				stepState.compactMu.Unlock()
 				continue
 			}
 
@@ -1650,7 +1658,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 				causalBuilder.RecordToolResult(step, call.ID, toolOutput)
 			}
 
-			stepState.compactMu.Lock()
 			messages = append(messages, Message{
 				Role:       "tool",
 				Name:       call.Name,
@@ -1668,7 +1675,6 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			}
 
 			r.setMessages(runID, messages)
-			stepState.compactMu.Unlock()
 
 			for _, metaMsg := range metaMessages {
 				r.emit(runID, EventMetaMessageInjected, map[string]any{

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1314,27 +1314,29 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			return
 		}
 
-		// Re-read messages from state so that any concurrent CompactRun()
-		// results take effect before we append the LLM response (#232).
-		{
-			r.mu.RLock()
-			st, ok := r.runs[runID]
-			r.mu.RUnlock()
-			if !ok {
-				return
-			}
-			messages = r.messagesForStep(st)
+		// Hold compactMu across the re-read -> append -> setMessages sequence
+		// so CompactRun() cannot interleave between our read and write-back (#232).
+		r.mu.RLock()
+		stepState, stepOk := r.runs[runID]
+		r.mu.RUnlock()
+		if !stepOk {
+			return
 		}
 
 		if len(result.ToolCalls) == 0 {
+			stepState.compactMu.Lock()
+			messages = copyMessages(stepState.messages)
 			if result.Content != "" {
 				messages = append(messages, Message{
 					Role:      "assistant",
 					Content:   result.Content,
 					Reasoning: capturedReasoning,
 				})
+			}
+			r.setMessages(runID, messages)
+			stepState.compactMu.Unlock()
+			if result.Content != "" {
 				r.snapshotRecordMessage(runID, "assistant", result.Content)
-				r.setMessages(runID, messages)
 				r.emit(runID, EventAssistantMessage, map[string]any{"content": result.Content})
 			}
 			r.observeMemory(runID, step, messages)
@@ -1348,6 +1350,8 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			return
 		}
 
+		stepState.compactMu.Lock()
+		messages = copyMessages(stepState.messages)
 		messages = append(messages, Message{
 			Role:      "assistant",
 			Content:   result.Content,
@@ -1355,6 +1359,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			Reasoning: capturedReasoning,
 		})
 		r.setMessages(runID, messages)
+		stepState.compactMu.Unlock()
 		r.snapshotRecordMessage(runID, "assistant", result.Content)
 
 		// Forensics Part 1: emit tool.decision event when tracing is enabled.
@@ -1455,6 +1460,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					"skill":   constraintSkillName,
 					"reason":  "not_in_allowed_tools",
 				})
+				stepState.compactMu.Lock()
 				messages = append(messages, Message{
 					Role:       "tool",
 					Name:       call.Name,
@@ -1462,6 +1468,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					Content:    toolOutput,
 				})
 				r.setMessages(runID, messages)
+				stepState.compactMu.Unlock()
 				continue
 			}
 
@@ -1484,6 +1491,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			// Apply pre-tool-use hooks; may deny execution or modify args.
 			callArgs := json.RawMessage(call.Arguments)
 			if denied, denialOutput := r.applyPreToolUseHooks(context.Background(), runID, call, &callArgs); denied {
+				stepState.compactMu.Lock()
 				messages = append(messages, Message{
 					Role:       "tool",
 					Name:       call.Name,
@@ -1491,6 +1499,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					Content:    denialOutput,
 				})
 				r.setMessages(runID, messages)
+				stepState.compactMu.Unlock()
 				continue
 			}
 
@@ -1641,6 +1650,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 				causalBuilder.RecordToolResult(step, call.ID, toolOutput)
 			}
 
+			stepState.compactMu.Lock()
 			messages = append(messages, Message{
 				Role:       "tool",
 				Name:       call.Name,
@@ -1655,14 +1665,18 @@ func (r *Runner) execute(runID string, req RunRequest) {
 					Content: metaMsg.Content,
 					IsMeta:  true,
 				})
+			}
+
+			r.setMessages(runID, messages)
+			stepState.compactMu.Unlock()
+
+			for _, metaMsg := range metaMessages {
 				r.emit(runID, EventMetaMessageInjected, map[string]any{
 					"call_id": call.ID,
 					"tool":    call.Name,
 					"length":  len(metaMsg.Content),
 				})
 			}
-
-			r.setMessages(runID, messages)
 		}
 		r.observeMemory(runID, step, messages)
 		r.emit(runID, EventRunStepCompleted, map[string]any{

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -991,6 +991,7 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			s.currentStep = step
 		}
 		r.mu.Unlock()
+
 		stepStartTime := time.Now()
 		r.emit(runID, EventRunStepStarted, map[string]any{
 			"step":          step,
@@ -1311,6 +1312,18 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			emitCausalGraph(step)
 			r.completeRun(runID, result.Content)
 			return
+		}
+
+		// Re-read messages from state so that any concurrent CompactRun()
+		// results take effect before we append the LLM response (#232).
+		{
+			r.mu.RLock()
+			st, ok := r.runs[runID]
+			r.mu.RUnlock()
+			if !ok {
+				return
+			}
+			messages = r.messagesForStep(st)
 		}
 
 		if len(result.ToolCalls) == 0 {
@@ -2898,6 +2911,15 @@ func (r *Runner) CompactRun(ctx context.Context, runID string, req CompactRunReq
 		removed = 0
 	}
 	return CompactRunResult{MessagesRemoved: removed}, nil
+}
+
+// messagesForStep returns a fresh copy of state.messages under compactMu,
+// ensuring that CompactRun() results are visible at the start of each step.
+func (r *Runner) messagesForStep(state *runState) []Message {
+	state.compactMu.Lock()
+	msgs := copyMessages(state.messages)
+	state.compactMu.Unlock()
+	return msgs
 }
 
 // autoCompactMessages performs compaction on the run's messages under compactMu.

--- a/internal/harness/runner_context_compact_test.go
+++ b/internal/harness/runner_context_compact_test.go
@@ -580,14 +580,19 @@ func TestCompactRunSurvivesConcurrentExecute(t *testing.T) {
 
 	// Wait until step 4 is blocked (provider.calls == 4 means step 4 entered beforeCall).
 	deadline := time.Now().Add(5 * time.Second)
+	gateReached := false
 	for time.Now().Before(deadline) {
 		provider.mu.Lock()
 		calls := provider.calls
 		provider.mu.Unlock()
 		if calls >= 4 {
+			gateReached = true
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+	if !gateReached {
+		t.Fatalf("timed out waiting for step 4 gate")
 	}
 
 	// At this point steps 1-3 are fully done (tool calls executed, messages stored).
@@ -643,26 +648,16 @@ func TestCompactRunSurvivesConcurrentExecute(t *testing.T) {
 		t.Fatalf("expected completed, got %q", state.Status)
 	}
 
-	// Key assertion: the final message count must build on the compacted base,
-	// not on the pre-compact full set.
-	//
-	// With the bug: execute() uses stale local messages (beforeCount) and appends
-	// the step 4 assistant response, then calls setMessages — overwriting compaction.
-	// Final count would be beforeCount + 1 (= beforeCount + assistant).
-	//
-	// With the fix: execute() re-reads state.messages (compactedCount) and appends
-	// the step 4 assistant response. Final count = compactedCount + 1.
+	// Step 4 has no tool calls, so execute() appends exactly 1 assistant message.
+	// With the fix: final = compactedCount + 1 (re-reads compacted base).
+	// With the bug: final = beforeCount + 1 (stale messages overwrite compaction).
 	msgsFinal := runner.GetRunMessages(run.ID)
 	finalCount := len(msgsFinal)
-
-	// Step 4 has no tool calls, so execute() appends exactly 1 assistant message.
-	// With the fix: final = compactedCount + 1.
-	// With the bug: final = beforeCount + 1 (stale messages overwrite compaction).
 	expectedWithFix := compactedCount + 1
-	expectedWithBug := beforeCount + 1
-	if result.MessagesRemoved > 0 && finalCount == expectedWithBug && finalCount != expectedWithFix {
-		t.Errorf("compaction was overwritten by stale messages: final=%d (matches buggy=%d, want fixed=%d), compacted=%d, pre-compact=%d",
-			finalCount, expectedWithBug, expectedWithFix, compactedCount, beforeCount)
+
+	if finalCount != expectedWithFix {
+		t.Errorf("compaction not preserved: final=%d, want=%d (compacted=%d + 1 assistant), pre-compact=%d",
+			finalCount, expectedWithFix, compactedCount, beforeCount)
 	}
 }
 
@@ -731,14 +726,19 @@ func TestCompactRunAtStepBoundary(t *testing.T) {
 
 	// Wait until step 4 is gated.
 	deadline := time.Now().Add(5 * time.Second)
+	gateReached := false
 	for time.Now().Before(deadline) {
 		provider.mu.Lock()
 		calls := provider.calls
 		provider.mu.Unlock()
 		if calls >= 4 {
+			gateReached = true
 			break
 		}
 		time.Sleep(5 * time.Millisecond)
+	}
+	if !gateReached {
+		t.Fatalf("timed out waiting for step 4 gate")
 	}
 
 	// Compact while step 4 is gated (steps 1-3 fully processed).
@@ -777,16 +777,14 @@ func TestCompactRunAtStepBoundary(t *testing.T) {
 		t.Errorf("expected output %q, got %q", "done", state.Output)
 	}
 
-	// The final messages should build on the compacted set, not the original.
 	// Step 4 adds exactly 1 assistant message (no tool calls).
+	// With the fix: final = compactedCount + 1 (re-reads compacted base).
 	msgsFinal := runner.GetRunMessages(run.ID)
 	finalCount := len(msgsFinal)
-	beforeCount := len(msgsBefore)
-
 	expectedWithFix := compactedCount + 1
-	expectedWithBug := beforeCount + 1
-	if compactedCount < beforeCount && finalCount == expectedWithBug && finalCount != expectedWithFix {
-		t.Errorf("compaction overwritten: final=%d (matches buggy=%d, want fixed=%d), compacted=%d, pre-compact=%d",
-			finalCount, expectedWithBug, expectedWithFix, compactedCount, beforeCount)
+
+	if finalCount != expectedWithFix {
+		t.Errorf("compaction not preserved: final=%d, want=%d (compacted=%d + 1 assistant), pre-compact=%d",
+			finalCount, expectedWithFix, compactedCount, len(msgsBefore))
 	}
 }

--- a/internal/harness/runner_context_compact_test.go
+++ b/internal/harness/runner_context_compact_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -509,4 +510,283 @@ type staticRunnerProvider struct {
 
 func (p *staticRunnerProvider) Complete(_ context.Context, _ CompletionRequest) (CompletionResult, error) {
 	return p.result, nil
+}
+
+// TestCompactRunSurvivesConcurrentExecute verifies that CompactRun() results
+// are not overwritten by execute()'s stale local messages copy.
+// Regression test for #232.
+func TestCompactRunSurvivesConcurrentExecute(t *testing.T) {
+	t.Parallel()
+
+	// step4Gate blocks the step 4 LLM call so we can compact in between.
+	step4Gate := make(chan struct{})
+
+	// Provider: steps 1-3 return tool calls (loop continues), step 4 returns text.
+	// This generates 4 turns (user + 3x assistant_tool) so strip with keepLast=2
+	// actually removes tool messages from the earlier turns.
+	provider := &contextCompactGatingProvider{
+		results: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-1",
+					Name:      "echo_json",
+					Arguments: `{"message":"step1"}`,
+				}},
+			},
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-2",
+					Name:      "echo_json",
+					Arguments: `{"message":"step2"}`,
+				}},
+			},
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-3",
+					Name:      "echo_json",
+					Arguments: `{"message":"step3"}`,
+				}},
+			},
+			{Content: "final answer"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				// Step 4 LLM call: wait for the test to compact first.
+				<-step4Gate
+			}
+		},
+	}
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "test",
+		MaxSteps:     6,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	// Wait until step 4 is blocked (provider.calls == 4 means step 4 entered beforeCall).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		provider.mu.Lock()
+		calls := provider.calls
+		provider.mu.Unlock()
+		if calls >= 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// At this point steps 1-3 are fully done (tool calls executed, messages stored).
+	// Step 4 is blocked in beforeCall. execute()'s local `messages` has the full
+	// history: user + 3x(assistant+tool) = 7 messages = 4 turns.
+	msgsBefore := runner.GetRunMessages(run.ID)
+	beforeCount := len(msgsBefore)
+	if beforeCount < 7 {
+		t.Fatalf("expected at least 7 messages after steps 1-3, got %d", beforeCount)
+	}
+
+	// Count tool messages before compaction.
+	toolMsgsBefore := 0
+	for _, m := range msgsBefore {
+		if m.Role == "tool" {
+			toolMsgsBefore++
+		}
+	}
+
+	// Compact: strip mode removes tool messages. Use KeepLast=2 so the early
+	// assistant_tool turns (turns 1-2) fall outside the keep window.
+	result, err := runner.CompactRun(context.Background(), run.ID, CompactRunRequest{Mode: "strip", KeepLast: 2})
+	if err != nil {
+		t.Fatalf("CompactRun: %v", err)
+	}
+	if result.MessagesRemoved == 0 && toolMsgsBefore > 0 {
+		t.Fatal("expected strip to remove tool messages, but removed 0")
+	}
+
+	compactedCount := len(runner.GetRunMessages(run.ID))
+
+	// Release step 4.
+	close(step4Gate)
+
+	// Wait for run to complete.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatal("run disappeared")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("run not found after completion")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected completed, got %q", state.Status)
+	}
+
+	// Key assertion: the final message count must build on the compacted base,
+	// not on the pre-compact full set.
+	//
+	// With the bug: execute() uses stale local messages (beforeCount) and appends
+	// the step 4 assistant response, then calls setMessages — overwriting compaction.
+	// Final count would be beforeCount + 1 (= beforeCount + assistant).
+	//
+	// With the fix: execute() re-reads state.messages (compactedCount) and appends
+	// the step 4 assistant response. Final count = compactedCount + 1.
+	msgsFinal := runner.GetRunMessages(run.ID)
+	finalCount := len(msgsFinal)
+
+	// Step 4 has no tool calls, so execute() appends exactly 1 assistant message.
+	// With the fix: final = compactedCount + 1.
+	// With the bug: final = beforeCount + 1 (stale messages overwrite compaction).
+	expectedWithFix := compactedCount + 1
+	expectedWithBug := beforeCount + 1
+	if result.MessagesRemoved > 0 && finalCount == expectedWithBug && finalCount != expectedWithFix {
+		t.Errorf("compaction was overwritten by stale messages: final=%d (matches buggy=%d, want fixed=%d), compacted=%d, pre-compact=%d",
+			finalCount, expectedWithBug, expectedWithFix, compactedCount, beforeCount)
+	}
+}
+
+// TestCompactRunAtStepBoundary verifies CompactRun takes effect when called
+// after tool-call steps complete but before the final step begins.
+// Regression test for #232.
+func TestCompactRunAtStepBoundary(t *testing.T) {
+	t.Parallel()
+
+	step4Gate := make(chan struct{})
+
+	// Provider: steps 1-3 return tool calls, step 4 returns text.
+	// 4 turns total so keepLast=2 leaves 2 turns in the compact window.
+	provider := &contextCompactGatingProvider{
+		results: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-1",
+					Name:      "echo_json",
+					Arguments: `{"message":"s1"}`,
+				}},
+			},
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-2",
+					Name:      "echo_json",
+					Arguments: `{"message":"s2"}`,
+				}},
+			},
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call-3",
+					Name:      "echo_json",
+					Arguments: `{"message":"s3"}`,
+				}},
+			},
+			{Content: "done"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				<-step4Gate
+			}
+		},
+	}
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "test",
+		MaxSteps:     6,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	// Wait until step 4 is gated.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		provider.mu.Lock()
+		calls := provider.calls
+		provider.mu.Unlock()
+		if calls >= 4 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Compact while step 4 is gated (steps 1-3 fully processed).
+	msgsBefore := runner.GetRunMessages(run.ID)
+	_, err = runner.CompactRun(context.Background(), run.ID, CompactRunRequest{Mode: "strip", KeepLast: 2})
+	if err != nil {
+		t.Fatalf("CompactRun: %v", err)
+	}
+
+	msgsAfterCompact := runner.GetRunMessages(run.ID)
+	compactedCount := len(msgsAfterCompact)
+
+	// Release step 4 so the run completes.
+	close(step4Gate)
+
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatal("run disappeared")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("run not found")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected completed, got %q", state.Status)
+	}
+	if state.Output != "done" {
+		t.Errorf("expected output %q, got %q", "done", state.Output)
+	}
+
+	// The final messages should build on the compacted set, not the original.
+	// Step 4 adds exactly 1 assistant message (no tool calls).
+	msgsFinal := runner.GetRunMessages(run.ID)
+	finalCount := len(msgsFinal)
+	beforeCount := len(msgsBefore)
+
+	expectedWithFix := compactedCount + 1
+	expectedWithBug := beforeCount + 1
+	if compactedCount < beforeCount && finalCount == expectedWithBug && finalCount != expectedWithFix {
+		t.Errorf("compaction overwritten: final=%d (matches buggy=%d, want fixed=%d), compacted=%d, pre-compact=%d",
+			finalCount, expectedWithBug, expectedWithFix, compactedCount, beforeCount)
+	}
 }


### PR DESCRIPTION
## Summary

- `execute()` read `state.messages` once at startup into a local variable held for the entire run; any concurrent `CompactRun()` result was silently overwritten on the next `setMessages()` call
- Previous fix attempt held `compactMu` across `setMessages()` which acquires `r.mu.Lock()`, while `CompactRun()` holds `compactMu` then calls `r.mu.RLock()` — deadlock cycle via writer-preference RWMutex
- **Correct fix**: `messagesForStep()` holds `compactMu` only for the brief slice copy, releases before returning; post-LLM paths call `messagesForStep()` then append+`setMessages()` without holding `compactMu`; tool-result paths have `compactMu` removed entirely

## Changes

- `internal/harness/runner.go`: top-of-loop re-read + post-LLM re-read via `messagesForStep()`; remove `compactMu` from all tool-result write paths
- `internal/harness/runner_context_compact_test.go`: regression tests `TestCompactRunSurvivesConcurrentExecute` and `TestCompactRunAtStepBoundary`
- `internal/harness/types.go`: `Message.Clone()` + `ToolCall.Clone()` + `copyMessages()` helpers (from #231)

## Test plan

- [x] `go test ./internal/harness/... -run TestCompact -race` — all pass
- [x] `go test ./internal/... ./cmd/... -race` — all pass

Closes #232