### PR TITLE
fix(#233): marshal accounting structs to map before inserting into event payloads

### DIFF
--- a/docs/implementation/issue-233-impl.md
+++ b/docs/implementation/issue-233-impl.md
@@ -1,0 +1,103 @@
+# Issue #233 Implementation: deepCloneValue struct/pointer field cloning
+
+## Summary
+
+Fixed a bug where `CompletionUsage` structs (which contain `*int` pointer fields) were being
+inserted directly into event payloads by `recordAccounting()`. Because `deepCloneValue()` only
+handles `reflect.Map` and `reflect.Slice` kinds, the struct would pass through unchanged, and any
+`*int` pointer fields inside would be shared across all event payload copies delivered to
+subscribers.
+
+## Root Cause
+
+`deepCloneValue()` (runner.go:3414-3453) has a `default` case that returns non-map, non-slice
+values as-is. The comment states this is safe for "scalar" types, but `CompletionUsage` is a struct
+with pointer fields:
+
+```go
+type CompletionUsage struct {
+    PromptTokens       int  `json:"prompt_tokens"`
+    CompletionTokens   int  `json:"completion_tokens"`
+    TotalTokens        int  `json:"total_tokens"`
+    CachedPromptTokens *int `json:"cached_prompt_tokens,omitempty"`
+    ReasoningTokens    *int `json:"reasoning_tokens,omitempty"`
+    InputAudioTokens   *int `json:"input_audio_tokens,omitempty"`
+    OutputAudioTokens  *int `json:"output_audio_tokens,omitempty"`
+}
+```
+
+When `recordAccounting()` put `CompletionUsage` values directly into the payload map, the
+`deepClonePayload()` call in `emit()` would not copy the struct's pointer fields — they remained
+shared between the stored forensic event and all subscriber copies.
+
+## Fix Approach: Option 2 — JSON marshal/unmarshal at the callsite
+
+Rather than extending `deepCloneValue` with reflect-based struct traversal (complex, fragile for
+structs with unexported fields), the fix converts `CompletionUsage` values to `map[string]any` via
+JSON marshal+unmarshal before inserting them into the payload.
+
+This approach:
+- Is simple and localized to `recordAccounting()`.
+- Uses the existing JSON struct tags to produce idiomatic map keys.
+- Completely breaks the reference chain — the resulting map contains only scalar `float64`/`bool`
+  values from JSON numbers.
+- Is consistent with `UsageDeltaPayload` which already declares `TurnUsage` and `CumulativeUsage`
+  as `map[string]any`.
+
+## Files Changed
+
+### `internal/harness/runner.go`
+
+1. Added `completionUsageToMap(u CompletionUsage) map[string]any` helper function that
+   JSON-marshals the struct and unmarshals to `map[string]any`. Fallback for the impossible marshal
+   error case manually constructs the map from the three non-pointer int fields.
+
+2. Updated `recordAccounting()` to call `completionUsageToMap()` on both `turnUsage` and
+   `cumulativeUsage` (and the early-exit `CompletionUsage{}` case) before inserting them into the
+   returned payload map.
+
+### `internal/harness/runner_forensics_test.go`
+
+Added `TestAccountingStructPointerFieldIsolation` regression test that:
+1. Creates a `CompletionResult` whose `Usage` has non-nil pointer fields (`CachedPromptTokens=42`,
+   `ReasoningTokens=7`).
+2. Runs the harness to completion.
+3. Finds the `usage.delta` event and asserts `cumulative_usage` is a `map[string]any` (not a raw
+   `CompletionUsage` struct).
+4. Asserts `turn_usage` is also a `map[string]any`.
+5. Verifies expected values are present in the map (`prompt_tokens=100`, `completion_tokens=50`,
+   `cached_prompt_tokens=42`).
+6. Mutates the map from the first subscription.
+7. Asserts the second subscription's copy is unaffected (isolated).
+
+The test failed before the fix (got `harness.CompletionUsage`, not `map[string]any`) and passes
+after.
+
+## Test Results
+
+```
+go test ./internal/harness -run TestAccountingStructPointerFieldIsolation -v
+--- PASS: TestAccountingStructPointerFieldIsolation (0.01s)
+PASS
+
+go test ./internal/harness/... -race
+ok  go-agent-harness/internal/harness   2.490s
+... (all pass)
+
+go test ./...
+... (all 25 packages pass)
+```
+
+## Edge Cases Discovered
+
+- The `completionUsageToMap` fallback (manual map construction from non-pointer fields) is
+  unreachable in practice since `CompletionUsage` contains only numeric types that `json.Marshal`
+  cannot fail on. It is included for defensive completeness.
+- The `omitempty` JSON tags on pointer fields mean that nil `*int` fields will be absent from the
+  resulting map rather than present as `null`. This matches the existing `UsageDeltaPayload` type
+  which uses `map[string]any` for these fields.
+
+## Commits
+
+1. `eb3d35f` — `test(#233): add regression test for struct/pointer field cloning` (failing test)
+2. `37db74d` — `fix(#233): marshal accounting structs to map before inserting into event payloads`

--- a/docs/plans/issue-233-plan.md
+++ b/docs/plans/issue-233-plan.md
@@ -1,0 +1,198 @@
+# Issue #233 Implementation Plan: deepCloneValue Does Not Clone Struct/Pointer Fields
+
+## Root Cause Analysis
+
+`deepCloneValue()` in `internal/harness/runner.go` (lines 3414-3453) handles map and slice kinds
+recursively, but its default case returns every other value type (including structs) as-is:
+
+```go
+default:
+    // Scalars (string, bool, int*, uint*, float*) are value types —
+    // no aliasing is possible through an interface{}.
+    return v
+```
+
+This comment is correct for Go primitive scalars but misleading: structs that contain pointer fields
+are NOT value-safe. Specifically, `CompletionUsage` has four `*int` pointer fields:
+
+```go
+type CompletionUsage struct {
+    PromptTokens       int  `json:"prompt_tokens"`
+    CompletionTokens   int  `json:"completion_tokens"`
+    TotalTokens        int  `json:"total_tokens"`
+    CachedPromptTokens *int `json:"cached_prompt_tokens,omitempty"`
+    ReasoningTokens    *int `json:"reasoning_tokens,omitempty"`
+    InputAudioTokens   *int `json:"input_audio_tokens,omitempty"`
+    OutputAudioTokens  *int `json:"output_audio_tokens,omitempty"`
+}
+```
+
+`recordAccounting()` inserts a `CompletionUsage` directly into the event payload:
+
+```go
+return map[string]any{
+    ...
+    "turn_usage":       turnUsage,        // CompletionUsage struct value
+    "cumulative_usage": cumulativeUsage,  // CompletionUsage struct value
+    ...
+}
+```
+
+When `deepClonePayload()` processes this map, it calls `deepCloneValue()` on each value. The
+`CompletionUsage` struct passes through the default case unchanged. The struct's value fields
+(`PromptTokens`, `CompletionTokens`, `TotalTokens`) are copied by value into the interface box, so
+they are safe. However the `*int` pointer fields (`CachedPromptTokens`, `ReasoningTokens`, etc.)
+inside the struct are shared between the event stored in forensic history and any subscriber copies.
+
+If anything mutates the pointed-to int via the pointer, or replaces the pointer itself by
+reassigning the outer struct, all consumers of the event payload that hold a reference to the same
+struct would be affected.
+
+## Bug Scenario
+
+1. `completionUsage()` creates a `CompletionUsage` with `CachedPromptTokens = &n` (pointer to a
+   local int).
+2. `recordAccounting()` puts the struct into the payload map.
+3. `emit()` calls `deepClonePayload()`, which calls `deepCloneValue(cumulativeUsage)`.
+4. The struct value is returned as-is. The `*int` pointer is shared with the stored forensic event.
+5. Any subsequent mutation of the pointed-to integer (or replacement of the struct in the original
+   accumulator) would be visible to existing event payload holders.
+
+## Chosen Fix: Option 2 — JSON Marshal/Unmarshal in recordAccounting()
+
+Rather than extending `deepCloneValue` to handle arbitrary structs via reflect (which would be
+complex and fragile), we convert `CompletionUsage` values to `map[string]any` at the callsite
+before inserting them into the event payload.
+
+This approach:
+- Is simple and localized to `recordAccounting()`.
+- Uses the existing JSON struct tags on `CompletionUsage` to produce idiomatic map keys.
+- Completely breaks the reference chain — the resulting `map[string]any` contains only scalar values
+  (JSON numbers map to `float64`, JSON booleans to `bool`).
+- Keeps `deepCloneValue` focused on its current domain (maps and slices).
+- Is consistent with how JSON-serialized events are eventually transmitted anyway.
+
+### Helper Function
+
+We will add a `completionUsageToMap(u CompletionUsage) map[string]any` helper that JSON-marshals
+the struct and unmarshals to `map[string]any`. On marshal error (which cannot happen for a plain
+numeric struct), it falls back to a manually constructed map.
+
+### Alternative Considered: Extend deepCloneValue with reflect
+
+Option 1 (extending `deepCloneValue` to handle `reflect.Struct` and `reflect.Ptr` kinds) was
+considered but rejected because:
+- Requires recursive traversal of arbitrary struct fields.
+- Would need to handle unexported fields (which reflect cannot set).
+- `encoding/json` already provides a correct, tested implementation of this via marshal+unmarshal.
+- The accounting struct is the only struct type known to be inserted into event payloads.
+
+## Files to Change
+
+1. `internal/harness/runner.go` — modify `recordAccounting()` to marshal `turnUsage` and
+   `cumulativeUsage` before inserting them into the payload.
+2. `internal/harness/runner_forensics_test.go` — add regression test.
+
+## Testing Strategy
+
+### Regression Test (to write FIRST — must FAIL before fix)
+
+`TestAccountingStructPointerFieldIsolation` in `runner_forensics_test.go`:
+
+1. Use a `stubProvider` that produces a `CompletionResult` with a `Usage` containing non-nil
+   pointer fields (`CachedPromptTokens`, `ReasoningTokens`).
+2. Run the harness to completion.
+3. Collect two separate Subscribe batches.
+4. In each batch, find the `usage.delta` event and extract `cumulative_usage` from the payload.
+5. Assert the value is a `map[string]any` (not a `CompletionUsage` struct) — this demonstrates
+   JSON serialization happened.
+6. Alternatively, assert that two separate Subscribe calls yield independent copies of the
+   pointer-fielded data (mutation of one does not affect the other).
+
+### Why It Fails Before Fix
+
+Before the fix, `cumulative_usage` in the payload is a `CompletionUsage` struct value. When
+`deepClonePayload` processes the event map, the struct passes through unchanged. The `*int` pointer
+fields inside the struct are shared across all event payload copies served by `Subscribe`.
+
+Mutating the `int` pointed to by `CachedPromptTokens` through one subscriber's payload would
+corrupt the stored forensic event and all other subscribers' copies.
+
+The test verifies:
+- `cumulative_usage` in the stored event is a `map[string]any` (after the fix), not the raw struct.
+- The `turn_usage` field similarly becomes a `map[string]any`.
+
+## Exact Code Changes
+
+### runner.go — recordAccounting()
+
+Change:
+```go
+return map[string]any{
+    "step":                step,
+    "usage_status":        usageStatus,
+    "cost_status":         costStatus,
+    "turn_usage":          turnUsage,
+    "turn_cost_usd":       turnCostUSD,
+    "cumulative_usage":    cumulativeUsage,
+    "cumulative_cost_usd": costTotals.CostUSDTotal,
+    "pricing_version":     costTotals.PricingVersion,
+}
+```
+
+To:
+```go
+return map[string]any{
+    "step":                step,
+    "usage_status":        usageStatus,
+    "cost_status":         costStatus,
+    "turn_usage":          completionUsageToMap(turnUsage),
+    "turn_cost_usd":       turnCostUSD,
+    "cumulative_usage":    completionUsageToMap(cumulativeUsage),
+    "cumulative_cost_usd": costTotals.CostUSDTotal,
+    "pricing_version":     costTotals.PricingVersion,
+}
+```
+
+And the early-exit case:
+```go
+return map[string]any{
+    "step":                step,
+    "usage_status":        usageStatus,
+    "cost_status":         costStatus,
+    "turn_usage":          completionUsageToMap(turnUsage),
+    "turn_cost_usd":       turnCostUSD,
+    "cumulative_usage":    completionUsageToMap(CompletionUsage{}),
+    "cumulative_cost_usd": 0.0,
+    "pricing_version":     pricingVersion,
+}
+```
+
+### runner.go — new helper
+
+```go
+// completionUsageToMap converts a CompletionUsage struct into a map[string]any
+// using its JSON representation. This breaks all pointer aliases: the returned
+// map contains only scalar values (float64 for numbers) safe for insertion into
+// event payloads that will be deep-cloned and distributed to subscribers.
+func completionUsageToMap(u CompletionUsage) map[string]any {
+    b, err := json.Marshal(u)
+    if err != nil {
+        // CompletionUsage contains only numeric types; marshal cannot fail.
+        return map[string]any{
+            "prompt_tokens":     u.PromptTokens,
+            "completion_tokens": u.CompletionTokens,
+            "total_tokens":      u.TotalTokens,
+        }
+    }
+    var m map[string]any
+    if err := json.Unmarshal(b, &m); err != nil {
+        return map[string]any{
+            "prompt_tokens":     u.PromptTokens,
+            "completion_tokens": u.CompletionTokens,
+            "total_tokens":      u.TotalTokens,
+        }
+    }
+    return m
+}
+```

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -2411,9 +2411,9 @@ func (r *Runner) recordAccounting(runID string, result CompletionResult, step in
 			"step":                step,
 			"usage_status":        usageStatus,
 			"cost_status":         costStatus,
-			"turn_usage":          turnUsage,
+			"turn_usage":          completionUsageToMap(turnUsage),
 			"turn_cost_usd":       turnCostUSD,
-			"cumulative_usage":    CompletionUsage{},
+			"cumulative_usage":    completionUsageToMap(CompletionUsage{}),
 			"cumulative_cost_usd": 0.0,
 			"pricing_version":     pricingVersion,
 		}
@@ -2436,12 +2436,37 @@ func (r *Runner) recordAccounting(runID string, result CompletionResult, step in
 		"step":                step,
 		"usage_status":        usageStatus,
 		"cost_status":         costStatus,
-		"turn_usage":          turnUsage,
+		"turn_usage":          completionUsageToMap(turnUsage),
 		"turn_cost_usd":       turnCostUSD,
-		"cumulative_usage":    cumulativeUsage,
+		"cumulative_usage":    completionUsageToMap(cumulativeUsage),
 		"cumulative_cost_usd": costTotals.CostUSDTotal,
 		"pricing_version":     costTotals.PricingVersion,
 	}
+}
+
+// completionUsageToMap converts a CompletionUsage struct into a map[string]any
+// using its JSON representation. This breaks all pointer aliases: the resulting
+// map contains only scalar values (float64 for JSON numbers) that are safe for
+// insertion into event payloads distributed to multiple subscribers.
+// CompletionUsage contains only numeric types so marshal cannot fail in practice.
+func completionUsageToMap(u CompletionUsage) map[string]any {
+	b, err := json.Marshal(u)
+	if err != nil {
+		return map[string]any{
+			"prompt_tokens":     u.PromptTokens,
+			"completion_tokens": u.CompletionTokens,
+			"total_tokens":      u.TotalTokens,
+		}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{
+			"prompt_tokens":     u.PromptTokens,
+			"completion_tokens": u.CompletionTokens,
+			"total_tokens":      u.TotalTokens,
+		}
+	}
+	return m
 }
 
 func normalizeTurnUsage(result CompletionResult) (CompletionUsage, UsageStatus) {

--- a/internal/harness/runner_forensics_test.go
+++ b/internal/harness/runner_forensics_test.go
@@ -951,3 +951,121 @@ func collectEvents(t *testing.T, r *Runner, runID string) []Event {
 	cancel()
 	return history
 }
+
+// TestAccountingStructPointerFieldIsolation verifies that CompletionUsage
+// structs inserted into event payloads by recordAccounting() are converted to
+// map[string]any before storage, so that pointer fields (*int) are not shared
+// across event payload copies delivered to different subscribers.
+// Regression test for issue #233.
+func TestAccountingStructPointerFieldIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Build a CompletionResult whose Usage has non-nil pointer fields.
+	cached := 42
+	reasoning := 7
+	usage := &CompletionUsage{
+		PromptTokens:       100,
+		CompletionTokens:   50,
+		TotalTokens:        150,
+		CachedPromptTokens: &cached,
+		ReasoningTokens:    &reasoning,
+	}
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{Content: "done", Usage: usage},
+	}}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+		MaxSteps:            2,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "accounting isolation test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	// Collect events via first subscription.
+	history1, _, cancel1, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe (1): %v", err)
+	}
+	cancel1()
+
+	// Find the usage.delta event in the first subscription.
+	var usageDeltaIdx1 int = -1
+	for i, ev := range history1 {
+		if ev.Type == EventUsageDelta {
+			usageDeltaIdx1 = i
+			break
+		}
+	}
+	if usageDeltaIdx1 < 0 {
+		t.Fatal("no usage.delta event found in first subscription")
+	}
+
+	// Assert cumulative_usage is a map[string]any (not a CompletionUsage struct).
+	// Before the fix, deepCloneValue returns the struct as-is, so the type
+	// assertion to map[string]any will fail.
+	cumUsage1, ok := history1[usageDeltaIdx1].Payload["cumulative_usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("cumulative_usage is not map[string]any: got %T — struct was stored by reference instead of converted to map",
+			history1[usageDeltaIdx1].Payload["cumulative_usage"])
+	}
+
+	// Assert turn_usage is also a map[string]any.
+	_, ok = history1[usageDeltaIdx1].Payload["turn_usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("turn_usage is not map[string]any: got %T — struct was stored by reference instead of converted to map",
+			history1[usageDeltaIdx1].Payload["turn_usage"])
+	}
+
+	// Verify the expected values are present in the map.
+	if pt, ok := cumUsage1["prompt_tokens"].(float64); !ok || int(pt) != 100 {
+		t.Errorf("cumulative_usage.prompt_tokens: got %v (%T), want 100", cumUsage1["prompt_tokens"], cumUsage1["prompt_tokens"])
+	}
+	if ct, ok := cumUsage1["completion_tokens"].(float64); !ok || int(ct) != 50 {
+		t.Errorf("cumulative_usage.completion_tokens: got %v, want 50", cumUsage1["completion_tokens"])
+	}
+	if cp, ok := cumUsage1["cached_prompt_tokens"].(float64); !ok || int(cp) != 42 {
+		t.Errorf("cumulative_usage.cached_prompt_tokens: got %v, want 42", cumUsage1["cached_prompt_tokens"])
+	}
+
+	// Mutate the map obtained from the first subscription and verify that
+	// the second subscription's payload is unaffected.
+	cumUsage1["prompt_tokens"] = float64(9999)
+	cumUsage1["cached_prompt_tokens"] = float64(9999)
+
+	// Collect events via second subscription.
+	history2, _, cancel2, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe (2): %v", err)
+	}
+	cancel2()
+
+	var usageDeltaIdx2 int = -1
+	for i, ev := range history2 {
+		if ev.Type == EventUsageDelta {
+			usageDeltaIdx2 = i
+			break
+		}
+	}
+	if usageDeltaIdx2 < 0 {
+		t.Fatal("no usage.delta event found in second subscription")
+	}
+
+	cumUsage2, ok := history2[usageDeltaIdx2].Payload["cumulative_usage"].(map[string]any)
+	if !ok {
+		t.Fatalf("cumulative_usage (sub2) is not map[string]any: got %T",
+			history2[usageDeltaIdx2].Payload["cumulative_usage"])
+	}
+
+	// The second subscriber's copy must not have been corrupted by the mutation above.
+	if pt, ok := cumUsage2["prompt_tokens"].(float64); !ok || int(pt) != 100 {
+		t.Errorf("second subscriber cumulative_usage.prompt_tokens corrupted: got %v, want 100", cumUsage2["prompt_tokens"])
+	}
+	if cp, ok := cumUsage2["cached_prompt_tokens"].(float64); !ok || int(cp) != 42 {
+		t.Errorf("second subscriber cumulative_usage.cached_prompt_tokens corrupted: got %v, want 42", cumUsage2["cached_prompt_tokens"])
+	}
+}


### PR DESCRIPTION
## Summary

Closes #233

- `deepCloneValue()` previously returned struct values as-is via the default case, leaving `*int` pointer fields in `CompletionUsage` shared across all event subscriber copies
- Added `completionUsageToMap()` which JSON-marshals the struct to a `map[string]any`, breaking all pointer aliases
- Updated both `recordAccounting()` call sites to use the new helper

## Changes

- `internal/harness/runner.go` — added `completionUsageToMap()` helper; updated `recordAccounting()` to marshal CompletionUsage to map
- `internal/harness/runner_forensics_test.go` — added `TestAccountingStructPointerFieldIsolation` regression test

## Testing

- [x] Regression tests added for affected code paths
- [x] `go test ./...` passing
- [x] `go test ./... -race` passing
- [x] `./scripts/test-regression.sh` passing

## Notes for Reviewer

Chose JSON marshal (Option 2 from issue) over reflect-based struct traversal — simpler, testable, and avoids extending `deepCloneValue` domain beyond map/slice.

🤖 Implemented via walk-the-issues skill