### PR TITLE
Fix #327

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -2641,8 +2641,6 @@ func (r *Runner) drainSteering(runID string, messages *[]Message) {
 }
 
 func (r *Runner) completeRun(runID, output string) {
-	r.setStatus(runID, RunStatusCompleted, output, "")
-
 	// Clean up deferred tool activations for this run
 	r.activations.Cleanup(runID)
 
@@ -2704,13 +2702,6 @@ func (r *Runner) completeRun(runID, output string) {
 		r.mu.RUnlock()
 	}
 
-	usageTotals, costTotals := r.accountingTotals(runID)
-	r.emit(runID, EventRunCompleted, map[string]any{
-		"output":       output,
-		"usage_totals": usageTotals,
-		"cost_totals":  costTotals,
-	})
-
 	// Audit trail: write run.completed and close the writer.
 	if r.config.AuditTrailEnabled {
 		r.writeAudit(runID, audittrail.AuditRecord{
@@ -2720,6 +2711,15 @@ func (r *Runner) completeRun(runID, output string) {
 		})
 		r.closeAuditWriter(runID)
 	}
+
+	r.setStatus(runID, RunStatusCompleted, output, "")
+
+	usageTotals, costTotals := r.accountingTotals(runID)
+	r.emit(runID, EventRunCompleted, map[string]any{
+		"output":       output,
+		"usage_totals": usageTotals,
+		"cost_totals":  costTotals,
+	})
 }
 
 // closeScopedMCP closes the per-run scoped MCP registry if one was configured
@@ -2855,7 +2855,6 @@ func (r *Runner) failRun(runID string, err error) {
 	if err == nil {
 		err = errors.New("run failed")
 	}
-	r.setStatus(runID, RunStatusFailed, "", err.Error())
 
 	// Clean up deferred tool activations for this run
 	r.activations.Cleanup(runID)
@@ -2882,13 +2881,6 @@ func (r *Runner) failRun(runID string, err error) {
 		}
 	}
 
-	usageTotals, costTotals := r.accountingTotals(runID)
-	r.emit(runID, EventRunFailed, map[string]any{
-		"error":        err.Error(),
-		"usage_totals": usageTotals,
-		"cost_totals":  costTotals,
-	})
-
 	// Audit trail: write run.failed and close the writer.
 	if r.config.AuditTrailEnabled {
 		r.writeAudit(runID, audittrail.AuditRecord{
@@ -2898,6 +2890,15 @@ func (r *Runner) failRun(runID string, err error) {
 		})
 		r.closeAuditWriter(runID)
 	}
+
+	r.setStatus(runID, RunStatusFailed, "", err.Error())
+
+	usageTotals, costTotals := r.accountingTotals(runID)
+	r.emit(runID, EventRunFailed, map[string]any{
+		"error":        err.Error(),
+		"usage_totals": usageTotals,
+		"cost_totals":  costTotals,
+	})
 }
 
 // failRunMaxSteps is a specialisation of failRun used when the step loop
@@ -2906,7 +2907,6 @@ func (r *Runner) failRun(runID string, err error) {
 // this terminal state from other failures without parsing the error string.
 func (r *Runner) failRunMaxSteps(runID string, maxSteps int) {
 	err := fmt.Errorf("max steps (%d) reached", maxSteps)
-	r.setStatus(runID, RunStatusFailed, "", err.Error())
 
 	// Clean up deferred tool activations for this run
 	r.activations.Cleanup(runID)
@@ -2916,15 +2916,6 @@ func (r *Runner) failRunMaxSteps(runID string, maxSteps int) {
 
 	// Clean up per-run MCP servers
 	r.closeScopedMCP(runID)
-	usageTotals, costTotals := r.accountingTotals(runID)
-	r.emit(runID, EventRunFailed, map[string]any{
-		"error":        err.Error(),
-		"reason":       "max_steps_reached",
-		"max_steps":    maxSteps,
-		"usage_totals": usageTotals,
-		"cost_totals":  costTotals,
-	})
-
 	// Audit trail: write run.failed and close the writer.
 	if r.config.AuditTrailEnabled {
 		r.writeAudit(runID, audittrail.AuditRecord{
@@ -2938,6 +2929,17 @@ func (r *Runner) failRunMaxSteps(runID string, maxSteps int) {
 		})
 		r.closeAuditWriter(runID)
 	}
+
+	r.setStatus(runID, RunStatusFailed, "", err.Error())
+
+	usageTotals, costTotals := r.accountingTotals(runID)
+	r.emit(runID, EventRunFailed, map[string]any{
+		"error":        err.Error(),
+		"reason":       "max_steps_reached",
+		"max_steps":    maxSteps,
+		"usage_totals": usageTotals,
+		"cost_totals":  costTotals,
+	})
 }
 
 func (r *Runner) recordAccounting(runID string, result CompletionResult, step int) map[string]any {

--- a/internal/harness/runner_audittrail_test.go
+++ b/internal/harness/runner_audittrail_test.go
@@ -7,12 +7,23 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
+	"time"
 
 	"go-agent-harness/internal/forensics/audittrail"
 )
 
 var errAuditTest = errors.New("audit test provider error")
+
+type blockingAuditProvider struct {
+	release <-chan struct{}
+}
+
+func (p *blockingAuditProvider) Complete(_ context.Context, _ CompletionRequest) (CompletionResult, error) {
+	<-p.release
+	return CompletionResult{Content: "done"}, nil
+}
 
 // readAuditEntries reads all entries from an audit.jsonl file.
 func readAuditEntries(t *testing.T, path string) []audittrail.AuditEntry {
@@ -222,6 +233,87 @@ func TestAuditTrail_HashChainValid(t *testing.T) {
 			t.Errorf("chain broken at %d: PrevHash=%q != entries[%d].EntryHash=%q",
 				i, entries[i].PrevHash, i-1, entries[i-1].EntryHash)
 		}
+	}
+}
+
+func TestAuditTrail_RunCompletedStatusWaitsForAuditPersistence(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	release := make(chan struct{})
+	runner := NewRunner(&blockingAuditProvider{release: release}, NewRegistry(), RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+		MaxSteps:            1,
+		RolloutDir:          dir,
+		AuditTrailEnabled:   true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "complete once"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	auditPath := auditLogPath(dir)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		entries := readAuditEntries(t, auditPath)
+		if len(entries) >= 1 && entries[0].EventType == string(EventRunStarted) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for run.started audit entry")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	lockFile, err := os.OpenFile(auditPath, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("OpenFile(%s): %v", auditPath, err)
+	}
+	locked := false
+	defer func() {
+		if lockFile == nil {
+			return
+		}
+		if locked {
+			if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+				t.Fatalf("flock unlock: %v", err)
+			}
+		}
+		if err := lockFile.Close(); err != nil {
+			t.Fatalf("close audit lock file: %v", err)
+		}
+	}()
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("flock exclusive: %v", err)
+	}
+	locked = true
+
+	close(release)
+	time.Sleep(50 * time.Millisecond)
+	current, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatalf("GetRun(%q): not found", run.ID)
+	}
+	if current.Status == RunStatusCompleted {
+		t.Fatalf("run reached completed status before terminal audit entry could be persisted")
+	}
+
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatalf("flock unlock: %v", err)
+	}
+	locked = false
+	if err := lockFile.Close(); err != nil {
+		t.Fatalf("close audit lock file: %v", err)
+	}
+	lockFile = nil
+
+	waitForStatus(t, runner, run.ID, RunStatusCompleted)
+
+	entries := readAuditEntries(t, auditPath)
+	if got := entries[len(entries)-1].EventType; got != string(EventRunCompleted) {
+		t.Fatalf("last entry = %q, want %q", got, EventRunCompleted)
 	}
 }
 


### PR DESCRIPTION
TDD + regression tests

- adds a deterministic audit-persistence regression test
- delays terminal status/event publication until the terminal audit record is durably written
- verifies the harness race path and full regression gate