### PR TITLE
test: add direct context grid coverage (issue #316)

### DIFF
--- a/cmd/harnesscli/tui/components/contextgrid/model.go
+++ b/cmd/harnesscli/tui/components/contextgrid/model.go
@@ -45,11 +45,10 @@ func (m Model) View() string {
 
 	pct := float64(used) / float64(total) * 100.0
 
-	// Build the progress bar. Reserve space for label prefix and suffix.
-	// "Context: [####...] 12.3% (12345 / 200000 tokens)"
-	barWidth := w - 4
-	if barWidth < 10 {
-		barWidth = 10
+	// Build the progress bar inside the available width once the brackets are added.
+	barWidth := w - 2
+	if barWidth < 1 {
+		barWidth = 1
 	}
 	if barWidth > 60 {
 		barWidth = 60

--- a/cmd/harnesscli/tui/components/contextgrid/model_test.go
+++ b/cmd/harnesscli/tui/components/contextgrid/model_test.go
@@ -1,0 +1,139 @@
+package contextgrid
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestViewDefaultsTotalTokensAndWidth(t *testing.T) {
+	t.Parallel()
+
+	view := New().View()
+
+	if !strings.Contains(view, "Context Window Usage") {
+		t.Fatalf("expected header in view, got %q", view)
+	}
+	if !strings.Contains(view, "Used:  0 tokens") {
+		t.Fatalf("expected zero used tokens in default view, got %q", view)
+	}
+	if !strings.Contains(view, "Total: 200000 tokens") {
+		t.Fatalf("expected default total token fallback, got %q", view)
+	}
+	if !strings.Contains(view, "Usage: 0.0%") {
+		t.Fatalf("expected default usage percentage, got %q", view)
+	}
+
+	barWidth := progressBarWidth(t, view)
+	if barWidth != 60 {
+		t.Fatalf("expected default width fallback to cap the bar at 60 cells, got %d", barWidth)
+	}
+}
+
+func TestViewClampsUsedTokensIntoValidRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		model        Model
+		wantUsedLine string
+		wantUsage    string
+		wantFilled   int
+	}{
+		{
+			name: "negative used tokens clamp to zero",
+			model: Model{
+				TotalTokens: 100,
+				UsedTokens:  -25,
+				Width:       20,
+			},
+			wantUsedLine: "Used:  0 tokens",
+			wantUsage:    "Usage: 0.0%",
+			wantFilled:   0,
+		},
+		{
+			name: "used tokens above total clamp to total",
+			model: Model{
+				TotalTokens: 100,
+				UsedTokens:  120,
+				Width:       20,
+			},
+			wantUsedLine: "Used:  100 tokens",
+			wantUsage:    "Usage: 100.0%",
+			wantFilled:   18,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			view := tt.model.View()
+			if !strings.Contains(view, tt.wantUsedLine) {
+				t.Fatalf("expected %q in view, got %q", tt.wantUsedLine, view)
+			}
+			if !strings.Contains(view, tt.wantUsage) {
+				t.Fatalf("expected %q in view, got %q", tt.wantUsage, view)
+			}
+
+			barLine := progressBarLine(t, view)
+			if filled := strings.Count(barLine, "█"); filled != tt.wantFilled {
+				t.Fatalf("expected %d filled cells, got %d in %q", tt.wantFilled, filled, barLine)
+			}
+		})
+	}
+}
+
+func TestViewCapsProgressBarAtMaximumWidth(t *testing.T) {
+	t.Parallel()
+
+	view := Model{
+		TotalTokens: 100,
+		UsedTokens:  50,
+		Width:       200,
+	}.View()
+
+	if barWidth := progressBarWidth(t, view); barWidth != 60 {
+		t.Fatalf("expected large widths to cap the progress bar at 60 cells, got %d", barWidth)
+	}
+	if !strings.Contains(view, "Usage: 50.0%") {
+		t.Fatalf("expected percentage formatting to remain stable, got %q", view)
+	}
+}
+
+func TestViewKeepsProgressBarWithinRequestedWidth(t *testing.T) {
+	t.Parallel()
+
+	const width = 8
+	view := Model{
+		TotalTokens: 100,
+		UsedTokens:  50,
+		Width:       width,
+	}.View()
+
+	barLine := progressBarLine(t, view)
+	if len([]rune(barLine)) > width {
+		t.Fatalf("expected bar line %q to fit within width %d", barLine, width)
+	}
+}
+
+func progressBarWidth(t *testing.T, view string) int {
+	t.Helper()
+
+	barLine := progressBarLine(t, view)
+	return len([]rune(strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(barLine), "["), "]")))
+}
+
+func progressBarLine(t *testing.T, view string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(view, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			return trimmed
+		}
+	}
+
+	t.Fatalf("progress bar line not found in view %q", view)
+	return ""
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,22 @@
 # Engineering Log
 
+## 2026-03-18 (Issue #316 Context Grid Coverage)
+
+- Added direct package coverage for `cmd/harnesscli/tui/components/contextgrid` in `cmd/harnesscli/tui/components/contextgrid/model_test.go`:
+  - default total-token fallback when `TotalTokens <= 0`
+  - used-token clamping for negative and over-limit values
+  - width fallback / max-width bar sizing
+  - rendered header, counts, percentage text, and bar glyph assertions
+- Tightened `cmd/harnesscli/tui/components/contextgrid/model.go` so the progress bar fits within the requested width after accounting for the surrounding brackets:
+  - `barWidth` now uses `width - 2`
+  - narrow widths clamp to at least one cell instead of forcing a 10-cell overflow
+- Verification:
+  - `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnesscli/tui/components/contextgrid`
+  - `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.tmp/go-build go test -cover ./cmd/harnesscli/tui/components/contextgrid`
+- Regression status:
+  - package coverage for `cmd/harnesscli/tui/components/contextgrid` is now `93.1%`
+  - full `./scripts/test-regression.sh` is blocked in this sandbox because many existing tests cannot bind local ports (`httptest.NewServer`, `listen tcp :0`, `127.0.0.1:0`) under the current environment; the failures are not isolated to the context-grid package
+
 ## 2026-03-18 (Ownership And Copy-Semantics Hardening)
 
 - Added an explicit clone contract for mutable exported/state-storing harness types:

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-18 (Issue #316 Context Grid Coverage)
+
+- Command intent: Take one open backlog issue to completion by adding direct regression coverage for the TUI context usage grid component and merging the work.
+- User intent: Close a clearly scoped backlog item end to end with strict TDD, proving the `/context` usage grid’s rendering contract directly instead of relying on indirect overlay tests.
+- Success definition:
+  - Issue `#316` is the only issue worked in this run.
+  - Dedicated tests exist for `cmd/harnesscli/tui/components/contextgrid`.
+  - Tests cover default total fallback, used-token clamping, width fallback/bar limits, and rendered usage text.
+  - The repo regression gate passes before merge.
+  - A PR is opened and merged, or a concrete GitHub permission blocker is reported.
+- Non-goals:
+  - Refactoring unrelated TUI code.
+  - Expanding scope to additional coverage-only issues.
+- Guardrails/constraints:
+  - Strict TDD: failing tests first, then minimal implementation.
+  - Keep changes inside the current worktree/branch.
+  - Preserve existing behavior unless acceptance-criteria coverage exposes a small required fix.
+- Open questions:
+  - Whether any production code change is needed, or the issue resolves with tests only.
+- Next verification step: Add the new package tests, run them red then green, and execute `./scripts/test-regression.sh` before opening the PR.
+
 ## 2026-03-18 (Repo-Wide Zero-Coverage Gate)
 
 - Command intent: Fix the repo-wide zero-coverage regression gate so pushes are no longer blocked.

--- a/docs/plans/2026-03-18-issue-316-contextgrid-coverage-plan.md
+++ b/docs/plans/2026-03-18-issue-316-contextgrid-coverage-plan.md
@@ -1,0 +1,52 @@
+# Plan: Issue 316 Context Grid Coverage
+
+## Context
+
+- Problem: `cmd/harnesscli/tui/components/contextgrid` has no direct package tests, so regressions in token normalization, width handling, and rendering can slip past higher-level overlay coverage.
+- User impact: `/context` overlay behavior can change silently, especially around default totals, clamping, and progress-bar output.
+- Constraints: Stay scoped to issue `#316`, follow strict TDD, avoid behavior changes outside the tested rendering contract, and keep docs/logs current.
+
+## Scope
+
+- In scope:
+  - Add direct package tests for `cmd/harnesscli/tui/components/contextgrid`.
+  - Cover default total fallback, token clamping, width fallback and bar limits, and rendered text/percentage output.
+  - Make any minimal production change needed only if a failing regression test exposes a mismatch with the issue’s acceptance criteria.
+- Out of scope:
+  - Refactoring unrelated TUI overlay code.
+  - Broad UI redesign or changes to unrelated components.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `View()` falls back to the default context window when `TotalTokens <= 0`.
+  - `View()` clamps negative and over-limit `UsedTokens`.
+  - `View()` applies width fallback/min/max progress-bar sizing.
+  - `View()` renders the expected header, token counts, and percentage text.
+- Existing tests to update:
+  - None expected.
+- Regression tests required:
+  - At least one rendering assertion that would fail if the bar glyphs or usage text regress.
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This task does not touch those surfaces, so no impact map is required.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] For provider/model flow work, add or update the one-page impact map before implementation.
+- [x] Write failing tests first.
+- [x] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [x] Implement minimal code changes.
+- [x] Refactor while tests remain green.
+- [x] Update docs and indexes.
+- [x] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: The component may already satisfy the intended contract, making test-first evidence less explicit.
+- Mitigation: Start with assertions that intentionally pin uncovered edge cases and run the package with coverage before and after to prove the added signal.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-18-issue-316-contextgrid-coverage-plan.md`: Active implementation plan for direct package coverage of the TUI context usage grid component.
 - `2026-03-18-repo-wide-zero-coverage-gate-plan.md`: Active plan for fixing repo-wide zero-function coverage failures and aligning regression coverage collection with repo-wide execution.
 - `2026-03-18-runner-concurrency-invariants-plan.md`: Active plan for making runner concurrency and lifecycle invariants explicit in code/tests after the recorder/compaction review loop.
 - `2026-03-18-ownership-copy-semantics-plan.md`: Active implementation plan for clone-contract hardening across exported and state-storing harness types.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: implementing provider/model impact-map workflow guardrails from repo review feedback.
+Current status: implementing issue #316 direct coverage for the TUI context usage grid component.
 
-Current active plan: `2026-03-18-provider-model-impact-map-guardrail-plan.md`
+Current active plan: `2026-03-18-issue-316-contextgrid-coverage-plan.md`
 
-Most recent completed plan: `2026-03-06-terminal-bench-periodic-suite-plan.md`
+Most recent completed plan: `2026-03-18-provider-model-impact-map-guardrail-plan.md`


### PR DESCRIPTION
## Summary
- add direct package tests for the TUI context usage grid component
- cover default total fallback, used-token clamping, width handling, rendered text, and progress-bar output
- tighten narrow-width rendering so the bar fits inside the requested width

## Testing
- `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnesscli/tui/components/contextgrid`
- `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.tmp/go-build go test -cover ./cmd/harnesscli/tui/components/contextgrid`
- `TMPDIR=$PWD/.tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` *(blocked in this sandbox: many existing tests fail to bind local ports via `httptest.NewServer`, `listen tcp :0`, or `127.0.0.1:0`; examples include `internal/cron`, `internal/provider/openai`, `cmd/harnesscli/tui`, `cmd/harnessd`)*

Closes #316.