### PR TITLE
test(#337): cover runWithSignals failure paths for config/storage/cron/MCP/subagent setup

### DIFF
--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -2062,3 +2062,248 @@ func TestRoleModelPrimaryFromGetenvAppliedToRun(t *testing.T) {
 		t.Fatalf("timed out waiting for graceful shutdown")
 	}
 }
+// ---------------------------------------------------------------------------
+// Issue #337: runWithSignals failure paths
+// ---------------------------------------------------------------------------
+
+// TestRunWithSignalsPromptEngineFailure verifies that a bad HARNESS_PROMPTS_DIR
+// (pointing to a directory with no catalog.yaml) causes runWithSignals to
+// return an error wrapping "load prompt engine".
+func TestRunWithSignalsPromptEngineFailure(t *testing.T) {
+	t.Parallel()
+
+	// Use a temp dir that has no catalog.yaml — NewFileEngine will fail.
+	emptyDir := t.TempDir()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":      "test-key",
+		"HARNESS_ADDR":        "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE": "off",
+		"HARNESS_PROMPTS_DIR": emptyDir,
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err := runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+
+	if err == nil {
+		t.Fatal("expected error when prompts dir is missing catalog.yaml")
+	}
+	if !strings.Contains(err.Error(), "load prompt engine") {
+		t.Fatalf("expected 'load prompt engine' in error, got: %v", err)
+	}
+}
+
+// TestRunWithSignalsMemoryManagerFailure verifies that an unsupported
+// HARNESS_MEMORY_DB_DRIVER causes runWithSignals to return an error wrapping
+// "create observational memory manager".
+func TestRunWithSignalsMemoryManagerFailure(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":           "test-key",
+		"HARNESS_ADDR":             "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE":      "auto",
+		"HARNESS_MEMORY_DB_DRIVER": "unsupported_driver_xyz",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err := runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+
+	if err == nil {
+		t.Fatal("expected error when memory driver is unsupported")
+	}
+	if !strings.Contains(err.Error(), "create observational memory manager") {
+		t.Fatalf("expected 'create observational memory manager' in error, got: %v", err)
+	}
+}
+
+// TestRunWithSignalsCronStoreFailure verifies that when the cron SQLite DB path
+// is unwritable, the cron store creation failure causes runWithSignals to return
+// an error wrapping "cron store".
+func TestRunWithSignalsCronStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	// Create a valid workspace dir with a proper .harness directory so
+	// config loading succeeds. Then pre-create cron.db as a directory (not a
+	// file) so the SQLite driver cannot open it as a database file.
+	workspaceDir := t.TempDir()
+	harnessSubDir := workspaceDir + "/.harness"
+	if err := os.MkdirAll(harnessSubDir, 0o755); err != nil {
+		t.Fatalf("setup: create .harness dir: %v", err)
+	}
+	// Make cron.db a directory — SQLite cannot open a directory as a DB file.
+	cronDBAsDir := harnessSubDir + "/cron.db"
+	if err := os.MkdirAll(cronDBAsDir, 0o755); err != nil {
+		t.Fatalf("setup: create cron.db as directory: %v", err)
+	}
+
+	env := map[string]string{
+		"OPENAI_API_KEY":      "test-key",
+		"HARNESS_ADDR":        "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE": "off",
+		"HARNESS_WORKSPACE":   workspaceDir,
+		"HARNESS_CRON_URL":    "", // force embedded path
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err := runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+
+	if err == nil {
+		t.Fatal("expected error when cron store path is unwritable")
+	}
+	if !strings.Contains(err.Error(), "cron store") {
+		t.Fatalf("expected 'cron store' in error, got: %v", err)
+	}
+}
+
+// TestRunWithSignalsConversationStoreFailure verifies that a bad
+// HARNESS_CONVERSATION_DB path causes an error wrapping "conversation store".
+func TestRunWithSignalsConversationStoreFailure(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":           "test-key",
+		"HARNESS_ADDR":             "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE":      "off",
+		"HARNESS_WORKSPACE":        workspaceDir,
+		// Point to a file path under /dev/null/... which cannot be created.
+		"HARNESS_CONVERSATION_DB":  "/dev/null/cannot/create.db",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err := runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+
+	if err == nil {
+		t.Fatal("expected error when conversation store path is invalid")
+	}
+	if !strings.Contains(err.Error(), "conversation store") {
+		t.Fatalf("expected 'conversation store' in error, got: %v", err)
+	}
+}
+
+// TestRunWithSignalsPricingCatalogFailure verifies that a non-existent pricing
+// catalog path causes runWithSignals to return an error wrapping "load pricing catalog".
+func TestRunWithSignalsPricingCatalogFailure(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":              "test-key",
+		"HARNESS_ADDR":                "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE":         "off",
+		"HARNESS_WORKSPACE":           workspaceDir,
+		"HARNESS_PRICING_CATALOG_PATH": "/nonexistent/path/pricing.json",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err := runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+
+	if err == nil {
+		t.Fatal("expected error when pricing catalog path is invalid")
+	}
+	if !strings.Contains(err.Error(), "pricing catalog") {
+		t.Fatalf("expected 'pricing catalog' in error, got: %v", err)
+	}
+}
+
+// TestRunWithSignalsMCPParseFailureContinues verifies that an unparseable
+// HARNESS_MCP_SERVERS value is logged as a warning but does NOT abort startup
+// (MCP failures are non-fatal — the server continues without env-configured MCP).
+func TestRunWithSignalsMCPParseFailureContinues(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":       "test-key",
+		"HARNESS_ADDR":         "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE":  "off",
+		"HARNESS_WORKSPACE":    workspaceDir,
+		"HARNESS_MCP_SERVERS":  "not-valid-json-{{{",
+	}
+	getenv := func(key string) string { return env[key] }
+	sig := make(chan os.Signal, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWithSignals(sig, getenv, func(openai.Config) (harness.Provider, error) {
+			return &noopProvider{}, nil
+		}, "")
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	sig <- os.Interrupt
+
+	select {
+	case err := <-done:
+		// MCP parse failure must NOT abort the server; a nil error is expected.
+		if err != nil {
+			t.Fatalf("expected server to continue despite MCP parse failure; got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for graceful shutdown")
+	}
+}
+
+// TestRunWithSignalsInvalidModelCatalogContinues verifies that a pointing
+// HARNESS_MODEL_CATALOG_PATH to an invalid JSON file is logged as a warning
+// and the server continues (catalog failures are non-fatal).
+func TestRunWithSignalsInvalidModelCatalogContinues(t *testing.T) {
+	t.Parallel()
+
+	workspaceDir := t.TempDir()
+
+	// Write a malformed catalog file.
+	badCatalog, err := os.CreateTemp(t.TempDir(), "bad-catalog*.json")
+	if err != nil {
+		t.Fatalf("create temp catalog: %v", err)
+	}
+	if _, err := badCatalog.WriteString(`{invalid json`); err != nil {
+		t.Fatalf("write bad catalog: %v", err)
+	}
+	badCatalog.Close()
+
+	env := map[string]string{
+		"OPENAI_API_KEY":             "test-key",
+		"HARNESS_ADDR":               "127.0.0.1:0",
+		"HARNESS_MEMORY_MODE":        "off",
+		"HARNESS_WORKSPACE":          workspaceDir,
+		"HARNESS_MODEL_CATALOG_PATH": badCatalog.Name(),
+	}
+	getenv := func(key string) string { return env[key] }
+	sig := make(chan os.Signal, 1)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runWithSignals(sig, getenv, func(openai.Config) (harness.Provider, error) {
+			return &noopProvider{}, nil
+		}, "")
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	sig <- os.Interrupt
+
+	select {
+	case err := <-done:
+		// Invalid model catalog must NOT abort the server; nil error expected.
+		if err != nil {
+			t.Fatalf("expected server to continue despite invalid model catalog; got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for graceful shutdown")
+	}
+}
+


### PR DESCRIPTION
## Summary

- Adds 245 lines to `cmd/harnessd/main_test.go` covering startup failure paths in `runWithSignals`
- Covers: prompt engine failure, memory manager failure, cron store failure, conversation store failure, pricing catalog failure, MCP parse warning (non-fatal), invalid model catalog warning (non-fatal)

## Test plan
- [x] `go test ./cmd/harnessd/... -run TestRunWithSignals`
- [x] All tests pass with `-race`

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)