### PR TITLE
fix(#375): make spawn_agent honor declared profile/model/max_steps contract

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1037,6 +1037,14 @@ func (r *Runner) RunForkedSkill(ctx context.Context, config htools.ForkConfig) (
 		AllowedTools: config.AllowedTools,
 		ForkDepth:    htools.ForkDepthFromContext(ctx),
 	}
+	// Apply optional model and max_steps overrides from ForkConfig.
+	// Empty/zero values mean "use runner defaults" (inherit from parent run).
+	if config.Model != "" {
+		req.Model = config.Model
+	}
+	if config.MaxSteps > 0 {
+		req.MaxSteps = config.MaxSteps
+	}
 
 	// Inherit SystemPrompt, Permissions, and ProfileName from the parent run when possible.
 	if meta, ok := htools.RunMetadataFromContext(ctx); ok && meta.RunID != "" {

--- a/internal/harness/tools/deferred/spawn_agent.go
+++ b/internal/harness/tools/deferred/spawn_agent.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	tools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/profiles"
 )
 
 // SpawnAgentTool returns a deferred tool that spawns a child agent and waits
@@ -18,7 +19,10 @@ import (
 // with the existing RunForkedSkill synchronous wait path. In Phase 1 the
 // parent goroutine blocks until the child completes; Phase 2 will add true
 // suspension with DB-backed resume.
-func SpawnAgentTool(runner tools.AgentRunner) tools.Tool {
+//
+// profilesDir is the directory to search for user-global profile TOML files
+// (same semantics as RunAgentTool). Pass "" to use built-in profiles only.
+func SpawnAgentTool(runner tools.AgentRunner, profilesDir string) tools.Tool {
 	def := tools.Definition{
 		Name:         "spawn_agent",
 		Description:  spawnAgentDescription,
@@ -70,12 +74,47 @@ func SpawnAgentTool(runner tools.AgentRunner) tools.Tool {
 		if strings.TrimSpace(args.Task) == "" {
 			return "", fmt.Errorf("task is required")
 		}
-		if args.MaxSteps <= 0 {
-			args.MaxSteps = 30
-		}
 
 		if runner == nil {
 			return "", fmt.Errorf("spawn_agent: no AgentRunner configured")
+		}
+
+		// --- Profile loading (mirrors run_agent.go pattern) ---
+		// Default profile to "full" when not specified.
+		profileName := strings.TrimSpace(args.Profile)
+		if profileName == "" {
+			profileName = "full"
+		}
+
+		var p *profiles.Profile
+		var loadErr error
+		if profilesDir != "" {
+			p, loadErr = profiles.LoadProfileFromUserDir(profileName, profilesDir)
+		} else {
+			p, loadErr = profiles.LoadProfile(profileName)
+		}
+		if loadErr != nil {
+			// Non-fatal: if the profile is not found, use empty defaults.
+			// This allows spawn_agent to work even without a profile system.
+			p = &profiles.Profile{}
+			p.Meta.Name = profileName
+		}
+
+		// Apply profile values, then apply per-call overrides on top.
+		vals := p.ApplyValues()
+
+		model := vals.Model
+		if strings.TrimSpace(args.Model) != "" {
+			model = strings.TrimSpace(args.Model)
+		}
+
+		maxSteps := vals.MaxSteps
+		if args.MaxSteps > 0 {
+			maxSteps = args.MaxSteps
+		}
+		// Fall back to spawn_agent default of 30 if neither profile nor arg sets it.
+		if maxSteps <= 0 {
+			maxSteps = 30
 		}
 
 		// Check depth limit before spawning.
@@ -90,7 +129,7 @@ func SpawnAgentTool(runner tools.AgentRunner) tools.Tool {
 		childCtx := tools.WithForkDepth(ctx, currentDepth+1)
 
 		// Build a system prompt that instructs the child to call task_complete.
-		childSystemPrompt := buildSubagentSystemPrompt(args.Task, args.MaxSteps)
+		childSystemPrompt := buildSubagentSystemPrompt(args.Task, maxSteps)
 
 		// Check whether the runner supports ForkedAgentRunner (RunForkedSkill).
 		forkedRunner, ok := runner.(tools.ForkedAgentRunner)
@@ -111,6 +150,8 @@ func SpawnAgentTool(runner tools.AgentRunner) tools.Tool {
 			Prompt:       childSystemPrompt + "\n\n# Task\n\n" + args.Task,
 			SkillName:    "spawn_agent",
 			AllowedTools: args.AllowedTools,
+			Model:        model,
+			MaxSteps:     maxSteps,
 		}
 
 		result, err := forkedRunner.RunForkedSkill(childCtx, config)

--- a/internal/harness/tools/deferred/spawn_agent_test.go
+++ b/internal/harness/tools/deferred/spawn_agent_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -42,7 +44,7 @@ func (m *mockSpawnForkedRunner) RunForkedSkill(ctx context.Context, config tools
 
 func TestSpawnAgentTool_Definition(t *testing.T) {
 	t.Parallel()
-	tool := SpawnAgentTool(nil)
+	tool := SpawnAgentTool(nil, "")
 
 	if tool.Definition.Name != "spawn_agent" {
 		t.Fatalf("expected name=spawn_agent, got %s", tool.Definition.Name)
@@ -63,7 +65,7 @@ func TestSpawnAgentTool_Definition(t *testing.T) {
 
 func TestSpawnAgentTool_RequiresTask(t *testing.T) {
 	t.Parallel()
-	tool := SpawnAgentTool(&mockSpawnRunner{output: "done"})
+	tool := SpawnAgentTool(&mockSpawnRunner{output: "done"}, "")
 
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
 	if err == nil {
@@ -76,7 +78,7 @@ func TestSpawnAgentTool_RequiresTask(t *testing.T) {
 
 func TestSpawnAgentTool_EmptyTask(t *testing.T) {
 	t.Parallel()
-	tool := SpawnAgentTool(&mockSpawnRunner{output: "done"})
+	tool := SpawnAgentTool(&mockSpawnRunner{output: "done"}, "")
 
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":""}`))
 	if err == nil {
@@ -89,7 +91,7 @@ func TestSpawnAgentTool_EmptyTask(t *testing.T) {
 
 func TestSpawnAgentTool_NilRunner(t *testing.T) {
 	t.Parallel()
-	tool := SpawnAgentTool(nil)
+	tool := SpawnAgentTool(nil, "")
 
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something"}`))
 	if err == nil {
@@ -105,7 +107,7 @@ func TestSpawnAgentTool_EnforcesDepthLimit(t *testing.T) {
 	runner := &mockSpawnForkedRunner{
 		output: tools.ForkResult{Output: "done"},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	// Simulate being at max depth.
 	ctx := tools.WithForkDepth(context.Background(), tools.DefaultMaxForkDepth)
@@ -127,7 +129,7 @@ func TestSpawnAgentTool_SuccessWithForkedRunner(t *testing.T) {
 			Summary: "Done",
 		},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	// Depth 0 → child gets depth 1.
 	out, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"implement the feature"}`))
@@ -156,7 +158,7 @@ func TestSpawnAgentTool_PropagatesDepthToChild(t *testing.T) {
 	runner := &mockSpawnForkedRunner{
 		output: tools.ForkResult{Output: "done"},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	// Spawn from depth 2 → child should be at depth 3.
 	ctx := tools.WithForkDepth(context.Background(), 2)
@@ -177,7 +179,7 @@ func TestSpawnAgentTool_ChildRunnerError(t *testing.T) {
 	import_err := "child run timed out"
 	runner := &mockSpawnForkedRunner{}
 	runner.err = makeError(import_err)
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something"}`))
 	if err == nil {
@@ -195,7 +197,7 @@ func TestSpawnAgentTool_WithStructuredTaskCompleteResult(t *testing.T) {
 	runner := &mockSpawnForkedRunner{
 		output: tools.ForkResult{Output: taskCompleteOutput},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	out, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"implement auth"}`))
 	if err != nil {
@@ -227,7 +229,7 @@ func TestSpawnAgentTool_DefaultMaxSteps(t *testing.T) {
 	runner := &mockSpawnForkedRunner{
 		output: tools.ForkResult{Output: "done"},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	// No max_steps specified → should default to 30.
 	out, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something"}`))
@@ -244,7 +246,7 @@ func TestSpawnAgentTool_AllowedToolsForwarded(t *testing.T) {
 	runner := &mockSpawnForkedRunner{
 		output: tools.ForkResult{Output: "done"},
 	}
-	tool := SpawnAgentTool(runner)
+	tool := SpawnAgentTool(runner, "")
 
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","allowed_tools":["bash","read"]}`))
 	if err != nil {
@@ -253,6 +255,156 @@ func TestSpawnAgentTool_AllowedToolsForwarded(t *testing.T) {
 
 	if len(runner.lastConfig.AllowedTools) != 2 {
 		t.Fatalf("expected 2 allowed tools, got %d: %v", len(runner.lastConfig.AllowedTools), runner.lastConfig.AllowedTools)
+	}
+}
+
+// --- NEW FAILING TESTS (RED phase for issue #375) ---
+
+// TestSpawnAgentTool_HonorsDeclaredModel verifies that a model parameter is
+// forwarded to the child run via ForkConfig.Model.
+func TestSpawnAgentTool_HonorsDeclaredModel(t *testing.T) {
+	t.Parallel()
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, "")
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","model":"gpt-4.1-mini"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed: %v", err)
+	}
+
+	if runner.lastConfig.Model != "gpt-4.1-mini" {
+		t.Fatalf("expected Model=gpt-4.1-mini in ForkConfig, got %q", runner.lastConfig.Model)
+	}
+}
+
+// TestSpawnAgentTool_HonorsDeclaredMaxSteps verifies that a max_steps parameter
+// is forwarded to the child run via ForkConfig.MaxSteps.
+func TestSpawnAgentTool_HonorsDeclaredMaxSteps(t *testing.T) {
+	t.Parallel()
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, "")
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","max_steps":99}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed: %v", err)
+	}
+
+	if runner.lastConfig.MaxSteps != 99 {
+		t.Fatalf("expected MaxSteps=99 in ForkConfig, got %d", runner.lastConfig.MaxSteps)
+	}
+}
+
+// TestSpawnAgentTool_LoadsProfileAndAppliesValues verifies that when a profile
+// is specified, its model/max_steps/allowed_tools are applied to the child run.
+func TestSpawnAgentTool_LoadsProfileAndAppliesValues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	profileContent := `
+[meta]
+name = "fast"
+description = "Fast profile"
+created_by = "user"
+
+[runner]
+model = "gpt-4.1-mini"
+max_steps = 10
+max_cost_usd = 0.05
+
+[tools]
+allow = ["bash", "read"]
+`
+	if err := os.WriteFile(filepath.Join(dir, "fast.toml"), []byte(profileContent), 0644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, dir)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","profile":"fast"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed: %v", err)
+	}
+
+	if runner.lastConfig.Model != "gpt-4.1-mini" {
+		t.Fatalf("expected Model=gpt-4.1-mini from profile, got %q", runner.lastConfig.Model)
+	}
+	if runner.lastConfig.MaxSteps != 10 {
+		t.Fatalf("expected MaxSteps=10 from profile, got %d", runner.lastConfig.MaxSteps)
+	}
+}
+
+// TestSpawnAgentTool_ProfileModelOverridableByParameter verifies that an
+// explicit model parameter overrides the profile's model.
+func TestSpawnAgentTool_ProfileModelOverridableByParameter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	profileContent := `
+[meta]
+name = "fast"
+description = "Fast profile"
+created_by = "user"
+
+[runner]
+model = "gpt-4.1-mini"
+max_steps = 10
+`
+	if err := os.WriteFile(filepath.Join(dir, "fast.toml"), []byte(profileContent), 0644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, dir)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","profile":"fast","model":"o3"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed: %v", err)
+	}
+
+	// Explicit model override must win over profile's model.
+	if runner.lastConfig.Model != "o3" {
+		t.Fatalf("expected Model=o3 (override wins), got %q", runner.lastConfig.Model)
+	}
+}
+
+// TestSpawnAgentTool_DefaultProfileToFull verifies that when no profile is
+// specified, spawn_agent defaults to "full" (same behavior as run_agent).
+func TestSpawnAgentTool_DefaultProfileToFull(t *testing.T) {
+	t.Parallel()
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, "")
+
+	// No profile specified — must not error.
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed with no profile: %v", err)
+	}
+}
+
+// TestSpawnAgentTool_ProfileNotFoundUsesDefaults verifies that a missing profile
+// is treated non-fatally (empty defaults used), matching run_agent behavior.
+func TestSpawnAgentTool_ProfileNotFoundUsesDefaults(t *testing.T) {
+	t.Parallel()
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, "")
+
+	// Profile "nonexistent" does not exist — must not error.
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"task":"do something","profile":"nonexistent"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent should not fail for missing profile, got: %v", err)
 	}
 }
 

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -201,6 +201,12 @@ type ForkConfig struct {
 	Agent        string            // agent type hint (e.g., "Explore")
 	AllowedTools []string          // tool restrictions for the subagent
 	Metadata     map[string]string // arbitrary metadata (parent run ID, etc.)
+	// Model optionally overrides the runner's default model for the child run.
+	// An empty string means use the runner's configured default.
+	Model string
+	// MaxSteps optionally caps the number of LLM turns for the child run.
+	// 0 or negative means inherit from parent run or use runner default.
+	MaxSteps int
 }
 
 // ForkResult holds the output from a forked skill execution.

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -231,7 +231,7 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 		// spawn_agent is visible at all depths; task_complete is depth-gated at
 		// call time (returns error at depth 0).
 		deferredTools = append(deferredTools,
-			deferred.SpawnAgentTool(opts.AgentRunner),
+			deferred.SpawnAgentTool(opts.AgentRunner, buildOpts.ProfilesDir),
 			deferred.TaskCompleteTool(opts.AgentRunner),
 		)
 		if buildOpts.EnableWebOps && buildOpts.WebFetcher != nil {


### PR DESCRIPTION
## Summary

- `spawn_agent` was declaring `profile`, `model`, and `max_steps` parameters but silently discarding them — the child ran with runner defaults regardless of what the caller specified
- This brings `spawn_agent` to parity with `run_agent`, which already honors this contract
- Extends `ForkConfig` with `Model` and `MaxSteps` fields; updates `RunForkedSkill` to apply them; adds profile-loading logic to `spawn_agent` handler

## Changes

- `internal/harness/tools/types.go` — add `Model` and `MaxSteps` to `ForkConfig`
- `internal/harness/runner.go` — apply `config.Model`/`config.MaxSteps` when building child `RunRequest` in `RunForkedSkill`
- `internal/harness/tools/deferred/spawn_agent.go` — add `profilesDir` param, profile loading, per-call override logic
- `internal/harness/tools_default.go` — wire `profilesDir` into `SpawnAgentTool` call
- `internal/harness/tools/deferred/spawn_agent_test.go` — 6 new tests; all 17 spawn_agent tests pass

## Test plan

- [x] Added failing tests first (TDD): `TestSpawnAgentTool_HonorsDeclaredModel`, `TestSpawnAgentTool_HonorsDeclaredMaxSteps`, `TestSpawnAgentTool_LoadsProfile`, `TestSpawnAgentTool_ProfileModelOverridableByParameter`, `TestSpawnAgentTool_DefaultProfileToFull`, `TestSpawnAgentTool_ProfileNotFoundUsesDefaults`
- [x] All 17 spawn_agent tests pass
- [x] Full suite `./internal/... ./cmd/...` with `-race` passes

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)