### PR TITLE
fix(#376): fail closed on unknown run_agent profiles

### DIFF
--- a/internal/harness/tools/deferred/run_agent.go
+++ b/internal/harness/tools/deferred/run_agent.go
@@ -69,6 +69,9 @@ func RunAgentTool(manager tools.SubagentManager, profilesDir string) tools.Tool 
 		}
 
 		// Load the profile using the three-tier resolution.
+		// Fail closed: any error (not-found, invalid name, parse failure) is
+		// returned explicitly so that a typo in a profile name never silently
+		// widens or narrows the child agent's capabilities.
 		var p *profiles.Profile
 		var loadErr error
 		if profilesDir != "" {
@@ -77,10 +80,7 @@ func RunAgentTool(manager tools.SubagentManager, profilesDir string) tools.Tool 
 			p, loadErr = profiles.LoadProfile(profileName)
 		}
 		if loadErr != nil {
-			// Non-fatal: if the profile is not found, use empty defaults.
-			// This allows run_agent to work even without a profile system.
-			p = &profiles.Profile{}
-			p.Meta.Name = profileName
+			return "", fmt.Errorf("run_agent: profile %q could not be loaded: %w; check available profiles with list_profiles or use a built-in profile (\"full\", \"fast\", \"minimal\")", profileName, loadErr)
 		}
 
 		// Apply profile values to the request, with per-call overrides on top.

--- a/internal/harness/tools/deferred/run_agent_test.go
+++ b/internal/harness/tools/deferred/run_agent_test.go
@@ -178,3 +178,70 @@ func TestRunAgentTool_BuiltinProfileGithub(t *testing.T) {
 	assert.Equal(t, 20, manager.lastReq.MaxSteps)
 	assert.Equal(t, []string{"bash", "read"}, manager.lastReq.AllowedTools)
 }
+
+// TestRunAgentTool_UnknownProfile verifies that run_agent returns an explicit error
+// when a non-existent profile is requested, rather than silently falling back to
+// an empty default profile.
+func TestRunAgentTool_UnknownProfile(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{Status: "completed", Output: "done"},
+	}
+	// Use a temp dir that exists but has no profiles — ensures the profile name
+	// is valid but truly not found anywhere.
+	dir := t.TempDir()
+	tool := RunAgentTool(manager, dir)
+
+	args := map[string]any{
+		"task":    "Do something",
+		"profile": "nonexistent-profile-abc123",
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err, "expected error for unknown profile, got nil")
+	assert.Contains(t, err.Error(), "nonexistent-profile-abc123")
+}
+
+// TestRunAgentTool_InvalidProfileNamePathTraversal verifies that run_agent returns
+// an explicit error when the profile name contains path traversal sequences.
+func TestRunAgentTool_InvalidProfileNamePathTraversal(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{Status: "completed", Output: "done"},
+	}
+	tool := RunAgentTool(manager, "")
+
+	args := map[string]any{
+		"task":    "Do something",
+		"profile": "../etc/passwd",
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err, "expected error for path traversal profile name, got nil")
+}
+
+// TestRunAgentTool_InvalidProfileNameEmpty verifies that run_agent returns an
+// explicit error when profile resolves to empty after trimming.
+// Note: empty profile defaults to "full" which is a valid built-in; this test
+// uses a profile consisting entirely of whitespace which has no default.
+func TestRunAgentTool_BrokenToml(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a profile file with invalid TOML content.
+	brokenContent := `[meta
+name = "broken"  # missing closing bracket — invalid TOML
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.toml"), []byte(brokenContent), 0644))
+
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{Status: "completed", Output: "done"},
+	}
+	tool := RunAgentTool(manager, dir)
+
+	args := map[string]any{
+		"task":    "Do something",
+		"profile": "broken",
+	}
+	raw, _ := json.Marshal(args)
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err, "expected error for broken TOML profile, got nil")
+	assert.Contains(t, err.Error(), "broken")
+}


### PR DESCRIPTION
## Summary

- `run_agent` was silently swallowing profile-load errors and substituting an empty `Profile{}` — a typo in a profile name would silently give the child agent unconstrained capabilities
- Now returns an explicit tool error with actionable message for: missing profiles, invalid names (path traversal), and broken TOML

## Changes

- `internal/harness/tools/deferred/run_agent.go` — replace 4-line silent fallback with `return "", fmt.Errorf(...)` fail-closed error
- `internal/harness/tools/deferred/run_agent_test.go` — 3 new tests: unknown profile, path traversal, broken TOML

## Test plan

- [x] TDD: failing tests committed first
- [x] `TestRunAgentTool_UnknownProfile`, `TestRunAgentTool_InvalidProfileNamePathTraversal`, `TestRunAgentTool_BrokenToml` — all pass after fix
- [x] All 11 `TestRunAgent*` tests pass
- [x] Full `./internal/... ./cmd/...` with `-race` passes

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)