### PR TITLE
chore(#390): align default registry, docs, and code-intel policy

### DIFF
--- a/docs/design/tool-roadmap.md
+++ b/docs/design/tool-roadmap.md
@@ -21,9 +21,9 @@ Status legend: `planned` | `in_progress` | `implemented` | `deferred`
 | `todos` | `todos` | `implemented` |
 | observational memory control | `observational_memory` | `implemented` (local sqlite + local coordinator mode) |
 | `sourcegraph` | `sourcegraph` | `implemented` (requires endpoint config) |
-| `lsp_diagnostics` | `lsp_diagnostics` | `implemented` (requires `gopls`) |
-| `lsp_references` | `lsp_references` | `implemented` (requires `gopls`) |
-| `lsp_restart` | `lsp_restart` | `implemented` |
+| `lsp_diagnostics` | `lsp_diagnostics` | `deferred` (code exists in `internal/harness/tools/deferred/lsp.go`; not wired into the default registry — bash + gopls is sufficient) |
+| `lsp_references` | `lsp_references` | `deferred` (code exists in `internal/harness/tools/deferred/lsp.go`; not wired into the default registry) |
+| `lsp_restart` | `lsp_restart` | `deferred` (code exists in `internal/harness/tools/deferred/lsp.go`; not wired into the default registry) |
 | `list_mcp_resources` | `list_mcp_resources` | `implemented` (requires MCP registry integration) |
 | `read_mcp_resource` | `read_mcp_resource` | `implemented` (requires MCP registry integration) |
 | dynamic `mcp_*` | dynamic `mcp_<server>_<tool>` | `implemented` (requires MCP registry integration) |
@@ -34,6 +34,7 @@ Status legend: `planned` | `in_progress` | `implemented` | `deferred`
 
 ## Notes
 
-- Tools are registered from a single catalog in `internal/harness/tools/catalog.go`.
-- New tools should be added as a new file (or directory for larger tools) in `internal/harness/tools/` and a catalog entry.
+- The production tool registry is built by `NewDefaultRegistryWithOptions` in `internal/harness/tools_default.go`. The legacy `BuildCatalog` in `internal/harness/tools/catalog.go` is a lower-level builder still used by some tests.
+- New tools should be added as a new file (or directory for larger tools) in `internal/harness/tools/` (core) or `internal/harness/tools/deferred/` (deferred), then wired into `tools_default.go`.
 - Not-yet-wired external dependencies (MCP, agent runner, web fetcher, sourcegraph endpoint) are not placeholders; they are fully implemented tool contracts gated by real dependency presence.
+- LSP tools have `deferred` status: code exists but is intentionally not wired into the default registry. The agent can use `bash` with `gopls` directly when needed.

--- a/internal/harness/tools_contract_test.go
+++ b/internal/harness/tools_contract_test.go
@@ -232,3 +232,37 @@ func TestDefaultRegistryToolContractWithoutConversations(t *testing.T) {
 		}
 	}
 }
+
+// TestDefaultRegistryNoLSPToolsInVisibleSet pins the policy that LSP/code-intel tools
+// are not included in the default visible registry. They require a running language
+// server and are intentionally excluded from the default configuration. This test
+// prevents accidental re-introduction of LSP tools into the visible set.
+func TestDefaultRegistryNoLSPToolsInVisibleSet(t *testing.T) {
+	t.Parallel()
+
+	lspToolNames := []string{"lsp_diagnostics", "lsp_references", "lsp_restart"}
+
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+	})
+
+	// Check visible (core) tools.
+	for _, def := range registry.Definitions() {
+		for _, lsp := range lspToolNames {
+			if def.Name == lsp {
+				t.Errorf("LSP tool %q must not appear in the default visible registry (core tier); "+
+					"it requires a running language server and is not supported in the default config", lsp)
+			}
+		}
+	}
+
+	// Check deferred tools as well — they should not be wired either.
+	for _, def := range registry.DeferredDefinitions() {
+		for _, lsp := range lspToolNames {
+			if def.Name == lsp {
+				t.Errorf("LSP tool %q must not appear in the default deferred registry; "+
+					"it requires a running language server and is not supported in the default config", lsp)
+			}
+		}
+	}
+}

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -139,7 +139,11 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 		SkillVerifier:       opts.SkillVerifier,
 		CronClient:          opts.CronClient,
 		EnableTodos:         true,
-		EnableLSP:           true,
+		// Code-intel/LSP tools (lsp_diagnostics, lsp_references, lsp_restart) are NOT
+		// included in the default registry. They require a running language server and
+		// are not supported in the default configuration. Implementations exist in
+		// internal/harness/tools/deferred/lsp.go and can be wired by custom registry
+		// builders that call deferred.LspDiagnosticsTool etc. directly.
 		EnableMCP:           true,
 		EnableAgent:         true,
 		EnableWebOps:        true,
@@ -204,7 +208,8 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 	if buildOpts.EnableTodos {
 		coreTools = append(coreTools, deferred.TodosTool())
 	}
-	// LSP tools removed — bash gopls/go-build are sufficient.
+	// LSP tools (lsp_diagnostics, lsp_references, lsp_restart) are intentionally
+	// absent from the default registry. See BuildOptions comment above.
 	if buildOpts.Sourcegraph.Endpoint != "" {
 		deferredTools = append(deferredTools, deferred.SourcegraphTool(buildOpts))
 	}


### PR DESCRIPTION
## Summary

Reconciles three-way drift between the production tool registry, docs, and test contracts around LSP/code-intel tools:

- `tools_default.go` had removed LSP tools but left a vestigial `EnableLSP: true` field in `buildOpts` — removed the dead field and added a clear policy comment
- `docs/design/tool-roadmap.md` listed `lsp_diagnostics`, `lsp_references`, `lsp_restart` as `implemented` — updated to `deferred` with explanation (implementations exist in `deferred/lsp.go` but are not wired into the default registry)
- `tools_contract_test.go` lacked an explicit assertion that LSP tools are absent — added `TestDefaultRegistryNoLSPToolsInVisibleSet`

## Changes

- `internal/harness/tools_default.go` — remove dead `EnableLSP: true`; add policy comment
- `internal/harness/tools_contract_test.go` — add `TestDefaultRegistryNoLSPToolsInVisibleSet`
- `docs/design/tool-roadmap.md` — update LSP tool status from `implemented` to `deferred`

## Test plan

- [x] `TestDefaultRegistryNoLSPToolsInVisibleSet` passes — pins that LSP tools are absent from both core and deferred visible sets
- [x] Full `./internal/... ./cmd/...` with `-race` passes

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)