### PR TITLE
feat(#387): persist per-profile usage history and efficiency stats

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -3178,6 +3178,9 @@ func (r *Runner) completeRun(runID, output string) {
 	// This is suggest-only — no profile changes are applied automatically.
 	r.maybeEmitProfileEfficiencySuggestion(runID, costTotals.CostUSDTotal)
 
+	// Profile run history: persist completion record for analysis.
+	r.persistProfileRun(runID, "completed", costTotals.CostUSDTotal)
+
 	r.emit(runID, EventRunCompleted, map[string]any{
 		"output":       output,
 		"usage_totals": usageTotals,
@@ -3219,6 +3222,70 @@ func (r *Runner) maybeEmitProfileEfficiencySuggestion(runID string, costUSD floa
 		"steps":            steps,
 		"cost_usd":         costUSD,
 	})
+}
+
+// persistProfileRun persists a profile run record to the ProfileRunStore when
+// the run has a non-empty profile name. It is a no-op when ProfileRunStore is
+// nil or the run has no profile name.  Errors are non-fatal: logged but never
+// propagated so that persistence failures never affect the run outcome.
+func (r *Runner) persistProfileRun(runID string, runStatus string, costUSD float64) {
+	if r.config.ProfileRunStore == nil {
+		return
+	}
+
+	r.mu.RLock()
+	state, ok := r.runs[runID]
+	if !ok {
+		r.mu.RUnlock()
+		return
+	}
+	profileName := state.profileName
+	steps := state.currentStep
+	startedAt := state.run.CreatedAt
+	// Collect used tool names from the event log (EventToolCallStarted payloads).
+	var usedTools []string
+	for _, evt := range state.events {
+		if evt.Type == EventToolCallStarted {
+			if name, ok := evt.Payload["tool"].(string); ok && name != "" {
+				usedTools = append(usedTools, name)
+			}
+		}
+	}
+	r.mu.RUnlock()
+
+	if profileName == "" {
+		return
+	}
+
+	finishedAt := time.Now().UTC()
+	recordID := fmt.Sprintf("%s:%s", profileName, runID)
+
+	stats := profiles.RunStats{
+		RunID:       runID,
+		ProfileName: profileName,
+		Steps:       steps,
+		CostUSD:     costUSD,
+		UsedTools:   usedTools,
+	}
+	completion := profiles.RunCompletionData{
+		RecordID:   recordID,
+		Status:     runStatus,
+		StartedAt:  startedAt,
+		FinishedAt: finishedAt,
+	}
+	rec := profiles.BuildProfileRunRecord(stats, completion)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := r.config.ProfileRunStore.RecordProfileRun(ctx, rec); err != nil {
+		if r.config.Logger != nil {
+			r.config.Logger.Error("failed to persist profile run",
+				"run_id", runID,
+				"profile", profileName,
+				"error", err,
+			)
+		}
+	}
 }
 
 // backupRunToS3 uploads the run's events as JSONL to S3 via the configured
@@ -3447,6 +3514,10 @@ func (r *Runner) failRun(runID string, err error) {
 	r.setStatus(runID, RunStatusFailed, "", err.Error())
 
 	usageTotals, costTotals := r.accountingTotals(runID)
+
+	// Profile run history: persist failure record for analysis.
+	r.persistProfileRun(runID, "failed", costTotals.CostUSDTotal)
+
 	r.emit(runID, EventRunFailed, map[string]any{
 		"error":        err.Error(),
 		"usage_totals": usageTotals,
@@ -3493,6 +3564,10 @@ func (r *Runner) failRunMaxSteps(runID string, maxSteps int) {
 	r.setStatus(runID, RunStatusFailed, "", err.Error())
 
 	usageTotals, costTotals := r.accountingTotals(runID)
+
+	// Profile run history: persist partial record (max steps reached) for analysis.
+	r.persistProfileRun(runID, "partial", costTotals.CostUSDTotal)
+
 	r.emit(runID, EventRunFailed, map[string]any{
 		"error":        err.Error(),
 		"reason":       "max_steps_reached",

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -403,6 +403,12 @@ type RunnerConfig struct {
 	// run state. Store errors are non-fatal: the runner logs them (when Logger
 	// is configured) but continues execution. A nil Store disables persistence.
 	Store               store.Store               `json:"-"`
+	// ProfileRunStore is the optional profile run history store. When set, the
+	// runner persists a ProfileRunRecord for each run that has a non-empty
+	// ProfileName at completion time (both success and failure paths).
+	// Errors are non-fatal: logged but never propagated to the caller.
+	// A nil ProfileRunStore disables profile run history persistence.
+	ProfileRunStore     store.ProfileRunStoreIface `json:"-"`
 	// S3Uploader is the optional S3 backup uploader. When set, the runner
 	// calls UploadRun on each terminal event (run.completed or run.failed) to
 	// stream the run's JSONL events to S3. Errors are non-fatal: the runner

--- a/internal/profiles/efficiency.go
+++ b/internal/profiles/efficiency.go
@@ -2,6 +2,8 @@ package profiles
 
 import (
 	"time"
+
+	"go-agent-harness/internal/store"
 )
 
 // EfficiencyThreshold is the minimum score below which an efficiency suggestion is emitted.
@@ -76,4 +78,73 @@ func BuildEfficiencyReport(stats RunStats) EfficiencyReport {
 // emitted for a run based on its score.
 func ShouldEmitSuggestion(score float64) bool {
 	return score < EfficiencyThreshold
+}
+
+// RunCompletionData holds the additional fields needed beyond RunStats to
+// build a complete ProfileRunRecord for persistence.
+type RunCompletionData struct {
+	// RecordID is a unique identifier for this profile run record (e.g. a UUID).
+	// When empty, callers should generate one before persisting.
+	RecordID   string
+	Status     string // "completed" | "failed" | "partial"
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// BuildProfileRunRecord converts run statistics and completion data into a
+// store.ProfileRunRecord suitable for persistence via store.SQLiteProfileRunStore.
+//
+// TopTools is populated from the top-3 most frequently used tools in
+// stats.UsedTools (preserving first-occurrence order when counts tie).
+// ToolCalls is set to len(stats.UsedTools).
+//
+// This function does NOT call the store; callers are responsible for persisting
+// the returned record via store.SQLiteProfileRunStore.RecordProfileRun.
+func BuildProfileRunRecord(stats RunStats, completion RunCompletionData) store.ProfileRunRecord {
+	// Count tool usage frequency.
+	counts := make(map[string]int, len(stats.UsedTools))
+	order := make([]string, 0, len(stats.UsedTools))
+	for _, t := range stats.UsedTools {
+		if counts[t] == 0 {
+			order = append(order, t)
+		}
+		counts[t]++
+	}
+
+	// Sort by frequency descending, preserving first-occurrence as tiebreaker.
+	topN := 3
+	if len(order) < topN {
+		topN = len(order)
+	}
+	// Simple selection sort for the top-N (small N, O(N²) is fine).
+	top := make([]string, 0, topN)
+	remaining := append([]string(nil), order...)
+	for i := 0; i < topN; i++ {
+		best := 0
+		for j := 1; j < len(remaining); j++ {
+			if counts[remaining[j]] > counts[remaining[best]] {
+				best = j
+			}
+		}
+		top = append(top, remaining[best])
+		remaining = append(remaining[:best], remaining[best+1:]...)
+	}
+
+	status := completion.Status
+	if status == "" {
+		status = "completed"
+	}
+
+	return store.ProfileRunRecord{
+		ID:          completion.RecordID,
+		ProfileName: stats.ProfileName,
+		RunID:       stats.RunID,
+		Status:      status,
+		StepCount:   stats.Steps,
+		CostUSD:     stats.CostUSD,
+		StartedAt:   completion.StartedAt,
+		FinishedAt:  completion.FinishedAt,
+		ToolCalls:   len(stats.UsedTools),
+		TopTools:    top,
+	}
 }

--- a/internal/profiles/efficiency_test.go
+++ b/internal/profiles/efficiency_test.go
@@ -2,6 +2,7 @@ package profiles
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -91,4 +92,69 @@ func TestBuildEfficiencyReportEmptyAllowedTools(t *testing.T) {
 
 	report := BuildEfficiencyReport(stats)
 	assert.Empty(t, report.UnusedTools)
+}
+
+func TestBuildProfileRunRecord(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	stats := RunStats{
+		RunID:       "run-xyz",
+		ProfileName: "researcher",
+		Steps:       7,
+		CostUSD:     0.03,
+		UsedTools:   []string{"read", "grep", "read", "glob", "read", "grep", "bash"},
+	}
+	completion := RunCompletionData{
+		RecordID:   "rec-1",
+		Status:     "completed",
+		StartedAt:  now,
+		FinishedAt: now.Add(20 * time.Second),
+	}
+
+	rec := BuildProfileRunRecord(stats, completion)
+
+	assert.Equal(t, "rec-1", rec.ID)
+	assert.Equal(t, "researcher", rec.ProfileName)
+	assert.Equal(t, "run-xyz", rec.RunID)
+	assert.Equal(t, "completed", rec.Status)
+	assert.Equal(t, 7, rec.StepCount)
+	assert.InDelta(t, 0.03, rec.CostUSD, 0.0001)
+	assert.Equal(t, now, rec.StartedAt)
+	assert.Equal(t, now.Add(20*time.Second), rec.FinishedAt)
+	// ToolCalls = len(UsedTools) = 7
+	assert.Equal(t, 7, rec.ToolCalls)
+	// Top 3 by frequency: read(3), grep(2), then glob or bash(1) — order of first occurrence
+	assert.Len(t, rec.TopTools, 3)
+	assert.Equal(t, "read", rec.TopTools[0])
+	assert.Equal(t, "grep", rec.TopTools[1])
+}
+
+func TestBuildProfileRunRecordEmptyUsedTools(t *testing.T) {
+	now := time.Now().UTC()
+	stats := RunStats{
+		RunID:       "run-empty",
+		ProfileName: "coder",
+		Steps:       2,
+		CostUSD:     0.001,
+		UsedTools:   nil,
+	}
+	completion := RunCompletionData{
+		RecordID:   "rec-empty",
+		Status:     "failed",
+		StartedAt:  now,
+		FinishedAt: now.Add(5 * time.Second),
+	}
+
+	rec := BuildProfileRunRecord(stats, completion)
+	assert.Equal(t, 0, rec.ToolCalls)
+	assert.Empty(t, rec.TopTools)
+	assert.Equal(t, "failed", rec.Status)
+}
+
+func TestBuildProfileRunRecordDefaultStatus(t *testing.T) {
+	// When Status is empty, it defaults to "completed".
+	now := time.Now().UTC()
+	stats := RunStats{RunID: "r1", ProfileName: "p", Steps: 1, CostUSD: 0}
+	completion := RunCompletionData{RecordID: "id", StartedAt: now, FinishedAt: now}
+	rec := BuildProfileRunRecord(stats, completion)
+	assert.Equal(t, "completed", rec.Status)
 }

--- a/internal/store/profile_run_store.go
+++ b/internal/store/profile_run_store.go
@@ -1,0 +1,238 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// profileRunsSchema defines the profile_runs table.
+const profileRunsSchema = `
+CREATE TABLE IF NOT EXISTS profile_runs (
+	id           TEXT PRIMARY KEY,
+	profile_name TEXT NOT NULL,
+	run_id       TEXT NOT NULL,
+	status       TEXT NOT NULL,
+	step_count   INTEGER NOT NULL DEFAULT 0,
+	cost_usd     REAL NOT NULL DEFAULT 0.0,
+	started_at   TEXT NOT NULL,
+	finished_at  TEXT NOT NULL,
+	tool_calls   INTEGER NOT NULL DEFAULT 0,
+	top_tools    TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX IF NOT EXISTS idx_profile_runs_profile    ON profile_runs(profile_name);
+CREATE INDEX IF NOT EXISTS idx_profile_runs_started    ON profile_runs(profile_name, started_at DESC);
+`
+
+// ProfileRunStoreIface is the interface used by the runner for profile run
+// persistence. SQLiteProfileRunStore implements this interface.
+type ProfileRunStoreIface interface {
+	RecordProfileRun(ctx context.Context, r ProfileRunRecord) error
+	QueryRecentProfileRuns(ctx context.Context, profileName string, limit int) ([]ProfileRunRecord, error)
+	AggregateProfileStats(ctx context.Context, profileName string) (ProfileStats, error)
+}
+
+// ProfileRunRecord holds one persisted profile run entry.
+type ProfileRunRecord struct {
+	ID          string
+	ProfileName string
+	RunID       string
+	// Status is "completed", "failed", or "partial".
+	Status     string
+	StepCount  int
+	CostUSD    float64
+	StartedAt  time.Time
+	FinishedAt time.Time
+	ToolCalls  int
+	TopTools   []string // top-3 tool names (JSON-encoded in the database)
+}
+
+// ProfileStats holds aggregate statistics for a profile.
+type ProfileStats struct {
+	ProfileName string
+	RunCount    int
+	AvgSteps    float64
+	AvgCostUSD  float64
+	SuccessRate float64
+	LastRunAt   time.Time
+}
+
+// SQLiteProfileRunStore persists per-profile run history in a SQLite database.
+// It is a separate database from the main run store to avoid coupling.
+type SQLiteProfileRunStore struct {
+	db *sql.DB
+}
+
+// NewSQLiteProfileRunStore opens (or creates) a SQLite database at path and
+// applies the profile_runs schema. The database is ready to use immediately.
+func NewSQLiteProfileRunStore(path string) (*SQLiteProfileRunStore, error) {
+	if path == "" {
+		return nil, fmt.Errorf("store: profile run store path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("store: create profile run store directory: %w", err)
+	}
+	dsn := path + "?_txlock=immediate"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("store: open profile run store: %w", err)
+	}
+	// Single writer to avoid SQLITE_BUSY.
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("store: profile run store set WAL: %w", err)
+	}
+	if _, err := db.Exec(`PRAGMA busy_timeout=5000;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("store: profile run store busy timeout: %w", err)
+	}
+	if _, err := db.Exec(profileRunsSchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("store: profile run store migrate: %w", err)
+	}
+	return &SQLiteProfileRunStore{db: db}, nil
+}
+
+// Close releases the database connection.
+func (s *SQLiteProfileRunStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// RecordProfileRun persists a completed profile run record.
+// If a record with the same ID already exists the call is a no-op (idempotent).
+func (s *SQLiteProfileRunStore) RecordProfileRun(ctx context.Context, r ProfileRunRecord) error {
+	topToolsJSON, err := json.Marshal(r.TopTools)
+	if err != nil {
+		return fmt.Errorf("store: marshal top_tools: %w", err)
+	}
+	_, execErr := s.db.ExecContext(ctx, `
+INSERT OR IGNORE INTO profile_runs
+	(id, profile_name, run_id, status, step_count, cost_usd, started_at, finished_at, tool_calls, top_tools)
+VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`,
+		r.ID,
+		r.ProfileName,
+		r.RunID,
+		r.Status,
+		r.StepCount,
+		r.CostUSD,
+		timeString(r.StartedAt),
+		timeString(r.FinishedAt),
+		r.ToolCalls,
+		string(topToolsJSON),
+	)
+	if execErr != nil {
+		return fmt.Errorf("store: record profile run: %w", execErr)
+	}
+	return nil
+}
+
+// QueryRecentProfileRuns returns the most recent `limit` runs for a profile,
+// ordered by started_at DESC. Returns an empty slice (not an error) when there
+// is no history for the given profile name.
+func (s *SQLiteProfileRunStore) QueryRecentProfileRuns(ctx context.Context, profileName string, limit int) ([]ProfileRunRecord, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, profile_name, run_id, status, step_count, cost_usd,
+       started_at, finished_at, tool_calls, top_tools
+FROM profile_runs
+WHERE profile_name = ?
+ORDER BY started_at DESC
+LIMIT ?
+`, profileName, limit)
+	if err != nil {
+		return nil, fmt.Errorf("store: query recent profile runs: %w", err)
+	}
+	defer rows.Close()
+
+	var records []ProfileRunRecord
+	for rows.Next() {
+		var rec ProfileRunRecord
+		var startedText, finishedText, topToolsJSON string
+		if err := rows.Scan(
+			&rec.ID,
+			&rec.ProfileName,
+			&rec.RunID,
+			&rec.Status,
+			&rec.StepCount,
+			&rec.CostUSD,
+			&startedText,
+			&finishedText,
+			&rec.ToolCalls,
+			&topToolsJSON,
+		); err != nil {
+			return nil, fmt.Errorf("store: scan profile run: %w", err)
+		}
+		if t, err := time.Parse(time.RFC3339Nano, startedText); err == nil {
+			rec.StartedAt = t
+		}
+		if t, err := time.Parse(time.RFC3339Nano, finishedText); err == nil {
+			rec.FinishedAt = t
+		}
+		if topToolsJSON != "" && topToolsJSON != "null" {
+			_ = json.Unmarshal([]byte(topToolsJSON), &rec.TopTools)
+		}
+		if rec.TopTools == nil {
+			rec.TopTools = []string{}
+		}
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("store: profile runs rows: %w", err)
+	}
+	if records == nil {
+		records = []ProfileRunRecord{}
+	}
+	return records, nil
+}
+
+// AggregateProfileStats returns aggregate statistics for a profile.
+// When there is no history for the profile, it returns a zero-value
+// ProfileStats (RunCount=0) without an error.
+func (s *SQLiteProfileRunStore) AggregateProfileStats(ctx context.Context, profileName string) (ProfileStats, error) {
+	row := s.db.QueryRowContext(ctx, `
+SELECT
+	COUNT(*)                                              AS run_count,
+	COALESCE(AVG(step_count), 0.0)                        AS avg_steps,
+	COALESCE(AVG(cost_usd), 0.0)                          AS avg_cost_usd,
+	COALESCE(
+		CAST(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS REAL)
+		/ NULLIF(COUNT(*), 0),
+		0.0
+	)                                                     AS success_rate,
+	COALESCE(MAX(started_at), '')                         AS last_run_at
+FROM profile_runs
+WHERE profile_name = ?
+`, profileName)
+
+	var stats ProfileStats
+	stats.ProfileName = profileName
+
+	var lastRunText string
+	if err := row.Scan(
+		&stats.RunCount,
+		&stats.AvgSteps,
+		&stats.AvgCostUSD,
+		&stats.SuccessRate,
+		&lastRunText,
+	); err != nil {
+		return ProfileStats{}, fmt.Errorf("store: aggregate profile stats: %w", err)
+	}
+	if lastRunText != "" {
+		if t, err := time.Parse(time.RFC3339Nano, lastRunText); err == nil {
+			stats.LastRunAt = t
+		}
+	}
+	return stats, nil
+}

--- a/internal/store/profile_runs_test.go
+++ b/internal/store/profile_runs_test.go
@@ -1,0 +1,204 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/store"
+)
+
+// newProfileRunsDB creates a fresh SQLiteProfileRunStore for testing.
+func newProfileRunsDB(t *testing.T) *store.SQLiteProfileRunStore {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "profile_runs_test.db")
+	s, err := store.NewSQLiteProfileRunStore(dbPath)
+	require.NoError(t, err, "NewSQLiteProfileRunStore")
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func TestProfileRunStore_RecordRun(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	rec := store.ProfileRunRecord{
+		ID:          "pr-1",
+		ProfileName: "researcher",
+		RunID:       "run-abc",
+		Status:      "completed",
+		StepCount:   10,
+		CostUSD:     0.05,
+		StartedAt:   now,
+		FinishedAt:  now.Add(30 * time.Second),
+		ToolCalls:   5,
+		TopTools:    []string{"read", "grep", "glob"},
+	}
+
+	err := s.RecordProfileRun(ctx, rec)
+	require.NoError(t, err, "RecordProfileRun should not return error")
+
+	// Read it back via QueryRecentProfileRuns.
+	runs, err := s.QueryRecentProfileRuns(ctx, "researcher", 10)
+	require.NoError(t, err, "QueryRecentProfileRuns should not return error")
+	require.Len(t, runs, 1, "should have exactly one run")
+
+	got := runs[0]
+	assert.Equal(t, "pr-1", got.ID)
+	assert.Equal(t, "researcher", got.ProfileName)
+	assert.Equal(t, "run-abc", got.RunID)
+	assert.Equal(t, "completed", got.Status)
+	assert.Equal(t, 10, got.StepCount)
+	assert.InDelta(t, 0.05, got.CostUSD, 0.0001)
+	assert.Equal(t, now, got.StartedAt)
+	assert.Equal(t, now.Add(30*time.Second), got.FinishedAt)
+	assert.Equal(t, 5, got.ToolCalls)
+	assert.Equal(t, []string{"read", "grep", "glob"}, got.TopTools)
+}
+
+func TestProfileRunStore_QueryRecentRuns(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+
+	// Insert 5 runs for "researcher".
+	for i := 0; i < 5; i++ {
+		rec := store.ProfileRunRecord{
+			ID:          fmt.Sprintf("pr-%d", i),
+			ProfileName: "researcher",
+			RunID:       fmt.Sprintf("run-%d", i),
+			Status:      "completed",
+			StepCount:   i + 1,
+			CostUSD:     float64(i) * 0.01,
+			StartedAt:   base.Add(time.Duration(i) * time.Minute),
+			FinishedAt:  base.Add(time.Duration(i)*time.Minute + 30*time.Second),
+			ToolCalls:   i,
+			TopTools:    []string{"read"},
+		}
+		require.NoError(t, s.RecordProfileRun(ctx, rec))
+	}
+
+	// Query with limit=3 — should return the 3 most recent.
+	runs, err := s.QueryRecentProfileRuns(ctx, "researcher", 3)
+	require.NoError(t, err)
+	assert.Len(t, runs, 3, "limit=3 should return exactly 3 runs")
+
+	// Verify they are ordered by started_at DESC (most recent first).
+	assert.True(t, runs[0].StartedAt.After(runs[1].StartedAt) || runs[0].StartedAt.Equal(runs[1].StartedAt),
+		"results should be ordered newest first")
+}
+
+func TestProfileRunStore_AggregateStats(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+
+	runs := []store.ProfileRunRecord{
+		{ID: "a1", ProfileName: "coder", RunID: "r1", Status: "completed", StepCount: 4, CostUSD: 0.04, StartedAt: base, FinishedAt: base.Add(time.Second), ToolCalls: 2},
+		{ID: "a2", ProfileName: "coder", RunID: "r2", Status: "completed", StepCount: 6, CostUSD: 0.06, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(time.Minute + time.Second), ToolCalls: 3},
+		{ID: "a3", ProfileName: "coder", RunID: "r3", Status: "failed", StepCount: 2, CostUSD: 0.02, StartedAt: base.Add(2 * time.Minute), FinishedAt: base.Add(2*time.Minute + time.Second), ToolCalls: 1},
+	}
+	for _, rec := range runs {
+		require.NoError(t, s.RecordProfileRun(ctx, rec))
+	}
+
+	stats, err := s.AggregateProfileStats(ctx, "coder")
+	require.NoError(t, err)
+
+	assert.Equal(t, "coder", stats.ProfileName)
+	assert.Equal(t, 3, stats.RunCount)
+	assert.InDelta(t, 4.0, stats.AvgSteps, 0.01, "avg steps: (4+6+2)/3=4")
+	assert.InDelta(t, 0.04, stats.AvgCostUSD, 0.001, "avg cost: (0.04+0.06+0.02)/3=0.04")
+	// 2 of 3 runs completed => success rate = 2/3 ≈ 0.667
+	assert.InDelta(t, 2.0/3.0, stats.SuccessRate, 0.01)
+	assert.False(t, stats.LastRunAt.IsZero(), "LastRunAt should be set")
+}
+
+func TestProfileRunStore_EmptyHistory(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	// No runs recorded yet — should return empty slice, not error.
+	runs, err := s.QueryRecentProfileRuns(ctx, "no-such-profile", 10)
+	require.NoError(t, err, "empty history should not error")
+	assert.Empty(t, runs, "empty history should return empty slice")
+}
+
+func TestProfileRunStore_EmptyHistoryAggregateStats(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	// AggregateProfileStats for a profile with no history.
+	stats, err := s.AggregateProfileStats(ctx, "no-such-profile")
+	require.NoError(t, err, "aggregate with no history should not error")
+	assert.Equal(t, "no-such-profile", stats.ProfileName)
+	assert.Equal(t, 0, stats.RunCount)
+	assert.InDelta(t, 0.0, stats.AvgSteps, 0.001)
+	assert.InDelta(t, 0.0, stats.AvgCostUSD, 0.001)
+	assert.InDelta(t, 0.0, stats.SuccessRate, 0.001)
+}
+
+func TestProfileRunStore_MultipleProfiles(t *testing.T) {
+	s := newProfileRunsDB(t)
+	ctx := context.Background()
+
+	base := time.Now().UTC().Truncate(time.Second)
+
+	// Insert runs for two different profiles.
+	for i := 0; i < 3; i++ {
+		require.NoError(t, s.RecordProfileRun(ctx, store.ProfileRunRecord{
+			ID:          fmt.Sprintf("alpha-%d", i),
+			ProfileName: "alpha",
+			RunID:       fmt.Sprintf("run-alpha-%d", i),
+			Status:      "completed",
+			StepCount:   5,
+			CostUSD:     0.05,
+			StartedAt:   base,
+			FinishedAt:  base.Add(time.Second),
+		}))
+		require.NoError(t, s.RecordProfileRun(ctx, store.ProfileRunRecord{
+			ID:          fmt.Sprintf("beta-%d", i),
+			ProfileName: "beta",
+			RunID:       fmt.Sprintf("run-beta-%d", i),
+			Status:      "completed",
+			StepCount:   3,
+			CostUSD:     0.03,
+			StartedAt:   base,
+			FinishedAt:  base.Add(time.Second),
+		}))
+	}
+
+	// Querying "alpha" should only return alpha's runs.
+	alphaRuns, err := s.QueryRecentProfileRuns(ctx, "alpha", 100)
+	require.NoError(t, err)
+	assert.Len(t, alphaRuns, 3, "alpha should have 3 runs")
+	for _, r := range alphaRuns {
+		assert.Equal(t, "alpha", r.ProfileName, "all runs should belong to alpha")
+	}
+
+	// Querying "beta" should only return beta's runs.
+	betaRuns, err := s.QueryRecentProfileRuns(ctx, "beta", 100)
+	require.NoError(t, err)
+	assert.Len(t, betaRuns, 3, "beta should have 3 runs")
+	for _, r := range betaRuns {
+		assert.Equal(t, "beta", r.ProfileName, "all runs should belong to beta")
+	}
+
+	// Stats for each profile should be independent.
+	alphaStats, err := s.AggregateProfileStats(ctx, "alpha")
+	require.NoError(t, err)
+	assert.Equal(t, 3, alphaStats.RunCount)
+
+	betaStats, err := s.AggregateProfileStats(ctx, "beta")
+	require.NoError(t, err)
+	assert.Equal(t, 3, betaStats.RunCount)
+}


### PR DESCRIPTION
## Summary

Adds a `profile_runs` SQLite table to persist per-profile run history (status, step count, cost, timestamps, top tools). Wires recording into the runner's completion hooks. Adds query helpers for recent history and rollup stats.

## Schema

```sql
CREATE TABLE IF NOT EXISTS profile_runs (
    id           TEXT PRIMARY KEY,
    profile_name TEXT NOT NULL,
    run_id       TEXT NOT NULL,
    status       TEXT NOT NULL,        -- "completed"|"failed"|"partial"
    step_count   INTEGER NOT NULL DEFAULT 0,
    cost_usd     REAL NOT NULL DEFAULT 0.0,
    started_at   TEXT NOT NULL,
    finished_at  TEXT NOT NULL,
    tool_calls   INTEGER NOT NULL DEFAULT 0,
    top_tools    TEXT NOT NULL DEFAULT '[]'
)
```

## Changes

- `internal/store/profile_run_store.go` — `RecordProfileRun`, `QueryRecentProfileRuns`, `AggregateProfileStats`
- `internal/store/profile_runs_test.go` — 6 tests
- `internal/harness/runner.go` — `persistProfileRun()` wired into `completeRun`/`failRun`/`failRunMaxSteps`
- `internal/harness/types.go` — `ProfileRunStore` field in `RunnerConfig`
- `internal/profiles/efficiency.go` — `ProfileRunRecord` type + `BuildProfileRunRecord()` bridge
- `internal/profiles/efficiency_test.go` — 3 tests

## Design

- Separate SQLite DB (not the main store) to avoid coupling
- `INSERT OR IGNORE` — idempotent, safe to retry
- Persistence errors are non-fatal (logged, never block run completion)

## Test plan

- [x] TDD: failing tests first
- [x] 9 new tests pass (round-trip, recent query, aggregate stats, empty history, multi-profile isolation)
- [x] Full `./internal/... ./cmd/...` with `-race` passes

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)