### PR TITLE
feat(#391): add profile selection and inspection to CLI and TUI

### DIFF
--- a/cmd/harnesscli/list_profiles_test.go
+++ b/cmd/harnesscli/list_profiles_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestListProfiles_Success verifies listProfilesCmd prints profiles and returns 0.
+func TestListProfiles_Success(t *testing.T) {
+	profiles := []map[string]any{
+		{
+			"name":        "alpha",
+			"description": "Alpha profile",
+			"model":       "gpt-4",
+		},
+		{
+			"name":        "beta",
+			"description": "Beta profile",
+			"model":       "claude-opus-4-6",
+		},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/profiles" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"profiles": profiles,
+			"count":    len(profiles),
+		})
+	}))
+	defer ts.Close()
+
+	var out strings.Builder
+	origStdout := stdout
+	stdout = &out
+	defer func() { stdout = origStdout }()
+
+	code := listProfilesCmd(requestHTTPClient, ts.URL)
+	if code != 0 {
+		t.Errorf("expected exit code 0; got %d\noutput: %s", code, out.String())
+	}
+	output := out.String()
+	if !strings.Contains(output, "alpha") {
+		t.Errorf("output should contain profile name 'alpha'; got:\n%s", output)
+	}
+	if !strings.Contains(output, "beta") {
+		t.Errorf("output should contain profile name 'beta'; got:\n%s", output)
+	}
+	if !strings.Contains(output, "gpt-4") {
+		t.Errorf("output should contain model 'gpt-4'; got:\n%s", output)
+	}
+}
+
+// TestListProfiles_EmptyList returns 0 and shows no-profiles message.
+func TestListProfiles_EmptyList(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []any{},
+			"count":    0,
+		})
+	}))
+	defer ts.Close()
+
+	var out strings.Builder
+	origStdout := stdout
+	stdout = &out
+	defer func() { stdout = origStdout }()
+
+	code := listProfilesCmd(requestHTTPClient, ts.URL)
+	if code != 0 {
+		t.Errorf("expected exit code 0; got %d", code)
+	}
+	output := out.String()
+	if !strings.Contains(output, "No profiles") {
+		t.Errorf("output should mention 'No profiles'; got:\n%s", output)
+	}
+}
+
+// TestListProfiles_ServerError returns exit code 1 on non-200 response.
+func TestListProfiles_ServerError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":"internal_error","message":"server error"}}`))
+	}))
+	defer ts.Close()
+
+	var out strings.Builder
+	origStderr := stderr
+	stderr = &out
+	defer func() { stderr = origStderr }()
+
+	code := listProfilesCmd(requestHTTPClient, ts.URL)
+	if code != 1 {
+		t.Errorf("expected exit code 1 on server error; got %d", code)
+	}
+}
+
+// TestListProfiles_NetworkError returns exit code 1 when server is unreachable.
+func TestListProfiles_NetworkError(t *testing.T) {
+	var errOut strings.Builder
+	origStderr := stderr
+	stderr = &errOut
+	defer func() { stderr = origStderr }()
+
+	// Use an invalid URL to force a network error.
+	code := listProfilesCmd(requestHTTPClient, "http://localhost:0")
+	if code != 1 {
+		t.Errorf("expected exit code 1 on network error; got %d", code)
+	}
+}
+
+// TestListProfiles_OutputFormat verifies that output is sorted by name.
+func TestListProfiles_OutputFormat(t *testing.T) {
+	profiles := []map[string]any{
+		{"name": "zebra", "description": "Zebra", "model": "gpt-4"},
+		{"name": "apple", "description": "Apple", "model": "gpt-4"},
+		{"name": "mango", "description": "Mango", "model": "gpt-4"},
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"profiles": profiles,
+			"count":    len(profiles),
+		})
+	}))
+	defer ts.Close()
+
+	var out strings.Builder
+	origStdout := stdout
+	stdout = &out
+	defer func() { stdout = origStdout }()
+
+	code := listProfilesCmd(requestHTTPClient, ts.URL)
+	if code != 0 {
+		t.Errorf("expected exit code 0; got %d", code)
+	}
+	output := out.String()
+
+	// Verify sorted order: apple < mango < zebra.
+	applePos := strings.Index(output, "apple")
+	mangoPos := strings.Index(output, "mango")
+	zebraPos := strings.Index(output, "zebra")
+	if applePos < 0 || mangoPos < 0 || zebraPos < 0 {
+		t.Fatalf("output missing expected names:\n%s", output)
+	}
+	if !(applePos < mangoPos && mangoPos < zebraPos) {
+		t.Errorf("output not sorted: apple=%d mango=%d zebra=%d\n%s", applePos, mangoPos, zebraPos, output)
+	}
+}

--- a/cmd/harnesscli/main.go
+++ b/cmd/harnesscli/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -130,6 +131,7 @@ func run(args []string) int {
 	promptProfile := flags.String("prompt-profile", "", "prompt profile override for model routing")
 	promptCustom := flags.String("prompt-custom", "", "custom prompt extension text")
 	enableTUI := flags.Bool("tui", false, "launch interactive BubbleTea TUI (experimental)")
+	listProfiles := flags.Bool("list-profiles", false, "list available profiles and exit")
 	var behaviorFlags csvListFlag
 	var talentFlags csvListFlag
 	flags.Var(&behaviorFlags, "prompt-behavior", "behavior extension ids (repeatable or comma-separated)")
@@ -138,6 +140,10 @@ func run(args []string) int {
 	if err := flags.Parse(args); err != nil {
 		fmt.Fprintf(stderr, "harnesscli: parse failed: %v\n", err)
 		return 1
+	}
+
+	if *listProfiles {
+		return listProfilesCmd(requestHTTPClient, *baseURL)
 	}
 
 	if *enableTUI {
@@ -360,6 +366,81 @@ func runTUI(baseURL string) error {
 	)
 	_, err := p.Run()
 	return err
+}
+
+// profileListResponse is the JSON shape returned by GET /v1/profiles.
+type profileListResponse struct {
+	Profiles []profileSummary `json:"profiles"`
+	Count    int              `json:"count"`
+}
+
+// profileSummary is a single entry from the profiles list response.
+type profileSummary struct {
+	Name             string `json:"name"`
+	Description      string `json:"description"`
+	Model            string `json:"model"`
+	AllowedToolCount int    `json:"allowed_tool_count"`
+	SourceTier       string `json:"source_tier"`
+}
+
+// listProfilesCmd fetches GET /v1/profiles and prints each profile.
+// Returns 0 on success, 1 on error.
+func listProfilesCmd(client *http.Client, baseURL string) int {
+	url := strings.TrimRight(baseURL, "/") + "/v1/profiles"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli: list-profiles: build request: %v\n", err)
+		return 1
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli: list-profiles: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli: list-profiles: read response: %v\n", err)
+		return 1
+	}
+
+	if resp.StatusCode >= 300 {
+		fmt.Fprintf(stderr, "harnesscli: list-profiles: %v\n", formatAPIError(resp.StatusCode, body))
+		return 1
+	}
+
+	var plr profileListResponse
+	if err := json.Unmarshal(body, &plr); err != nil {
+		fmt.Fprintf(stderr, "harnesscli: list-profiles: decode response: %v\n", err)
+		return 1
+	}
+
+	if len(plr.Profiles) == 0 {
+		fmt.Fprintln(stdout, "No profiles available")
+		return 0
+	}
+
+	// Sort profiles by name for deterministic output.
+	profiles := make([]profileSummary, len(plr.Profiles))
+	copy(profiles, plr.Profiles)
+	sort.Slice(profiles, func(i, j int) bool {
+		return profiles[i].Name < profiles[j].Name
+	})
+
+	for _, p := range profiles {
+		desc := p.Description
+		if desc == "" {
+			desc = "(no description)"
+		}
+		model := p.Model
+		if model == "" {
+			model = "(default)"
+		}
+		fmt.Fprintf(stdout, "Name: %-30s | Description: %-40s | Model: %s\n", p.Name, desc, model)
+	}
+	return 0
 }
 
 func formatAPIError(statusCode int, responseBody []byte) error {

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -20,6 +20,7 @@ type runCreateRequest struct {
 	Model           string `json:"model,omitempty"`
 	ProviderName    string `json:"provider_name,omitempty"`
 	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	PromptProfile   string `json:"prompt_profile,omitempty"`
 }
 
 type runCreateResponse struct {
@@ -45,7 +46,8 @@ type RemoteSubagent struct {
 // conversationID may be empty for the first message in a new conversation;
 // subsequent messages should pass the run ID returned by the first run so that
 // the harness groups them under the same conversation.
-func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort string) tea.Cmd {
+// profile is the name of the prompt profile to use (may be empty).
+func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile string) tea.Cmd {
 	return func() tea.Msg {
 		body, _ := json.Marshal(runCreateRequest{
 			Prompt:          prompt,
@@ -53,6 +55,7 @@ func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffo
 			Model:           model,
 			ProviderName:    provider,
 			ReasoningEffort: reasoningEffort,
+			PromptProfile:   profile,
 		})
 		url := strings.TrimRight(baseURL, "/") + "/v1/runs"
 		resp, err := http.Post(url, "application/json", bytes.NewReader(body))
@@ -241,6 +244,49 @@ func setProviderKeyCmd(baseURL, provider, apiKey string) tea.Cmd {
 			return APIKeySetMsg{Provider: provider, Key: apiKey}
 		}
 		return ProvidersLoadedMsg{}
+	}
+}
+
+// profilesListResponse matches the JSON body returned by GET /v1/profiles.
+type profilesListResponse struct {
+	Profiles []struct {
+		Name             string `json:"name"`
+		Description      string `json:"description"`
+		Model            string `json:"model"`
+		AllowedToolCount int    `json:"allowed_tool_count"`
+		SourceTier       string `json:"source_tier"`
+	} `json:"profiles"`
+	Count int `json:"count"`
+}
+
+// loadProfilesCmd fetches profile list from GET /v1/profiles.
+// On success it emits ProfilesLoadedMsg; on failure it emits ProfilesLoadedMsg with Err set.
+func loadProfilesCmd(baseURL string) tea.Cmd {
+	return func() tea.Msg {
+		url := strings.TrimRight(baseURL, "/") + "/v1/profiles"
+		resp, err := http.Get(url) //nolint:noctx
+		if err != nil {
+			return ProfilesLoadedMsg{Err: err}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return ProfilesLoadedMsg{Err: fmt.Errorf("server returned %d", resp.StatusCode)}
+		}
+		var plr profilesListResponse
+		if err := json.NewDecoder(resp.Body).Decode(&plr); err != nil {
+			return ProfilesLoadedMsg{Err: err}
+		}
+		entries := make([]ProfileEntry, len(plr.Profiles))
+		for i, p := range plr.Profiles {
+			entries[i] = ProfileEntry{
+				Name:        p.Name,
+				Description: p.Description,
+				Model:       p.Model,
+				ToolCount:   p.AllowedToolCount,
+				SourceTier:  p.SourceTier,
+			}
+		}
+		return ProfilesLoadedMsg{Entries: entries}
 	}
 }
 

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -150,6 +150,14 @@ func builtinCommandEntries() []CommandEntry {
 			},
 			Execute: executeSubagentsCommand,
 		},
+		{
+			Name:        "profiles",
+			Description: "View and select a profile for next run",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeProfilesCommand,
+		},
 	}
 }
 

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
 		"clear", "context", "export", "help", "keys",
-		"model", "quit", "stats", "subagents",
+		"model", "profiles", "quit", "stats", "subagents",
 	}
 
 	r := tui.NewCommandRegistry()

--- a/cmd/harnesscli/tui/components/profilepicker/messages.go
+++ b/cmd/harnesscli/tui/components/profilepicker/messages.go
@@ -1,0 +1,6 @@
+package profilepicker
+
+// ProfileSelectedMsg is emitted when the user presses Enter on a profile entry.
+type ProfileSelectedMsg struct {
+	Entry ProfileEntry
+}

--- a/cmd/harnesscli/tui/components/profilepicker/model.go
+++ b/cmd/harnesscli/tui/components/profilepicker/model.go
@@ -1,0 +1,157 @@
+package profilepicker
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const maxVisibleRows = 10
+
+// ProfileEntry holds display data for a single profile.
+type ProfileEntry struct {
+	Name        string // profile name
+	Description string // short description
+	Model       string // LLM model used
+	ToolCount   int    // number of allowed tools
+	SourceTier  string // "project" | "user" | "built-in"
+}
+
+// Model is the profile picker list state machine.
+// All methods return a new Model (value semantics — safe for concurrent use
+// when each goroutine holds its own copy).
+type Model struct {
+	entries      []ProfileEntry
+	selected     int
+	scrollOffset int
+	open         bool
+	Width        int
+	Height       int
+}
+
+// New creates a new Model seeded with the given entries.
+// The model starts closed.
+func New(entries []ProfileEntry) Model {
+	cp := make([]ProfileEntry, len(entries))
+	copy(cp, entries)
+	return Model{
+		entries: cp,
+	}
+}
+
+// Open opens the profile picker overlay.
+func (m Model) Open() Model {
+	m.open = true
+	return m
+}
+
+// Close closes the profile picker overlay.
+func (m Model) Close() Model {
+	m.open = false
+	return m
+}
+
+// IsOpen reports whether the profile picker is currently visible.
+func (m Model) IsOpen() bool {
+	return m.open
+}
+
+// SetEntries replaces the entries list and resets selection and scroll.
+func (m Model) SetEntries(entries []ProfileEntry) Model {
+	cp := make([]ProfileEntry, len(entries))
+	copy(cp, entries)
+	m.entries = cp
+	m.selected = 0
+	m.scrollOffset = 0
+	return m
+}
+
+// SelectUp moves the selection up by one, wrapping to the last entry.
+func (m Model) SelectUp() Model {
+	if len(m.entries) == 0 {
+		return m
+	}
+	m.selected = (m.selected - 1 + len(m.entries)) % len(m.entries)
+	m.scrollOffset = adjustScroll(m.scrollOffset, m.selected, len(m.entries), maxVisibleRows)
+	return m
+}
+
+// SelectDown moves the selection down by one, wrapping to the first entry.
+func (m Model) SelectDown() Model {
+	if len(m.entries) == 0 {
+		return m
+	}
+	m.selected = (m.selected + 1) % len(m.entries)
+	m.scrollOffset = adjustScroll(m.scrollOffset, m.selected, len(m.entries), maxVisibleRows)
+	return m
+}
+
+// Selected returns the currently selected entry.
+// Returns (zero, false) when the entries list is empty.
+func (m Model) Selected() (ProfileEntry, bool) {
+	if len(m.entries) == 0 {
+		return ProfileEntry{}, false
+	}
+	return m.entries[m.selected], true
+}
+
+// Update processes a tea.Msg and returns the updated Model plus any commands.
+// Key bindings:
+//   - Up / 'k' → SelectUp
+//   - Down / 'j' → SelectDown
+//   - Enter → emit ProfileSelectedMsg
+//   - Escape → Close
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.open {
+		return m, nil
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Type == tea.KeyUp || (key.Type == tea.KeyRunes && string(key.Runes) == "k"):
+		return m.SelectUp(), nil
+
+	case key.Type == tea.KeyDown || (key.Type == tea.KeyRunes && string(key.Runes) == "j"):
+		return m.SelectDown(), nil
+
+	case key.Type == tea.KeyEnter:
+		entry, ok := m.Selected()
+		if !ok {
+			return m, nil
+		}
+		return m, func() tea.Msg {
+			return ProfileSelectedMsg{Entry: entry}
+		}
+
+	case key.Type == tea.KeyEsc:
+		return m.Close(), nil
+	}
+
+	return m, nil
+}
+
+// adjustScroll ensures the selected index is visible within the scroll window.
+func adjustScroll(offset, selected, total, maxVisible int) int {
+	if total <= maxVisible {
+		return 0
+	}
+	// Scroll down if selected is below visible window.
+	if selected >= offset+maxVisible {
+		offset = selected - maxVisible + 1
+	}
+	// Scroll up if selected is above visible window.
+	if selected < offset {
+		offset = selected
+	}
+	// Clamp offset.
+	maxOffset := total - maxVisible
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return offset
+}

--- a/cmd/harnesscli/tui/components/profilepicker/model_test.go
+++ b/cmd/harnesscli/tui/components/profilepicker/model_test.go
@@ -1,0 +1,299 @@
+package profilepicker_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/profilepicker"
+)
+
+var testEntries = []profilepicker.ProfileEntry{
+	{Name: "alpha", Description: "Alpha profile", Model: "gpt-4", ToolCount: 5, SourceTier: "project"},
+	{Name: "beta", Description: "Beta profile", Model: "claude-opus-4-6", ToolCount: 10, SourceTier: "built-in"},
+	{Name: "gamma", Description: "Gamma profile", Model: "gpt-4o", ToolCount: 3, SourceTier: "user"},
+}
+
+// TestNew verifies that New creates a model with the given entries and closed state.
+func TestNew(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	if m.IsOpen() {
+		t.Error("New model should start closed")
+	}
+	_, ok := m.Selected()
+	if !ok {
+		t.Error("New model with entries should return Selected() ok=true")
+	}
+}
+
+// TestNew_Empty verifies that New with empty entries works and Selected returns false.
+func TestNew_Empty(t *testing.T) {
+	m := profilepicker.New(nil)
+	if m.IsOpen() {
+		t.Error("New model should start closed")
+	}
+	_, ok := m.Selected()
+	if ok {
+		t.Error("New model with no entries should return Selected() ok=false")
+	}
+}
+
+// TestOpen closes/opens state.
+func TestOpen(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	m2 := m.Open()
+	if !m2.IsOpen() {
+		t.Error("Open() should set IsOpen() to true")
+	}
+	// Original is not modified (value semantics).
+	if m.IsOpen() {
+		t.Error("Open() should not mutate original")
+	}
+}
+
+// TestClose verifies Close sets IsOpen() to false.
+func TestClose(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2 := m.Close()
+	if m2.IsOpen() {
+		t.Error("Close() should set IsOpen() to false")
+	}
+	// Value semantics: original remains open.
+	if !m.IsOpen() {
+		t.Error("Close() should not mutate original")
+	}
+}
+
+// TestSetEntries replaces entries and resets selection.
+func TestSetEntries(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	// Move selection down.
+	m = m.SelectDown().SelectDown()
+	entry, _ := m.Selected()
+	if entry.Name != "gamma" {
+		t.Fatalf("expected gamma selected after 2 SelectDown, got %q", entry.Name)
+	}
+
+	newEntries := []profilepicker.ProfileEntry{
+		{Name: "new1", Description: "New 1", Model: "gpt-4"},
+		{Name: "new2", Description: "New 2", Model: "gpt-4o"},
+	}
+	m = m.SetEntries(newEntries)
+	entry, ok := m.Selected()
+	if !ok {
+		t.Fatal("SetEntries should reset to valid selection")
+	}
+	if entry.Name != "new1" {
+		t.Errorf("SetEntries should reset selection to 0; got %q", entry.Name)
+	}
+}
+
+// TestSelectUp wraps around to the last entry.
+func TestSelectUp(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	// At index 0, SelectUp should wrap to last (index 2 = gamma).
+	m = m.SelectUp()
+	entry, _ := m.Selected()
+	if entry.Name != "gamma" {
+		t.Errorf("SelectUp() at index 0 should wrap to last; got %q", entry.Name)
+	}
+}
+
+// TestSelectDown advances selection and wraps around.
+func TestSelectDown(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	m = m.SelectDown()
+	entry, _ := m.Selected()
+	if entry.Name != "beta" {
+		t.Errorf("SelectDown() at 0 should yield beta; got %q", entry.Name)
+	}
+
+	// Advance to last and wrap.
+	m = m.SelectDown().SelectDown()
+	entry, _ = m.Selected()
+	if entry.Name != "alpha" {
+		t.Errorf("SelectDown() wrap should return alpha; got %q", entry.Name)
+	}
+}
+
+// TestSelectUp_Empty does not panic on empty entries list.
+func TestSelectUp_Empty(t *testing.T) {
+	m := profilepicker.New(nil)
+	m2 := m.SelectUp() // should be a no-op
+	if m2.IsOpen() != m.IsOpen() {
+		t.Error("SelectUp on empty should be no-op")
+	}
+}
+
+// TestSelectDown_Empty does not panic on empty entries list.
+func TestSelectDown_Empty(t *testing.T) {
+	m := profilepicker.New(nil)
+	m2 := m.SelectDown() // should be a no-op
+	_ = m2
+}
+
+// TestUpdate_KeyUp routes Up key to SelectUp.
+func TestUpdate_KeyUp(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	entry, _ := m2.Selected()
+	// was at alpha (0), up → gamma (2).
+	if entry.Name != "gamma" {
+		t.Errorf("Up key should move to gamma (wrap); got %q", entry.Name)
+	}
+}
+
+// TestUpdate_KeyDown routes Down key to SelectDown.
+func TestUpdate_KeyDown(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	entry, _ := m2.Selected()
+	if entry.Name != "beta" {
+		t.Errorf("Down key should move to beta; got %q", entry.Name)
+	}
+}
+
+// TestUpdate_KeyVimJ routes 'j' to SelectDown.
+func TestUpdate_KeyVimJ(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	entry, _ := m2.Selected()
+	if entry.Name != "beta" {
+		t.Errorf("'j' key should move to beta; got %q", entry.Name)
+	}
+}
+
+// TestUpdate_KeyVimK routes 'k' to SelectUp.
+func TestUpdate_KeyVimK(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	entry, _ := m2.Selected()
+	if entry.Name != "gamma" {
+		t.Errorf("'k' key should wrap to gamma; got %q", entry.Name)
+	}
+}
+
+// TestUpdate_KeyEnter emits ProfileSelectedMsg with the current selection.
+func TestUpdate_KeyEnter(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter key should return a non-nil tea.Cmd")
+	}
+	msg := cmd()
+	sel, ok := msg.(profilepicker.ProfileSelectedMsg)
+	if !ok {
+		t.Fatalf("Enter key cmd should emit ProfileSelectedMsg; got %T", msg)
+	}
+	if sel.Entry.Name != "alpha" {
+		t.Errorf("ProfileSelectedMsg.Entry.Name: want %q, got %q", "alpha", sel.Entry.Name)
+	}
+}
+
+// TestUpdate_KeyEnter_Empty does not emit when list is empty.
+func TestUpdate_KeyEnter_Empty(t *testing.T) {
+	m := profilepicker.New(nil).Open()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Error("Enter with empty list should return nil cmd")
+	}
+}
+
+// TestUpdate_KeyEsc closes the picker.
+func TestUpdate_KeyEsc(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m2.IsOpen() {
+		t.Error("Escape key should close the picker")
+	}
+}
+
+// TestUpdate_WhenClosed ignores all keys.
+func TestUpdate_WhenClosed(t *testing.T) {
+	m := profilepicker.New(testEntries) // closed
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if m2.IsOpen() {
+		t.Error("Closed model should ignore Enter")
+	}
+	if cmd != nil {
+		t.Error("Closed model should not emit commands")
+	}
+}
+
+// TestScrollLogic verifies that scroll adjusts when going past the visible window.
+func TestScrollLogic(t *testing.T) {
+	// Create 15 entries to exceed maxVisibleRows (10).
+	entries := make([]profilepicker.ProfileEntry, 15)
+	for i := range entries {
+		entries[i] = profilepicker.ProfileEntry{
+			Name:        string(rune('a' + i)),
+			Description: "desc",
+			Model:       "gpt-4",
+		}
+	}
+	m := profilepicker.New(entries).Open()
+	// Navigate down past maxVisibleRows.
+	for i := 0; i < 11; i++ {
+		m = m.SelectDown()
+	}
+	entry, _ := m.Selected()
+	// After 11 SelectDown from 0, we should be at index 11 (letter 'l').
+	if entry.Name != "l" {
+		t.Errorf("After 11 SelectDown, expected 'l'; got %q", entry.Name)
+	}
+	// The view should not panic.
+	m.Width = 80
+	_ = m.View()
+}
+
+// TestView_Closed returns empty string when not open.
+func TestView_Closed(t *testing.T) {
+	m := profilepicker.New(testEntries)
+	m.Width = 80
+	v := m.View()
+	if v != "" {
+		t.Errorf("View() when closed should return empty string; got %q", v)
+	}
+}
+
+// TestView_Open renders box with entries.
+func TestView_Open(t *testing.T) {
+	m := profilepicker.New(testEntries).Open()
+	m.Width = 80
+	v := m.View()
+	if v == "" {
+		t.Error("View() when open should return non-empty string")
+	}
+	// Should contain profile names.
+	for _, e := range testEntries {
+		if !containsStr(v, e.Name) {
+			t.Errorf("View() should contain profile name %q", e.Name)
+		}
+	}
+}
+
+// TestView_Empty shows "no profiles" message.
+func TestView_Empty(t *testing.T) {
+	m := profilepicker.New(nil).Open()
+	m.Width = 80
+	v := m.View()
+	if v == "" {
+		t.Error("View() with no profiles should return non-empty box")
+	}
+	if !containsStr(v, "No profiles") {
+		t.Errorf("View() with no entries should contain 'No profiles'; got:\n%s", v)
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 || findSubstr(s, sub))
+}
+
+func findSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/harnesscli/tui/components/profilepicker/view.go
+++ b/cmd/harnesscli/tui/components/profilepicker/view.go
@@ -1,0 +1,140 @@
+package profilepicker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	ppDimColor  = lipgloss.AdaptiveColor{Light: "#9B9B9B", Dark: "#5C5C5C"}
+	ppHighlight = lipgloss.AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}
+
+	ppDimStyle       = lipgloss.NewStyle().Foreground(ppDimColor)
+	ppHighlightStyle = lipgloss.NewStyle().Background(ppHighlight).Foreground(lipgloss.Color("#FFFFFF"))
+	ppBoldStyle      = lipgloss.NewStyle().Bold(true)
+)
+
+// View renders the profile picker as a rounded-border lipgloss box.
+// Returns "" when the model is not open.
+// Width=0 defaults to 80.
+func (m Model) View() string {
+	if !m.open {
+		return ""
+	}
+	width := m.Width
+	if width <= 0 {
+		width = 80
+	}
+
+	// Inner content width: rounded border uses 2 cols (border+space) on each side.
+	const padding = 4
+	innerWidth := width - padding
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+
+	var sb strings.Builder
+
+	// Title row.
+	sb.WriteString(ppBoldStyle.Render("Profiles"))
+	sb.WriteByte('\n')
+	sb.WriteByte('\n')
+
+	if len(m.entries) == 0 {
+		msg := "No profiles available"
+		pad := (innerWidth - len(msg)) / 2
+		if pad < 0 {
+			pad = 0
+		}
+		sb.WriteString(strings.Repeat(" ", pad))
+		sb.WriteString(ppDimStyle.Render(msg))
+		sb.WriteByte('\n')
+	} else {
+		total := len(m.entries)
+		visStart := m.scrollOffset
+		visEnd := visStart + maxVisibleRows
+		if visEnd > total {
+			visEnd = total
+		}
+
+		for i := visStart; i < visEnd; i++ {
+			e := m.entries[i]
+			isSelected := i == m.selected
+
+			// Build description truncated to reasonable length.
+			desc := truncateStr(e.Description, 40)
+			sourceTier := e.SourceTier
+			if sourceTier == "" {
+				sourceTier = "built-in"
+			}
+
+			// Compose the row: Name  Model  SourceTier  Description
+			metaPart := fmt.Sprintf("  %-20s  %-20s  %-10s  ", truncateStr(e.Name, 20), truncateStr(e.Model, 20), sourceTier)
+			rowContent := metaPart + desc
+
+			// Truncate to innerWidth.
+			runes := []rune(rowContent)
+			if len(runes) > innerWidth {
+				runes = runes[:innerWidth]
+				rowContent = string(runes)
+			}
+
+			if isSelected {
+				// Render full row with reverse-video highlight.
+				padded := rowContent + strings.Repeat(" ", innerWidth-len([]rune(rowContent)))
+				sb.WriteString(ppHighlightStyle.Render(padded))
+			} else {
+				// Dim the metadata portion, normal color for description.
+				metaRunes := []rune(metaPart)
+				if len(metaRunes) > innerWidth {
+					metaRunes = metaRunes[:innerWidth]
+				}
+				remainWidth := innerWidth - len(metaRunes)
+				descRunes := []rune(desc)
+				if len(descRunes) > remainWidth {
+					descRunes = descRunes[:remainWidth]
+				}
+				sb.WriteString(ppDimStyle.Render(string(metaRunes)))
+				sb.WriteString(string(descRunes))
+			}
+			sb.WriteByte('\n')
+		}
+
+		// Footer: "... N more" if list extends beyond visible window.
+		below := total - visEnd
+		if below > 0 {
+			footer := fmt.Sprintf("  ... %d more", below)
+			sb.WriteString(ppDimStyle.Render(footer))
+			sb.WriteByte('\n')
+		}
+	}
+
+	// Instructions footer.
+	sb.WriteByte('\n')
+	sb.WriteString(ppDimStyle.Render("  ↑/↓ navigate  enter select  esc cancel"))
+	sb.WriteByte('\n')
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(0, 1).
+		Width(innerWidth)
+
+	return boxStyle.Render(sb.String())
+}
+
+// truncateStr clips s to at most maxLen runes, appending "…" if truncated.
+func truncateStr(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	if maxLen <= 1 {
+		return "…"
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -177,3 +177,18 @@ type APIKeySetMsg struct {
 	Provider string
 	Key      string
 }
+
+// ProfilesLoadedMsg carries the profile list fetched from GET /v1/profiles.
+type ProfilesLoadedMsg struct {
+	Entries []ProfileEntry
+	Err     error
+}
+
+// ProfileEntry is a simplified view of a profile for the TUI picker.
+type ProfileEntry struct {
+	Name        string
+	Description string
+	Model       string
+	ToolCount   int
+	SourceTier  string
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -20,6 +20,7 @@ import (
 	"go-agent-harness/cmd/harnesscli/tui/components/layout"
 	"go-agent-harness/cmd/harnesscli/tui/components/messagebubble"
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+	"go-agent-harness/cmd/harnesscli/tui/components/profilepicker"
 	"go-agent-harness/cmd/harnesscli/tui/components/slashcomplete"
 	"go-agent-harness/cmd/harnesscli/tui/components/statspanel"
 	"go-agent-harness/cmd/harnesscli/tui/components/statusbar"
@@ -212,6 +213,10 @@ type Model struct {
 	// modelConfigKeyInput is the text being typed.
 	modelConfigKeyInput string
 
+	// Profile picker component and selection state.
+	profilePicker   profilepicker.Model
+	selectedProfile string // name of profile selected for next run (not persisted)
+
 	// Components
 	statusBar   statusbar.Model
 	vp          viewport.Model
@@ -392,6 +397,12 @@ func (m Model) SelectedModel() string {
 // SelectedReasoningEffort returns the currently active reasoning effort (for testing).
 func (m Model) SelectedReasoningEffort() string {
 	return m.selectedReasoningEffort
+}
+
+// SelectedProfile returns the currently selected profile name (for testing).
+// Returns "" when no profile is selected.
+func (m Model) SelectedProfile() string {
+	return m.selectedProfile
 }
 
 // gatewayIndex returns the index of the gateway option with the given ID,
@@ -889,6 +900,15 @@ func executeSubagentsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	}, false
 }
 
+func executeProfilesCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	m.overlayActive = true
+	m.activeOverlay = "profiles"
+	return []tea.Cmd{
+		m.setStatusMsg("Loading profiles..."),
+		loadProfilesCmd(m.config.BaseURL),
+	}, false
+}
+
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
@@ -928,6 +948,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.autocompleteProvider != nil {
 			m.input = m.input.SetAutocompleteProvider(m.autocompleteProvider)
 		}
+		// Update profile picker width on resize.
+		m.profilePicker.Width = msg.Width
 
 	case tea.KeyMsg:
 		switch {
@@ -1003,6 +1025,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeOverlay = ""
 				return m, tea.Batch(cmds...)
 			}
+			if m.activeOverlay == "profiles" {
+				m.profilePicker = m.profilePicker.Close()
+				m.overlayActive = false
+				m.activeOverlay = ""
+				return m, tea.Batch(cmds...)
+			}
 			if m.overlayActive {
 				m.overlayActive = false
 				m.activeOverlay = ""
@@ -1035,6 +1063,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.rerenderActiveToolView()
 			}
 		case key.Matches(msg, m.keys.Submit):
+			// When the profiles overlay is active, Enter confirms selection via the picker.
+			if m.overlayActive && m.activeOverlay == "profiles" {
+				var ppCmd tea.Cmd
+				m.profilePicker, ppCmd = m.profilePicker.Update(msg)
+				if ppCmd != nil {
+					cmds = append(cmds, ppCmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
 			// When the apikeys overlay is active, Enter enters input mode or confirms.
 			if m.overlayActive && m.activeOverlay == "apikeys" {
 				if m.apiKeyInputMode && m.apiKeyInput != "" {
@@ -1269,6 +1306,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.gatewaySelected = (m.gatewaySelected + 1) % len(gatewayOptions)
 			}
 			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "profiles":
+			// Route all keys to the profile picker component.
+			var ppCmd tea.Cmd
+			m.profilePicker, ppCmd = m.profilePicker.Update(msg)
+			if ppCmd != nil {
+				cmds = append(cmds, ppCmd)
+			}
+			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.ScrollUp):
 			// When the provider overlay is active, Up/Down navigates the gateway list.
 			if m.overlayActive && m.activeOverlay == "provider" {
@@ -1419,7 +1464,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Fire off the run against the harness API, carrying the current
 		// conversationID so the harness links this turn to the conversation.
 		effModel, effProvider := m.effectiveModelAndProvider()
-		cmds = append(cmds, startRunCmd(m.config.BaseURL, msg.Value, m.conversationID, effModel, effProvider, m.selectedReasoningEffort))
+		cmds = append(cmds, startRunCmd(m.config.BaseURL, msg.Value, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile))
 
 	case AssistantDeltaMsg:
 		m.lastAssistantText += msg.Delta
@@ -1739,6 +1784,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusMsg = ""
 			m.statusMsgExpiry = time.Time{}
 		}
+
+	case ProfilesLoadedMsg:
+		if msg.Err != nil {
+			m.overlayActive = false
+			m.activeOverlay = ""
+			cmds = append(cmds, m.setStatusMsg("Load profiles failed: "+msg.Err.Error()))
+			return m, tea.Batch(cmds...)
+		}
+		entries := make([]profilepicker.ProfileEntry, len(msg.Entries))
+		for i, e := range msg.Entries {
+			entries[i] = profilepicker.ProfileEntry{
+				Name:        e.Name,
+				Description: e.Description,
+				Model:       e.Model,
+				ToolCount:   e.ToolCount,
+				SourceTier:  e.SourceTier,
+			}
+		}
+		m.profilePicker = profilepicker.New(entries).Open()
+		m.profilePicker.Width = m.width
+
+	case profilepicker.ProfileSelectedMsg:
+		m.selectedProfile = msg.Entry.Name
+		m.profilePicker = m.profilePicker.Close()
+		m.overlayActive = false
+		m.activeOverlay = ""
+		cmds = append(cmds, m.setStatusMsg("Profile: "+msg.Entry.Name))
 	}
 
 	return m, tea.Batch(cmds...)
@@ -1783,6 +1855,12 @@ func (m Model) View() string {
 			mainContent = m.viewProviderOverlay()
 		case "apikeys":
 			mainContent = m.viewAPIKeysOverlay()
+		case "profiles":
+			m.profilePicker.Width = m.width
+			mainContent = m.profilePicker.View()
+			if mainContent == "" {
+				mainContent = m.vp.View()
+			}
 		default:
 			// Unknown overlay kind — fall back to viewport.
 			mainContent = m.vp.View()

--- a/cmd/harnesscli/tui/profile_test.go
+++ b/cmd/harnesscli/tui/profile_test.go
@@ -1,0 +1,197 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/cmd/harnesscli/tui/components/profilepicker"
+)
+
+// TestProfilesCommand_Opens_Overlay verifies that /profiles sets overlayActive
+// and activeOverlay == "profiles".
+func TestProfilesCommand_Opens_Overlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/profiles")
+
+	if !m.OverlayActive() {
+		t.Fatal("overlayActive must be true after /profiles")
+	}
+	if m.ActiveOverlay() != "profiles" {
+		t.Errorf("activeOverlay: want %q, got %q", "profiles", m.ActiveOverlay())
+	}
+}
+
+// TestProfilesCommand_IsRegistered verifies that /profiles is a registered command.
+func TestProfilesCommand_IsRegistered(t *testing.T) {
+	reg := tui.NewCommandRegistry()
+	_, ok := reg.Lookup("profiles")
+	if !ok {
+		t.Fatal("profiles command must be registered in NewCommandRegistry()")
+	}
+}
+
+// TestProfilesLoaded_OpensPicker verifies that ProfilesLoadedMsg populates and
+// opens the picker when there is no error.
+func TestProfilesLoaded_OpensPicker(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Trigger the profiles overlay first.
+	m = sendSlashCommand(m, "/profiles")
+
+	entries := []tui.ProfileEntry{
+		{Name: "test-profile", Description: "Test", Model: "gpt-4"},
+	}
+	m2, _ := m.Update(tui.ProfilesLoadedMsg{Entries: entries})
+	m = m2.(tui.Model)
+
+	if !m.OverlayActive() {
+		t.Error("overlay should still be active after profiles loaded")
+	}
+	if m.ActiveOverlay() != "profiles" {
+		t.Errorf("activeOverlay: want %q, got %q", "profiles", m.ActiveOverlay())
+	}
+
+	// View should render the picker with the profile name.
+	view := m.View()
+	if !strings.Contains(view, "test-profile") {
+		t.Errorf("View() should show profile 'test-profile' after ProfilesLoadedMsg; got:\n%s", view)
+	}
+}
+
+// TestProfilesLoaded_Error_ClosesOverlay verifies that a ProfilesLoadedMsg
+// with an error closes the overlay and shows an error in the status.
+func TestProfilesLoaded_Error_ClosesOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/profiles")
+	if !m.OverlayActive() {
+		t.Fatal("overlay should be active")
+	}
+
+	m2, _ := m.Update(tui.ProfilesLoadedMsg{Err: &profileLoadErr{"connection refused"}})
+	m = m2.(tui.Model)
+
+	if m.OverlayActive() {
+		t.Error("overlay should be closed after ProfilesLoadedMsg with error")
+	}
+}
+
+// profileLoadErr is a simple test error type.
+type profileLoadErr struct{ msg string }
+
+func (e *profileLoadErr) Error() string { return e.msg }
+
+// TestProfileSelected_UpdatesModel verifies that ProfileSelectedMsg closes the
+// overlay and stores the selected profile name.
+func TestProfileSelected_UpdatesModel(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Open profiles overlay.
+	m = sendSlashCommand(m, "/profiles")
+
+	// Send a ProfilesLoadedMsg to populate the picker.
+	entries := []tui.ProfileEntry{
+		{Name: "chosen-profile", Description: "Desc", Model: "gpt-4"},
+	}
+	m2, _ := m.Update(tui.ProfilesLoadedMsg{Entries: entries})
+	m = m2.(tui.Model)
+
+	// Simulate selection.
+	msg := profilepicker.ProfileSelectedMsg{
+		Entry: profilepicker.ProfileEntry{Name: "chosen-profile"},
+	}
+	m3, _ := m.Update(msg)
+	m = m3.(tui.Model)
+
+	if m.OverlayActive() {
+		t.Error("overlay should be closed after ProfileSelectedMsg")
+	}
+	if m.ActiveOverlay() != "" {
+		t.Errorf("activeOverlay should be empty after selection; got %q", m.ActiveOverlay())
+	}
+	if m.SelectedProfile() != "chosen-profile" {
+		t.Errorf("selectedProfile: want %q, got %q", "chosen-profile", m.SelectedProfile())
+	}
+}
+
+// TestProfiles_EscapeClosesOverlay verifies that Escape while the profiles
+// overlay is open closes it without selecting a profile.
+func TestProfiles_EscapeClosesOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/profiles")
+	if !m.OverlayActive() {
+		t.Fatal("overlay must be active after /profiles")
+	}
+
+	// Send a profiles loaded message to have something in the picker.
+	entries := []tui.ProfileEntry{
+		{Name: "test", Description: "Test", Model: "gpt-4"},
+	}
+	m2, _ := m.Update(tui.ProfilesLoadedMsg{Entries: entries})
+	m = m2.(tui.Model)
+
+	// Press Escape.
+	m, _ = sendEscape(m)
+
+	if m.OverlayActive() {
+		t.Error("overlay must be closed after Escape")
+	}
+	if m.SelectedProfile() != "" {
+		t.Errorf("selectedProfile must remain empty after Escape; got %q", m.SelectedProfile())
+	}
+}
+
+// TestProfilesOverlay_KeyboardNavigation verifies that Up/Down keys navigate
+// the profile picker when it is open, and Enter selects the profile.
+func TestProfilesOverlay_KeyboardNavigation(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/profiles")
+
+	entries := []tui.ProfileEntry{
+		{Name: "alpha", Description: "Alpha", Model: "gpt-4"},
+		{Name: "beta", Description: "Beta", Model: "gpt-4"},
+	}
+	m2, _ := m.Update(tui.ProfilesLoadedMsg{Entries: entries})
+	m = m2.(tui.Model)
+
+	// Press Down — should move to beta.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = m3.(tui.Model)
+
+	// Press Enter — picker emits ProfileSelectedMsg via returned cmd.
+	m4, batchCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m4.(tui.Model)
+
+	// The batch cmd contains the ProfileSelectedMsg — unwrap it by running all
+	// inner cmds. tea.Batch returns a BatchMsg when called; we need to iterate.
+	if batchCmd != nil {
+		msg := batchCmd()
+		// Handle BatchMsg from tea.Batch
+		if batchMsgs, ok := msg.(tea.BatchMsg); ok {
+			for _, innerCmd := range batchMsgs {
+				if innerCmd != nil {
+					innerMsg := innerCmd()
+					if innerMsg != nil {
+						mx, _ := m.Update(innerMsg)
+						m = mx.(tui.Model)
+					}
+				}
+			}
+		} else if msg != nil {
+			mx, _ := m.Update(msg)
+			m = mx.(tui.Model)
+		}
+	}
+
+	if m.SelectedProfile() != "beta" {
+		t.Errorf("SelectedProfile: want %q, got %q", "beta", m.SelectedProfile())
+	}
+}
+
+// TestSelectedProfile_PassedInRunRequest verifies that SelectedProfile is initially empty.
+func TestSelectedProfile_InitiallyEmpty(t *testing.T) {
+	m := tui.New(tui.DefaultTUIConfig())
+	if m.SelectedProfile() != "" {
+		t.Errorf("SelectedProfile should be empty on new model; got %q", m.SelectedProfile())
+	}
+}

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -6,6 +6,7 @@ Command Registry - 120x40
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/profiles — View and select a profile for next run
 /quit — Quit the TUI
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -6,6 +6,7 @@ Command Registry - 200x50
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/profiles — View and select a profile for next run
 /quit — Quit the TUI
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -6,6 +6,7 @@ Command Registry - 80x24
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/profiles — View and select a profile for next run
 /quit — Quit the TUI
 /stats — Show cost and token statistics
 /subagents — View active subagent processes


### PR DESCRIPTION
## Summary

- Adds `-list-profiles` CLI flag that calls `GET /v1/profiles` and prints each profile's name, description, and model
- Adds `profilepicker` TUI component (modeled on `sessionpicker`) for profile discovery in the TUI
- Wires `/profiles` slash command to open the profile picker overlay
- Profile selection in TUI sets `PromptProfile` for the next run in the session (not persisted)
- Selected profile displayed in the TUI status bar
- All surfaces are read-only (no profile creation/editing)

## Test plan

- [x] 5 CLI tests for `-list-profiles` flag (`cmd/harnesscli/list_profiles_test.go`)
- [x] 21 profilepicker component tests (`cmd/harnesscli/tui/components/profilepicker/model_test.go`)
- [x] 8 TUI profile integration tests (`cmd/harnesscli/tui/profile_test.go`)
- [x] All `./internal/... ./cmd/...` tests pass
- [x] TUI-041 slash command list snapshots updated to include `/profiles`

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)