### PR TITLE
test(#393): add profile-backed golden path smoke test

### DIFF
--- a/docs/runbooks/golden-path-deployment.md
+++ b/docs/runbooks/golden-path-deployment.md
@@ -107,7 +107,13 @@ The smoke test:
 5. Creates a run with the prompt `Reply with exactly: SMOKE_TEST_PASS`
 6. Polls until the run reaches `completed` status (120s timeout)
 7. Streams `GET /v1/runs/{id}/events` and verifies at least one event arrived
-8. Exits 0 on all-pass, non-zero on any failure
+8. Verifies `GET /v1/profiles` returns at least one profile (profile-backed golden path)
+9. Fetches `GET /v1/profiles/full` and verifies `name` and `model` fields are present
+10. Creates a run with `"profile": "full"` and the prompt `Reply with exactly: PROFILE_TEST_OK`
+11. Polls until the profile-backed run reaches `completed` status (120s timeout)
+12. Verifies the completed run's `output` field is non-empty
+13. Re-fetches `GET /v1/runs/{id}` to verify the run is still readable (idempotent readback)
+14. Exits 0 on all-pass, non-zero on any failure
 
 ### Smoke test environment variables
 
@@ -122,6 +128,102 @@ The smoke test:
 
 ---
 
+## Profile-Backed Golden Path
+
+The smoke test includes a profile-backed validation path (steps 9-14) that exercises
+the end-to-end flow for runs created with a named profile. The `full` built-in profile
+is used as the reference target.
+
+### Manual curl walkthrough
+
+The following curl examples replicate steps 9-14 of the smoke test against a running
+server at `http://localhost:8080`. Adjust the port to match your deployment.
+
+**Step 9 — List profiles, verify count >= 1**
+
+```bash
+curl -s http://localhost:8080/v1/profiles | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print('count:', data.get('count', 0))
+print('profiles:', [p['name'] for p in data.get('profiles', [])])
+"
+```
+
+Expected: `count: 1` (or more) and `profiles: ['full']` (at minimum).
+
+**Step 10 — Fetch profile detail, verify required fields**
+
+```bash
+curl -s http://localhost:8080/v1/profiles/full | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print('name:', data.get('name'))
+print('model:', data.get('model'))
+print('max_steps:', data.get('max_steps'))
+print('source_tier:', data.get('source_tier'))
+"
+```
+
+Expected: `name: full`, non-empty `model`, numeric `max_steps`, `source_tier: built-in`.
+
+**Step 11 — Create a profile-backed run**
+
+```bash
+curl -s -X POST http://localhost:8080/v1/runs \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Reply with exactly: PROFILE_TEST_OK", "profile": "full"}'
+```
+
+Expected: a JSON object with a `run_id` (or `id`) field.
+
+```json
+{"run_id": "run-abc123", "status": "queued"}
+```
+
+**Step 12 — Poll until completed**
+
+```bash
+RUN_ID="run-abc123"  # replace with actual run_id from step 11
+while true; do
+  STATUS=$(curl -s http://localhost:8080/v1/runs/${RUN_ID} | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
+  echo "status: $STATUS"
+  [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ] && break
+  sleep 2
+done
+```
+
+Expected: `status: completed` within 120 seconds.
+
+**Step 13 — Verify output is non-empty**
+
+```bash
+curl -s http://localhost:8080/v1/runs/${RUN_ID} | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+output = data.get('output', '')
+print('output:', repr(output))
+print('non-empty:', bool(output))
+"
+```
+
+Expected: `non-empty: True`.
+
+**Step 14 — Idempotent readback**
+
+```bash
+curl -s http://localhost:8080/v1/runs/${RUN_ID} | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print('status:', data.get('status'))
+"
+```
+
+Expected: the same `completed` status as in step 12. This verifies the run remains
+readable from the store after it has finished.
+
+---
+
 ## Key Endpoints
 
 | Endpoint | Method | Description |
@@ -132,6 +234,11 @@ The smoke test:
 | `/v1/runs` | POST | Create a new run |
 | `/v1/runs/{id}` | GET | Get run status and output |
 | `/v1/runs/{id}/events` | GET | SSE stream of run events |
+| `/v1/profiles` | GET | List all profiles (built-in, project, user) |
+| `/v1/profiles/{name}` | GET | Get a single profile by name |
+| `/v1/profiles/{name}` | POST | Create a user profile (requires `profiles_dir` config) |
+| `/v1/profiles/{name}` | PUT | Update a user profile (requires `profiles_dir` config) |
+| `/v1/profiles/{name}` | DELETE | Delete a user profile (requires `profiles_dir` config) |
 
 ---
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -296,7 +296,162 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 9: Summary
+# Step 9: GET /v1/profiles — verify list returns at least 1 profile
+# ---------------------------------------------------------------------------
+
+PROFILE_SMOKE_STEPS_PASSED=0
+PROFILE_SMOKE_STEPS_FAILED=0
+
+profile_pass() { echo "[smoke] PASS: $*"; PROFILE_SMOKE_STEPS_PASSED=$(( PROFILE_SMOKE_STEPS_PASSED + 1 )); PASS_COUNT=$(( PASS_COUNT + 1 )); }
+profile_fail() { echo "[smoke] FAIL: $*"; PROFILE_SMOKE_STEPS_FAILED=$(( PROFILE_SMOKE_STEPS_FAILED + 1 )); FAIL_COUNT=$(( FAIL_COUNT + 1 )); }
+
+info "GET /v1/profiles..."
+PROFILES_BODY=$(curl -sf "${BASE_URL}/v1/profiles")
+PROFILE_COUNT=$(echo "${PROFILES_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('count', len(data.get('profiles', []))))
+" 2>/dev/null || echo "0")
+
+if [ "${PROFILE_COUNT}" -ge 1 ]; then
+    profile_pass "GET /v1/profiles → 200, ${PROFILE_COUNT} profile(s) in catalog"
+else
+    profile_fail "GET /v1/profiles returned 0 profiles (body: ${PROFILES_BODY})"
+fi
+
+# Extract the first profile name for subsequent steps.
+SMOKE_PROFILE_NAME=$(echo "${PROFILES_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+profiles = data.get('profiles', [])
+print(profiles[0].get('name', '') if profiles else '')
+" 2>/dev/null || echo "")
+
+if [ -z "${SMOKE_PROFILE_NAME}" ]; then
+    SMOKE_PROFILE_NAME="full"
+    info "could not extract profile name from list response; falling back to 'full'"
+fi
+
+info "using profile for smoke: ${SMOKE_PROFILE_NAME}"
+
+# ---------------------------------------------------------------------------
+# Step 10: GET /v1/profiles/full — verify required fields
+# ---------------------------------------------------------------------------
+
+info "GET /v1/profiles/${SMOKE_PROFILE_NAME}..."
+PROFILE_DETAIL_BODY=$(curl -sf "${BASE_URL}/v1/profiles/${SMOKE_PROFILE_NAME}")
+PROFILE_NAME_FIELD=$(echo "${PROFILE_DETAIL_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('name', ''))
+" 2>/dev/null || echo "")
+PROFILE_MODEL_FIELD=$(echo "${PROFILE_DETAIL_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('model', ''))
+" 2>/dev/null || echo "")
+
+if [ -n "${PROFILE_NAME_FIELD}" ] && [ -n "${PROFILE_MODEL_FIELD}" ]; then
+    profile_pass "GET /v1/profiles/${SMOKE_PROFILE_NAME} → name=${PROFILE_NAME_FIELD}, model=${PROFILE_MODEL_FIELD}"
+else
+    profile_fail "GET /v1/profiles/${SMOKE_PROFILE_NAME} missing required fields (body: ${PROFILE_DETAIL_BODY})"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 11: POST /v1/runs with profile field — create a profile-backed run
+# ---------------------------------------------------------------------------
+
+info "POST /v1/runs with profile=${SMOKE_PROFILE_NAME}..."
+PROFILE_RUN_RESPONSE=$(curl -sf -X POST "${BASE_URL}/v1/runs" \
+    -H "Content-Type: application/json" \
+    -d "{\"prompt\": \"Reply with exactly: PROFILE_TEST_OK\", \"profile\": \"${SMOKE_PROFILE_NAME}\"}")
+
+PROFILE_RUN_ID=$(echo "${PROFILE_RUN_RESPONSE}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('run_id', data.get('id', '')))
+" 2>/dev/null || true)
+
+if [ -z "${PROFILE_RUN_ID}" ]; then
+    profile_fail "POST /v1/runs with profile did not return a run_id (response: ${PROFILE_RUN_RESPONSE})"
+else
+    profile_pass "POST /v1/runs with profile=${SMOKE_PROFILE_NAME} → run_id=${PROFILE_RUN_ID}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 12: Poll until profile-backed run reaches completed status
+# ---------------------------------------------------------------------------
+
+if [ -n "${PROFILE_RUN_ID}" ]; then
+    info "polling GET /v1/runs/${PROFILE_RUN_ID} for completion (timeout ${TIMEOUT_S}s)..."
+    PROFILE_ELAPSED=0
+    PROFILE_RUN_STATUS=""
+    PROFILE_RUN_OUTPUT=""
+    while true; do
+        PROFILE_RUN_STATUS_BODY=$(curl -sf "${BASE_URL}/v1/runs/${PROFILE_RUN_ID}" || echo "{}")
+        PROFILE_RUN_STATUS=$(echo "${PROFILE_RUN_STATUS_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('status', ''))
+" 2>/dev/null || echo "")
+
+        if [ "${PROFILE_RUN_STATUS}" = "completed" ]; then
+            PROFILE_RUN_OUTPUT=$(echo "${PROFILE_RUN_STATUS_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('output', ''))
+" 2>/dev/null || echo "")
+            profile_pass "profile-backed run completed (status=completed)"
+            break
+        elif [ "${PROFILE_RUN_STATUS}" = "failed" ]; then
+            profile_fail "profile-backed run ${PROFILE_RUN_ID} ended in status: failed"
+            break
+        fi
+
+        PROFILE_ELAPSED=$(( PROFILE_ELAPSED + 2 ))
+        if [ "${PROFILE_ELAPSED}" -ge "${TIMEOUT_S}" ]; then
+            profile_fail "profile-backed run ${PROFILE_RUN_ID} did not complete within ${TIMEOUT_S}s (last status: ${PROFILE_RUN_STATUS})"
+            break
+        fi
+        info "  profile run status=${PROFILE_RUN_STATUS}, elapsed=${PROFILE_ELAPSED}s..."
+        sleep 2
+    done
+
+    # -----------------------------------------------------------------------
+    # Step 13: Verify output field is non-empty in the completed run
+    # -----------------------------------------------------------------------
+
+    if [ "${PROFILE_RUN_STATUS}" = "completed" ]; then
+        if [ -n "${PROFILE_RUN_OUTPUT}" ]; then
+            profile_pass "profile-backed run output is non-empty: \"${PROFILE_RUN_OUTPUT}\""
+        else
+            profile_fail "profile-backed run ${PROFILE_RUN_ID} completed but output field is empty"
+        fi
+    else
+        profile_fail "skipping output verification — run did not reach completed status"
+    fi
+
+    # -----------------------------------------------------------------------
+    # Step 14: Re-fetch GET /v1/runs/{id} — verify run is still readable
+    # -----------------------------------------------------------------------
+
+    info "GET /v1/runs/${PROFILE_RUN_ID} (idempotent readback)..."
+    PROFILE_RUN_READBACK=$(curl -sf "${BASE_URL}/v1/runs/${PROFILE_RUN_ID}" || echo "{}")
+    PROFILE_RUN_READBACK_STATUS=$(echo "${PROFILE_RUN_READBACK}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('status', ''))
+" 2>/dev/null || echo "")
+
+    if [ -n "${PROFILE_RUN_READBACK_STATUS}" ]; then
+        profile_pass "GET /v1/runs/${PROFILE_RUN_ID} readable after completion (status=${PROFILE_RUN_READBACK_STATUS})"
+    else
+        profile_fail "GET /v1/runs/${PROFILE_RUN_ID} returned empty or unparseable response on readback"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 15: Summary
 # ---------------------------------------------------------------------------
 
 echo ""
@@ -305,6 +460,7 @@ echo " Smoke Test Summary"
 echo "======================================================"
 echo " PASS: ${PASS_COUNT}"
 echo " FAIL: ${FAIL_COUNT}"
+echo " (profile steps passed: ${PROFILE_SMOKE_STEPS_PASSED}, failed: ${PROFILE_SMOKE_STEPS_FAILED})"
 echo "======================================================"
 
 if [ "${FAIL_COUNT}" -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Extends `scripts/smoke-test.sh` with steps 9-14 for the profile-backed golden path
- Step 9: `GET /v1/profiles` — verify count >= 1
- Step 10: `GET /v1/profiles/full` — verify required fields
- Step 11: `POST /v1/runs` with `"profile": "full"` — create profile-backed run
- Step 12: Poll until run reaches `completed` status (120s timeout)
- Step 13: Verify `output` field is non-empty
- Step 14: Idempotent run readback via `GET /v1/runs/{id}`
- Adds separate `PROFILE_SMOKE_STEPS_PASSED`/`FAILED` counters in summary
- Updates `docs/runbooks/golden-path-deployment.md` with new section and curl examples

## Test plan

- [x] `bash -n scripts/smoke-test.sh` — syntax valid
- [x] `go build ./internal/... ./cmd/...` — clean build
- [x] Existing steps 1-8 structure preserved
- [x] New steps follow existing curl+python3 pattern

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)