### PR TITLE
feat(#410): auto-load repo AGENTS.md into resolved system prompts

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -436,7 +436,11 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 	if model == "" {
 		model = r.config.DefaultModel
 	}
-	systemPrompt, resolvedPrompt, err := r.resolveSystemPrompt(req, model)
+	// Use RepoPath as the initial workspace path so that AGENTS.md from the
+	// base repository is loaded for all runs. For workspace-type runs, the
+	// system prompt is re-resolved after provisioning with the actual workspace
+	// path (see execute()).
+	systemPrompt, resolvedPrompt, err := r.resolveSystemPrompt(req, model, r.config.WorkspaceBaseOptions.RepoPath)
 	if err != nil {
 		return Run{}, err
 	}
@@ -622,7 +626,7 @@ func (r *Runner) checkConversationOwnership(convID, tenantID, agentID string) er
 	return nil
 }
 
-func (r *Runner) resolveSystemPrompt(req RunRequest, model string) (string, *systemprompt.ResolvedPrompt, error) {
+func (r *Runner) resolveSystemPrompt(req RunRequest, model, workspacePath string) (string, *systemprompt.ResolvedPrompt, error) {
 	if strings.TrimSpace(req.SystemPrompt) != "" {
 		return req.SystemPrompt, nil, nil
 	}
@@ -637,6 +641,7 @@ func (r *Runner) resolveSystemPrompt(req RunRequest, model string) (string, *sys
 		PromptProfile:      req.PromptProfile,
 		TaskContext:        req.TaskContext,
 		Extensions:         extensions,
+		WorkspacePath:      workspacePath,
 	})
 	if err != nil {
 		return "", nil, err
@@ -1271,6 +1276,27 @@ func (r *Runner) execute(runID string, req RunRequest) {
 			"workspace_type": req.WorkspaceType,
 			"workspace_path": wsPath,
 		})
+		// Re-resolve system prompt with the provisioned workspace path so that
+		// AGENTS.md from the workspace is injected (overriding any AGENTS.md
+		// loaded from WorkspaceBaseOptions.RepoPath during StartRun). This is a
+		// no-op when the workspace path matches the repo path.
+		wsModel := req.Model
+		if wsModel == "" {
+			wsModel = r.config.DefaultModel
+		}
+		if wsPath != "" && r.config.PromptEngine != nil {
+			if wsSP, wsRP, wsErr := r.resolveSystemPrompt(req, wsModel, wsPath); wsErr == nil {
+				r.mu.Lock()
+				if st, ok := r.runs[runID]; ok {
+					st.staticSystemPrompt = wsSP
+					st.promptResolved = wsRP
+				}
+				r.mu.Unlock()
+			} else if r.config.Logger != nil {
+				r.config.Logger.Error("failed to re-resolve system prompt with workspace path",
+					"run_id", runID, "workspace_path", wsPath, "error", wsErr)
+			}
+		}
 		// Store cleanup function so completeRun/failRun/cancelledRun can call it
 		// before the terminal event, keeping workspace.destroyed before run.completed.
 		wsType := req.WorkspaceType

--- a/internal/systemprompt/engine.go
+++ b/internal/systemprompt/engine.go
@@ -3,6 +3,8 @@ package systemprompt
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -61,12 +63,24 @@ func (e *FileEngine) Resolve(req ResolveRequest) (ResolvedPrompt, error) {
 		}
 	}
 
-	sections := make([]promptSection, 0, 8)
+	// Load AGENTS.md from the workspace if a path was provided.
+	agentsMdContent, agentsMdErr := readAgentsMd(req.WorkspacePath)
+	if agentsMdErr != nil {
+		warnings = append(warnings, Warning{
+			Code:    "agents_md_read_failed",
+			Message: fmt.Sprintf("failed to read AGENTS.md from workspace %q: %v", req.WorkspacePath, agentsMdErr),
+		})
+	}
+
+	sections := make([]promptSection, 0, 9)
 	sections = append(sections,
 		promptSection{Name: "BASE", Content: e.basePrompt},
 		promptSection{Name: "INTENT", Content: intentPrompt},
 		promptSection{Name: "MODEL_PROFILE", Content: profile.Content},
 	)
+	if agentsMdContent != "" {
+		sections = append(sections, promptSection{Name: "AGENTS_MD", Content: agentsMdContent})
+	}
 	if taskContext := strings.TrimSpace(req.TaskContext); taskContext != "" {
 		sections = append(sections, promptSection{Name: "TASK_CONTEXT", Content: taskContext})
 	}
@@ -92,6 +106,7 @@ func (e *FileEngine) Resolve(req ResolveRequest) (ResolvedPrompt, error) {
 		Talents:              extensionIDs(talents),
 		Skills:               extensionIDs(skillSections),
 		Warnings:             warnings,
+		AgentsMdLoaded:       agentsMdContent != "",
 	}, nil
 }
 
@@ -139,6 +154,35 @@ func extensionIDs(items []resolvedExtension) []string {
 		ids = append(ids, item.id)
 	}
 	return ids
+}
+
+// readAgentsMd reads the AGENTS.md file from the given workspace root directory.
+// It returns the file content on success, empty string if the file does not
+// exist (soft fail), or an error if the file cannot be read for other reasons.
+// Path traversal is prevented by verifying the candidate path is exactly
+// "<absRoot>/AGENTS.md" after cleaning.
+func readAgentsMd(workspaceRoot string) (string, error) {
+	if workspaceRoot == "" {
+		return "", nil
+	}
+	absRoot, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("invalid workspace path: %w", err)
+	}
+	absRoot = filepath.Clean(absRoot)
+	candidate := filepath.Join(absRoot, "AGENTS.md")
+	rel, err := filepath.Rel(absRoot, candidate)
+	if err != nil || rel != "AGENTS.md" {
+		return "", fmt.Errorf("AGENTS.md path escape detected")
+	}
+	content, err := os.ReadFile(candidate)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }
 
 func composeStaticPrompt(sections []promptSection) string {

--- a/internal/systemprompt/engine_test.go
+++ b/internal/systemprompt/engine_test.go
@@ -3,6 +3,8 @@ package systemprompt
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -313,6 +315,177 @@ func TestRuntimeContextUsesFixedFormat(t *testing.T) {
 		"message_count: 0",
 		"</runtime_context>",
 	)
+}
+
+func TestResolveWithEmptyWorkspacePath(t *testing.T) {
+	t.Parallel()
+	root := makePromptFixture(t)
+	engine, err := NewFileEngine(root)
+	if err != nil {
+		t.Fatalf("new file engine: %v", err)
+	}
+
+	out, err := engine.Resolve(ResolveRequest{
+		Model:         "gpt-5-nano",
+		WorkspacePath: "",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if strings.Contains(out.StaticPrompt, "[SECTION AGENTS_MD]") {
+		t.Fatalf("expected no AGENTS_MD section when WorkspacePath is empty, got: %q", out.StaticPrompt)
+	}
+	if out.AgentsMdLoaded {
+		t.Fatalf("expected AgentsMdLoaded=false when WorkspacePath is empty")
+	}
+}
+
+func TestResolveSkipsAgentsMdWhenAbsent(t *testing.T) {
+	t.Parallel()
+	root := makePromptFixture(t)
+	engine, err := NewFileEngine(root)
+	if err != nil {
+		t.Fatalf("new file engine: %v", err)
+	}
+
+	// tmpDir has no AGENTS.md file
+	tmpDir := t.TempDir()
+
+	out, err := engine.Resolve(ResolveRequest{
+		Model:         "gpt-5-nano",
+		WorkspacePath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if strings.Contains(out.StaticPrompt, "[SECTION AGENTS_MD]") {
+		t.Fatalf("expected no AGENTS_MD section when AGENTS.md is absent, got: %q", out.StaticPrompt)
+	}
+	if out.AgentsMdLoaded {
+		t.Fatalf("expected AgentsMdLoaded=false when AGENTS.md is absent")
+	}
+	if len(out.Warnings) != 0 {
+		t.Fatalf("expected no warnings on absent AGENTS.md, got: %+v", out.Warnings)
+	}
+}
+
+func TestResolveLoadsAgentsMdFromWorkspace(t *testing.T) {
+	t.Parallel()
+	root := makePromptFixture(t)
+	engine, err := NewFileEngine(root)
+	if err != nil {
+		t.Fatalf("new file engine: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentsMdContent := "AGENTS_MD_CONTENT_FOR_TEST"
+	if writeErr := os.WriteFile(filepath.Join(tmpDir, "AGENTS.md"), []byte(agentsMdContent), 0o644); writeErr != nil {
+		t.Fatalf("write AGENTS.md: %v", writeErr)
+	}
+
+	out, err := engine.Resolve(ResolveRequest{
+		Model:         "gpt-5-nano",
+		WorkspacePath: tmpDir,
+		TaskContext:   "some task",
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !strings.Contains(out.StaticPrompt, "[SECTION AGENTS_MD]") {
+		t.Fatalf("expected AGENTS_MD section in prompt, got: %q", out.StaticPrompt)
+	}
+	if !strings.Contains(out.StaticPrompt, agentsMdContent) {
+		t.Fatalf("expected AGENTS.md content in prompt, got: %q", out.StaticPrompt)
+	}
+	if !out.AgentsMdLoaded {
+		t.Fatalf("expected AgentsMdLoaded=true when AGENTS.md is present")
+	}
+	// Verify AGENTS_MD appears after MODEL_PROFILE and before TASK_CONTEXT
+	mustContainOrdered(t, out.StaticPrompt,
+		"[SECTION MODEL_PROFILE]",
+		"[SECTION AGENTS_MD]",
+		agentsMdContent,
+		"[SECTION TASK_CONTEXT]",
+	)
+}
+
+func TestResolveWarnsOnAgentsMdReadFailure(t *testing.T) {
+	t.Parallel()
+	root := makePromptFixture(t)
+	engine, err := NewFileEngine(root)
+	if err != nil {
+		t.Fatalf("new file engine: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentsMdPath := filepath.Join(tmpDir, "AGENTS.md")
+	// Write an unreadable file (mode 000)
+	if writeErr := os.WriteFile(agentsMdPath, []byte("secret"), 0o000); writeErr != nil {
+		t.Fatalf("write AGENTS.md: %v", writeErr)
+	}
+	t.Cleanup(func() { _ = os.Chmod(agentsMdPath, 0o644) })
+
+	out, err := engine.Resolve(ResolveRequest{
+		Model:         "gpt-5-nano",
+		WorkspacePath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("resolve should not fail entirely on unreadable AGENTS.md: %v", err)
+	}
+	if strings.Contains(out.StaticPrompt, "[SECTION AGENTS_MD]") {
+		t.Fatalf("expected no AGENTS_MD section on read failure, got: %q", out.StaticPrompt)
+	}
+	if out.AgentsMdLoaded {
+		t.Fatalf("expected AgentsMdLoaded=false on read failure")
+	}
+	// Should have a warning
+	found := false
+	for _, w := range out.Warnings {
+		if w.Code == "agents_md_read_failed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected agents_md_read_failed warning on read failure, got: %+v", out.Warnings)
+	}
+}
+
+func TestResolveRejectsPathEscape(t *testing.T) {
+	t.Parallel()
+	root := makePromptFixture(t)
+	engine, err := NewFileEngine(root)
+	if err != nil {
+		t.Fatalf("new file engine: %v", err)
+	}
+
+	// Even with a path-escape attempt, Resolve should not crash
+	// and should not load AGENTS.md from outside the workspace.
+	// filepath.Join normalises the path so "/tmp/../etc" → "/etc",
+	// so the escape protection is that the candidate path is always
+	// exactly "<absRoot>/AGENTS.md" after cleaning.
+	//
+	// We verify the behaviour by using a workspace root and confirming
+	// that no AGENTS.md section leaks from an unexpected location.
+	tmpDir := t.TempDir()
+	// Place AGENTS.md in the parent of tmpDir to try to trick the loader.
+	// The loader should only look at <tmpDir>/AGENTS.md.
+	parentDir := filepath.Dir(tmpDir)
+	if writeErr := os.WriteFile(filepath.Join(parentDir, "AGENTS.md"), []byte("SHOULD_NOT_APPEAR"), 0o644); writeErr != nil {
+		// Parent may not be writable in all test environments; skip this subcheck.
+		t.Skip("cannot write to parent dir, skipping path-escape sub-check")
+	}
+	// No AGENTS.md inside tmpDir itself.
+	out, err := engine.Resolve(ResolveRequest{
+		Model:         "gpt-5-nano",
+		WorkspacePath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if strings.Contains(out.StaticPrompt, "SHOULD_NOT_APPEAR") {
+		t.Fatalf("path-escape: AGENTS.md from parent appeared in prompt")
+	}
 }
 
 func mustContainOrdered(t *testing.T, text string, parts ...string) {

--- a/internal/systemprompt/types.go
+++ b/internal/systemprompt/types.go
@@ -19,6 +19,11 @@ type ResolveRequest struct {
 	PromptProfile      string
 	TaskContext        string
 	Extensions         Extensions
+	// WorkspacePath is the root directory of the workspace/repository. When set,
+	// the engine will attempt to read an AGENTS.md file from that directory and
+	// inject its contents as an AGENTS_MD section after MODEL_PROFILE. An absent
+	// file is silently skipped; a read error produces a warning.
+	WorkspacePath string
 }
 
 type EnvironmentInfo struct {
@@ -69,6 +74,9 @@ type ResolvedPrompt struct {
 	Talents              []string
 	Skills               []string
 	Warnings             []Warning
+	// AgentsMdLoaded is true when an AGENTS.md file was found and successfully
+	// loaded from the workspace path and injected into the static prompt.
+	AgentsMdLoaded bool
 }
 
 type Engine interface {


### PR DESCRIPTION
## Summary

- Adds `WorkspacePath string` to `ResolveRequest` so callers can specify a repo root
- Adds `AgentsMdLoaded bool` to `ResolvedPrompt` for observability
- Implements `readAgentsMd()` with path-escape protection, soft fail on absent file, warning on read error
- Injects `AGENTS_MD` section between `MODEL_PROFILE` and `TASK_CONTEXT` in the prompt chain
- Threads workspace path from the provisioned workspace into prompt resolution in `runner.go`

## Test plan

- [x] `TestResolveWithEmptyWorkspacePath` — no section injected, no error
- [x] `TestResolveSkipsAgentsMdWhenAbsent` — absent file → no section, `AgentsMdLoaded=false`
- [x] `TestResolveLoadsAgentsMdFromWorkspace` — present file → content in prompt, `AgentsMdLoaded=true`, section position correct
- [x] `TestResolveWarnsOnAgentsMdReadFailure` — unreadable file → warning appended, no crash
- [x] `TestResolveRejectsPathEscape` — traversal attempt → fails closed
- [x] Full `./internal/... ./cmd/...` suite passes (zero regressions)

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)