### PR TITLE
feat(#411): add source-agnostic trigger envelope and deterministic external thread routing

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -30,6 +30,7 @@ import (
 	"go-agent-harness/internal/profiles"
 	"go-agent-harness/internal/server"
 	"go-agent-harness/internal/skills"
+	"go-agent-harness/internal/trigger"
 	istore "go-agent-harness/internal/store"
 	"go-agent-harness/internal/store/s3backup"
 	"go-agent-harness/internal/subagents"
@@ -680,6 +681,23 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		skillManager = sla
 	}
 
+	// Build the external-trigger validator registry from webhook secrets (issue #411).
+	// Validators are only registered when the corresponding env var is non-empty;
+	// missing secrets mean the source is simply unavailable (fail-closed).
+	triggerValidators := trigger.NewValidatorRegistry()
+	if s := strings.TrimSpace(getenv("GITHUB_WEBHOOK_SECRET")); s != "" {
+		triggerValidators.Register("github", &trigger.GitHubValidator{Secret: s})
+		log.Printf("registered GitHub webhook validator")
+	}
+	if s := strings.TrimSpace(getenv("SLACK_SIGNING_SECRET")); s != "" {
+		triggerValidators.Register("slack", &trigger.SlackValidator{Secret: s})
+		log.Printf("registered Slack webhook validator")
+	}
+	if s := strings.TrimSpace(getenv("LINEAR_WEBHOOK_SECRET")); s != "" {
+		triggerValidators.Register("linear", &trigger.LinearValidator{Secret: s})
+		log.Printf("registered Linear webhook validator")
+	}
+
 	handler := server.NewWithOptions(server.ServerOptions{
 		Runner:           runner,
 		Catalog:          modelCatalog,
@@ -690,6 +708,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		SubagentManager:  subagentMgr,
 		ProviderRegistry: providerRegistry,
 		Store:            runStore,
+		Validators:       triggerValidators,
 	})
 	httpServer := &http.Server{
 		Addr:              addr,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -19,6 +19,7 @@ import (
 	"go-agent-harness/internal/provider/catalog"
 	"go-agent-harness/internal/store"
 	"go-agent-harness/internal/subagents"
+	"go-agent-harness/internal/trigger"
 )
 
 // CronClient is the interface the HTTP server uses to manage cron jobs.
@@ -88,6 +89,9 @@ type ServerOptions struct {
 	// ProfilesDir is the directory for user-created profiles.
 	// When non-empty, POST/PUT/DELETE /v1/profiles/{name} endpoints are enabled.
 	ProfilesDir string
+	// Validators is an optional registry of webhook signature validators for
+	// POST /v1/external/trigger. When nil, the endpoint returns 401 for all requests.
+	Validators *trigger.ValidatorRegistry
 }
 
 // NewWithOptions creates an HTTP handler with the full set of optional dependencies.
@@ -115,6 +119,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		authDisabled:      opts.AuthDisabled || authDisabledFromEnv(),
 		profilesProject:   opts.ProfilesProject,
 		profilesUser:      opts.ProfilesUser,
+		validators:        opts.Validators,
 	}
 	// If runner config has an approval broker, use it as default when none
 	// is explicitly supplied in ServerOptions.
@@ -202,6 +207,11 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux.Handle("/v1/profiles", auth(read(http.HandlerFunc(s.handleProfilesRoot))))
 	mux.Handle("/v1/profiles/", auth(http.HandlerFunc(s.handleProfileByName)))
 
+	// POST /v1/external/trigger — source-agnostic external trigger endpoint (issue #411).
+	// Authentication is performed via source-specific HMAC signature validation rather
+	// than the standard Bearer token middleware, so this route bypasses auth middleware.
+	mux.HandleFunc("/v1/external/trigger", s.handleExternalTrigger)
+
 	return mux
 }
 
@@ -249,6 +259,10 @@ type Server struct {
 	// profilesProject and profilesUser are the directories used by GET /v1/profiles.
 	profilesProject string
 	profilesUser    string
+
+	// validators is the registry of webhook signature validators for
+	// POST /v1/external/trigger (issue #411).
+	validators *trigger.ValidatorRegistry
 }
 
 // ModelResponse is the JSON shape for a single model in the /v1/models response.

--- a/internal/server/http_external_trigger.go
+++ b/internal/server/http_external_trigger.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/store"
+	"go-agent-harness/internal/trigger"
+)
+
+// handleExternalTrigger handles POST /v1/external/trigger.
+//
+// It accepts a normalized ExternalTriggerEnvelope, validates the source-specific
+// HMAC signature, derives a deterministic ExternalThreadID, looks up any existing
+// run associated with that thread, and routes to SteerRun, ContinueRun, or
+// StartRun based on the requested action and the current run state.
+//
+// Response codes:
+//
+//	202 — request accepted (steer/continue/start succeeded)
+//	400 — invalid JSON or missing required fields
+//	401 — signature validation failed or no validator configured for source
+//	404 — action is "steer" or "continue" but no existing run found for thread
+//	409 — run state mismatch (e.g. "steer" on completed run, "continue" on active run)
+//	501 — runStore not configured (required for thread lookup)
+func (s *Server) handleExternalTrigger(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	// 1. Read the raw body so we can validate the HMAC signature.
+	rawBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "failed to read request body")
+		return
+	}
+
+	// 2. Decode the JSON envelope.
+	var env trigger.ExternalTriggerEnvelope
+	if err := json.Unmarshal(rawBody, &env); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	env.RawBody = rawBody
+
+	// Prefer X-Trigger-Signature header over the JSON body field when both are
+	// present; this avoids the circular dependency where the HMAC would need to
+	// cover the field that carries the HMAC itself.
+	if hdrSig := strings.TrimSpace(r.Header.Get("X-Trigger-Signature")); hdrSig != "" {
+		env.Signature = hdrSig
+	}
+
+	// Validate required fields.
+	if strings.TrimSpace(env.Source) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "source is required")
+		return
+	}
+	if strings.TrimSpace(env.Action) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "action is required")
+		return
+	}
+	if strings.TrimSpace(env.ThreadID) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "thread_id is required")
+		return
+	}
+	if strings.TrimSpace(env.Message) == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "message is required")
+		return
+	}
+
+	// 3. Validate the webhook signature.
+	if s.validators == nil {
+		writeError(w, http.StatusUnauthorized, "invalid_signature", "no validator registry configured")
+		return
+	}
+	validator, ok := s.validators.Get(env.Source)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "invalid_signature", "no validator configured for source: "+env.Source)
+		return
+	}
+	if err := validator.ValidateSignature(r.Context(), env); err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid_signature", err.Error())
+		return
+	}
+
+	// 4. Derive the deterministic thread ID.
+	threadID := trigger.DeriveExternalThreadID(env.Source, env.RepoOwner, env.RepoName, env.ThreadID)
+
+	// 5. Look up existing runs by conversation ID (requires a store).
+	if s.runStore == nil {
+		writeError(w, http.StatusNotImplemented, "not_implemented", "run persistence is not configured")
+		return
+	}
+
+	tenantID := strings.TrimSpace(env.TenantID)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+
+	runs, err := s.runStore.ListRuns(r.Context(), store.RunFilter{
+		ConversationID: threadID.String(),
+		TenantID:       tenantID,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	action := strings.ToLower(strings.TrimSpace(env.Action))
+
+	// 6. Route by action and run state.
+	switch action {
+	case "start":
+		// Start a new run regardless of existing runs.
+		req := harness.RunRequest{
+			Prompt:         env.Message,
+			ConversationID: threadID.String(),
+			TenantID:       tenantID,
+		}
+		if strings.TrimSpace(env.AgentID) != "" {
+			req.AgentID = env.AgentID
+		}
+		run, err := s.runner.StartRun(req)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		if s.runStore != nil {
+			storeRun := harnessRunToStore(run)
+			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"run_id": run.ID,
+			"status": run.Status,
+		})
+
+	case "steer":
+		if len(runs) == 0 {
+			writeError(w, http.StatusNotFound, "no_thread_found", "no existing run found for this thread")
+			return
+		}
+		// Find the most recent active run (first in list since ListRuns returns newest first).
+		latestRun := runs[0]
+		if latestRun.Status != store.RunStatusRunning && latestRun.Status != store.RunStatusQueued &&
+			latestRun.Status != store.RunStatusWaitingForUser {
+			writeError(w, http.StatusConflict, "run_state_mismatch",
+				"cannot steer a run with status: "+string(latestRun.Status))
+			return
+		}
+		if err := s.runner.SteerRun(latestRun.ID, env.Message); err != nil {
+			if errors.Is(err, harness.ErrRunNotFound) {
+				writeError(w, http.StatusNotFound, "no_thread_found", "run not found in runner")
+				return
+			}
+			if errors.Is(err, harness.ErrRunNotActive) {
+				writeError(w, http.StatusConflict, "run_state_mismatch", err.Error())
+				return
+			}
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "accepted"})
+
+	case "continue":
+		if len(runs) == 0 {
+			writeError(w, http.StatusNotFound, "no_thread_found", "no existing run found for this thread")
+			return
+		}
+		// Find the most recent completed run.
+		latestRun := runs[0]
+		if latestRun.Status != store.RunStatusCompleted && latestRun.Status != store.RunStatusFailed {
+			writeError(w, http.StatusConflict, "run_state_mismatch",
+				"cannot continue a run with status: "+string(latestRun.Status))
+			return
+		}
+		newRun, err := s.runner.ContinueRun(latestRun.ID, env.Message)
+		if err != nil {
+			if errors.Is(err, harness.ErrRunNotFound) {
+				writeError(w, http.StatusNotFound, "no_thread_found", "run not found in runner")
+				return
+			}
+			if errors.Is(err, harness.ErrRunNotCompleted) {
+				writeError(w, http.StatusConflict, "run_state_mismatch", err.Error())
+				return
+			}
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		if s.runStore != nil {
+			storeRun := harnessRunToStore(newRun)
+			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{
+			"run_id": newRun.ID,
+			"status": newRun.Status,
+		})
+
+	default:
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"unknown action: "+env.Action+"; valid actions are: start, steer, continue")
+	}
+}

--- a/internal/server/http_external_trigger_test.go
+++ b/internal/server/http_external_trigger_test.go
@@ -1,0 +1,467 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/store"
+	"go-agent-harness/internal/trigger"
+)
+
+// --- test helpers ---
+
+// githubWebhookSig computes the X-Hub-Signature-256 value for a body and secret.
+func githubWebhookSig(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// buildTriggerRequest encodes an ExternalTriggerEnvelope as JSON (without the
+// signature field) and computes an HMAC-SHA256 signature over that body.
+// The signature is returned separately to be sent as X-Trigger-Signature header.
+// This avoids the circular dependency where the HMAC would need to cover itself.
+func buildTriggerRequest(t *testing.T, source, secret, action, message, threadID string, extras map[string]string) ([]byte, string) {
+	t.Helper()
+	env := map[string]string{
+		"source":    source,
+		"action":    action,
+		"message":   message,
+		"thread_id": threadID,
+	}
+	for k, v := range extras {
+		env[k] = v
+	}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	sig := githubWebhookSig(secret, string(raw))
+	return raw, sig
+}
+
+// makeGitHubRegistry returns a ValidatorRegistry with a GitHub validator.
+func makeGitHubRegistry(secret string) *trigger.ValidatorRegistry {
+	reg := trigger.NewValidatorRegistry()
+	reg.Register("github", &trigger.GitHubValidator{Secret: secret})
+	return reg
+}
+
+// newTriggerServer creates a test HTTP server backed by a runner+MemoryStore with
+// auth disabled and the provided ValidatorRegistry.
+func newTriggerServer(t *testing.T, provider harness.Provider, reg *trigger.ValidatorRegistry) (*httptest.Server, *store.MemoryStore) {
+	t.Helper()
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+	ms := store.NewMemoryStore()
+	handler := NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        ms,
+		AuthDisabled: true,
+		Validators:   reg,
+	})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts, ms
+}
+
+// sendTrigger sends a POST /v1/external/trigger request with the given body and
+// X-Trigger-Signature header.
+func sendTrigger(t *testing.T, ts *httptest.Server, body []byte, sig string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/external/trigger", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Trigger-Signature", sig)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return res
+}
+
+// blockingExternalProvider is a scripted provider that calls beforeCall before
+// returning so the test can gate on run execution (keeping the run active).
+type blockingExternalProvider struct {
+	mu         sync.Mutex
+	results    []harness.CompletionResult
+	calls      int
+	beforeCall func(idx int)
+}
+
+func (p *blockingExternalProvider) Complete(_ context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	var result harness.CompletionResult
+	if idx < len(p.results) {
+		result = p.results[idx]
+	}
+	p.mu.Unlock()
+	if p.beforeCall != nil {
+		p.beforeCall(idx)
+	}
+	return result, nil
+}
+
+// --- Tests ---
+
+// TestHandleExternalTrigger_StartNewRun verifies that action="start" creates a
+// new run and returns 202 with a run_id.
+func TestHandleExternalTrigger_StartNewRun(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	body, sig := buildTriggerRequest(t, "github", secret, "start", "build the feature", "PR#42", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID  string `json:"run_id"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Error("expected non-empty run_id")
+	}
+}
+
+// TestHandleExternalTrigger_SteerActiveRun verifies that action="steer" on an
+// active run returns 202.
+func TestHandleExternalTrigger_SteerActiveRun(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+	provider := &blockingExternalProvider{
+		results: []harness.CompletionResult{{Content: "done"}},
+		beforeCall: func(idx int) {
+			if idx == 0 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+	reg := makeGitHubRegistry(secret)
+	ts, ms := newTriggerServer(t, provider, reg)
+
+	// Derive the thread ID so we can pre-populate the store.
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#42")
+
+	// Start a run via the direct API so the runner knows about it.
+	startBody, _ := json.Marshal(map[string]string{
+		"prompt":          "hello",
+		"conversation_id": threadID.String(),
+	})
+	startRes, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewReader(startBody))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	_ = json.NewDecoder(startRes.Body).Decode(&created)
+	startRes.Body.Close()
+
+	// Pre-populate the store so ListRuns finds the run.
+	_ = ms.CreateRun(context.Background(), &store.Run{
+		ID:             created.RunID,
+		ConversationID: threadID.String(),
+		TenantID:       "default",
+		Status:         store.RunStatusRunning,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	})
+
+	// Wait for run to block inside the provider.
+	<-blockCh
+
+	body, sig := buildTriggerRequest(t, "github", secret, "steer", "pivot the approach", "PR#42", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+
+	close(releaseCh)
+}
+
+// TestHandleExternalTrigger_ContinueCompletedRun verifies that action="continue"
+// on a completed run returns 202 with a new run_id.
+func TestHandleExternalTrigger_ContinueCompletedRun(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, ms := newTriggerServer(t, provider, reg)
+
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#99")
+
+	// Start a run via the API and wait for it to complete.
+	startBody, _ := json.Marshal(map[string]string{
+		"prompt":          "original prompt",
+		"conversation_id": threadID.String(),
+	})
+	startRes, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewReader(startBody))
+	if err != nil {
+		t.Fatalf("start run via API: %v", err)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	_ = json.NewDecoder(startRes.Body).Decode(&created)
+	startRes.Body.Close()
+
+	// Wait for completion.
+	waitForRunStatus(t, ts, created.RunID, "completed", "failed")
+
+	// Update the store to reflect the completed run with the correct thread ID.
+	_ = ms.UpdateRun(context.Background(), &store.Run{
+		ID:             created.RunID,
+		ConversationID: threadID.String(),
+		TenantID:       "default",
+		Status:         store.RunStatusCompleted,
+		Prompt:         "original prompt",
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	})
+
+	body, sig := buildTriggerRequest(t, "github", secret, "continue", "follow up", "PR#99", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Error("expected non-empty run_id in continue response")
+	}
+}
+
+// TestHandleExternalTrigger_InvalidSignature verifies that a wrong HMAC returns 401.
+func TestHandleExternalTrigger_InvalidSignature(t *testing.T) {
+	t.Parallel()
+
+	const secret = "correct-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	body, _ := buildTriggerRequest(t, "github", secret, "start", "build", "PR#1", nil)
+	// Send a signature computed with the WRONG secret.
+	wrongSig := githubWebhookSig("wrong-secret", string(body))
+
+	res := sendTrigger(t, ts, body, wrongSig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 401, got %d: %s", res.StatusCode, raw)
+	}
+}
+
+// TestHandleExternalTrigger_SteerCompletedRun_Conflict verifies that steering a
+// completed run returns 409 Conflict.
+func TestHandleExternalTrigger_SteerCompletedRun_Conflict(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, ms := newTriggerServer(t, provider, reg)
+
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#77")
+
+	// Pre-populate store with a completed run.
+	_ = ms.CreateRun(context.Background(), &store.Run{
+		ID:             "run-conflict-test",
+		ConversationID: threadID.String(),
+		TenantID:       "default",
+		Status:         store.RunStatusCompleted,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	})
+
+	body, sig := buildTriggerRequest(t, "github", secret, "steer", "too late", "PR#77", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusConflict {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 409, got %d: %s", res.StatusCode, raw)
+	}
+}
+
+// TestHandleExternalTrigger_SteerNoThread_NotFound verifies that steering a
+// thread with no existing run returns 404.
+func TestHandleExternalTrigger_SteerNoThread_NotFound(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	body, sig := buildTriggerRequest(t, "github", secret, "steer", "where am I", "PR#9999", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNotFound {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 404, got %d: %s", res.StatusCode, raw)
+	}
+}
+
+// TestHandleExternalTrigger_NoValidatorForSource verifies that an unknown source
+// returns 401 when no validator is registered for it.
+func TestHandleExternalTrigger_NoValidatorForSource(t *testing.T) {
+	t.Parallel()
+
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	// Registry has only GitHub, not Slack.
+	reg := makeGitHubRegistry("secret")
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	body, sig := buildTriggerRequest(t, "slack", "slack-secret", "start", "hello", "C012/123", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusUnauthorized {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 401, got %d: %s", res.StatusCode, raw)
+	}
+}
+
+// TestHandleExternalTrigger_MethodNotAllowed verifies that non-POST methods
+// return 405.
+func TestHandleExternalTrigger_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry("secret")
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/external/trigger", nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 405, got %d: %s", res.StatusCode, raw)
+	}
+}
+
+// TestHandleExternalTrigger_DirectAPIUnaffected verifies that the existing
+// POST /v1/runs endpoint still works normally after adding the new route.
+func TestHandleExternalTrigger_DirectAPIUnaffected(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"test direct api"}`))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202 from direct /v1/runs, got %d: %s", res.StatusCode, raw)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Error("expected non-empty run_id from direct API")
+	}
+}
+
+// TestHandleExternalTrigger_MissingRequiredFields verifies 400 for missing
+// required envelope fields (source, action, message, thread_id).
+func TestHandleExternalTrigger_MissingRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts, _ := newTriggerServer(t, provider, reg)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"missing_source", `{"action":"start","message":"hi","thread_id":"t1"}`},
+		{"missing_action", `{"source":"github","message":"hi","thread_id":"t1"}`},
+		{"missing_message", `{"source":"github","action":"start","thread_id":"t1"}`},
+		{"missing_thread_id", `{"source":"github","action":"start","message":"hi"}`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			sig := githubWebhookSig(secret, tc.body)
+			res := sendTrigger(t, ts, []byte(tc.body), sig)
+			defer res.Body.Close()
+			if res.StatusCode != http.StatusBadRequest {
+				raw, _ := io.ReadAll(res.Body)
+				t.Fatalf("%s: expected 400, got %d: %s", tc.name, res.StatusCode, raw)
+			}
+		})
+	}
+}

--- a/internal/trigger/thread_id.go
+++ b/internal/trigger/thread_id.go
@@ -1,0 +1,29 @@
+package trigger
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// DeriveExternalThreadID computes a stable, deterministic conversation ID
+// from external source identifiers. The algorithm is:
+//
+//   - If repoOwner and repoName are both non-empty:
+//     SHA256("source\x00repoOwner\x00repoName\x00threadID")
+//   - Otherwise:
+//     SHA256("source\x00threadID")
+//
+// The source is normalized to lowercase before hashing. The returned ID has
+// the form "source:hexhash" so it is both human-readable and globally unique.
+func DeriveExternalThreadID(source, repoOwner, repoName, threadID string) ExternalThreadID {
+	normalized := strings.ToLower(source)
+	var preimage string
+	if repoOwner != "" && repoName != "" {
+		preimage = normalized + "\x00" + repoOwner + "\x00" + repoName + "\x00" + threadID
+	} else {
+		preimage = normalized + "\x00" + threadID
+	}
+	hash := sha256.Sum256([]byte(preimage))
+	return ExternalThreadID(normalized + ":" + hex.EncodeToString(hash[:]))
+}

--- a/internal/trigger/thread_id_test.go
+++ b/internal/trigger/thread_id_test.go
@@ -1,0 +1,102 @@
+package trigger
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDeriveExternalThreadID_Deterministic verifies that the same inputs always
+// produce the same ExternalThreadID.
+func TestDeriveExternalThreadID_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	id1 := DeriveExternalThreadID("github", "anthropic", "go-agent-harness", "42")
+	id2 := DeriveExternalThreadID("github", "anthropic", "go-agent-harness", "42")
+	if id1 != id2 {
+		t.Errorf("expected identical IDs, got %q and %q", id1, id2)
+	}
+}
+
+// TestDeriveExternalThreadID_UniquePerInput verifies that different inputs
+// produce different ExternalThreadIDs.
+func TestDeriveExternalThreadID_UniquePerInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		source, repoOwner, repoName, threadID string
+	}{
+		{"github", "anthropic", "go-agent-harness", "42"},
+		{"github", "anthropic", "go-agent-harness", "43"},
+		{"github", "anthropic", "other-repo", "42"},
+		{"slack", "anthropic", "go-agent-harness", "42"},
+		{"github", "other-org", "go-agent-harness", "42"},
+	}
+
+	seen := make(map[ExternalThreadID]struct{})
+	for _, c := range cases {
+		id := DeriveExternalThreadID(c.source, c.repoOwner, c.repoName, c.threadID)
+		if _, exists := seen[id]; exists {
+			t.Errorf("collision: inputs %+v produced duplicate ID %q", c, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestDeriveExternalThreadID_EmptyRepo verifies that empty repoOwner/repoName
+// produces a valid, stable ID (no panic, deterministic).
+func TestDeriveExternalThreadID_EmptyRepo(t *testing.T) {
+	t.Parallel()
+
+	id1 := DeriveExternalThreadID("slack", "", "", "C012AB3CD/1699999999.000001")
+	id2 := DeriveExternalThreadID("slack", "", "", "C012AB3CD/1699999999.000001")
+	if id1 != id2 {
+		t.Errorf("expected identical IDs for empty repo, got %q and %q", id1, id2)
+	}
+	if id1.String() == "" {
+		t.Error("expected non-empty ID")
+	}
+	if !strings.HasPrefix(id1.String(), "slack:") {
+		t.Errorf("expected ID to start with 'slack:', got %q", id1)
+	}
+}
+
+// TestDeriveExternalThreadID_SourceNormalization verifies that source casing
+// does not affect the resulting ID ("GitHub" == "github").
+func TestDeriveExternalThreadID_SourceNormalization(t *testing.T) {
+	t.Parallel()
+
+	lower := DeriveExternalThreadID("github", "org", "repo", "99")
+	upper := DeriveExternalThreadID("GitHub", "org", "repo", "99")
+	mixed := DeriveExternalThreadID("GITHUB", "org", "repo", "99")
+
+	if lower != upper {
+		t.Errorf("expected 'github' == 'GitHub', got %q vs %q", lower, upper)
+	}
+	if lower != mixed {
+		t.Errorf("expected 'github' == 'GITHUB', got %q vs %q", lower, mixed)
+	}
+	// The prefix should always be lowercase.
+	if !strings.HasPrefix(lower.String(), "github:") {
+		t.Errorf("expected ID to start with 'github:', got %q", lower)
+	}
+}
+
+// TestDeriveExternalThreadID_Format verifies the output format is "source:hexhash".
+func TestDeriveExternalThreadID_Format(t *testing.T) {
+	t.Parallel()
+
+	id := DeriveExternalThreadID("linear", "myorg", "myrepo", "ENG-123")
+	s := id.String()
+
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		t.Fatalf("expected 'source:hash' format, got %q", s)
+	}
+	if parts[0] != "linear" {
+		t.Errorf("expected source prefix 'linear', got %q", parts[0])
+	}
+	// SHA-256 hex is 64 characters.
+	if len(parts[1]) != 64 {
+		t.Errorf("expected 64-char hex hash, got %d chars: %q", len(parts[1]), parts[1])
+	}
+}

--- a/internal/trigger/types.go
+++ b/internal/trigger/types.go
@@ -1,0 +1,29 @@
+package trigger
+
+import "context"
+
+// ExternalTriggerEnvelope is a normalized incoming trigger from any external source.
+type ExternalTriggerEnvelope struct {
+	Source    string `json:"source"`     // "github" | "slack" | "linear"
+	SourceID  string `json:"source_id"`  // webhook delivery ID or event ID
+	RepoOwner string `json:"repo_owner"` // e.g. "anthropic"
+	RepoName  string `json:"repo_name"`  // e.g. "go-agent-harness"
+	ThreadID  string `json:"thread_id"`  // PR#, issue#, thread TS, Linear issue key
+	Action    string `json:"action"`     // "start" | "steer" | "continue"
+	Message   string `json:"message"`    // user-supplied prompt text
+	TenantID  string `json:"tenant_id"`  // "" defaults to "default"
+	AgentID   string `json:"agent_id"`   // "" defaults to "default"
+	Signature string `json:"signature"`  // source-specific HMAC signature
+	RawBody   []byte `json:"-"`          // raw request body for sig validation (not serialized)
+}
+
+// ExternalThreadID is a stable, deterministic conversation ID derived from external identifiers.
+type ExternalThreadID string
+
+// String returns the string form of the thread ID.
+func (e ExternalThreadID) String() string { return string(e) }
+
+// ExternalThreadValidator validates webhook signatures for an external source.
+type ExternalThreadValidator interface {
+	ValidateSignature(ctx context.Context, env ExternalTriggerEnvelope) error
+}

--- a/internal/trigger/validator.go
+++ b/internal/trigger/validator.go
@@ -1,0 +1,129 @@
+package trigger
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ValidatorRegistry maps source names to their signature validators.
+type ValidatorRegistry struct {
+	validators map[string]ExternalThreadValidator
+}
+
+// NewValidatorRegistry returns an empty ValidatorRegistry.
+func NewValidatorRegistry() *ValidatorRegistry {
+	return &ValidatorRegistry{validators: make(map[string]ExternalThreadValidator)}
+}
+
+// Register adds a validator for the given source name.
+// Source names are normalized to lowercase.
+func (r *ValidatorRegistry) Register(source string, v ExternalThreadValidator) {
+	r.validators[strings.ToLower(source)] = v
+}
+
+// Get retrieves the validator for source. The bool reports whether one was found.
+// Source names are normalized to lowercase.
+func (r *ValidatorRegistry) Get(source string) (ExternalThreadValidator, bool) {
+	v, ok := r.validators[strings.ToLower(source)]
+	return v, ok
+}
+
+// GitHubValidator validates GitHub webhook HMAC-SHA256 signatures.
+// The signature is expected in the X-Hub-Signature-256 header format: "sha256=<hex>".
+type GitHubValidator struct {
+	Secret string
+}
+
+// ValidateSignature verifies that env.Signature matches the HMAC-SHA256 of env.RawBody
+// using v.Secret as the key. The expected format is "sha256=<hex>".
+func (v *GitHubValidator) ValidateSignature(_ context.Context, env ExternalTriggerEnvelope) error {
+	if v.Secret == "" {
+		return fmt.Errorf("github webhook secret not configured")
+	}
+	mac := hmac.New(sha256.New, []byte(v.Secret))
+	mac.Write(env.RawBody)
+	expected := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(env.Signature), []byte(expected)) != 1 {
+		return fmt.Errorf("invalid github webhook signature")
+	}
+	return nil
+}
+
+// SlackValidator validates Slack webhook HMAC-SHA256 signatures with timestamp
+// freshness enforcement (±5 minutes).
+//
+// Slack packs both the timestamp and the signature into env.Signature using the
+// format "timestamp:v0=<hex>" so that a single envelope field carries all of the
+// validation material without requiring extra HTTP-header plumbing.
+type SlackValidator struct {
+	Secret string
+	// nowFunc is injectable for testing; defaults to time.Now.
+	nowFunc func() time.Time
+}
+
+// ValidateSignature verifies the Slack request signature.
+// env.Signature must be in the format "<unix_timestamp>:v0=<hex>".
+func (v *SlackValidator) ValidateSignature(_ context.Context, env ExternalTriggerEnvelope) error {
+	if v.Secret == "" {
+		return fmt.Errorf("slack signing secret not configured")
+	}
+	// Parse timestamp from Signature field (packed as "timestamp:sig" for Slack).
+	parts := strings.SplitN(env.Signature, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid slack signature format (expected timestamp:sig)")
+	}
+	tsStr, sig := parts[0], parts[1]
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid slack timestamp: %w", err)
+	}
+	now := time.Now
+	if v.nowFunc != nil {
+		now = v.nowFunc
+	}
+	if absInt64(now().Unix()-ts) > 300 {
+		return fmt.Errorf("slack request timestamp expired")
+	}
+	basestring := fmt.Sprintf("v0:%d:%s", ts, string(env.RawBody))
+	mac := hmac.New(sha256.New, []byte(v.Secret))
+	mac.Write([]byte(basestring))
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(sig), []byte(expected)) != 1 {
+		return fmt.Errorf("invalid slack signature")
+	}
+	return nil
+}
+
+// LinearValidator validates Linear webhook HMAC-SHA256 signatures.
+// The signature is the raw hex-encoded HMAC-SHA256 of the body.
+type LinearValidator struct {
+	Secret string
+}
+
+// ValidateSignature verifies that env.Signature is the HMAC-SHA256 hex of env.RawBody.
+func (v *LinearValidator) ValidateSignature(_ context.Context, env ExternalTriggerEnvelope) error {
+	if v.Secret == "" {
+		return fmt.Errorf("linear webhook secret not configured")
+	}
+	mac := hmac.New(sha256.New, []byte(v.Secret))
+	mac.Write(env.RawBody)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	if subtle.ConstantTimeCompare([]byte(env.Signature), []byte(expected)) != 1 {
+		return fmt.Errorf("invalid linear webhook signature")
+	}
+	return nil
+}
+
+func absInt64(n int64) int64 {
+	if n < 0 {
+		return -n
+	}
+	return n
+}

--- a/internal/trigger/validator_test.go
+++ b/internal/trigger/validator_test.go
@@ -1,0 +1,310 @@
+package trigger
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- helpers ---
+
+func githubSig(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func slackSig(secret string, ts int64, body string) string {
+	basestring := fmt.Sprintf("v0:%d:%s", ts, body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(basestring))
+	return fmt.Sprintf("%d:v0=%s", ts, hex.EncodeToString(mac.Sum(nil)))
+}
+
+func linearSig(secret, body string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(body))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// --- GitHubValidator ---
+
+func TestGitHubValidator_ValidSignature(t *testing.T) {
+	t.Parallel()
+	body := `{"action":"opened"}`
+	secret := "my-github-secret"
+	v := &GitHubValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "github",
+		RawBody:   []byte(body),
+		Signature: githubSig(secret, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err != nil {
+		t.Errorf("expected valid signature, got error: %v", err)
+	}
+}
+
+func TestGitHubValidator_InvalidSignature(t *testing.T) {
+	t.Parallel()
+	body := `{"action":"opened"}`
+	v := &GitHubValidator{Secret: "correct-secret"}
+	env := ExternalTriggerEnvelope{
+		Source:    "github",
+		RawBody:   []byte(body),
+		Signature: githubSig("wrong-secret", body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for invalid signature, got nil")
+	}
+}
+
+func TestGitHubValidator_NoSecret(t *testing.T) {
+	t.Parallel()
+	v := &GitHubValidator{Secret: ""}
+	env := ExternalTriggerEnvelope{
+		Source:    "github",
+		RawBody:   []byte(`{}`),
+		Signature: "sha256=anything",
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error when secret is empty, got nil")
+	}
+}
+
+func TestGitHubValidator_TamperedBody(t *testing.T) {
+	t.Parallel()
+	secret := "secret"
+	originalBody := `{"action":"opened"}`
+	tamperedBody := `{"action":"deleted"}`
+	v := &GitHubValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "github",
+		RawBody:   []byte(tamperedBody),
+		Signature: githubSig(secret, originalBody), // sig for original body
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for tampered body, got nil")
+	}
+}
+
+// --- SlackValidator ---
+
+func TestSlackValidator_ValidSignature(t *testing.T) {
+	t.Parallel()
+	body := `payload=test`
+	secret := "slack-signing-secret"
+	ts := time.Now().Unix()
+	v := &SlackValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(body),
+		Signature: slackSig(secret, ts, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err != nil {
+		t.Errorf("expected valid signature, got error: %v", err)
+	}
+}
+
+func TestSlackValidator_InvalidSignature(t *testing.T) {
+	t.Parallel()
+	body := `payload=test`
+	ts := time.Now().Unix()
+	v := &SlackValidator{Secret: "correct-secret"}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(body),
+		Signature: slackSig("wrong-secret", ts, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for invalid signature, got nil")
+	}
+}
+
+func TestSlackValidator_ExpiredTimestamp(t *testing.T) {
+	t.Parallel()
+	body := `payload=test`
+	secret := "slack-signing-secret"
+	// Timestamp is 10 minutes in the past — beyond the 5-minute window.
+	ts := time.Now().Add(-10 * time.Minute).Unix()
+	v := &SlackValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(body),
+		Signature: slackSig(secret, ts, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for expired timestamp, got nil")
+	}
+	if err := v.ValidateSignature(context.Background(), env); !strings.Contains(err.Error(), "expired") {
+		t.Errorf("expected 'expired' in error, got: %v", err)
+	}
+}
+
+func TestSlackValidator_NoSecret(t *testing.T) {
+	t.Parallel()
+	v := &SlackValidator{Secret: ""}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(`payload=test`),
+		Signature: "1234567890:v0=abc",
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error when secret is empty, got nil")
+	}
+}
+
+func TestSlackValidator_BadSignatureFormat(t *testing.T) {
+	t.Parallel()
+	v := &SlackValidator{Secret: "secret"}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(`payload=test`),
+		Signature: "invalidsig-no-colon",
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for bad signature format, got nil")
+	}
+}
+
+func TestSlackValidator_FutureTimestamp(t *testing.T) {
+	t.Parallel()
+	body := `payload=test`
+	secret := "slack-signing-secret"
+	// Timestamp is 10 minutes in the future — also outside the 5-minute window.
+	ts := time.Now().Add(10 * time.Minute).Unix()
+	v := &SlackValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "slack",
+		RawBody:   []byte(body),
+		Signature: slackSig(secret, ts, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for future timestamp, got nil")
+	}
+}
+
+// --- LinearValidator ---
+
+func TestLinearValidator_ValidSignature(t *testing.T) {
+	t.Parallel()
+	body := `{"action":"create"}`
+	secret := "linear-webhook-secret"
+	v := &LinearValidator{Secret: secret}
+	env := ExternalTriggerEnvelope{
+		Source:    "linear",
+		RawBody:   []byte(body),
+		Signature: linearSig(secret, body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err != nil {
+		t.Errorf("expected valid signature, got error: %v", err)
+	}
+}
+
+func TestLinearValidator_InvalidSignature(t *testing.T) {
+	t.Parallel()
+	body := `{"action":"create"}`
+	v := &LinearValidator{Secret: "correct-secret"}
+	env := ExternalTriggerEnvelope{
+		Source:    "linear",
+		RawBody:   []byte(body),
+		Signature: linearSig("wrong-secret", body),
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error for invalid signature, got nil")
+	}
+}
+
+func TestLinearValidator_NoSecret(t *testing.T) {
+	t.Parallel()
+	v := &LinearValidator{Secret: ""}
+	env := ExternalTriggerEnvelope{
+		Source:    "linear",
+		RawBody:   []byte(`{}`),
+		Signature: "deadbeef",
+	}
+	if err := v.ValidateSignature(context.Background(), env); err == nil {
+		t.Error("expected error when secret is empty, got nil")
+	}
+}
+
+// --- ValidatorRegistry ---
+
+func TestValidatorRegistry_RegisterAndGet(t *testing.T) {
+	t.Parallel()
+	reg := NewValidatorRegistry()
+	v := &GitHubValidator{Secret: "s"}
+	reg.Register("github", v)
+	got, ok := reg.Get("github")
+	if !ok {
+		t.Fatal("expected to find registered validator")
+	}
+	if got != v {
+		t.Error("expected same validator instance")
+	}
+}
+
+func TestValidatorRegistry_GetMissing(t *testing.T) {
+	t.Parallel()
+	reg := NewValidatorRegistry()
+	_, ok := reg.Get("unknown-source")
+	if ok {
+		t.Error("expected false for missing source")
+	}
+}
+
+func TestValidatorRegistry_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	reg := NewValidatorRegistry()
+	v := &GitHubValidator{Secret: "s"}
+	reg.Register("GitHub", v)
+
+	got, ok := reg.Get("github")
+	if !ok {
+		t.Fatal("expected to find validator registered under 'GitHub' via lowercase lookup")
+	}
+	if got != v {
+		t.Error("expected same validator instance")
+	}
+
+	got2, ok2 := reg.Get("GITHUB")
+	if !ok2 {
+		t.Fatal("expected to find validator registered under 'GitHub' via uppercase lookup")
+	}
+	if got2 != v {
+		t.Error("expected same validator instance")
+	}
+}
+
+func TestValidatorRegistry_MultipleValidators(t *testing.T) {
+	t.Parallel()
+	reg := NewValidatorRegistry()
+	gh := &GitHubValidator{Secret: "gh"}
+	sl := &SlackValidator{Secret: "sl"}
+	li := &LinearValidator{Secret: "li"}
+	reg.Register("github", gh)
+	reg.Register("slack", sl)
+	reg.Register("linear", li)
+
+	for _, tc := range []struct {
+		source string
+		want   ExternalThreadValidator
+	}{
+		{"github", gh},
+		{"slack", sl},
+		{"linear", li},
+	} {
+		got, ok := reg.Get(tc.source)
+		if !ok {
+			t.Errorf("expected to find validator for %q", tc.source)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("validator for %q: got %T, want %T", tc.source, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/trigger/` package with `ExternalTriggerEnvelope`, `ExternalThreadID`, and `ExternalThreadValidator` interface
- `DeriveExternalThreadID` uses SHA-256 over `source\x00repoOwner\x00repoName\x00threadID` for deterministic, stable conversation IDs
- `ValidatorRegistry` with `GitHubValidator`, `SlackValidator`, `LinearValidator` — all fail closed on missing secret, use `crypto/subtle.ConstantTimeCompare`
- New `POST /v1/external/trigger` endpoint: validates HMAC signature, derives thread ID, routes to `StartRun`/`SteerRun`/`ContinueRun` based on action + run state
- Wired into `cmd/harnessd/main.go` via `GITHUB_WEBHOOK_SECRET`, `SLACK_SIGNING_SECRET`, `LINEAR_WEBHOOK_SECRET` env vars

## Test plan

- [x] 5 thread-ID tests: determinism, uniqueness, empty-repo, source normalization, format
- [x] 15 validator tests: valid/invalid HMAC, expired Slack timestamp, no-secret fail-closed, registry ops
- [x] 10 HTTP handler tests: start/steer/continue happy paths, 401 on bad sig, 409 on state mismatch, 404 no thread, 405 wrong method, regression for direct API
- [x] Full `./internal/... ./cmd/...` suite — 0 failures

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)