### PR TITLE
feat(#414): add workspace-backend selection via profile isolation-mode precedence

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1251,16 +1251,36 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		})
 	}
 
-	// Per-run workspace provisioning (issue #324).
-	// If workspace_type is set, provision it now and register cleanup in runState.
+	// Per-run workspace provisioning (issue #324, extended by issue #414).
+	// Resolve the effective workspace type: RunRequest.WorkspaceType takes
+	// precedence; if unset, Profile.IsolationMode provides the fallback.
+	// Load the full profile now (if a profile is named) so we can extract
+	// IsolationMode. Profile loading errors are non-fatal for this field —
+	// a missing or unparseable profile falls back to no provisioning rather
+	// than failing the run at this early stage (the MCP loading path below
+	// already handles the authoritative profile error reporting).
+	var resolvedProfile *profiles.Profile
+	if req.ProfileName != "" {
+		profilesDir := r.config.ProfilesDir
+		if profilesDir == "" {
+			profilesDir = defaultProfilesDir()
+		}
+		if p, loadErr := profiles.LoadProfileFromUserDir(req.ProfileName, profilesDir); loadErr == nil && p != nil {
+			resolvedProfile = p
+		}
+	}
+	effectiveWorkspaceType := resolveWorkspaceType(req.WorkspaceType, resolvedProfile)
+
+	// If workspace_type is set (explicitly or via profile), provision it now
+	// and register cleanup in runState.
 	// The cleanup function is called by runWorkspaceCleanup() before each terminal
 	// event, ensuring workspace.destroyed is emitted before run.completed/failed.
 	// Provisioning failure immediately fails the run (no LLM call is made).
-	if req.WorkspaceType != "" {
-		ws, provisionErr := provisionRunWorkspace(ctx, runID, req.WorkspaceType, r.config.WorkspaceBaseOptions)
+	if effectiveWorkspaceType != "" {
+		ws, provisionErr := provisionRunWorkspace(ctx, runID, effectiveWorkspaceType, r.config.WorkspaceBaseOptions)
 		if provisionErr != nil {
 			r.emit(runID, EventWorkspaceProvisionFailed, map[string]any{
-				"workspace_type": req.WorkspaceType,
+				"workspace_type": effectiveWorkspaceType,
 				"error":          provisionErr.Error(),
 			})
 			r.failRun(runID, fmt.Errorf("workspace provisioning failed: %w", provisionErr))
@@ -1268,12 +1288,12 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		}
 		wsPath := ws.WorkspacePath()
 		r.emit(runID, EventWorkspaceProvisioned, map[string]any{
-			"workspace_type": req.WorkspaceType,
+			"workspace_type": effectiveWorkspaceType,
 			"workspace_path": wsPath,
 		})
 		// Store cleanup function so completeRun/failRun/cancelledRun can call it
 		// before the terminal event, keeping workspace.destroyed before run.completed.
-		wsType := req.WorkspaceType
+		wsType := effectiveWorkspaceType
 		logger := r.config.Logger
 		cleanupFn := func() {
 			destroyErr := ws.Destroy(context.Background())
@@ -5376,13 +5396,16 @@ func safeRecorderSend(ch chan rollout.RecordableEvent, ev rollout.RecordableEven
 	}
 }
 
-// knownWorkspaceTypes is the set of workspace types supported by the per-run
-// workspace selection feature. Only types that can be provisioned entirely
-// within the runner process are listed here; orchestrator-level types
-// (container, vm, pool) are not directly supported via RunRequest.WorkspaceType.
+// knownWorkspaceTypes is the set of workspace types recognised by the per-run
+// workspace selection feature. "local" and "worktree" are provisioned entirely
+// within the runner process. "container" and "vm" require orchestrator-level
+// configuration (symphd) — the runner records their type in events but the
+// provisioning path for those types ultimately delegates to the orchestrator.
 var knownWorkspaceTypes = map[string]bool{
-	"local":    true,
-	"worktree": true,
+	"local":     true,
+	"worktree":  true,
+	"container": true,
+	"vm":        true,
 }
 
 // validateWorkspaceType returns an error when wsType is not in the known set.
@@ -5394,7 +5417,30 @@ func validateWorkspaceType(wsType string) error {
 	if knownWorkspaceTypes[wsType] {
 		return nil
 	}
-	return fmt.Errorf("unsupported workspace_type %q: must be one of local, worktree", wsType)
+	return fmt.Errorf("unsupported workspace_type %q: must be one of local, worktree, container, vm", wsType)
+}
+
+// resolveWorkspaceType returns the effective workspace type for a run.
+// Precedence (highest to lowest):
+//  1. RunRequest.WorkspaceType — explicit per-run override wins unconditionally.
+//  2. Profile.IsolationMode — when a profile is loaded and IsolationMode is a
+//     provisionable value ("worktree", "container", "vm"), that value is used.
+//  3. "" (empty) — no provisioning; the run executes in the local process.
+//
+// Profile IsolationMode values of "none" or "" are treated as no preference
+// so that profiles can explicitly opt out of isolation without causing
+// provisioning to occur.
+func resolveWorkspaceType(reqWorkspaceType string, profile *profiles.Profile) string {
+	if reqWorkspaceType != "" {
+		return reqWorkspaceType
+	}
+	if profile != nil {
+		switch profile.IsolationMode {
+		case "worktree", "container", "vm":
+			return profile.IsolationMode
+		}
+	}
+	return ""
 }
 
 // provisionRunWorkspace provisions a workspace for a run based on wsType and

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -271,13 +271,16 @@ type RunRequest struct {
 	// on run completion (success, failure, or cancellation).
 	//
 	// Supported values:
-	//   ""        — use the server default (local process, no provisioning).
-	//   "local"   — provision a local directory workspace (same host, no isolation).
-	//   "worktree"— provision a git worktree (requires WorkspaceBaseOptions.RepoPath).
+	//   ""          — use the server default (local process, no provisioning).
+	//   "local"     — provision a local directory workspace (same host, no isolation).
+	//   "worktree"  — provision a git worktree (requires WorkspaceBaseOptions.RepoPath).
+	//   "container" — provision a container workspace (requires orchestrator config).
+	//   "vm"        — provision a VM workspace (requires orchestrator config).
 	//
 	// Unknown values are rejected at StartRun time with a validation error.
-	// Container, VM, and pool types require orchestrator-level configuration and
-	// are not available through the per-run field at this time.
+	// When empty, the runner falls back to Profile.IsolationMode if a profile is
+	// named in ProfileName. Explicit WorkspaceType always takes precedence over
+	// the profile's IsolationMode setting.
 	WorkspaceType string `json:"workspace_type,omitempty"`
 	// ProviderName explicitly selects which catalog provider to use for this run.
 	// When set, overrides the automatic provider resolution from the model name.

--- a/internal/harness/workspace_selection_test.go
+++ b/internal/harness/workspace_selection_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"go-agent-harness/internal/profiles"
 )
 
 // staticProviderWS is a minimal Provider for workspace selection tests.
@@ -321,7 +323,10 @@ func TestRunRequest_WorkspaceType_WorkspaceDestroyed_OnFailure(t *testing.T) {
 func TestRunRequest_WorkspaceType_ValidTypes(t *testing.T) {
 	t.Parallel()
 
-	validTypes := []string{"", "local", "worktree"}
+	// "container" and "vm" pass validation (type name is known) but
+	// provisioning will fail at execute() time for lack of orchestrator config.
+	// StartRun itself must not reject them.
+	validTypes := []string{"", "local", "worktree", "container", "vm"}
 	runner := NewRunner(
 		&staticProviderWS{result: CompletionResult{Content: "done"}},
 		NewRegistry(),
@@ -369,5 +374,356 @@ func TestRunRequest_WorkspaceType_JSONField(t *testing.T) {
 	}
 	if strings.Contains(string(b), "workspace_type") {
 		t.Errorf("empty WorkspaceType should be omitted from JSON, got: %s", string(b))
+	}
+}
+
+// ---- resolveWorkspaceType unit tests (issue #414) ----
+
+// TestResolveWorkspaceType_ExplicitOverride verifies that a non-empty
+// RunRequest.WorkspaceType always wins, regardless of what the profile says.
+func TestResolveWorkspaceType_ExplicitOverride(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "container"}
+	got := resolveWorkspaceType("worktree", profile)
+	if got != "worktree" {
+		t.Errorf("resolveWorkspaceType(\"worktree\", container-profile) = %q, want \"worktree\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_ProfileFallback_Worktree verifies that when
+// RunRequest.WorkspaceType is empty the profile's IsolationMode="worktree"
+// is used.
+func TestResolveWorkspaceType_ProfileFallback_Worktree(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "worktree"}
+	got := resolveWorkspaceType("", profile)
+	if got != "worktree" {
+		t.Errorf("resolveWorkspaceType(\"\", worktree-profile) = %q, want \"worktree\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_ProfileFallback_Container verifies that
+// IsolationMode="container" is propagated when WorkspaceType is empty.
+func TestResolveWorkspaceType_ProfileFallback_Container(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "container"}
+	got := resolveWorkspaceType("", profile)
+	if got != "container" {
+		t.Errorf("resolveWorkspaceType(\"\", container-profile) = %q, want \"container\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_ProfileFallback_VM verifies that
+// IsolationMode="vm" is propagated when WorkspaceType is empty.
+func TestResolveWorkspaceType_ProfileFallback_VM(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "vm"}
+	got := resolveWorkspaceType("", profile)
+	if got != "vm" {
+		t.Errorf("resolveWorkspaceType(\"\", vm-profile) = %q, want \"vm\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_ProfileNone verifies that IsolationMode="none"
+// results in "" (no provisioning), since "none" is an explicit opt-out.
+func TestResolveWorkspaceType_ProfileNone(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "none"}
+	got := resolveWorkspaceType("", profile)
+	if got != "" {
+		t.Errorf("resolveWorkspaceType(\"\", none-profile) = %q, want \"\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_NoProfile verifies that when both WorkspaceType and
+// profile are absent the result is "" (no provisioning).
+func TestResolveWorkspaceType_NoProfile(t *testing.T) {
+	t.Parallel()
+
+	got := resolveWorkspaceType("", nil)
+	if got != "" {
+		t.Errorf("resolveWorkspaceType(\"\", nil) = %q, want \"\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_EmptyIsolationMode verifies that a profile with an
+// empty IsolationMode field falls back to "" (no provisioning).
+func TestResolveWorkspaceType_EmptyIsolationMode(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: ""}
+	got := resolveWorkspaceType("", profile)
+	if got != "" {
+		t.Errorf("resolveWorkspaceType(\"\", empty-isolation-profile) = %q, want \"\"", got)
+	}
+}
+
+// TestResolveWorkspaceType_ExplicitOverride_VM verifies that an explicit
+// WorkspaceType="vm" overrides a profile that specifies "worktree".
+func TestResolveWorkspaceType_ExplicitOverride_VM(t *testing.T) {
+	t.Parallel()
+
+	profile := &profiles.Profile{IsolationMode: "worktree"}
+	got := resolveWorkspaceType("vm", profile)
+	if got != "vm" {
+		t.Errorf("resolveWorkspaceType(\"vm\", worktree-profile) = %q, want \"vm\"", got)
+	}
+}
+
+// TestValidateWorkspaceType_Container verifies that "container" is now accepted.
+func TestValidateWorkspaceType_Container(t *testing.T) {
+	t.Parallel()
+
+	if err := validateWorkspaceType("container"); err != nil {
+		t.Errorf("validateWorkspaceType(\"container\") = %v, want nil", err)
+	}
+}
+
+// TestValidateWorkspaceType_VM verifies that "vm" is now accepted.
+func TestValidateWorkspaceType_VM(t *testing.T) {
+	t.Parallel()
+
+	if err := validateWorkspaceType("vm"); err != nil {
+		t.Errorf("validateWorkspaceType(\"vm\") = %v, want nil", err)
+	}
+}
+
+// TestValidateWorkspaceType_ErrorMessage verifies that the error message for
+// an unknown type lists all four valid options.
+func TestValidateWorkspaceType_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	err := validateWorkspaceType("bogus")
+	if err == nil {
+		t.Fatal("expected error for unknown workspace type")
+	}
+	for _, expected := range []string{"local", "worktree", "container", "vm"} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Errorf("error message should mention %q, got: %v", expected, err)
+		}
+	}
+}
+
+// TestRunRequest_WorkspaceType_ValidTypes_Extended verifies that the full set
+// of known workspace types (including container and vm) pass validation.
+func TestRunRequest_WorkspaceType_ValidTypes_Extended(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{MaxSteps: 1},
+	)
+
+	// container and vm pass validation but provisioning will fail at execute()
+	// time since they require orchestrator config. We only test that StartRun
+	// does NOT return a validation error (the error comes later as run.failed).
+	for _, wsType := range []string{"container", "vm"} {
+		wsType := wsType
+		t.Run("type="+wsType, func(t *testing.T) {
+			t.Parallel()
+			_, err := runner.StartRun(RunRequest{
+				Prompt:        "hello",
+				WorkspaceType: wsType,
+			})
+			// StartRun validates the type name only — should not error.
+			if err != nil {
+				t.Errorf("StartRun with workspace_type=%q rejected by validation: %v", wsType, err)
+			}
+		})
+	}
+}
+
+// TestProfile_IsolationMode_Worktree_Integration verifies that when a profile
+// with IsolationMode="worktree" is loaded from disk, the runner provisions a
+// worktree workspace (workspace.provisioned event is emitted).
+func TestProfile_IsolationMode_Worktree_Integration(t *testing.T) {
+	t.Parallel()
+
+	// Set up a git repo for the worktree.
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+
+	// Create a profiles dir with a profile that specifies isolation_mode = "worktree".
+	// IMPORTANT: isolation_mode is a top-level TOML field — it must appear before
+	// any section header ([meta], [runner], [tools]) to avoid being parsed as a
+	// nested field under the last section.
+	profilesDir := t.TempDir()
+	profileTOML := `isolation_mode = "worktree"
+
+[meta]
+name = "isolated-worktree"
+description = "Test profile with worktree isolation"
+version = 1
+
+[runner]
+model = ""
+max_steps = 1
+
+[tools]
+allow = []
+`
+	if err := os.WriteFile(filepath.Join(profilesDir, "isolated-worktree.toml"), []byte(profileTOML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps:    1,
+			ProfilesDir: profilesDir,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	// No WorkspaceType in the request — the profile's IsolationMode should kick in.
+	run, err := runner.StartRun(RunRequest{
+		Prompt:      "hello",
+		ProfileName: "isolated-worktree",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	var provisionedEv *Event
+	var destroyedEv *Event
+	for i := range events {
+		switch events[i].Type {
+		case EventWorkspaceProvisioned:
+			provisionedEv = &events[i]
+		case EventWorkspaceDestroyed:
+			destroyedEv = &events[i]
+		}
+	}
+
+	if provisionedEv == nil {
+		t.Error("expected workspace.provisioned event — profile IsolationMode should have triggered provisioning")
+	} else {
+		if provisionedEv.Payload["workspace_type"] != "worktree" {
+			t.Errorf("workspace.provisioned workspace_type = %v, want worktree",
+				provisionedEv.Payload["workspace_type"])
+		}
+	}
+
+	if destroyedEv == nil {
+		t.Error("expected workspace.destroyed event after run completion")
+	}
+}
+
+// TestProfile_IsolationMode_None_NoProvisioning verifies that a profile with
+// IsolationMode="none" does NOT trigger workspace provisioning.
+func TestProfile_IsolationMode_None_NoProvisioning(t *testing.T) {
+	t.Parallel()
+
+	profilesDir := t.TempDir()
+	// isolation_mode must appear before section headers in TOML.
+	profileTOML := `isolation_mode = "none"
+
+[meta]
+name = "no-isolation"
+description = "Test profile with no isolation"
+version = 1
+
+[runner]
+model = ""
+max_steps = 1
+
+[tools]
+allow = []
+`
+	if err := os.WriteFile(filepath.Join(profilesDir, "no-isolation.toml"), []byte(profileTOML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps:    1,
+			ProfilesDir: profilesDir,
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:      "hello",
+		ProfileName: "no-isolation",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	for _, ev := range events {
+		if ev.Type == EventWorkspaceProvisioned {
+			t.Error("unexpected workspace.provisioned event — IsolationMode=none should not provision")
+		}
+	}
+}
+
+// TestProfile_IsolationMode_Explicit_Override verifies that an explicit
+// RunRequest.WorkspaceType="local" overrides a profile's IsolationMode.
+func TestProfile_IsolationMode_Explicit_Override(t *testing.T) {
+	t.Parallel()
+
+	// Profile says "worktree" but request says "local" — "local" wins.
+	profilesDir := t.TempDir()
+	// isolation_mode must appear before section headers in TOML.
+	profileTOML := `isolation_mode = "worktree"
+
+[meta]
+name = "wants-worktree"
+description = "Profile that prefers worktree"
+version = 1
+
+[runner]
+model = ""
+max_steps = 1
+
+[tools]
+allow = []
+`
+	if err := os.WriteFile(filepath.Join(profilesDir, "wants-worktree.toml"), []byte(profileTOML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps:    1,
+			ProfilesDir: profilesDir,
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		ProfileName:   "wants-worktree",
+		WorkspaceType: "local", // explicit override: local, not worktree
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	for _, ev := range events {
+		if ev.Type == EventWorkspaceProvisioned {
+			wsType, _ := ev.Payload["workspace_type"].(string)
+			if wsType == "worktree" {
+				t.Errorf("workspace.provisioned type = worktree, want local — explicit WorkspaceType should win")
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `resolveWorkspaceType(reqWorkspaceType string, profile *profiles.Profile) string` to the runner
- Precedence: `RunRequest.WorkspaceType` → `Profile.IsolationMode` → `""` (no provisioning)
- Extends `knownWorkspaceTypes` to include `"container"` and `"vm"` (pass validation; provisioning fails naturally without orchestrator config)
- Runner now loads the full profile before workspace provisioning when `ProfileName` is set, so `IsolationMode` is respected for parent runs (not just subagents via `run_agent`)
- Updates `RunRequest.WorkspaceType` doc comment to reflect all valid values and precedence

## Test plan

- [x] `TestResolveWorkspaceType_ExplicitOverride` — explicit type wins over profile
- [x] `TestResolveWorkspaceType_ProfileFallback` — profile IsolationMode used when req empty
- [x] `TestResolveWorkspaceType_NoProfile` — nil profile → empty (no provisioning)
- [x] `TestResolveWorkspaceType_ProfileNone` — IsolationMode="none" → no provisioning
- [x] `TestResolveWorkspaceType_ProfileContainer` — "container" propagated
- [x] Integration: real TOML profile with `isolation_mode="worktree"` → provisioned correctly
- [x] Integration: `isolation_mode="none"` → no provisioning
- [x] Integration: explicit WorkspaceType overrides profile IsolationMode
- [x] Full `./internal/... ./cmd/...` suite — 0 failures

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)