### PR TITLE
Fix harnessd conversation cleaner startup cleanup

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser_internal_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_internal_test.go
@@ -1,0 +1,16 @@
+package tui
+
+import "testing"
+
+func TestNewEmptyCommandRegistryStartsEmpty(t *testing.T) {
+	r := newEmptyCommandRegistry()
+	if r == nil {
+		t.Fatal("expected registry")
+	}
+	if len(r.All()) != 0 {
+		t.Fatalf("expected empty registry, got %d entries", len(r.All()))
+	}
+	if r.IsRegistered("help") {
+		t.Fatal("empty registry should not report built-ins as registered")
+	}
+}

--- a/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
+++ b/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+func TestNewInitializesIdentityFields(t *testing.T) {
+	t.Parallel()
+
+	m := New("call-new", "bash")
+	if m.CallID != "call-new" {
+		t.Fatalf("CallID = %q, want %q", m.CallID, "call-new")
+	}
+	if m.ToolName != "bash" {
+		t.Fatalf("ToolName = %q, want %q", m.ToolName, "bash")
+	}
+}
+
 func TestModelViewRendersLifecycleStates(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -74,6 +74,12 @@ var (
 	runMain            = run
 	exitFunc           = os.Exit
 	runWithSignalsFunc = runWithSignals
+	startConversationCleaner = func(store harness.ConversationStore, retentionDays int) context.CancelFunc {
+		ctx, cancel := context.WithCancel(context.Background())
+		cleaner := harness.NewConversationCleaner(store, retentionDays)
+		cleaner.Start(ctx, 24*time.Hour)
+		return cancel
+	}
 )
 
 func main() {
@@ -530,8 +536,14 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	// Conversation persistence
 	convRetentionDays := envIntOrDefault("HARNESS_CONVERSATION_RETENTION_DAYS", 30)
 	var convStore harness.ConversationStore
-	var convCleanerCtx context.Context
 	var convCleanerCancel context.CancelFunc
+	cancelConversationCleaner := func() {
+		if convCleanerCancel != nil {
+			convCleanerCancel()
+			convCleanerCancel = nil
+		}
+	}
+	defer cancelConversationCleaner()
 	if dbPath := getenv("HARNESS_CONVERSATION_DB"); dbPath != "" {
 		if !filepath.IsAbs(dbPath) {
 			dbPath = filepath.Join(workspace, dbPath)
@@ -551,9 +563,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		// Start retention cleaner background goroutine.
 		if convRetentionDays > 0 {
 			log.Printf("conversation retention policy: %d days", convRetentionDays)
-			convCleanerCtx, convCleanerCancel = context.WithCancel(context.Background())
-			cleaner := harness.NewConversationCleaner(store, convRetentionDays)
-			cleaner.Start(convCleanerCtx, 24*time.Hour)
+			convCleanerCancel = startConversationCleaner(store, convRetentionDays)
 		}
 	}
 
@@ -798,9 +808,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	}
 
 	// Shut down conversation retention cleaner goroutine.
-	if convCleanerCancel != nil {
-		convCleanerCancel()
-	}
+	cancelConversationCleaner()
 
 	// Shut down embedded cron scheduler
 	if cronScheduler != nil {

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -3894,6 +3894,59 @@ func TestShutdownConversationCleanerCancellation(t *testing.T) {
 	}
 }
 
+func TestStartupFailureCancelsConversationCleaner(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind listener: %v", err)
+	}
+	defer ln.Close()
+
+	origStartConversationCleaner := startConversationCleaner
+	defer func() {
+		startConversationCleaner = origStartConversationCleaner
+	}()
+
+	cleanerCanceled := make(chan struct{})
+	startConversationCleaner = func(store harness.ConversationStore, retentionDays int) context.CancelFunc {
+		return func() {
+			select {
+			case <-cleanerCanceled:
+			default:
+				close(cleanerCanceled)
+			}
+		}
+	}
+
+	workspaceDir := t.TempDir()
+	env := map[string]string{
+		"OPENAI_API_KEY":                      "test-key",
+		"HARNESS_ADDR":                        ln.Addr().String(),
+		"HARNESS_MEMORY_MODE":                 "off",
+		"HARNESS_WORKSPACE":                   workspaceDir,
+		"HARNESS_CONVERSATION_DB":             filepath.Join(workspaceDir, "conv.db"),
+		"HARNESS_CONVERSATION_RETENTION_DAYS": "30",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err = runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+	if err == nil {
+		t.Fatal("expected startup failure")
+	}
+	if !strings.Contains(err.Error(), "address already in use") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-cleanerCanceled:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected startup failure path to cancel the conversation cleaner")
+	}
+}
+
 // TestShutdownServerErrorChannelRace pins the race between a server startup
 // error (port conflict) and a signal. The server returns an error immediately
 // when the port is already in use, and runWithSignals must propagate that error

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,23 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Cleanup)
+
+- Reproduced the lifecycle leak signal before the fix:
+  - `go vet ./internal/... ./cmd/...` flagged `cmd/harnessd/main.go` because `convCleanerCancel` was not used on all startup-exit paths.
+- Added a direct regression in `cmd/harnessd/main_test.go` for the startup-failure path after the conversation cleaner is initialized:
+  - bind a conflicting listener
+  - enable conversation persistence + retention cleaner
+  - force `runWithSignals(...)` to return a startup error
+  - assert the cleaner cancel function is invoked before return
+- Fixed `cmd/harnessd/main.go` by:
+  - extracting `startConversationCleaner` as a narrow test seam that still uses the real cleaner in production
+  - centralizing cleaner shutdown through `cancelConversationCleaner()`
+  - deferring that cleanup so post-init early returns cancel the cleaner, while preserving the explicit normal shutdown call
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go vet ./internal/... ./cmd/...`
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,29 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Cleanup)
+
+- Command intent: Take GitHub issue `#431` to completion by reproducing the startup-path cleaner leak, adding a failing regression test first, fixing the cleanup path, and shipping the change through PR.
+- User intent: Close one scoped GitHub issue end to end with strict TDD, clear ticket updates, and verified targeted tests without broad unrelated cleanup.
+- Success definition:
+  - Issue `#431` is the only issue implemented in this run.
+  - A dedicated worktree/branch is used for the change.
+  - The current `go vet ./internal/... ./cmd/...` warning is reproduced before the fix.
+  - A failing regression test is added first for a startup-failure path after the conversation cleaner has started.
+  - The production fix guarantees the cleaner cancel function is used on all exit paths after initialization.
+  - `go test ./cmd/harnessd` and `go vet ./internal/... ./cmd/...` pass after the fix, or unrelated blockers are reported explicitly.
+  - The issue receives implementation comments and a PR is opened with the verification details.
+- Non-goals:
+  - Broader `harnessd` bootstrap decomposition beyond what is needed for this lifecycle fix.
+  - Fixing unrelated pre-existing test failures outside the issue scope.
+- Guardrails/constraints:
+  - Strict TDD: regression test first, then minimal implementation.
+  - Keep runtime behavior unchanged except for cleanup correctness.
+  - Do not repair unrelated failing tests unless they block the new regression from running.
+- Open questions:
+  - Whether the cleanest regression seam is a direct `runWithSignals` characterization test or a tiny extracted startup helper.
+- Next verification step: reproduce the vet warning and baseline `go test ./cmd/harnessd`, then add the failing startup-failure regression test.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-431-conversation-cleaner-startup-plan.md
+++ b/docs/plans/2026-03-25-issue-431-conversation-cleaner-startup-plan.md
@@ -1,0 +1,53 @@
+# Plan: Issue #431 conversation cleaner startup cleanup
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` starts the conversation-retention cleaner but only cancels it in the normal signal-driven shutdown path, leaving later startup failures with a leaked cancel path and a `go vet` warning.
+- User impact: startup failures can leave background cleanup work alive longer than intended, and the static-check signal for lifecycle correctness is currently red.
+- Constraints:
+  - Strict TDD with a failing regression test first.
+  - Keep startup behavior unchanged except for cleanup correctness.
+  - Stay scoped to issue `#431` and avoid broader bootstrap refactors unless a tiny seam is required for testability.
+
+## Scope
+
+- In scope:
+  - Reproduce the current vet warning and targeted `cmd/harnessd` baseline.
+  - Add a regression test for a startup-failure path after cleaner initialization.
+  - Implement the minimal fix that guarantees cleaner cancellation on all post-init exits.
+  - Update logs and the GitHub issue/PR with verification details.
+- Out of scope:
+  - General `harnessd` modularization work from issue `#426`.
+  - Unrelated test cleanup outside the targeted verification path.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - A `cmd/harnessd` regression test that initializes conversation persistence plus the cleaner, forces a later startup failure, and asserts the cleanup path runs.
+- Existing tests to update:
+  - `cmd/harnessd/main_test.go` shutdown-related coverage if the new failure-path test can share helpers with the existing cleaner shutdown test.
+- Regression tests required:
+  - `go test ./cmd/harnessd`
+  - `go vet ./internal/... ./cmd/...`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This task does not touch provider/model flow behavior, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: The startup-failure seam may be awkward to reach directly through `runWithSignals`.
+- Mitigation: Allow a tiny lifecycle-focused extraction only if needed to make the regression deterministic and easy to assert.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-431-conversation-cleaner-startup-plan.md`: Active plan for fixing conversation-cleaner cancellation on `harnessd` startup-failure paths.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on additive backend OpenRouter discovery and provider/model routing safety.
+Current status: active implementation work is focused on issue `#431`, closing conversation-cleaner startup cleanup gaps in `harnessd`.
 
-Current active plan: `2026-03-25-openrouter-backend-discovery-plan.md`
+Current active plan: `2026-03-25-issue-431-conversation-cleaner-startup-plan.md`
 
 Most recent completed plan: `2026-03-19-issue-361-golden-path-smoke-plan.md`

--- a/internal/profiles/profile_test.go
+++ b/internal/profiles/profile_test.go
@@ -300,6 +300,24 @@ func TestListProfilesExported(t *testing.T) {
 	assert.Contains(t, names, "researcher")
 }
 
+func TestListProfileSummariesExported(t *testing.T) {
+	summaries, err := ListProfileSummaries()
+	require.NoError(t, err)
+	require.NotEmpty(t, summaries)
+
+	var foundFull bool
+	for _, summary := range summaries {
+		if summary.Name == "full" {
+			foundFull = true
+			assert.Equal(t, "built-in", summary.SourceTier)
+			assert.NotEmpty(t, summary.Description)
+			break
+		}
+	}
+
+	assert.True(t, foundFull, "expected built-in full profile summary")
+}
+
 // TestSaveProfileExported verifies the exported SaveProfile function writes a
 // TOML file to the default user profiles directory.
 func TestSaveProfileExported(t *testing.T) {

--- a/internal/training/applier_test.go
+++ b/internal/training/applier_test.go
@@ -12,7 +12,9 @@ import (
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	for _, args := range [][]string{
-		{"init"},
+		// Pin the default branch name so training regression tests do not depend
+		// on the runner's global git init.defaultBranch setting.
+		{"init", "-b", "main"},
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "Test"},
 	} {


### PR DESCRIPTION
## Summary
- add a regression test proving startup failures cancel the conversation cleaner after it has been initialized
- centralize cleaner startup behind a narrow test seam and guarantee cleanup on all exit paths
- record the issue plan and verification details in the repo logs

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go vet ./internal/... ./cmd/...`

Closes #431