### PR TITLE
Fix harnessd cleaner startup cancellation leak

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -74,6 +74,9 @@ var (
 	runMain            = run
 	exitFunc           = os.Exit
 	runWithSignalsFunc = runWithSignals
+	newConversationCleanerContext = func() (context.Context, context.CancelFunc) {
+		return context.WithCancel(context.Background())
+	}
 )
 
 func main() {
@@ -551,7 +554,8 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		// Start retention cleaner background goroutine.
 		if convRetentionDays > 0 {
 			log.Printf("conversation retention policy: %d days", convRetentionDays)
-			convCleanerCtx, convCleanerCancel = context.WithCancel(context.Background())
+			convCleanerCtx, convCleanerCancel = newConversationCleanerContext()
+			defer convCleanerCancel()
 			cleaner := harness.NewConversationCleaner(store, convRetentionDays)
 			cleaner.Start(convCleanerCtx, 24*time.Hour)
 		}

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -3894,6 +3894,56 @@ func TestShutdownConversationCleanerCancellation(t *testing.T) {
 	}
 }
 
+func TestStartupErrorCancelsConversationCleaner(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind listener: %v", err)
+	}
+	defer ln.Close()
+
+	workspaceDir := t.TempDir()
+	convDBPath := filepath.Join(workspaceDir, "conv.db")
+	env := map[string]string{
+		"OPENAI_API_KEY":                      "test-key",
+		"HARNESS_ADDR":                        ln.Addr().String(),
+		"HARNESS_MEMORY_MODE":                 "off",
+		"HARNESS_WORKSPACE":                   workspaceDir,
+		"HARNESS_CONVERSATION_DB":             convDBPath,
+		"HARNESS_CONVERSATION_RETENTION_DAYS": "30",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	cancelled := make(chan struct{}, 1)
+	origFactory := newConversationCleanerContext
+	newConversationCleanerContext = func() (context.Context, context.CancelFunc) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var once sync.Once
+		return ctx, func() {
+			once.Do(func() {
+				cancel()
+				cancelled <- struct{}{}
+			})
+		}
+	}
+	defer func() { newConversationCleanerContext = origFactory }()
+
+	err = runWithSignals(make(chan os.Signal, 1), getenv, func(openai.Config) (harness.Provider, error) {
+		return &noopProvider{}, nil
+	}, "")
+	if err == nil {
+		t.Fatalf("expected startup error")
+	}
+	if !strings.Contains(err.Error(), "address already in use") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected conversation cleaner cancel on startup error")
+	}
+}
+
 // TestShutdownServerErrorChannelRace pins the race between a server startup
 // error (port conflict) and a signal. The server returns an error immediately
 // when the port is already in use, and runWithSignals must propagate that error

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,24 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Cleanup)
+
+- Reproduced the startup-path cleanup bug in `cmd/harnessd/main.go`:
+  - `go vet ./cmd/harnessd` reported `convCleanerCancel` as a possible context leak because startup errors could return without using the cancel function after cleaner initialization.
+- Added strict-TDD regression coverage in `cmd/harnessd/main_test.go`:
+  - `TestStartupErrorCancelsConversationCleaner` forces a startup failure after conversation-cleaner setup and asserts the cleaner cancel path runs.
+- Fixed the startup cleanup path in `cmd/harnessd/main.go`:
+  - introduced a tiny `newConversationCleanerContext` seam for deterministic testing
+  - immediately defers `convCleanerCancel()` once the cleaner context is created, preserving the existing explicit shutdown cancel while guaranteeing early-return cleanup
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run 'TestStartupErrorCancelsConversationCleaner|TestShutdownConversationCleanerCancellation|TestShutdownServerErrorChannelRace'`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test -race ./cmd/harnessd`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go vet ./internal/... ./cmd/...`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh`
+- Regression status:
+  - the issue-specific fix and `cmd/harnessd` package verification are green
+  - the repo-wide regression script still exits non-zero at the existing coverage-gate stage after reporting `84.8%` total coverage, matching the repo’s broader zero-coverage/coverage-gate debt rather than a failure introduced by this fix
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Cleanup)
+
+- Command intent: Complete GitHub issue `#431` by making `harnessd` cancel the conversation-retention cleaner on startup-failure paths, with TDD-first coverage and verification.
+- User intent: Close one backlog bug end to end so startup lifecycle cleanup is correct, `go vet` stops flagging the leak, and the resulting PR is mergeable.
+- Success definition:
+  - Issue `#431` is the only implementation scope in this run.
+  - A failing regression test first proves cleaner cancellation happens when startup fails after cleaner initialization.
+  - `cmd/harnessd/main.go` guarantees the cleaner cancel function is used on all exit paths after initialization.
+  - `go test ./cmd/harnessd` passes.
+  - `go vet ./internal/... ./cmd/...` is clean for the updated path.
+- Non-goals:
+  - Broad `harnessd` bootstrap refactoring beyond what is needed to expose cleanup behavior safely.
+  - Changing normal startup or shutdown semantics outside the cleaner lifecycle fix.
+- Guardrails/constraints:
+  - Strict TDD: add the failing regression test before production edits.
+  - Keep the change narrow and reviewable.
+  - Use workspace-local Go cache paths in this sandbox.
+- Open questions:
+  - Whether repo-wide regression/CI will surface unrelated existing failures after the targeted fix is green.
+- Next verification step: add the failing startup-error cleanup test, implement the smallest fix, then rerun targeted tests and broader verification.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-431-cleaner-startup-plan.md
+++ b/docs/plans/2026-03-25-issue-431-cleaner-startup-plan.md
@@ -1,0 +1,50 @@
+# Plan: Issue #431 conversation cleaner startup cleanup
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` starts the conversation-retention cleaner with `context.WithCancel(...)`, but startup errors can return before the cancel function is called.
+- User impact: startup failures can leak the cleaner goroutine/context, and `go vet` already flags the path as a real lifecycle bug.
+- Constraints: keep the change small, use strict TDD, and preserve existing `harnessd` startup and shutdown behavior aside from cleanup correctness.
+
+## Scope
+
+- In scope:
+  - add regression coverage for startup failure after cleaner initialization
+  - ensure the cleaner cancel function is always used after initialization
+  - verify `cmd/harnessd` tests and vet checks
+- Out of scope:
+  - broader `harnessd` bootstrap decomposition
+  - unrelated shutdown-order refactors
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - startup failure after conversation cleaner initialization still invokes cleaner cancellation
+- Existing tests to update:
+  - `cmd/harnessd/main_test.go`
+- Regression tests required:
+  - `go test ./cmd/harnessd`
+  - `go vet ./internal/... ./cmd/...`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue does not touch provider/model flow surfaces, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: regression coverage could rely on timing or goroutine counting and become flaky.
+- Mitigation: inject a tiny test seam around cleaner context creation so the test can assert cancellation deterministically.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-431-cleaner-startup-plan.md`: Active implementation plan for closing the conversation-cleaner startup cleanup leak in `harnessd`.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.


### PR DESCRIPTION
## Summary
- guarantee the conversation cleaner cancel function is used on startup-failure paths after initialization
- add a regression test that forces a startup error after cleaner setup and asserts cancellation happens
- record the issue-specific plan and verification notes required by the repo workflow

## Verification
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run 'TestStartupErrorCancelsConversationCleaner|TestShutdownConversationCleanerCancellation|TestShutdownServerErrorChannelRace'`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test -race ./cmd/harnessd`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go vet ./internal/... ./cmd/...`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` (still fails at the repo-wide coverage gate unrelated to this fix)

## Notes
Fixes #431.

The branch-specific cleaner fix is green, but the repo regression script remains blocked by the existing coverage-gate debt already noted in the engineering log, so this PR is not yet cleanly mergeable.