### PR TITLE
Fix forked child-run failure propagation

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,24 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
+
+- Reproduced the bug with new failing regressions on all three affected caller surfaces:
+  - `internal/server/http_agents_test.go`
+  - `internal/harness/tools/skill_test.go`
+  - `internal/harness/tools/core/skill_test.go`
+- Added `internal/harness/tools/fork_result.go` with a small shared helper so tool-layer callers can treat `ForkResult.Error` as terminal child-run failure information.
+- Updated:
+  - `internal/server/http_agents.go` so `/v1/agents` returns `execution_error` instead of HTTP 200 when a forked skill completes with `result.Error`.
+  - `internal/harness/tools/skill.go` so flat-catalog forked skills do not emit `status: completed` for failed child runs.
+  - `internal/harness/tools/core/skill.go` so core skill-tool fork execution follows the same failure contract.
+- Verification:
+  - baseline before changes:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core`
+  - red phase:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
+  - green phase:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
+
+- Command intent: Complete GitHub issue `#429` by ensuring callers do not report forked child runs as successful when `RunForkedSkill(...)` returns `ForkResult.Error` with a nil Go error.
+- User intent: Make `/v1/agents` and fork-context skill tools surface real child-run failures instead of silently treating them as success.
+- Success definition:
+  - `/v1/agents` returns an execution error when a forked skill returns `ForkResult{Error: ...}`.
+  - The flat skill tool and core skill tool both fail fast on `ForkResult.Error` instead of returning `status: completed`.
+  - Healthy forked success paths still prefer `Summary` over `Output` exactly as before.
+  - Focused regression tests cover all three caller surfaces.
+- Non-goals:
+  - Changing fallback `RunPrompt(...)` behavior.
+  - Refactoring the runner orchestration path beyond what is needed to expose the failure consistently.
+  - Addressing unrelated `allowed_tools` fallback work in issue `#430`.
+- Guardrails/constraints:
+  - Strict TDD: add failing regressions first.
+  - Keep the fix narrow and behavior-preserving for successful forked runs.
+  - Do not fix unrelated pre-existing failures if broader verification exposes them.
+- Open questions:
+  - Whether other `ForkResult` consumers outside this issue already normalize `result.Error` consistently enough or should be audited in a later pass.
+- Next verification step: run the focused package suite, then the repo regression gate, then open a PR and verify CI completes cleanly.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -2,6 +2,25 @@
 
 Use this file to document systems, interfaces, and interactions as they are built.
 
+## 2026-03-25 (Forked Child-Run Failure Contract)
+
+- System/component: `/v1/agents` forked execution plus fork-context skill tools in `internal/server/http_agents.go`, `internal/harness/tools/skill.go`, and `internal/harness/tools/core/skill.go`.
+- Responsibilities:
+  - Treat `ForkResult.Error` as authoritative terminal child-run failure information even when the transport call returned a nil Go error.
+  - Preserve the existing `Summary`-then-`Output` success rendering for healthy forked runs.
+- Inputs/outputs:
+  - Input: `RunForkedSkill(...)` responses containing `Output`, `Summary`, and optional terminal failure text in `Error`.
+  - Output: HTTP execution errors or tool-call failures when `Error` is populated; successful response payloads only when the child run actually succeeded.
+- Dependencies:
+  - `/v1/agents` uses a local result guard because the server package cannot import the harness tools package without creating the wrong dependency shape.
+  - Tool-layer callers share `ForkResultExecutionError(...)` in `internal/harness/tools/fork_result.go`.
+- Failure modes:
+  - If a child run fails normally and returns `ForkResult.Error`, callers now fail fast instead of reporting `status: completed`.
+  - If the fork transport itself fails, the existing Go `error` path remains authoritative.
+- Operational notes:
+  - This change is behavior-preserving for successful forked runs.
+  - Fallback `RunPrompt(...)` paths are unchanged in this pass.
+
 ## 2026-03-18 (Runner Event Ledger Ordering Contract)
 
 - System/component: `internal/harness/runner.go`

--- a/docs/plans/2026-03-25-issue-429-fork-result-failure-plan.md
+++ b/docs/plans/2026-03-25-issue-429-fork-result-failure-plan.md
@@ -1,0 +1,53 @@
+# Plan: Issue #429 forked child-run failure propagation
+
+## Context
+
+- Problem: several callers treat `RunForkedSkill(...)` as successful whenever the Go `error` is nil, even if the returned `ForkResult` carries a terminal child-run failure in `Error`.
+- User impact: `/v1/agents` and fork-context skill tools can report success and surface partial output when the child run actually failed.
+- Constraints: keep the fix narrow, preserve healthy success paths, and follow strict TDD with regression coverage on each affected caller surface.
+
+## Scope
+
+- In scope:
+  - `/v1/agents` forked skill execution failure handling
+  - flat skill-tool fork path failure handling
+  - core skill-tool fork path failure handling
+  - issue-specific plan/log updates
+- Out of scope:
+  - broader runner refactors
+  - unrelated `allowed_tools` fallback work
+  - transport or tool contract redesign
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `/v1/agents` returns an execution error when `RunForkedSkill(...)` returns `ForkResult{Error: ...}` with `err == nil`
+  - flat skill-tool fork path returns an error when `ForkResult.Error` is populated
+  - core skill-tool fork path returns an error when `ForkResult.Error` is populated
+- Existing tests to update:
+  - none expected beyond the new focused regressions
+- Regression tests required:
+  - `go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue does not touch provider/model flow surfaces, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: error handling drifts between server and tool call sites again.
+- Mitigation: centralize the child-failure check in small shared helpers local to each package boundary and pin each caller with regression tests.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on additive backend OpenRouter discovery and provider/model routing safety.
+Current status: active implementation work is focused on issue #429 forked child-run failure propagation across `/v1/agents` and fork-context skill tools.
 
-Current active plan: `2026-03-25-openrouter-backend-discovery-plan.md`
+Current active plan: `2026-03-25-issue-429-fork-result-failure-plan.md`
 
-Most recent completed plan: `2026-03-19-issue-361-golden-path-smoke-plan.md`
+Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`

--- a/internal/harness/tools/core/skill.go
+++ b/internal/harness/tools/core/skill.go
@@ -150,6 +150,9 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 		if err != nil {
 			return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 		}
+		if resultErr := tools.ForkResultExecutionError(result); resultErr != nil {
+			return "", fmt.Errorf("forked skill %q failed: %w", info.Name, resultErr)
+		}
 
 		// Prefer summary over full output
 		output := result.Summary

--- a/internal/harness/tools/core/skill_test.go
+++ b/internal/harness/tools/core/skill_test.go
@@ -657,6 +657,23 @@ func TestSkillTool_Handler_ForkRunnerError(t *testing.T) {
 	}
 }
 
+func TestSkillTool_Handler_ForkResultError(t *testing.T) {
+	t.Parallel()
+	lister := newForkSkillLister()
+	runner := &mockForkedRunner{
+		forkOutput: tools.ForkResult{Error: "child run failed"},
+	}
+	tool := SkillTool(lister, runner)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"research OAuth2"}`))
+	if err == nil {
+		t.Fatal("expected error when child run reports failure")
+	}
+	if !strings.Contains(err.Error(), "child run failed") {
+		t.Fatalf("expected child failure in error, got %v", err)
+	}
+}
+
 func TestSkillTool_Handler_ForkSummaryPreference(t *testing.T) {
 	t.Parallel()
 	lister := newForkSkillLister()

--- a/internal/harness/tools/fork_result.go
+++ b/internal/harness/tools/fork_result.go
@@ -1,0 +1,15 @@
+package tools
+
+import (
+	"errors"
+	"strings"
+)
+
+// ForkResultExecutionError returns a concrete error when a forked child run
+// finished with terminal failure information in ForkResult.Error.
+func ForkResultExecutionError(result ForkResult) error {
+	if strings.TrimSpace(result.Error) == "" {
+		return nil
+	}
+	return errors.New(result.Error)
+}

--- a/internal/harness/tools/skill.go
+++ b/internal/harness/tools/skill.go
@@ -93,6 +93,9 @@ func flatSkillFork(ctx context.Context, runner AgentRunner, info SkillInfo, cont
 		if err != nil {
 			return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 		}
+		if resultErr := ForkResultExecutionError(result); resultErr != nil {
+			return "", fmt.Errorf("forked skill %q failed: %w", info.Name, resultErr)
+		}
 		output := result.Summary
 		if output == "" {
 			output = result.Output

--- a/internal/harness/tools/skill_test.go
+++ b/internal/harness/tools/skill_test.go
@@ -440,6 +440,22 @@ func TestFlatSkillForkForkedAgentRunnerError(t *testing.T) {
 	}
 }
 
+func TestFlatSkillForkForkedAgentRunnerResultError(t *testing.T) {
+	t.Parallel()
+	runner := &mockForkedAgentRunner{
+		result: ForkResult{Error: "child run failed"},
+	}
+	info := SkillInfo{Name: "failed-fork", Context: "fork", Agent: "Code"}
+
+	_, err := flatSkillFork(context.Background(), runner, info, "prompt")
+	if err == nil {
+		t.Fatalf("expected error from ForkResult.Error")
+	}
+	if !strings.Contains(err.Error(), "child run failed") {
+		t.Fatalf("expected child failure in error, got %v", err)
+	}
+}
+
 func TestFlatSkillForkViaSkillToolHandler(t *testing.T) {
 	t.Parallel()
 	lister := &mockSkillLister{

--- a/internal/server/http_agents.go
+++ b/internal/server/http_agents.go
@@ -36,6 +36,13 @@ type agentForkResult struct {
 	Error   string
 }
 
+func agentForkExecutionError(result agentForkResult) error {
+	if strings.TrimSpace(result.Error) == "" {
+		return nil
+	}
+	return errors.New(result.Error)
+}
+
 // skillListerIface supports resolving skill content for the fallback path.
 type skillListerIface interface {
 	ResolveSkill(ctx context.Context, name, args, workspace string) (string, error)
@@ -139,6 +146,10 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				writeError(w, http.StatusInternalServerError, "execution_error", err.Error())
+				return
+			}
+			if resultErr := agentForkExecutionError(result); resultErr != nil {
+				writeError(w, http.StatusInternalServerError, "execution_error", resultErr.Error())
 				return
 			}
 			output = result.Output

--- a/internal/server/http_agents_test.go
+++ b/internal/server/http_agents_test.go
@@ -157,6 +157,44 @@ func TestAgentsEndpoint_SkillUsesForkedRunner(t *testing.T) {
 	}
 }
 
+func TestAgentsEndpoint_SkillForkResultErrorReturns500(t *testing.T) {
+	t.Parallel()
+
+	runner := testRunnerForAgents(t)
+	forked := &mockForkedAgentRunner{result: agentForkResult{
+		Error: "child run failed",
+	}}
+	handler := NewWithOptions(ServerOptions{Runner: runner, AgentRunner: forked, ForkedAgentRunner: forked})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res := postAgents(t, ts, map[string]any{
+		"skill": "deploy",
+	})
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusInternalServerError {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 500, got %d: %s", res.StatusCode, string(body))
+	}
+
+	var errResp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&errResp); err != nil {
+		t.Fatalf("decode error response: %v", err)
+	}
+	if errResp.Error.Code != "execution_error" {
+		t.Fatalf("expected execution_error code, got %q", errResp.Error.Code)
+	}
+	if !strings.Contains(errResp.Error.Message, "child run failed") {
+		t.Fatalf("expected child failure in message, got %q", errResp.Error.Message)
+	}
+}
+
 func TestAgentsEndpoint_SkillFallbackToSkillLister(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add failing regressions for `/v1/agents`, the flat skill tool, and the core skill tool when a forked child run returns `ForkResult.Error` with a nil Go error
- treat `ForkResult.Error` as authoritative terminal failure information instead of reporting success on those caller surfaces
- record the issue-specific plan and implementation/contract notes in the repo logs

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` launched in `tmux` as `issue-429-regression`; full package and race phases reached green, coverage phase was still running when the PR was opened

Closes #429