### PR TITLE
Cancel timed-out subruns on parent cancellation

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -65,7 +65,6 @@
     - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
 ## 2026-03-25 (Issue #431 Startup Cleaner Cancellation)
 
-<<<<<<< HEAD
 - Reproduced the `go vet` startup-leak warning in `cmd/harnessd/main.go` where `convCleanerCancel` was only reached from the normal shutdown path after the conversation cleaner had already been started.
 - Added a deterministic regression seam in `cmd/harnessd/main.go` so tests can supply a fake conversation cleaner without mutating package globals across parallel test runs.
 - Added `TestStartupFailureCancelsConversationCleaner` in `cmd/harnessd/main_test.go`:
@@ -111,6 +110,25 @@
     - `go test ./cmd/harnessd -count=1`
     - `go test ./internal/config -count=1`
   - Repo regression gate: `./scripts/test-regression.sh` launched in `tmux` (`issue421-regression`); final status recorded after completion.
+  - `go test ./internal/profiles -run TestListProfileSummariesPrefersHigherPriorityDirs -count=1`
+
+## 2026-03-25 (Issue #428 Timed-Out Subrun Cancellation)
+
+- Reproduced the subrun cancellation leak in `internal/harness/runner.go`: `waitForTerminalResult(...)` returned on parent `ctx.Done()` without cancelling the spawned child run, leaving it in `running` status.
+- Added regression coverage in:
+  - `internal/harness/runner_orchestration_test.go`
+    - `TestRunPrompt_CancelsChildRunOnContextCancellation`
+    - `TestRunForkedSkill_CancelsChildRunOnContextCancellation`
+  - `internal/server/http_agents_test.go`
+    - `TestAgentsEndpoint_TimeoutCancelsSpawnedRun`
+- Implemented a minimal runner fix:
+  - `waitForTerminalResult(...)` now checks whether the child run already reached a terminal state before treating parent cancellation as authoritative.
+  - if the child run is still active when the parent context ends, the runner now calls `CancelRun(runID)` before returning the parent cancellation error.
+- Verification:
+  - baseline before changes: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server`
+  - red step: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run 'TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation'`
+  - green focused step: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server -run 'TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation|TestAgentsEndpoint_Timeout(Exceeded_Returns408|CancelsSpawnedRun)'`
+  - package verification: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server`
 
 ## 2026-03-25 (Harness Review Bug Tickets)
 

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -121,6 +121,26 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether any runner-config fields besides `auto_compact` and `forensics` should move into the shared projection helper in this pass for consistency.
 - Next verification step: add failing projection tests in `cmd/harnessd/main_test.go`, introduce the minimal shared builder/helper, run targeted package tests, then run `./scripts/test-regression.sh`.
+## 2026-03-25 (Issue #428 Timed-Out Subrun Cancellation)
+
+- Command intent: Complete GitHub issue `#428` by ensuring timed-out or cancelled parent calls actively cancel spawned child runs instead of leaving them executing in the background.
+- User intent: Make agent and skill timeout behavior trustworthy so callers do not get a timeout while hidden work continues consuming tokens or mutating state.
+- Success definition:
+  - `waitForTerminalResult(...)` actively requests child-run cancellation when the parent context ends before a terminal event arrives.
+  - Regression coverage proves the child run transitions to `cancelled` for both `RunPrompt(...)` and `RunForkedSkill(...)`.
+  - Existing successful terminal-result behavior remains intact when the child run already finished.
+  - Relevant harness/server tests pass after the fix.
+- Non-goals:
+  - Redesigning the runner lifecycle model.
+  - Changing unrelated timeout or error mapping behavior.
+  - Fixing unrelated pre-existing test failures outside the touched surfaces.
+- Guardrails/constraints:
+  - Follow strict TDD: write the failing tests first.
+  - Keep the fix scoped to run lifecycle/cancellation plumbing.
+  - Preserve idempotent cancellation and terminal result behavior.
+- Open questions:
+  - Whether `/v1/agents` needs additional direct assertions beyond harness-level cancellation coverage.
+- Next verification step: run the current harness/server baseline, add failing orchestration tests that expose the leak, then implement the minimal cancellation propagation fix.
 
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -9,6 +9,8 @@
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
+- `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
+- `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/issue-428-plan.md
+++ b/docs/plans/issue-428-plan.md
@@ -1,0 +1,55 @@
+# Plan: Issue #428 timed-out subrun cancellation
+
+## Context
+
+- Problem: `RunPrompt(...)` and `RunForkedSkill(...)` wait on child runs through `waitForTerminalResult(...)`, but if the parent context times out or is cancelled the helper returns immediately without cancelling the spawned child run.
+- User impact: timed-out agent and skill calls can keep consuming provider/tool resources after the caller already received a timeout or cancellation.
+- Constraints: keep the change scoped to subrun lifecycle plumbing, preserve normal terminal result behavior, and follow strict TDD.
+
+## Scope
+
+- In scope:
+  - characterize the current cancellation leak with failing tests
+  - make parent cancellation actively cancel the spawned child run
+  - keep regression coverage for both `RunPrompt(...)` and `RunForkedSkill(...)`
+  - verify the relevant harness/server surfaces
+- Out of scope:
+  - broader runner lifecycle refactors
+  - changing unrelated timeout handling semantics
+  - fixing unrelated pre-existing regression failures
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `waitForTerminalResult(...)` cancels the spawned run when `ctx.Done()` fires
+  - `RunPrompt(...)` parent cancellation transitions the child run to `cancelled`
+  - `RunForkedSkill(...)` parent cancellation transitions the child run to `cancelled`
+- Existing tests to update:
+  - extend orchestration coverage in `internal/harness/runner_orchestration_test.go`
+  - add or extend `/v1/agents` timeout coverage in `internal/server/http_agents_test.go` if the current tests do not pin the cancellation side effect
+- Regression tests required:
+  - `go test ./internal/harness`
+  - `go test ./internal/server`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- None for this bugfix; the change is limited to runner subrun cancellation behavior plus server timeout verification.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: cancelling too aggressively could race with a child run that already reached a terminal state.
+- Mitigation: keep `CancelRun` idempotent and preserve the existing terminal-history fast path before invoking cancellation on parent timeout.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1108,9 +1108,32 @@ func (r *Runner) waitForTerminalResult(ctx context.Context, runID string, histor
 				return r.forkResultFromRun(runID), nil
 			}
 		case <-ctx.Done():
+			if result, terminal := r.terminalForkResult(runID); terminal {
+				return result, nil
+			}
+			_ = r.CancelRun(runID)
 			return htools.ForkResult{Error: ctx.Err().Error()}, ctx.Err()
 		}
 	}
+}
+
+func (r *Runner) terminalForkResult(runID string) (htools.ForkResult, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	state, ok := r.runs[runID]
+	if !ok {
+		return htools.ForkResult{}, false
+	}
+	if state.run.Status != RunStatusCompleted && state.run.Status != RunStatusFailed && state.run.Status != RunStatusCancelled {
+		return htools.ForkResult{}, false
+	}
+
+	result := htools.ForkResult{Output: state.run.Output}
+	if state.run.Status == RunStatusFailed || state.run.Status == RunStatusCancelled {
+		result.Error = state.run.Error
+	}
+	return result, true
 }
 
 // forkResultFromRun extracts a ForkResult from a completed run state.

--- a/internal/harness/runner_orchestration_test.go
+++ b/internal/harness/runner_orchestration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	htools "go-agent-harness/internal/harness/tools"
 )
@@ -139,4 +140,137 @@ func TestRunForkedSkill_ReturnsFailedForkResult(t *testing.T) {
 	if result.Output != "" {
 		t.Fatalf("result.Output = %q, want empty", result.Output)
 	}
+}
+
+func TestRunPrompt_CancelsChildRunOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingCancelProvider()
+	t.Cleanup(func() {
+		close(provider.releaseCh)
+	})
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     2,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := runner.RunPrompt(ctx, "do some work")
+		errCh <- err
+	}()
+
+	select {
+	case <-provider.blockCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("provider never started blocking")
+	}
+
+	runID := singleRunID(t, runner)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunPrompt error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunPrompt did not return after context cancellation")
+	}
+
+	waitForObservedRunStatus(t, runner, runID, RunStatusCancelled)
+}
+
+func TestRunForkedSkill_CancelsChildRunOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	provider := newBlockingCancelProvider()
+	t.Cleanup(func() {
+		close(provider.releaseCh)
+	})
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     2,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan htools.ForkResult, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		result, err := runner.RunForkedSkill(ctx, htools.ForkConfig{Prompt: "forked task"})
+		resultCh <- result
+		errCh <- err
+	}()
+
+	select {
+	case <-provider.blockCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("provider never started blocking")
+	}
+
+	runID := singleRunID(t, runner)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunForkedSkill error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunForkedSkill did not return after context cancellation")
+	}
+
+	result := <-resultCh
+	if result.Error == "" {
+		t.Fatal("expected fork result to contain cancellation error text")
+	}
+
+	waitForObservedRunStatus(t, runner, runID, RunStatusCancelled)
+}
+
+func singleRunID(t *testing.T, runner *Runner) string {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		runner.mu.RLock()
+		if len(runner.runs) == 1 {
+			for runID := range runner.runs {
+				runner.mu.RUnlock()
+				return runID
+			}
+		}
+		runner.mu.RUnlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	runner.mu.RLock()
+	defer runner.mu.RUnlock()
+	t.Fatalf("expected exactly one run, found %d", len(runner.runs))
+	return ""
+}
+
+func waitForObservedRunStatus(t *testing.T, runner *Runner, runID string, want RunStatus) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		run, ok := runner.GetRun(runID)
+		if !ok {
+			t.Fatalf("run %q not found", runID)
+		}
+		if run.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	run, ok := runner.GetRun(runID)
+	if !ok {
+		t.Fatalf("run %q not found", runID)
+	}
+	t.Fatalf("run %q status = %q, want %q", runID, run.Status, want)
 }

--- a/internal/server/http_agents_test.go
+++ b/internal/server/http_agents_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/store"
 )
 
 // mockAgentRunner is a simple in-memory implementation of agentRunnerIface for tests.
@@ -409,12 +410,92 @@ func TestAgentsEndpoint_TimeoutExceeded_Returns408(t *testing.T) {
 	}
 }
 
+func TestAgentsEndpoint_TimeoutCancelsSpawnedRun(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	provider := newBlockingHarnessProvider()
+	t.Cleanup(func() {
+		close(provider.releaseCh)
+	})
+
+	runner := harness.NewRunner(
+		provider,
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel: "gpt-4.1-mini",
+			MaxSteps:     2,
+			Store:        ms,
+		},
+	)
+	handler := NewWithOptions(ServerOptions{
+		Runner:       runner,
+		AgentRunner:  runner,
+		Store:        ms,
+		AuthDisabled: true,
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	resCh := make(chan *http.Response, 1)
+	go func() {
+		resCh <- postAgents(t, ts, map[string]any{
+			"prompt":          "hang forever",
+			"timeout_seconds": 1,
+		})
+	}()
+
+	select {
+	case <-provider.blockCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("provider never started blocking")
+	}
+
+	res := <-resCh
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusRequestTimeout {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 408, got %d: %s", res.StatusCode, string(body))
+	}
+
+	runID := listSingleRunID(t, ts)
+	waitForServerRunStatus(t, ts, runID, "cancelled")
+}
+
 // blockingAgentRunner blocks until context is cancelled, then returns DeadlineExceeded.
 type blockingAgentRunner struct{}
 
 func (b *blockingAgentRunner) RunPrompt(ctx context.Context, _ string) (string, error) {
 	<-ctx.Done()
 	return "", ctx.Err()
+}
+
+type blockingHarnessProvider struct {
+	blockCh   chan struct{}
+	releaseCh chan struct{}
+}
+
+func newBlockingHarnessProvider() *blockingHarnessProvider {
+	return &blockingHarnessProvider{
+		blockCh:   make(chan struct{}),
+		releaseCh: make(chan struct{}),
+	}
+}
+
+func (p *blockingHarnessProvider) Complete(ctx context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+	select {
+	case <-p.blockCh:
+	default:
+		close(p.blockCh)
+	}
+
+	select {
+	case <-p.releaseCh:
+		return harness.CompletionResult{Content: "done"}, nil
+	case <-ctx.Done():
+		return harness.CompletionResult{}, ctx.Err()
+	}
 }
 
 func TestAgentsEndpoint_NoAgentRunner_Returns501(t *testing.T) {
@@ -628,4 +709,72 @@ func TestAgentsEndpoint_InvalidJSON_Returns400(t *testing.T) {
 	if errResp.Error.Code != "invalid_json" {
 		t.Errorf("expected error code invalid_json, got %q", errResp.Error.Code)
 	}
+}
+
+func listSingleRunID(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+
+	res, err := http.Get(ts.URL + "/v1/runs")
+	if err != nil {
+		t.Fatalf("GET /v1/runs: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200 from GET /v1/runs, got %d: %s", res.StatusCode, string(body))
+	}
+
+	var payload struct {
+		Runs []struct {
+			ID string `json:"id"`
+		} `json:"runs"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode GET /v1/runs: %v", err)
+	}
+	if len(payload.Runs) != 1 {
+		t.Fatalf("expected exactly one run, got %d", len(payload.Runs))
+	}
+	return payload.Runs[0].ID
+}
+
+func waitForServerRunStatus(t *testing.T, ts *httptest.Server, runID, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		res, err := http.Get(ts.URL + "/v1/runs/" + runID)
+		if err != nil {
+			t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+		}
+
+		var payload struct {
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+			res.Body.Close()
+			t.Fatalf("decode GET /v1/runs/%s: %v", runID, err)
+		}
+		res.Body.Close()
+
+		if payload.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	res, err := http.Get(ts.URL + "/v1/runs/" + runID)
+	if err != nil {
+		t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+	}
+	defer res.Body.Close()
+
+	var payload struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode GET /v1/runs/%s: %v", runID, err)
+	}
+	t.Fatalf("run %q status = %q, want %q", runID, payload.Status, want)
 }


### PR DESCRIPTION
## Summary
- cancel spawned child runs when `RunPrompt(...)` or `RunForkedSkill(...)` lose their parent context before a terminal event arrives
- preserve the existing terminal-result fast path by returning success/failure directly when the child already finished
- add regressions for harness orchestration and `/v1/agents` timeout behavior so timed-out child runs must transition to `cancelled`

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server -run 'TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation|TestAgentsEndpoint_Timeout(Exceeded_Returns408|CancelsSpawnedRun)'`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` (rerun on top of latest `main` after pulling in the separate CI-blocker fix; still running locally at PR creation time)

Closes #428