### PR TITLE
Consolidate run persistence ownership into the runner boundary

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,24 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Added focused HTTP persistence-ownership regressions in `internal/server/http_persistence_ownership_test.go` to prove that:
+  - `POST /v1/runs` persists exactly once when a shared store is configured
+  - external-trigger `start` persists exactly once
+  - external-trigger `continue` persists exactly once for the new run record
+- Confirmed the red state first:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server -run 'Test(PostRunPersistsExactlyOnce|ExternalTriggerStartPersistsExactlyOnce|ExternalTriggerContinuePersistsExactlyOnce)' -count=1`
+  - failed because each new run hit `CreateRun` twice
+- Consolidated ownership by removing duplicate transport-layer `CreateRun` calls from:
+  - `internal/server/http.go`
+  - `internal/server/http_external_trigger.go`
+- Updated `internal/server/http_test.go` so the existing store-backed run test uses a shared runner/server store and reflects runner-owned persistence explicitly.
+- Baseline observation before changes:
+  - `go test ./...` still fails in `go-agent-harness/training-regex` (`TestQuest`, `TestAlt`, `TestGroup`, `TestAnchors`, `TestEmptyString`, `TestEdgeCases`), which is unrelated pre-existing test debt outside this issue’s scope.
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server -run 'Test(PostRunPersistsExactlyOnce|ExternalTriggerStartPersistsExactlyOnce|ExternalTriggerContinuePersistsExactlyOnce|HarnessRunToStore)' -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness`
+
 ## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
 
 - Reproduced the bug with new failing regressions on all three affected caller surfaces:

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,28 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Command intent: Complete GitHub issue `#422` by consolidating run-record persistence ownership into the runner boundary and removing duplicate HTTP-side `CreateRun` calls.
+- User intent: Make run persistence predictable and test-backed so transports stop guessing whether they need to write run records themselves.
+- Success definition:
+  - Issue `#422` is the only implementation target in this run.
+  - `POST /v1/runs` persists exactly once when a store is configured.
+  - External-trigger `start` and `continue` paths also persist exactly once for new run records.
+  - Store-backed get/list behavior remains unchanged for clients.
+  - Focused tests pass and the repo regression gate is rerun before merge.
+- Non-goals:
+  - Redesigning the store API.
+  - Broadly refactoring the HTTP transport.
+  - Changing response shapes or persistence fatality semantics.
+- Guardrails/constraints:
+  - Strict TDD with failing tests first.
+  - Keep the change narrow and centered on ownership.
+  - Preserve best-effort persistence behavior where it is already non-fatal.
+- Open questions:
+  - Whether any non-HTTP transport path still duplicates run creation beyond the currently visible `/v1/runs` and external-trigger handlers.
+- Next verification step: capture the baseline test status, add failing single-write regressions in `internal/server`, then remove the duplicate transport-layer `CreateRun` calls and rerun targeted plus repo-wide verification.
+
 ## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
 
 - Command intent: Complete GitHub issue `#429` by ensuring callers do not report forked child runs as successful when `RunForkedSkill(...)` returns `ForkResult.Error` with a nil Go error.

--- a/docs/logs/observational-log.md
+++ b/docs/logs/observational-log.md
@@ -12,6 +12,8 @@ Use this file for observations about system behavior without immediately prescri
 
 ## 2026-03-25
 
+- Persistence observation: before this fix, both direct `/v1/runs` and external-trigger start/continue paths attempted `CreateRun` twice when the server and runner shared the same store.
+- Ownership observation: the cleanest contract is runner-owned initial persistence with the server staying read/transport-focused.
 - Discovery observation: OpenRouter is the current provider where live model discovery materially reduces backend drift from the real model surface.
 - Safety observation: keeping live discovery additive over the static catalog preserves deterministic pricing and alias behavior while still exposing dynamic OpenRouter slugs.
 - Failure-mode observation: a TTL cache with stale-cache fallback is enough to keep `/v1/models` and runtime routing from degenerating into fetch-on-every-request behavior.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -2,6 +2,25 @@
 
 Use this file to document systems, interfaces, and interactions as they are built.
 
+## 2026-03-25 (Run Persistence Ownership Boundary)
+
+- System/component: `internal/harness/runner.go`, `internal/server/http.go`, and `internal/server/http_external_trigger.go`.
+- Responsibilities:
+  - The runner owns initial run-record persistence for both `StartRun(...)` and `ContinueRun(...)`.
+  - HTTP transports return run IDs/status and rely on the runner’s shared store wiring rather than duplicating `CreateRun`.
+- Inputs/outputs:
+  - Input: transport requests that create runs through direct `/v1/runs` or external-trigger `start`/`continue`.
+  - Output: exactly one `CreateRun` attempt per logical new run record, followed by the existing non-fatal update path as the run progresses.
+- Dependencies:
+  - A shared `store.Store` must be wired into the runner when persistence is desired.
+  - The server may still read from the store for historical `GET /v1/runs` and list surfaces.
+- Failure modes:
+  - If the shared store is absent from the runner, the server no longer compensates by inserting the run record itself.
+  - Store create failures remain non-fatal where the runner already treats persistence as best-effort.
+- Operational notes:
+  - This makes the runner/domain layer the single persistence authority for new run records.
+  - External-trigger flows now match the same ownership rule as direct runner-driven continuation.
+
 ## 2026-03-25 (Forked Child-Run Failure Contract)
 
 - System/component: `/v1/agents` forked execution plus fork-context skill tools in `internal/server/http_agents.go`, `internal/harness/tools/skill.go`, and `internal/harness/tools/core/skill.go`.

--- a/docs/plans/2026-03-25-issue-422-run-persistence-ownership-plan.md
+++ b/docs/plans/2026-03-25-issue-422-run-persistence-ownership-plan.md
@@ -1,0 +1,55 @@
+# Plan: Issue #422 run persistence ownership
+
+## Context
+
+- Problem: run-record persistence is owned by both the runner and the HTTP transport, so `POST /v1/runs` and external-trigger start/continue paths can call `CreateRun` twice for the same logical run.
+- User impact: duplicate writes make persistence behavior harder to reason about, blur the boundary between transport and domain layers, and raise the risk of store-specific bugs or misleading failure handling.
+- Constraints: keep the change small, preserve current response shapes and non-fatal persistence behavior, and follow strict TDD with regression coverage before code changes.
+
+## Scope
+
+- In scope:
+  - `POST /v1/runs` persistence ownership
+  - external-trigger `start` and `continue` persistence ownership
+  - focused regression coverage for single-write behavior and store-backed retrieval
+  - issue-specific docs/log updates
+- Out of scope:
+  - store API redesign
+  - broader transport decomposition
+  - unrelated runtime or provider behavior
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `POST /v1/runs` persists exactly once when a store is configured
+  - external-trigger `start` persists exactly once when a store is configured
+  - external-trigger `continue` persists exactly once for the new run record
+- Existing tests to update:
+  - store-backed HTTP tests that currently describe transport-side persistence should be reworded around runner-owned persistence
+- Regression tests required:
+  - `go test ./internal/server`
+  - `go test ./internal/harness`
+  - `./scripts/test-regression.sh`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue is a persistence-ownership fix and does not touch provider/model flow surfaces, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: removing HTTP-side inserts could accidentally break store-backed list/get flows if the runner is not the only write path in practice.
+- Mitigation: pin both single-write behavior and store-backed retrieval/continuation flows with focused tests before deleting the duplicate transport writes.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on issue #429 forked child-run failure propagation across `/v1/agents` and fork-context skill tools.
+Current status: active implementation work is focused on issue #422 run persistence ownership between the runner and HTTP transport.
 
-Current active plan: `2026-03-25-issue-429-fork-result-failure-plan.md`
+Current active plan: `2026-03-25-issue-422-run-persistence-ownership-plan.md`
 
-Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`
+Most recent completed plan: `2026-03-25-issue-429-fork-result-failure-plan.md`

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -603,12 +603,6 @@ func (s *Server) handlePostRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Persist the initial run record to the store when configured.
-	if s.runStore != nil {
-		storeRun := harnessRunToStore(run)
-		_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-	}
-
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"run_id": run.ID,
 		"status": run.Status,
@@ -1560,25 +1554,6 @@ func (s *Server) handleDeleteConversation(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
-}
-
-// harnessRunToStore converts a harness.Run to a store.Run for initial persistence.
-// Usage/cost JSON fields are left empty; they are updated via UpdateRun later.
-func harnessRunToStore(run harness.Run) *store.Run {
-	return &store.Run{
-		ID:             run.ID,
-		ConversationID: run.ConversationID,
-		TenantID:       run.TenantID,
-		AgentID:        run.AgentID,
-		Model:          run.Model,
-		ProviderName:   run.ProviderName,
-		Prompt:         run.Prompt,
-		Status:         store.RunStatus(run.Status),
-		Output:         run.Output,
-		Error:          run.Error,
-		CreatedAt:      run.CreatedAt,
-		UpdatedAt:      run.UpdatedAt,
-	}
 }
 
 // storeRunToHarness converts a store.Run to a map suitable for JSON response.

--- a/internal/server/http_external_trigger.go
+++ b/internal/server/http_external_trigger.go
@@ -142,10 +142,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(run)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": run.ID,
 			"status": run.Status,
@@ -202,10 +198,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			}
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
-		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(newRun)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
 		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": newRun.ID,

--- a/internal/server/http_persistence_ownership_test.go
+++ b/internal/server/http_persistence_ownership_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/store"
+	"go-agent-harness/internal/trigger"
+)
+
+type createRunCountingStore struct {
+	*store.MemoryStore
+
+	mu             sync.Mutex
+	createRunCalls map[string]int
+}
+
+func newCreateRunCountingStore() *createRunCountingStore {
+	return &createRunCountingStore{
+		MemoryStore:    store.NewMemoryStore(),
+		createRunCalls: make(map[string]int),
+	}
+}
+
+func (s *createRunCountingStore) CreateRun(ctx context.Context, run *store.Run) error {
+	s.mu.Lock()
+	s.createRunCalls[run.ID]++
+	s.mu.Unlock()
+	return s.MemoryStore.CreateRun(ctx, run)
+}
+
+func (s *createRunCountingStore) createRunCount(runID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createRunCalls[runID]
+}
+
+func TestPostRunPersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	runStore := newCreateRunCountingStore()
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel:        "gpt-4.1-mini",
+			DefaultSystemPrompt: "You are helpful.",
+			MaxSteps:            1,
+			Store:               runStore,
+		},
+	)
+	ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, Store: runStore, AuthDisabled: true}))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(`{"prompt":"Hello"}`))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+
+	if got := runStore.createRunCount(created.RunID); got != 1 {
+		t.Fatalf("expected exactly 1 CreateRun call for %q, got %d", created.RunID, got)
+	}
+}
+
+func TestExternalTriggerStartPersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	runStore := newCreateRunCountingStore()
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "done"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "test-model", MaxSteps: 4, Store: runStore},
+	)
+	ts := httptest.NewServer(NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        runStore,
+		AuthDisabled: true,
+		Validators:   makeGitHubRegistry(secret),
+	}))
+	defer ts.Close()
+
+	body, sig := buildTriggerRequest(t, "github", secret, "start", "build the feature", "PR#422", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+
+	if got := runStore.createRunCount(created.RunID); got != 1 {
+		t.Fatalf("expected exactly 1 CreateRun call for %q, got %d", created.RunID, got)
+	}
+}
+
+func TestExternalTriggerContinuePersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	runStore := newCreateRunCountingStore()
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "done"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "test-model", MaxSteps: 4, Store: runStore},
+	)
+	ts := httptest.NewServer(NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        runStore,
+		AuthDisabled: true,
+		Validators:   makeGitHubRegistry(secret),
+	}))
+	defer ts.Close()
+
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#422").String()
+	run, err := runner.StartRun(harness.RunRequest{
+		Prompt:         "original prompt",
+		ConversationID: threadID,
+		TenantID:       "default",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForRunStatus(t, ts, run.ID, "completed", "failed")
+
+	body, sig := buildTriggerRequest(t, "github", secret, "continue", "follow up", "PR#422", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+
+	if got := runStore.createRunCount(created.RunID); got != 1 {
+		t.Fatalf("expected exactly 1 CreateRun call for %q, got %d", created.RunID, got)
+	}
+}

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -2311,7 +2311,7 @@ func TestStoreRunFallback(t *testing.T) {
 }
 
 // TestHarnessRunToStore tests that POST /v1/runs persists the run to the store
-// when a runStore is configured (exercises harnessRunToStore).
+// when the runner owns run-record persistence and shares that store with the server.
 func TestHarnessRunToStore(t *testing.T) {
 	t.Parallel()
 
@@ -2320,12 +2320,17 @@ func TestHarnessRunToStore(t *testing.T) {
 	runner := harness.NewRunner(
 		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
 		registry,
-		harness.RunnerConfig{DefaultModel: "gpt-4.1-mini", DefaultSystemPrompt: "You are helpful.", MaxSteps: 1},
+		harness.RunnerConfig{
+			DefaultModel:        "gpt-4.1-mini",
+			DefaultSystemPrompt: "You are helpful.",
+			MaxSteps:            1,
+			Store:               memStore,
+		},
 	)
 	ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, Store: memStore, AuthDisabled: true}))
 	defer ts.Close()
 
-	// Start a run via the server — this should call harnessRunToStore internally.
+	// Start a run via the server — the runner should persist it to the shared store.
 	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(`{"prompt":"Hello"}`))
 	if err != nil {
 		t.Fatalf("POST /v1/runs: %v", err)
@@ -2347,7 +2352,7 @@ func TestHarnessRunToStore(t *testing.T) {
 		t.Fatal("expected non-empty run_id")
 	}
 
-	// The store should have a record for this run (best-effort write on POST /v1/runs).
+	// The store should have a record for this run via runner-owned persistence.
 	ctx := context.Background()
 	// Poll briefly since the run is async.
 	var storeRun *store.Run


### PR DESCRIPTION
## Summary
- remove duplicate transport-layer `CreateRun` calls from direct `/v1/runs` and external-trigger start/continue handlers
- add failing-first regression coverage that proves each new run record is persisted exactly once
- update the existing store-backed HTTP test and repo planning/log docs to reflect runner-owned persistence

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server -run 'Test(PostRunPersistsExactlyOnce|ExternalTriggerStartPersistsExactlyOnce|ExternalTriggerContinuePersistsExactlyOnce|HarnessRunToStore)' -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` *(currently fails on unrelated pre-existing `internal/symphd` test `TestDispatcher_Shutdown`)*

## Notes
- Baseline `go test ./...` in this worktree also showed unrelated existing failures in `go-agent-harness/training-regex` before the issue-specific changes.
- This PR keeps persistence non-fatal; it only removes the duplicate write attempts so the runner remains the single owner of initial run-record creation.

Closes #422