### PR TITLE
fix: consolidate run persistence ownership in runner

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,23 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Added persistence-ownership regression coverage in:
+  - `internal/server/http_test.go`
+  - `internal/server/http_external_trigger_test.go`
+  - `internal/harness/runner_store_durability_test.go`
+- Removed duplicate transport-layer `CreateRun(...)` calls from:
+  - `internal/server/http.go`
+  - `internal/server/http_external_trigger.go`
+- Ownership decision:
+  - the runner/domain layer remains the single owner of initial run-record persistence for `StartRun(...)` and `ContinueRun(...)`
+  - HTTP transports still read from the shared store for history/listing, but they no longer create initial run records themselves
+- Verification so far:
+  - red first:
+    - `go test ./internal/server ./internal/harness -run 'Test(PostRunsPersistsExactlyOnce|HandleExternalTrigger_StartPersistsExactlyOnce|HandleExternalTrigger_ContinuePersistsExactlyOnce|RunnerStore_ContinueRunCreateRunCalledExactlyOnce)' -count=1`
+  - green after fix:
+    - `go test ./internal/server ./internal/harness -run 'Test(PostRunsPersistsExactlyOnce|HandleExternalTrigger_StartPersistsExactlyOnce|HandleExternalTrigger_ContinuePersistsExactlyOnce|RunnerStore_ContinueRunCreateRunCalledExactlyOnce)' -count=1`
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -40,6 +40,28 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
   - Whether the backend `list_models` tool should be discovery-aware now or in a follow-up once `/v1/models` and routing are stabilized.
 - Next verification step: add failing tests for discovery/cache/merge/routing, implement the minimal backend layer, then run targeted packages and the regression suite.
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Command intent: Complete issue `#422` by making the runner the sole owner of initial run-record persistence and removing duplicate HTTP-side `CreateRun` calls.
+- User intent: Close one backlog issue end to end with strict TDD, preserve current API behavior, and land a cleanly mergeable PR.
+- Success definition:
+  - `POST /v1/runs` persists each run exactly once when a store is configured.
+  - External trigger `start` and `continue` paths also persist each new run exactly once.
+  - `Runner.ContinueRun(...)` remains the owner of continuation persistence.
+  - Store-backed `GET /v1/runs/{id}` and `GET /v1/runs` behavior remains unchanged.
+  - Targeted packages and the repo regression gate pass before merge.
+- Non-goals:
+  - redesigning the store interface
+  - broader server-layer refactors
+  - changing HTTP response payloads
+- Guardrails/constraints:
+  - strict TDD with red tests first
+  - keep store persistence non-fatal
+  - keep changes small and reviewable
+- Open questions:
+  - none at implementation start; the ownership boundary is explicit in the issue.
+- Next verification step: run the new red tests, remove the transport duplication, rerun targeted packages, then run `./scripts/test-regression.sh`.
+
 ## 2026-03-24 (Worktree Bootstrap Script)
 
 - Command intent: Build a reusable setup script that creates a fresh agent worktree and leaves it ready for local development and verification.

--- a/docs/logs/observational-log.md
+++ b/docs/logs/observational-log.md
@@ -12,6 +12,8 @@ Use this file for observations about system behavior without immediately prescri
 
 ## 2026-03-25
 
+- Persistence observation: when both the runner and HTTP transport share the same store, duplicate `CreateRun` writes are easy to miss because the second write is treated as best-effort and can fail silently.
+- Boundary observation: retrieval and listing can stay transport-owned while initial run creation still belongs entirely to the runner/domain layer.
 - Discovery observation: OpenRouter is the current provider where live model discovery materially reduces backend drift from the real model surface.
 - Safety observation: keeping live discovery additive over the static catalog preserves deterministic pricing and alias behavior while still exposing dynamic OpenRouter slugs.
 - Failure-mode observation: a TTL cache with stale-cache fallback is enough to keep `/v1/models` and runtime routing from degenerating into fetch-on-every-request behavior.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -2,6 +2,26 @@
 
 Use this file to document systems, interfaces, and interactions as they are built.
 
+## 2026-03-25 (Run Persistence Ownership Boundary)
+
+- System/component: `internal/harness/runner.go`, `internal/server/http.go`, `internal/server/http_external_trigger.go`.
+- Responsibilities:
+  - `Runner.StartRun(...)` and `Runner.ContinueRun(...)` create the initial persisted run record when a store is configured.
+  - HTTP entrypoints submit run requests and continue to use the store for listing and historical retrieval.
+  - transports do not duplicate initial `CreateRun(...)` writes.
+- Inputs/outputs:
+  - Input: run start/continue requests arriving through direct HTTP or external-trigger HTTP surfaces.
+  - Output: exactly one `store.CreateRun(...)` call per new run ID, followed by the existing `UpdateRun`, message-append, and event-append flow.
+- Dependencies:
+  - shared `store.Store` wiring into both runner and server
+  - runner persistence helpers (`storeCreateRun`, `storeUpdateRun`, `storeAppend*`)
+- Failure modes:
+  - if the runner store is nil, no run persistence occurs and historical retrieval/listing still requires a separately configured server store
+  - if `CreateRun(...)` fails, the run continues because persistence remains best-effort/non-fatal
+- Operational notes:
+  - store-backed `GET /v1/runs/{id}` and `GET /v1/runs` semantics are unchanged
+  - external trigger `start` and `continue` now follow the same persistence ownership rule as direct HTTP
+
 ## 2026-03-18 (Runner Event Ledger Ordering Contract)
 
 - System/component: `internal/harness/runner.go`

--- a/docs/plans/2026-03-25-issue-422-run-persistence-plan.md
+++ b/docs/plans/2026-03-25-issue-422-run-persistence-plan.md
@@ -1,0 +1,57 @@
+# Plan: Issue #422 Run Persistence Ownership
+
+## Context
+
+- Problem: both the runner and the HTTP transport create the initial persisted run record, so `CreateRun` happens twice for the same run on some entrypoints.
+- User impact: persistence ownership is ambiguous, duplicate writes hide the real domain boundary, and future transports can easily repeat the same mistake.
+- Constraints:
+  - strict TDD
+  - keep HTTP response shapes unchanged
+  - leave store persistence best-effort and non-fatal where it is today
+
+## Scope
+
+- In scope:
+  - `POST /v1/runs` persistence ownership
+  - external trigger `start` and `continue` persistence ownership
+  - explicit regression coverage for runner-owned `ContinueRun` persistence
+- Out of scope:
+  - store API redesign
+  - broader `internal/server` decomposition
+  - changes to retrieval/listing contracts
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `TestPostRunsPersistsExactlyOnce`
+  - `TestHandleExternalTrigger_StartPersistsExactlyOnce`
+  - `TestHandleExternalTrigger_ContinuePersistsExactlyOnce`
+  - `TestRunnerStore_ContinueRunCreateRunCalledExactlyOnce`
+- Existing tests to update:
+  - none required beyond renaming the direct POST persistence test to match the ownership contract
+- Regression tests required:
+  - `go test ./internal/server ./internal/harness`
+  - `./scripts/test-regression.sh`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- None. This issue changes run-store ownership only and does not alter provider/model flow surfaces.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] For provider/model flow work, add or update the one-page impact map before implementation.
+- [x] Write failing tests first.
+- [x] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [x] Implement minimal code changes.
+- [x] Refactor while tests remain green.
+- [x] Update docs and indexes.
+- [x] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: removing transport writes could break store-backed historical retrieval if the runner store is not wired.
+- Mitigation: share the same store with runner and server in regression tests and verify the persisted run is still retrievable with a single `CreateRun`.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-422-run-persistence-plan.md`: Active plan for consolidating run-store ownership into the runner boundary.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/internal/harness/runner_store_durability_test.go
+++ b/internal/harness/runner_store_durability_test.go
@@ -7,6 +7,7 @@ package harness
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -51,6 +52,41 @@ func TestRunnerStore_CreateRunCalledOnStartRun(t *testing.T) {
 	// Initial model must be preserved.
 	if storedRun.Model != "test" {
 		t.Errorf("stored run Model: got %q, want %q", storedRun.Model, "test")
+	}
+}
+
+func TestRunnerStore_ContinueRunCreateRunCalledExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	st := &countingRunStore{inner: store.NewMemoryStore()}
+	provider := &stubProvider{turns: []CompletionResult{{Content: "first"}, {Content: "second"}}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test",
+		MaxSteps:     2,
+		Store:        st,
+	})
+
+	run1, err := runner.StartRun(RunRequest{Prompt: "first prompt"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run1.ID); err != nil {
+		t.Fatalf("collectRunEvents run1: %v", err)
+	}
+
+	run2, err := runner.ContinueRun(run1.ID, "second prompt")
+	if err != nil {
+		t.Fatalf("ContinueRun: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run2.ID); err != nil {
+		t.Fatalf("collectRunEvents run2: %v", err)
+	}
+
+	if got := st.CreateRunCount(run1.ID); got != 1 {
+		t.Fatalf("CreateRun count for original run %s: got %d, want 1", run1.ID, got)
+	}
+	if got := st.CreateRunCount(run2.ID); got != 1 {
+		t.Fatalf("CreateRun count for continued run %s: got %d, want 1", run2.ID, got)
 	}
 }
 
@@ -627,6 +663,75 @@ func TestRunnerStore_StoreErrorDoesNotFailRun(t *testing.T) {
 // simulating a transient database outage.
 type failingStore struct {
 	inner *store.MemoryStore
+}
+
+type countingRunStore struct {
+	inner *store.MemoryStore
+
+	mu            sync.Mutex
+	createRunByID map[string]int
+}
+
+func (s *countingRunStore) CreateRun(ctx context.Context, run *store.Run) error {
+	s.mu.Lock()
+	if s.createRunByID == nil {
+		s.createRunByID = make(map[string]int)
+	}
+	s.createRunByID[run.ID]++
+	s.mu.Unlock()
+	return s.inner.CreateRun(ctx, run)
+}
+
+func (s *countingRunStore) CreateRunCount(runID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createRunByID[runID]
+}
+
+func (s *countingRunStore) UpdateRun(ctx context.Context, run *store.Run) error {
+	return s.inner.UpdateRun(ctx, run)
+}
+
+func (s *countingRunStore) GetRun(ctx context.Context, id string) (*store.Run, error) {
+	return s.inner.GetRun(ctx, id)
+}
+
+func (s *countingRunStore) ListRuns(ctx context.Context, filter store.RunFilter) ([]*store.Run, error) {
+	return s.inner.ListRuns(ctx, filter)
+}
+
+func (s *countingRunStore) AppendMessage(ctx context.Context, msg *store.Message) error {
+	return s.inner.AppendMessage(ctx, msg)
+}
+
+func (s *countingRunStore) GetMessages(ctx context.Context, runID string) ([]*store.Message, error) {
+	return s.inner.GetMessages(ctx, runID)
+}
+
+func (s *countingRunStore) AppendEvent(ctx context.Context, event *store.Event) error {
+	return s.inner.AppendEvent(ctx, event)
+}
+
+func (s *countingRunStore) GetEvents(ctx context.Context, runID string, afterSeq int) ([]*store.Event, error) {
+	return s.inner.GetEvents(ctx, runID, afterSeq)
+}
+
+func (s *countingRunStore) Close() error { return s.inner.Close() }
+
+func (s *countingRunStore) CreateAPIKey(ctx context.Context, key store.APIKey) error {
+	return s.inner.CreateAPIKey(ctx, key)
+}
+
+func (s *countingRunStore) ValidateAPIKey(ctx context.Context, rawToken string) (*store.APIKey, error) {
+	return s.inner.ValidateAPIKey(ctx, rawToken)
+}
+
+func (s *countingRunStore) ListAPIKeys(ctx context.Context, tenantID string) ([]store.APIKey, error) {
+	return s.inner.ListAPIKeys(ctx, tenantID)
+}
+
+func (s *countingRunStore) RevokeAPIKey(ctx context.Context, id string) error {
+	return s.inner.RevokeAPIKey(ctx, id)
 }
 
 func (f *failingStore) CreateRun(_ context.Context, _ *store.Run) error {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -603,12 +603,6 @@ func (s *Server) handlePostRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Persist the initial run record to the store when configured.
-	if s.runStore != nil {
-		storeRun := harnessRunToStore(run)
-		_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-	}
-
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"run_id": run.ID,
 		"status": run.Status,

--- a/internal/server/http_external_trigger.go
+++ b/internal/server/http_external_trigger.go
@@ -142,10 +142,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(run)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": run.ID,
 			"status": run.Status,
@@ -202,10 +198,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			}
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
-		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(newRun)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
 		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": newRun.ID,

--- a/internal/server/http_external_trigger_test.go
+++ b/internal/server/http_external_trigger_test.go
@@ -78,6 +78,24 @@ func newTriggerServer(t *testing.T, provider harness.Provider, reg *trigger.Vali
 	return ts, ms
 }
 
+func newTriggerServerWithStore(t *testing.T, provider harness.Provider, reg *trigger.ValidatorRegistry, st store.Store) *httptest.Server {
+	t.Helper()
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+		Store:        st,
+	})
+	handler := NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        st,
+		AuthDisabled: true,
+		Validators:   reg,
+	})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
 // sendTrigger sends a POST /v1/external/trigger request with the given body and
 // X-Trigger-Signature header.
 func sendTrigger(t *testing.T, ts *httptest.Server, body []byte, sig string) *http.Response {
@@ -148,6 +166,34 @@ func TestHandleExternalTrigger_StartNewRun(t *testing.T) {
 	}
 	if resp.RunID == "" {
 		t.Error("expected non-empty run_id")
+	}
+}
+
+func TestHandleExternalTrigger_StartPersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	memStore := newCountingStore()
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts := newTriggerServerWithStore(t, provider, reg, memStore)
+
+	body, sig := buildTriggerRequest(t, "github", secret, "start", "build the feature", "PR#422", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := memStore.CreateRunCount(resp.RunID); got != 1 {
+		t.Fatalf("CreateRun count for %s: got %d, want 1", resp.RunID, got)
 	}
 }
 
@@ -277,6 +323,56 @@ func TestHandleExternalTrigger_ContinueCompletedRun(t *testing.T) {
 	}
 	if resp.RunID == "" {
 		t.Error("expected non-empty run_id in continue response")
+	}
+}
+
+func TestHandleExternalTrigger_ContinuePersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	memStore := newCountingStore()
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	ts := newTriggerServerWithStore(t, provider, reg, memStore)
+
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#422")
+	startBody, _ := json.Marshal(map[string]string{
+		"prompt":          "original prompt",
+		"conversation_id": threadID.String(),
+	})
+	startRes, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewReader(startBody))
+	if err != nil {
+		t.Fatalf("start run via API: %v", err)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(startRes.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	startRes.Body.Close()
+
+	waitForRunStatus(t, ts, created.RunID, "completed", "failed")
+
+	body, sig := buildTriggerRequest(t, "github", secret, "continue", "follow up", "PR#422", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got := memStore.CreateRunCount(resp.RunID); got != 1 {
+		t.Fatalf("CreateRun count for %s: got %d, want 1", resp.RunID, got)
 	}
 }
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -44,6 +44,83 @@ func (s *scriptedProvider) Complete(_ context.Context, _ harness.CompletionReque
 	return out, nil
 }
 
+type countingStore struct {
+	inner *store.MemoryStore
+
+	mu             sync.Mutex
+	createRunCalls int
+	createRunByID  map[string]int
+}
+
+func newCountingStore() *countingStore {
+	return &countingStore{
+		inner:         store.NewMemoryStore(),
+		createRunByID: make(map[string]int),
+	}
+}
+
+func (s *countingStore) CreateRun(ctx context.Context, run *store.Run) error {
+	s.mu.Lock()
+	s.createRunCalls++
+	s.createRunByID[run.ID]++
+	s.mu.Unlock()
+	return s.inner.CreateRun(ctx, run)
+}
+
+func (s *countingStore) CreateRunCount(runID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createRunByID[runID]
+}
+
+func (s *countingStore) UpdateRun(ctx context.Context, run *store.Run) error {
+	return s.inner.UpdateRun(ctx, run)
+}
+
+func (s *countingStore) GetRun(ctx context.Context, id string) (*store.Run, error) {
+	return s.inner.GetRun(ctx, id)
+}
+
+func (s *countingStore) ListRuns(ctx context.Context, filter store.RunFilter) ([]*store.Run, error) {
+	return s.inner.ListRuns(ctx, filter)
+}
+
+func (s *countingStore) AppendMessage(ctx context.Context, msg *store.Message) error {
+	return s.inner.AppendMessage(ctx, msg)
+}
+
+func (s *countingStore) GetMessages(ctx context.Context, runID string) ([]*store.Message, error) {
+	return s.inner.GetMessages(ctx, runID)
+}
+
+func (s *countingStore) AppendEvent(ctx context.Context, event *store.Event) error {
+	return s.inner.AppendEvent(ctx, event)
+}
+
+func (s *countingStore) GetEvents(ctx context.Context, runID string, afterSeq int) ([]*store.Event, error) {
+	return s.inner.GetEvents(ctx, runID, afterSeq)
+}
+
+func (s *countingStore) Close() error {
+	return s.inner.Close()
+}
+
+func (s *countingStore) CreateAPIKey(ctx context.Context, key store.APIKey) error {
+	return s.inner.CreateAPIKey(ctx, key)
+}
+
+func (s *countingStore) ValidateAPIKey(ctx context.Context, rawToken string) (*store.APIKey, error) {
+	return s.inner.ValidateAPIKey(ctx, rawToken)
+}
+
+func (s *countingStore) ListAPIKeys(ctx context.Context, tenantID string) ([]store.APIKey, error) {
+	return s.inner.ListAPIKeys(ctx, tenantID)
+}
+
+func (s *countingStore) RevokeAPIKey(ctx context.Context, id string) error {
+	return s.inner.RevokeAPIKey(ctx, id)
+}
+
 func TestRunLifecycleEndpoints(t *testing.T) {
 	t.Parallel()
 
@@ -502,9 +579,9 @@ func TestRunSummaryEndpoint(t *testing.T) {
 	cached := 10
 	provider := &scriptedProvider{turns: []harness.CompletionResult{
 		{
-			ToolCalls: []harness.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"echo hi"}`}},
-			Usage:     &harness.CompletionUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150, CachedPromptTokens: &cached},
-			CostUSD:   ptrFloat64(0.005),
+			ToolCalls:  []harness.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"echo hi"}`}},
+			Usage:      &harness.CompletionUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150, CachedPromptTokens: &cached},
+			CostUSD:    ptrFloat64(0.005),
 			CostStatus: harness.CostStatusAvailable,
 		},
 		{Content: "done", Usage: &harness.CompletionUsage{PromptTokens: 200, CompletionTokens: 30, TotalTokens: 230}, CostUSD: ptrFloat64(0.003), CostStatus: harness.CostStatusAvailable},
@@ -616,20 +693,20 @@ func ptrFloat64(v float64) *float64 { return &v }
 
 // mockConversationStore implements harness.ConversationStore for testing.
 type mockConversationStore struct {
-	conversations       []harness.Conversation
-	messages            map[string][]harness.Message
-	listErr             error
-	deleteErr           error
-	loadErr             error
-	searchResults       []harness.MessageSearchResult
-	searchErr           error
-	deletedIDs          []string
-	searchedQuery       string
-	searchedLimit       int
-	deleteOldCount      int          // number to return from DeleteOldConversations
-	deleteOldErr        error        // error to return from DeleteOldConversations
-	deleteOldThreshold  time.Time    // last threshold passed to DeleteOldConversations
-	deleteOldCalled     bool         // whether DeleteOldConversations was called
+	conversations      []harness.Conversation
+	messages           map[string][]harness.Message
+	listErr            error
+	deleteErr          error
+	loadErr            error
+	searchResults      []harness.MessageSearchResult
+	searchErr          error
+	deletedIDs         []string
+	searchedQuery      string
+	searchedLimit      int
+	deleteOldCount     int       // number to return from DeleteOldConversations
+	deleteOldErr       error     // error to return from DeleteOldConversations
+	deleteOldThreshold time.Time // last threshold passed to DeleteOldConversations
+	deleteOldCalled    bool      // whether DeleteOldConversations was called
 }
 
 func (m *mockConversationStore) Migrate(_ context.Context) error { return nil }
@@ -747,9 +824,9 @@ func (c *capturingServerProvider) lastRequest() *harness.CompletionRequest {
 func TestWriteSSE_IncludesIDAndRetry(t *testing.T) {
 	rec := httptest.NewRecorder()
 	event := harness.Event{
-		ID:    "run_1:42",
-		RunID: "run_1",
-		Type:  harness.EventRunStarted,
+		ID:        "run_1:42",
+		RunID:     "run_1",
+		Type:      harness.EventRunStarted,
 		Timestamp: time.Now(),
 	}
 	err := writeSSE(rec, event)
@@ -1950,7 +2027,6 @@ func TestCleanupEndpoint(t *testing.T) {
 		ts := httptest.NewServer(mux)
 		defer ts.Close()
 
-
 		// POST without body — should default to 30 days.
 		res, err := http.Post(ts.URL+"/v1/conversations/cleanup", "application/json", bytes.NewBufferString(`{}`))
 		if err != nil {
@@ -2310,17 +2386,22 @@ func TestStoreRunFallback(t *testing.T) {
 	}
 }
 
-// TestHarnessRunToStore tests that POST /v1/runs persists the run to the store
-// when a runStore is configured (exercises harnessRunToStore).
-func TestHarnessRunToStore(t *testing.T) {
+// TestPostRunsPersistsExactlyOnce verifies that POST /v1/runs relies on the
+// runner-owned persistence path instead of duplicating CreateRun in HTTP.
+func TestPostRunsPersistsExactlyOnce(t *testing.T) {
 	t.Parallel()
 
-	memStore := store.NewMemoryStore()
+	memStore := newCountingStore()
 	registry := harness.NewRegistry()
 	runner := harness.NewRunner(
 		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
 		registry,
-		harness.RunnerConfig{DefaultModel: "gpt-4.1-mini", DefaultSystemPrompt: "You are helpful.", MaxSteps: 1},
+		harness.RunnerConfig{
+			DefaultModel:        "gpt-4.1-mini",
+			DefaultSystemPrompt: "You are helpful.",
+			MaxSteps:            1,
+			Store:               memStore,
+		},
 	)
 	ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, Store: memStore, AuthDisabled: true}))
 	defer ts.Close()
@@ -2347,13 +2428,12 @@ func TestHarnessRunToStore(t *testing.T) {
 		t.Fatal("expected non-empty run_id")
 	}
 
-	// The store should have a record for this run (best-effort write on POST /v1/runs).
+	// The store should have exactly one CreateRun for this run.
 	ctx := context.Background()
-	// Poll briefly since the run is async.
 	var storeRun *store.Run
 	for i := 0; i < 50; i++ {
 		r, err := memStore.GetRun(ctx, created.RunID)
-		if err == nil {
+		if err == nil && memStore.CreateRunCount(created.RunID) > 0 {
 			storeRun = r
 			break
 		}
@@ -2364,6 +2444,9 @@ func TestHarnessRunToStore(t *testing.T) {
 	}
 	if storeRun.Prompt != "Hello" {
 		t.Errorf("store run prompt: got %q, want Hello", storeRun.Prompt)
+	}
+	if got := memStore.CreateRunCount(created.RunID); got != 1 {
+		t.Fatalf("CreateRun count for %s: got %d, want 1", created.RunID, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the runner the sole owner of initial run-record persistence
- remove duplicate transport-layer `CreateRun` calls from direct and external-trigger HTTP entrypoints
- add regression coverage for single-write ownership on start and continue flows

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness -run 'Test(PostRunsPersistsExactlyOnce|HandleExternalTrigger_StartPersistsExactlyOnce|HandleExternalTrigger_ContinuePersistsExactlyOnce|RunnerStore_ContinueRunCreateRunCalledExactlyOnce)' -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh` *(currently fails at the pre-existing repo-wide zero-coverage-function gate; local run reported `84.7%` total coverage and exited non-zero after the coverage gate, not from this issue’s targeted packages)*

## Notes
- this preserves existing HTTP response shapes and store-backed retrieval/listing behavior
- issue docs/logs were updated with the ownership boundary and verification trail