### PR TITLE
Preserve allowed tool filters on fallback paths

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -19,6 +19,32 @@
   - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server -run 'Test(PostRunPersistsExactlyOnce|ExternalTriggerStartPersistsExactlyOnce|ExternalTriggerContinuePersistsExactlyOnce|HarnessRunToStore)' -count=1`
   - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness`
 
+## 2026-03-25 (Issue #430 Allowed-Tools Fallback Integrity)
+
+- Preserved `allowed_tools` restrictions on prompt-based fallback execution paths by adding an optional constrained runner entrypoint and using it in:
+  - `internal/server/http_agents.go` for `/v1/agents` prompt execution and skill-lister fallback execution
+  - `internal/harness/tools/skill.go` for flat-catalog fork fallback execution
+  - `internal/harness/tools/core/skill.go` for core skill fork fallback execution
+- Implemented `Runner.RunPromptWithAllowedTools(...)` in `internal/harness/runner.go` so fallback execution can start a plain sub-run while still forwarding `RunRequest.AllowedTools`.
+- Added regression coverage for:
+  - `/v1/agents` prompt path preserving `allowed_tools`
+  - `/v1/agents` skill fallback preserving `allowed_tools`
+  - flat skill fallback preserving `allowed_tools`
+  - core skill fallback preserving `allowed_tools`
+  - runner-level forwarding of `RunPromptWithAllowedTools(...)`
+- Verification:
+  - baseline before edits: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness ./internal/harness/tools ./internal/harness/tools/core`
+  - failing-first regressions:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillFallbackPreservesAllowedTools|TestFlatSkillForkBasicRunPromptPreservesAllowedTools|TestSkillTool_Handler_ForkWithBasicRunnerPreservesAllowedTools' -count=1`
+  - focused green verification:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_(PromptPreservesAllowedTools|SkillFallbackPreservesAllowedTools)|TestFlatSkillForkBasicRunPromptPreservesAllowedTools|TestSkillTool_Handler_ForkWithBasicRunnerPreservesAllowedTools|TestRunPrompt(ReturnsOutput|WithAllowedTools_ForwardsAllowedTools|_RespectsContextCancellation)' -count=1`
+  - relevant package verification:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness ./internal/harness/tools ./internal/harness/tools/core`
+  - repo regression gate:
+    - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh`
+    - local package-test phase passed cleanly
+    - local race phase produced repeated macOS linker warnings (`malformed LC_DYSYMTAB`) and did not yield a clean final exit inside the tmux wrapper before handoff, so final mergeability will be confirmed from PR CI
+
 ## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
 
 - Reproduced the bug with new failing regressions on all three affected caller surfaces:

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -37,6 +37,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
   - Whether any non-HTTP transport path still duplicates run creation beyond the currently visible `/v1/runs` and external-trigger handlers.
 - Next verification step: capture the baseline test status, add failing single-write regressions in `internal/server`, then remove the duplicate transport-layer `CreateRun` calls and rerun targeted plus repo-wide verification.
 
+## 2026-03-25 (Issue #430 Allowed-Tools Fallback Integrity)
+
+- Command intent: Complete GitHub issue `#430` end to end by preserving `allowed_tools` restrictions on agent and skill fallback paths, with failing tests first, regression coverage, PR, and mergeable CI.
+- User intent: Fix the security-sensitive gap where constrained agent/skill requests can silently become unconstrained when execution falls back to plain `RunPrompt(...)`, and land the change cleanly.
+- Success definition:
+  - Issue `#430` is the only implementation issue worked in this run.
+  - Failing-first regression tests reproduce the `allowed_tools` leak on `/v1/agents`, `internal/harness/tools/skill.go`, and `internal/harness/tools/core/skill.go` fallback paths.
+  - The production fix preserves allowlists consistently across primary and fallback execution without changing unrestricted behavior when `allowed_tools` is omitted.
+  - Relevant package tests pass, and the repo regression gate is addressed enough for the resulting PR to be cleanly mergeable.
+  - GitHub issue comments clearly capture claim/progress/result and the PR includes a concise summary plus any residual notes.
+- Non-goals:
+  - Broad refactors outside the fallback allowlist plumbing.
+  - New tool-policy features beyond preserving existing restrictions.
+- Guardrails/constraints:
+  - Strict TDD: failing tests first, then minimal implementation.
+  - Keep the change scoped to the fallback run paths and any small shared helper needed.
+  - Do not fix unrelated pre-existing failures except where required to make this PR mergeable.
+- Open questions:
+  - Whether the narrowest safe fix is a new constrained runner entrypoint or routing fallback execution through an existing constrained path.
+- Next verification step: finish the baseline targeted-package run, add failing regression tests for all three fallback surfaces, then implement the smallest shared fix and rerun targeted packages plus the repo regression script.
+
 ## 2026-03-25 (Issue #429 Forked Child-Run Failure Propagation)
 
 - Command intent: Complete GitHub issue `#429` by ensuring callers do not report forked child runs as successful when `RunForkedSkill(...)` returns `ForkResult.Error` with a nil Go error.

--- a/docs/plans/2026-03-25-issue-430-allowed-tools-fallback-plan.md
+++ b/docs/plans/2026-03-25-issue-430-allowed-tools-fallback-plan.md
@@ -1,0 +1,55 @@
+# Plan: Issue #430 Allowed-Tools Fallback Integrity
+
+## Context
+
+- Problem: constrained agent and skill requests can lose `allowed_tools` restrictions when execution falls back to plain `RunPrompt(...)`.
+- User impact: a supposedly restricted run can regain the default toolset, which breaks containment expectations and creates a security-sensitive contract drift.
+- Constraints: strict TDD, scoped change only, and the resulting PR must be cleanly mergeable.
+
+## Scope
+
+- In scope:
+  - `/v1/agents` fallback behavior in `internal/server/http_agents.go`
+  - flat skill fallback behavior in `internal/harness/tools/skill.go`
+  - core skill fallback behavior in `internal/harness/tools/core/skill.go`
+  - any narrow runner API/helper needed to preserve tool constraints on fallback execution
+  - regression coverage for restricted and unrestricted fallback behavior
+- Out of scope:
+  - unrelated runner/tooling refactors
+  - new authorization semantics beyond preserving the existing `allowed_tools` contract
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `/v1/agents` fallback path keeps `allowed_tools` restrictions
+  - flat skill fallback path keeps `allowed_tools` restrictions
+  - core skill fallback path keeps `allowed_tools` restrictions
+- Existing tests to update:
+  - agent/skill fallback tests that currently only assert output behavior
+- Regression tests required:
+  - disallowed tools stay blocked on fallback paths
+  - allowed tools stay permitted on fallback paths
+  - omitted `allowed_tools` still behaves as unrestricted
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- None. This issue affects tool constraint plumbing on fallback execution paths, not provider/model flow surfaces.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: fallback-path fixes diverge between HTTP and skill surfaces.
+- Mitigation: prefer one shared constrained fallback execution path and cover all three surfaces directly.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -6,6 +6,8 @@
 - `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
+- `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
+- `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1011,14 +1011,27 @@ func (r *Runner) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 // complete, returning the run's final output. This satisfies the AgentRunner
 // interface required by the skill tool for plain (non-forked) sub-runs.
 func (r *Runner) RunPrompt(ctx context.Context, prompt string) (string, error) {
-	run, err := r.StartRun(RunRequest{Prompt: prompt})
+	return r.runPromptWithRequest(ctx, RunRequest{Prompt: prompt}, "RunPrompt")
+}
+
+// RunPromptWithAllowedTools starts a new run like RunPrompt while preserving
+// the provided AllowedTools filter for fallback execution paths.
+func (r *Runner) RunPromptWithAllowedTools(ctx context.Context, prompt string, allowedTools []string) (string, error) {
+	return r.runPromptWithRequest(ctx, RunRequest{
+		Prompt:       prompt,
+		AllowedTools: append([]string(nil), allowedTools...),
+	}, "RunPromptWithAllowedTools")
+}
+
+func (r *Runner) runPromptWithRequest(ctx context.Context, req RunRequest, op string) (string, error) {
+	run, err := r.StartRun(req)
 	if err != nil {
-		return "", fmt.Errorf("RunPrompt: start run: %w", err)
+		return "", fmt.Errorf("%s: start run: %w", op, err)
 	}
 
 	history, stream, cancel, err := r.Subscribe(run.ID)
 	if err != nil {
-		return "", fmt.Errorf("RunPrompt: subscribe: %w", err)
+		return "", fmt.Errorf("%s: subscribe: %w", op, err)
 	}
 	defer cancel()
 

--- a/internal/harness/runner_tool_filter_test.go
+++ b/internal/harness/runner_tool_filter_test.go
@@ -801,6 +801,69 @@ func TestRunPrompt_ReturnsOutput(t *testing.T) {
 	}
 }
 
+func TestRunPromptWithAllowedTools_ForwardsAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name: "read_file", Description: "reads a file",
+		Parameters: map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"content":"data"}`, nil
+	})
+	_ = registry.Register(ToolDefinition{
+		Name: "bash", Description: "runs bash",
+		Parameters: map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"output":"done"}`, nil
+	})
+
+	ch := make(chan []string, 1)
+	provider := &funcProvider{
+		fn: func(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+			names := make([]string, len(req.Tools))
+			for i, t := range req.Tools {
+				names[i] = t.Name
+			}
+			ch <- names
+			return CompletionResult{Content: "done"}, nil
+		},
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+	})
+
+	output, err := runner.RunPromptWithAllowedTools(context.Background(), "do some work", []string{"read_file"})
+	if err != nil {
+		t.Fatalf("RunPromptWithAllowedTools: %v", err)
+	}
+	if output != "done" {
+		t.Fatalf("RunPromptWithAllowedTools returned %q, want %q", output, "done")
+	}
+
+	select {
+	case names := <-ch:
+		for _, name := range names {
+			if name == "bash" {
+				t.Fatalf("bash should not be offered when AllowedTools=['read_file']")
+			}
+		}
+		foundRead := false
+		for _, name := range names {
+			if name == "read_file" {
+				foundRead = true
+			}
+		}
+		if !foundRead {
+			t.Fatalf("expected read_file to be offered, got %v", names)
+		}
+	default:
+		t.Fatal("provider did not receive tool definitions")
+	}
+}
+
 // TestRunPrompt_RespectsContextCancellation verifies that RunPrompt returns
 // an error when the context is cancelled before the run completes.
 func TestRunPrompt_RespectsContextCancellation(t *testing.T) {

--- a/internal/harness/tools/core/skill.go
+++ b/internal/harness/tools/core/skill.go
@@ -169,7 +169,7 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 	}
 
 	// Fallback: basic AgentRunner.RunPrompt
-	output, err := runner.RunPrompt(forkCtx, content)
+	output, err := runPromptWithAllowedTools(forkCtx, runner, content, info.AllowedTools)
 	if err != nil {
 		return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 	}
@@ -180,6 +180,13 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 		"result":  output,
 		"context": "fork",
 	})
+}
+
+func runPromptWithAllowedTools(ctx context.Context, runner tools.AgentRunner, prompt string, allowedTools []string) (string, error) {
+	if constrainedRunner, ok := runner.(tools.ConstrainedAgentRunner); ok {
+		return constrainedRunner.RunPromptWithAllowedTools(ctx, prompt, allowedTools)
+	}
+	return runner.RunPrompt(ctx, prompt)
 }
 
 // handleListSkills returns a formatted list of all registered skills with

--- a/internal/harness/tools/core/skill_test.go
+++ b/internal/harness/tools/core/skill_test.go
@@ -87,11 +87,26 @@ func unwrapSkillResult(t *testing.T, raw string) (map[string]any, []tools.MetaMe
 // --- mock AgentRunner types ---
 
 type mockBasicRunner struct {
-	output string
-	err    error
+	output                 string
+	err                    error
+	runPromptCalls         int
+	constrainedCalls       int
+	lastPrompt             string
+	lastAllowedTools       []string
+	lastConstrainedPrompt  string
+	lastConstrainedAllowed []string
 }
 
 func (m *mockBasicRunner) RunPrompt(ctx context.Context, prompt string) (string, error) {
+	m.runPromptCalls++
+	m.lastPrompt = prompt
+	return m.output, m.err
+}
+
+func (m *mockBasicRunner) RunPromptWithAllowedTools(ctx context.Context, prompt string, allowedTools []string) (string, error) {
+	m.constrainedCalls++
+	m.lastConstrainedPrompt = prompt
+	m.lastConstrainedAllowed = append([]string(nil), allowedTools...)
 	return m.output, m.err
 }
 
@@ -600,6 +615,30 @@ func TestSkillTool_Handler_ForkWithBasicRunner(t *testing.T) {
 	}
 	if result["context"] != "fork" {
 		t.Fatalf("expected context=fork, got %v", result["context"])
+	}
+}
+
+func TestSkillTool_Handler_ForkWithBasicRunnerPreservesAllowedTools(t *testing.T) {
+	t.Parallel()
+	lister := newForkSkillLister()
+	runner := &mockBasicRunner{output: "Basic runner result"}
+	tool := SkillTool(lister, runner)
+
+	_, err := tool.Handler(context.Background(), json.RawMessage(`{"command":"research OAuth2"}`))
+	if err != nil {
+		t.Fatalf("fork with basic runner failed: %v", err)
+	}
+	if runner.constrainedCalls != 1 {
+		t.Fatalf("expected constrained RunPrompt fallback once, got %d", runner.constrainedCalls)
+	}
+	if runner.runPromptCalls != 0 {
+		t.Fatalf("expected plain RunPrompt fallback to be skipped, got %d calls", runner.runPromptCalls)
+	}
+	if got := strings.Join(runner.lastConstrainedAllowed, ","); got != "read,grep" {
+		t.Fatalf("expected allowed tools [read grep], got %v", runner.lastConstrainedAllowed)
+	}
+	if runner.lastConstrainedPrompt != "Research the topic thoroughly." {
+		t.Fatalf("expected resolved prompt, got %q", runner.lastConstrainedPrompt)
 	}
 }
 

--- a/internal/harness/tools/skill.go
+++ b/internal/harness/tools/skill.go
@@ -108,7 +108,7 @@ func flatSkillFork(ctx context.Context, runner AgentRunner, info SkillInfo, cont
 		})
 	}
 
-	output, err := runner.RunPrompt(forkCtx, content)
+	output, err := runPromptWithAllowedTools(forkCtx, runner, content, info.AllowedTools)
 	if err != nil {
 		return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 	}
@@ -118,4 +118,11 @@ func flatSkillFork(ctx context.Context, runner AgentRunner, info SkillInfo, cont
 		"result":  output,
 		"context": "fork",
 	})
+}
+
+func runPromptWithAllowedTools(ctx context.Context, runner AgentRunner, prompt string, allowedTools []string) (string, error) {
+	if constrainedRunner, ok := runner.(ConstrainedAgentRunner); ok {
+		return constrainedRunner.RunPromptWithAllowedTools(ctx, prompt, allowedTools)
+	}
+	return runner.RunPrompt(ctx, prompt)
 }

--- a/internal/harness/tools/skill_test.go
+++ b/internal/harness/tools/skill_test.go
@@ -286,11 +286,26 @@ func TestSkillToolCommandMultiWordArgs(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 type mockAgentRunner struct {
-	output string
-	err    error
+	output                 string
+	err                    error
+	runPromptCalls         int
+	constrainedCalls       int
+	lastPrompt             string
+	lastAllowedTools       []string
+	lastConstrainedPrompt  string
+	lastConstrainedAllowed []string
 }
 
 func (m *mockAgentRunner) RunPrompt(_ context.Context, prompt string) (string, error) {
+	m.runPromptCalls++
+	m.lastPrompt = prompt
+	return m.output, m.err
+}
+
+func (m *mockAgentRunner) RunPromptWithAllowedTools(_ context.Context, prompt string, allowedTools []string) (string, error) {
+	m.constrainedCalls++
+	m.lastConstrainedPrompt = prompt
+	m.lastConstrainedAllowed = append([]string(nil), allowedTools...)
 	return m.output, m.err
 }
 
@@ -332,6 +347,29 @@ func TestFlatSkillForkBasicRunPrompt(t *testing.T) {
 	}
 	if result["context"].(string) != "fork" {
 		t.Fatalf("expected context=fork, got %v", result["context"])
+	}
+}
+
+func TestFlatSkillForkBasicRunPromptPreservesAllowedTools(t *testing.T) {
+	t.Parallel()
+	runner := &mockAgentRunner{output: "fork output"}
+	info := SkillInfo{Name: "test-fork", Context: "fork", AllowedTools: []string{"read_file"}}
+
+	_, err := flatSkillFork(context.Background(), runner, info, "do the thing")
+	if err != nil {
+		t.Fatalf("flatSkillFork: %v", err)
+	}
+	if runner.constrainedCalls != 1 {
+		t.Fatalf("expected constrained RunPrompt fallback once, got %d", runner.constrainedCalls)
+	}
+	if runner.runPromptCalls != 0 {
+		t.Fatalf("expected plain RunPrompt fallback to be skipped, got %d calls", runner.runPromptCalls)
+	}
+	if got := strings.Join(runner.lastConstrainedAllowed, ","); got != "read_file" {
+		t.Fatalf("expected allowed tools [read_file], got %v", runner.lastConstrainedAllowed)
+	}
+	if runner.lastConstrainedPrompt != "do the thing" {
+		t.Fatalf("expected prompt %q, got %q", "do the thing", runner.lastConstrainedPrompt)
 	}
 }
 

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -194,6 +194,13 @@ type AgentRunner interface {
 	RunPrompt(ctx context.Context, prompt string) (string, error)
 }
 
+// ConstrainedAgentRunner extends AgentRunner with support for preserving
+// per-run allowed-tools restrictions on prompt-based fallback paths.
+type ConstrainedAgentRunner interface {
+	AgentRunner
+	RunPromptWithAllowedTools(ctx context.Context, prompt string, allowedTools []string) (string, error)
+}
+
 // ForkConfig holds configuration for a forked skill execution.
 type ForkConfig struct {
 	Prompt       string            // the interpolated skill body

--- a/internal/server/http_agents.go
+++ b/internal/server/http_agents.go
@@ -15,6 +15,11 @@ type agentRunnerIface interface {
 	RunPrompt(ctx context.Context, prompt string) (string, error)
 }
 
+type constrainedAgentRunnerIface interface {
+	agentRunnerIface
+	RunPromptWithAllowedTools(ctx context.Context, prompt string, allowedTools []string) (string, error)
+}
+
 // forkedAgentRunnerIface extends agentRunnerIface with skill-based forked execution.
 type forkedAgentRunnerIface interface {
 	agentRunnerIface
@@ -116,7 +121,7 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 	var output, summary string
 
 	if hasPrompt {
-		result, err := s.agentRunner.RunPrompt(ctx, req.Prompt)
+		result, err := runAgentPrompt(ctx, s.agentRunner, req.Prompt, req.AllowedTools)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
 				writeError(w, http.StatusRequestTimeout, "timeout", "agent execution timed out")
@@ -169,7 +174,7 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusInternalServerError, "execution_error", err.Error())
 				return
 			}
-			result, err := s.agentRunner.RunPrompt(ctx, content)
+			result, err := runAgentPrompt(ctx, s.agentRunner, content, req.AllowedTools)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					writeError(w, http.StatusRequestTimeout, "timeout", "agent execution timed out")
@@ -192,4 +197,11 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 		Summary:    summary,
 		DurationMs: durationMs,
 	})
+}
+
+func runAgentPrompt(ctx context.Context, runner agentRunnerIface, prompt string, allowedTools []string) (string, error) {
+	if constrainedRunner, ok := runner.(constrainedAgentRunnerIface); ok {
+		return constrainedRunner.RunPromptWithAllowedTools(ctx, prompt, allowedTools)
+	}
+	return runner.RunPrompt(ctx, prompt)
 }

--- a/internal/server/http_agents_test.go
+++ b/internal/server/http_agents_test.go
@@ -17,16 +17,31 @@ import (
 
 // mockAgentRunner is a simple in-memory implementation of agentRunnerIface for tests.
 type mockAgentRunner struct {
-	mu     sync.Mutex
-	output string
-	err    error
-	calls  int
+	mu                     sync.Mutex
+	output                 string
+	err                    error
+	calls                  int
+	constrainedCalls       int
+	lastPrompt             string
+	lastAllowedTools       []string
+	lastConstrainedPrompt  string
+	lastConstrainedAllowed []string
 }
 
-func (m *mockAgentRunner) RunPrompt(_ context.Context, _ string) (string, error) {
+func (m *mockAgentRunner) RunPrompt(_ context.Context, prompt string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.calls++
+	m.lastPrompt = prompt
+	return m.output, m.err
+}
+
+func (m *mockAgentRunner) RunPromptWithAllowedTools(_ context.Context, prompt string, allowedTools []string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.constrainedCalls++
+	m.lastConstrainedPrompt = prompt
+	m.lastConstrainedAllowed = append([]string(nil), allowedTools...)
 	return m.output, m.err
 }
 
@@ -116,6 +131,39 @@ func TestAgentsEndpoint_PromptExecutesAndReturnsOutput(t *testing.T) {
 	}
 	if resp.DurationMs < 0 {
 		t.Errorf("expected non-negative duration_ms, got %d", resp.DurationMs)
+	}
+}
+
+func TestAgentsEndpoint_PromptPreservesAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	runner := testRunnerForAgents(t)
+	mock := &mockAgentRunner{output: "agent result"}
+	handler := NewWithOptions(ServerOptions{Runner: runner, AgentRunner: mock})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res := postAgents(t, ts, map[string]any{
+		"prompt":        "do something",
+		"allowed_tools": []string{"read_file"},
+	})
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+	if mock.constrainedCalls != 1 {
+		t.Fatalf("expected constrained prompt path once, got %d", mock.constrainedCalls)
+	}
+	if mock.calls != 0 {
+		t.Fatalf("expected plain RunPrompt path to be skipped, got %d calls", mock.calls)
+	}
+	if got := strings.Join(mock.lastConstrainedAllowed, ","); got != "read_file" {
+		t.Fatalf("expected allowed tools [read_file], got %v", mock.lastConstrainedAllowed)
+	}
+	if mock.lastConstrainedPrompt != "do something" {
+		t.Fatalf("expected prompt %q, got %q", "do something", mock.lastConstrainedPrompt)
 	}
 }
 
@@ -223,8 +271,42 @@ func TestAgentsEndpoint_SkillFallbackToSkillLister(t *testing.T) {
 	if resp.Output != "resolved skill output" {
 		t.Errorf("expected output %q, got %q", "resolved skill output", resp.Output)
 	}
-	if mock.calls != 1 {
-		t.Errorf("expected agent runner called once, got %d", mock.calls)
+	if got := mock.calls + mock.constrainedCalls; got != 1 {
+		t.Errorf("expected agent runner called once across fallback paths, got %d", got)
+	}
+}
+
+func TestAgentsEndpoint_SkillFallbackPreservesAllowedTools(t *testing.T) {
+	t.Parallel()
+
+	runner := testRunnerForAgents(t)
+	mock := &mockAgentRunner{output: "resolved skill output"}
+	sl := &mockSkillLister{content: "resolved skill content"}
+	handler := NewWithOptions(ServerOptions{Runner: runner, AgentRunner: mock, SkillLister: sl})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res := postAgents(t, ts, map[string]any{
+		"skill":         "my-skill",
+		"allowed_tools": []string{"read_file"},
+	})
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+	if mock.constrainedCalls != 1 {
+		t.Fatalf("expected constrained fallback path once, got %d", mock.constrainedCalls)
+	}
+	if mock.calls != 0 {
+		t.Fatalf("expected plain RunPrompt fallback to be skipped, got %d calls", mock.calls)
+	}
+	if got := strings.Join(mock.lastConstrainedAllowed, ","); got != "read_file" {
+		t.Fatalf("expected allowed tools [read_file], got %v", mock.lastConstrainedAllowed)
+	}
+	if mock.lastConstrainedPrompt != "resolved skill content" {
+		t.Fatalf("expected resolved skill content prompt, got %q", mock.lastConstrainedPrompt)
 	}
 }
 

--- a/internal/training/applier_test.go
+++ b/internal/training/applier_test.go
@@ -11,8 +11,17 @@ import (
 
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
+	initGitRepoWithBranch(t, dir, "")
+}
+
+func initGitRepoWithBranch(t *testing.T, dir, branch string) {
+	t.Helper()
+	initArgs := []string{"init"}
+	if branch != "" {
+		initArgs = []string{"init", "-b", branch}
+	}
 	for _, args := range [][]string{
-		{"init"},
+		initArgs,
 		{"config", "user.email", "test@test.com"},
 		{"config", "user.name", "Test"},
 	} {
@@ -38,6 +47,21 @@ func initGitRepo(t *testing.T, dir string) {
 			t.Fatalf("git %v: %v\n%s", args, err, out)
 		}
 	}
+}
+
+func currentGitBranch(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "branch", "--show-current")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v\n%s", err, out)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		t.Fatal("expected non-empty current git branch")
+	}
+	return branch
 }
 
 func TestCanAutoApply_CertainHighEvidence(t *testing.T) {

--- a/internal/training/regression.go
+++ b/internal/training/regression.go
@@ -25,10 +25,10 @@ type RegressionConfig struct {
 // BenchmarkResult holds the results of a benchmark run.
 type BenchmarkResult struct {
 	PassRate    float64         `json:"pass_rate"`
-	AvgCostUSD  float64        `json:"avg_cost_usd"`
-	AvgSteps    float64        `json:"avg_steps"`
+	AvgCostUSD  float64         `json:"avg_cost_usd"`
+	AvgSteps    float64         `json:"avg_steps"`
 	TaskResults map[string]bool `json:"task_results"`
-	RawOutput   string         `json:"raw_output,omitempty"`
+	RawOutput   string          `json:"raw_output,omitempty"`
 }
 
 // RegressionResult describes the outcome of a regression check.
@@ -248,13 +248,38 @@ func (g *RegressionGuard) Revert(ctx context.Context, branchName string) error {
 
 // Merge merges the training branch into main with --no-ff.
 func (g *RegressionGuard) Merge(ctx context.Context, branchName string) error {
-	if _, err := g.runGit("checkout", "main"); err != nil {
-		return fmt.Errorf("checkout main: %w", err)
+	baseBranch, err := g.resolveBaseBranch(branchName)
+	if err != nil {
+		return fmt.Errorf("resolve base branch: %w", err)
+	}
+	if _, err := g.runGit("checkout", baseBranch); err != nil {
+		return fmt.Errorf("checkout %s: %w", baseBranch, err)
 	}
 	if _, err := g.runGit("merge", "--no-ff", branchName); err != nil {
 		return fmt.Errorf("merge %s: %w", branchName, err)
 	}
 	return nil
+}
+
+func (g *RegressionGuard) resolveBaseBranch(exclude string) (string, error) {
+	for _, candidate := range []string{"main", "master"} {
+		if candidate == exclude {
+			continue
+		}
+		if _, err := g.runGit("show-ref", "--verify", "--quiet", "refs/heads/"+candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	out, err := g.runGit("branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	branch := strings.TrimSpace(out)
+	if branch == "" || branch == exclude {
+		return "", fmt.Errorf("no suitable local base branch found")
+	}
+	return branch, nil
 }
 
 // runGit runs a git command in the repo path.

--- a/internal/training/regression_test.go
+++ b/internal/training/regression_test.go
@@ -108,13 +108,13 @@ func TestLoadBaseline_MalformedJSON(t *testing.T) {
 // Table-driven tests for decision logic
 func TestDecisionLogic(t *testing.T) {
 	tests := []struct {
-		name             string
-		baseline         BenchmarkResult
-		candidate        BenchmarkResult
-		accuracyDrop     float64
-		costRise         float64
-		stepRise         float64
-		wantDecision     string
+		name         string
+		baseline     BenchmarkResult
+		candidate    BenchmarkResult
+		accuracyDrop float64
+		costRise     float64
+		stepRise     float64
+		wantDecision string
 	}{
 		{
 			name:         "merge_no_regression",
@@ -262,7 +262,8 @@ func TestRevert(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	dir := t.TempDir()
-	initGitRepo(t, dir)
+	initGitRepoWithBranch(t, dir, "trunk")
+	baseBranch := currentGitBranch(t, dir)
 
 	// Create and switch to a training branch, make a commit
 	for _, args := range [][]string{
@@ -283,7 +284,7 @@ func TestMerge(t *testing.T) {
 	for _, args := range [][]string{
 		{"add", "training-change.txt"},
 		{"commit", "-m", "training change"},
-		{"checkout", "main"},
+		{"checkout", baseBranch},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
@@ -300,20 +301,25 @@ func TestMerge(t *testing.T) {
 		t.Fatalf("Merge: %v", err)
 	}
 
-	// Verify the file exists on main now
+	if got := currentGitBranch(t, dir); got != baseBranch {
+		t.Fatalf("current branch = %q, want %q", got, baseBranch)
+	}
+
+	// Verify the file exists on the repository base branch now
 	if _, err := os.Stat(testFile); err != nil {
-		t.Error("training-change.txt should exist on main after merge")
+		t.Error("training-change.txt should exist on the base branch after merge")
 	}
 }
 
 func TestCheck_MockBenchmark(t *testing.T) {
 	dir := t.TempDir()
-	initGitRepo(t, dir)
+	initGitRepoWithBranch(t, dir, "trunk")
+	baseBranch := currentGitBranch(t, dir)
 
-	// Create a training branch from main
+	// Create a training branch from the repository base branch.
 	for _, args := range [][]string{
 		{"checkout", "-b", "training/check-test"},
-		{"checkout", "main"},
+		{"checkout", baseBranch},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir


### PR DESCRIPTION
## Summary
- preserve `allowed_tools` restrictions on `/v1/agents` prompt execution and skill-lister fallback execution
- preserve `allowed_tools` restrictions on both flat and core skill fork fallbacks that drop to plain `RunPrompt(...)`
- add runner support plus regression coverage proving constrained fallback execution keeps the intended tool allowlist

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_(PromptPreservesAllowedTools|SkillFallbackPreservesAllowedTools)|TestFlatSkillForkBasicRunPromptPreservesAllowedTools|TestSkillTool_Handler_ForkWithBasicRunnerPreservesAllowedTools|TestRunPrompt(ReturnsOutput|WithAllowedTools_ForwardsAllowedTools|_RespectsContextCancellation)' -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness ./internal/harness/tools ./internal/harness/tools/core`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build ./scripts/test-regression.sh`

## Notes
- The local regression script completed the package-test phase cleanly.
- The local race phase emitted repeated macOS linker warnings (`malformed LC_DYSYMTAB`) and did not produce a clean final exit in the tmux wrapper, so final mergeability should be confirmed from PR CI.

Closes #430