### PR TITLE
Fix cleaner cleanup on harnessd startup failure

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -65,15 +65,23 @@ func (a *callbackRunStarter) StartRun(prompt, conversationID string) error {
 }
 
 type providerFactory func(cfg openai.Config) (harness.Provider, error)
+type conversationCleaner interface {
+	Start(ctx context.Context, interval time.Duration)
+}
+
+type conversationCleanerFactory func(store harness.ConversationStore, retentionDays int) conversationCleaner
 
 // profileFlag is the --profile CLI flag. Registered at package level so it
 // integrates cleanly with Go's test infrastructure flags.
 var profileFlag = flag.String("profile", "", "named profile to load from ~/.harness/profiles/<name>.toml")
 
 var (
-	runMain            = run
-	exitFunc           = os.Exit
-	runWithSignalsFunc = runWithSignals
+	runMain                                                      = run
+	exitFunc                                                     = os.Exit
+	runWithSignalsFunc                                           = runWithSignals
+	defaultConversationCleanerFactory conversationCleanerFactory = func(store harness.ConversationStore, retentionDays int) conversationCleaner {
+		return harness.NewConversationCleaner(store, retentionDays)
+	}
 )
 
 func main() {
@@ -95,16 +103,42 @@ func run() error {
 }
 
 func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvider providerFactory, profileName string) error {
+	return runWithSignalsWithOptions(runWithSignalsOptions{
+		sig:                    sig,
+		getenv:                 getenv,
+		newProvider:            newProvider,
+		profileName:            profileName,
+		conversationCleanerNew: defaultConversationCleanerFactory,
+	})
+}
+
+type runWithSignalsOptions struct {
+	sig                    <-chan os.Signal
+	getenv                 func(string) string
+	newProvider            providerFactory
+	profileName            string
+	conversationCleanerNew conversationCleanerFactory
+}
+
+func runWithSignalsWithOptions(opts runWithSignalsOptions) error {
+	sig := opts.sig
 	if sig == nil {
 		return fmt.Errorf("signal channel is required")
 	}
+	getenv := opts.getenv
 	if getenv == nil {
 		getenv = os.Getenv
 	}
+	newProvider := opts.newProvider
 	if newProvider == nil {
 		newProvider = func(config openai.Config) (harness.Provider, error) {
 			return openai.NewClient(config)
 		}
+	}
+	profileName := opts.profileName
+	conversationCleanerNew := opts.conversationCleanerNew
+	if conversationCleanerNew == nil {
+		conversationCleanerNew = defaultConversationCleanerFactory
 	}
 
 	// Local helpers that use the injected getenv instead of os.Getenv,
@@ -530,8 +564,12 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	// Conversation persistence
 	convRetentionDays := envIntOrDefault("HARNESS_CONVERSATION_RETENTION_DAYS", 30)
 	var convStore harness.ConversationStore
-	var convCleanerCtx context.Context
 	var convCleanerCancel context.CancelFunc
+	defer func() {
+		if convCleanerCancel != nil {
+			convCleanerCancel()
+		}
+	}()
 	if dbPath := getenv("HARNESS_CONVERSATION_DB"); dbPath != "" {
 		if !filepath.IsAbs(dbPath) {
 			dbPath = filepath.Join(workspace, dbPath)
@@ -551,8 +589,9 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		// Start retention cleaner background goroutine.
 		if convRetentionDays > 0 {
 			log.Printf("conversation retention policy: %d days", convRetentionDays)
-			convCleanerCtx, convCleanerCancel = context.WithCancel(context.Background())
-			cleaner := harness.NewConversationCleaner(store, convRetentionDays)
+			convCleanerCtx, cancel := context.WithCancel(context.Background())
+			convCleanerCancel = cancel
+			cleaner := conversationCleanerNew(store, convRetentionDays)
 			cleaner.Start(convCleanerCtx, 24*time.Hour)
 		}
 	}
@@ -800,6 +839,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	// Shut down conversation retention cleaner goroutine.
 	if convCleanerCancel != nil {
 		convCleanerCancel()
+		convCleanerCancel = nil
 	}
 
 	// Shut down embedded cron scheduler

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -72,6 +72,16 @@ func (p *scriptedHarnessdProvider) Complete(_ context.Context, _ harness.Complet
 	return result, nil
 }
 
+type stubConversationCleaner struct {
+	start func(ctx context.Context, interval time.Duration)
+}
+
+func (s *stubConversationCleaner) Start(ctx context.Context, interval time.Duration) {
+	if s.start != nil {
+		s.start(ctx, interval)
+	}
+}
+
 func TestMainDoesNotExitWhenRunSucceeds(t *testing.T) {
 	origRun := runMain
 	origExit := exitFunc
@@ -3891,6 +3901,59 @@ func TestShutdownConversationCleanerCancellation(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out: conversation cleaner cancellation may have hung")
+	}
+}
+
+func TestStartupFailureCancelsConversationCleaner(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind listener: %v", err)
+	}
+	defer ln.Close()
+
+	workspaceDir := t.TempDir()
+	convDBPath := workspaceDir + "/conv.db"
+	env := map[string]string{
+		"OPENAI_API_KEY":                      "test-key",
+		"HARNESS_ADDR":                        ln.Addr().String(),
+		"HARNESS_MEMORY_MODE":                 "off",
+		"HARNESS_WORKSPACE":                   workspaceDir,
+		"HARNESS_CONVERSATION_DB":             convDBPath,
+		"HARNESS_CONVERSATION_RETENTION_DAYS": "30",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	started := make(chan struct{}, 1)
+	cancelled := make(chan struct{}, 1)
+
+	err = runWithSignalsWithOptions(runWithSignalsOptions{
+		sig:         make(chan os.Signal, 1),
+		getenv:      getenv,
+		newProvider: func(openai.Config) (harness.Provider, error) { return &noopProvider{}, nil },
+		conversationCleanerNew: func(store harness.ConversationStore, retentionDays int) conversationCleaner {
+			return &stubConversationCleaner{
+				start: func(ctx context.Context, interval time.Duration) {
+					started <- struct{}{}
+					go func() {
+						<-ctx.Done()
+						cancelled <- struct{}{}
+					}()
+				},
+			}
+		},
+	})
+	if err == nil {
+		t.Fatal("expected startup failure when port is already bound")
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected conversation cleaner to start before startup failure")
+	}
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected startup failure path to cancel conversation cleaner")
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,25 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Failures)
+
+- Fixed the `harnessd` conversation-retention cleaner lifecycle so startup failures after cleaner initialization still cancel the cleaner context before returning.
+- Added a narrow test seam in `cmd/harnessd/main.go` so the startup path can be characterized without changing runtime behavior:
+  - `runWithSignals(...)` now delegates to `runWithSignalsWithOptions(...)`.
+  - the cleaner factory stays unexported and defaults to `harness.NewConversationCleaner(...)`.
+  - cleaner cancellation is deferred once initialized, with the normal shutdown path still cancelling early and clearing the handle.
+- Added regression coverage in `cmd/harnessd/main_test.go` for:
+  - clean shutdown with conversation cleaner enabled
+  - startup failure after cleaner initialization cancels the cleaner context
+- Added planning/logging artifacts for the issue-specific work:
+  - `docs/plans/2026-03-25-issue-431-cleaner-startup-failure-plan.md`
+  - `docs/logs/long-term-thinking-log.md`
+  - `docs/plans/INDEX.md`
+- Verification:
+  - `GOCACHE=$PWD/.tmp/gocache go test ./cmd/harnessd -run 'TestStartupFailureCancelsConversationCleaner|TestShutdownConversationCleanerCancellation'`
+  - `GOCACHE=$PWD/.tmp/gocache go test ./cmd/harnessd`
+  - `GOCACHE=$PWD/.tmp/gocache go vet ./internal/... ./cmd/...`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/gocache ./scripts/test-regression.sh` (fails for unrelated existing zero-coverage functions, including `cmd/harnesscli/tui/cmd_parser.go:73`, `cmd/harnesscli/tui/components/tooluse/model.go:44`, and `internal/profiles/loader.go:101`)
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,26 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #431 Conversation Cleaner Startup Cleanup)
+
+- Command intent: Complete GitHub issue `#431` by ensuring the conversation-retention cleaner is cancelled on every startup-exit path after it has been initialized.
+- User intent: Fix the `go vet`-flagged bootstrap leak cleanly with strict TDD, keep the change narrow, and land a mergeable PR with clear verification.
+- Success definition:
+  - `go vet ./internal/... ./cmd/...` no longer reports the `convCleanerCancel` possible context leak in `cmd/harnessd/main.go`.
+  - A regression test proves a startup failure after cleaner initialization cancels the cleaner context before returning.
+  - `go test ./cmd/harnessd` passes without changing unrelated startup behavior.
+  - The issue is worked in a dedicated worktree, documented on GitHub, and delivered in a clean PR.
+- Non-goals:
+  - Broad `harnessd` bootstrap decomposition.
+  - Changing shutdown ordering beyond what is required to guarantee cleanup on early returns.
+- Guardrails/constraints:
+  - Strict TDD: add failing coverage first.
+  - Keep the fix scoped to cleaner lifecycle/bootstrap cleanup.
+  - Report unrelated sandbox or CI blockers explicitly rather than folding them into this change.
+- Open questions:
+  - Whether the smallest safe seam is a helper or a factory injection point for the cleaner startup path.
+- Next verification step: add a failing startup-error regression test, implement the minimal cleanup fix, then rerun `go test ./cmd/harnessd` and `go vet ./internal/... ./cmd/...`.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-431-cleaner-startup-failure-plan.md
+++ b/docs/plans/2026-03-25-issue-431-cleaner-startup-failure-plan.md
@@ -1,0 +1,52 @@
+# Plan: Issue #431 Conversation Cleaner Startup Failure Cleanup
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` starts the conversation-retention cleaner but only cancels it on the normal signal-driven shutdown path, so later startup failures can bypass cleanup and `go vet` reports a possible context leak.
+- User impact: operators can hit bootstrap failures that leave a background cleaner context alive longer than intended, and the codebase currently fails a useful static check.
+- Constraints:
+  - Follow strict TDD.
+  - Keep the change narrow and avoid a broad bootstrap refactor.
+  - Preserve existing shutdown behavior except for guaranteed cleanup on startup-error paths.
+
+## Scope
+
+- In scope:
+  - Add failing regression coverage for startup failure after cleaner initialization.
+  - Introduce the smallest test seam needed to observe cleaner cancellation.
+  - Ensure cleaner cleanup runs on all exits after initialization.
+- Out of scope:
+  - General `harnessd` bootstrap decomposition.
+  - Unrelated startup or shutdown behavior changes.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - startup failure after conversation-cleaner init cancels the cleaner context before `runWithSignals` returns.
+- Existing tests to update:
+  - keep the existing clean shutdown cleaner test green.
+- Regression tests required:
+  - `go test ./cmd/harnessd`
+  - `go vet ./internal/... ./cmd/...`
+
+## Cross-Surface Impact Map
+
+- None. This task does not touch provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: a test-only seam for cleaner startup could accidentally broaden runtime behavior.
+- Mitigation: keep the seam unexported, default it to the real cleaner, and use it only to characterize the startup-failure cleanup path.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-431-cleaner-startup-failure-plan.md`: Active implementation plan for conversation-cleaner cleanup on `harnessd` startup failures.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.


### PR DESCRIPTION
## Summary
- cancel the conversation-retention cleaner on all startup-exit paths after it has been initialized
- add a startup-failure regression test that proves the cleaner context is cancelled before `runWithSignals` returns
- record the issue plan/log entries and note the current repo-wide regression blocker

## Testing
- `GOCACHE=$PWD/.tmp/gocache go test ./cmd/harnessd -run 'TestStartupFailureCancelsConversationCleaner|TestShutdownConversationCleanerCancellation'`
- `GOCACHE=$PWD/.tmp/gocache go test ./cmd/harnessd`
- `GOCACHE=$PWD/.tmp/gocache go vet ./internal/... ./cmd/...`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/gocache ./scripts/test-regression.sh` *(currently fails on unrelated existing zero-coverage functions such as `cmd/harnesscli/tui/cmd_parser.go:73`, `cmd/harnesscli/tui/components/tooluse/model.go:44`, and `internal/profiles/loader.go:101`)*

## Notes
- This closes the `go vet` warning reported in issue #431.
- The repo's required `test-regression` workflow runs the same coverage gate, so this PR is expected to stay blocked until the unrelated zero-coverage debt is addressed.

Closes #431