### PR TITLE
Fix harnessd cleaner cancellation on startup failure

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser_coverage_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_coverage_test.go
@@ -1,0 +1,19 @@
+package tui
+
+import "testing"
+
+func TestNewEmptyCommandRegistryStartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	r := newEmptyCommandRegistry()
+
+	if got := r.All(); len(got) != 0 {
+		t.Fatalf("All() length = %d, want 0", len(got))
+	}
+	if _, ok := r.Lookup("clear"); ok {
+		t.Fatal("Lookup(clear) should fail for an empty registry")
+	}
+	if r.IsRegistered("clear") {
+		t.Fatal("IsRegistered(clear) should be false for an empty registry")
+	}
+}

--- a/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
+++ b/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
@@ -66,6 +66,22 @@ func TestModelViewExpandedUsesComponentEntryPoint(t *testing.T) {
 	}
 }
 
+func TestNewInitializesIdentityFields(t *testing.T) {
+	t.Parallel()
+
+	m := New("call-new", "bash")
+
+	if m.CallID != "call-new" {
+		t.Fatalf("CallID = %q, want call-new", m.CallID)
+	}
+	if m.ToolName != "bash" {
+		t.Fatalf("ToolName = %q, want bash", m.ToolName)
+	}
+	if m.Status != "" {
+		t.Fatalf("Status = %q, want empty", m.Status)
+	}
+}
+
 func TestModelViewExpandedBashOutputUsesTopLevelEntryPoint(t *testing.T) {
 	m := Model{
 		CallID:   "call-bash",

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -66,6 +66,14 @@ func (a *callbackRunStarter) StartRun(prompt, conversationID string) error {
 
 type providerFactory func(cfg openai.Config) (harness.Provider, error)
 
+type conversationCleanerStarter interface {
+	Start(ctx context.Context, interval time.Duration)
+}
+
+type runDeps struct {
+	newConversationCleaner func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter
+}
+
 // profileFlag is the --profile CLI flag. Registered at package level so it
 // integrates cleanly with Go's test infrastructure flags.
 var profileFlag = flag.String("profile", "", "named profile to load from ~/.harness/profiles/<name>.toml")
@@ -95,6 +103,14 @@ func run() error {
 }
 
 func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvider providerFactory, profileName string) error {
+	return runWithSignalsWithDeps(sig, getenv, newProvider, profileName, runDeps{
+		newConversationCleaner: func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter {
+			return harness.NewConversationCleaner(store, retentionDays)
+		},
+	})
+}
+
+func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, newProvider providerFactory, profileName string, deps runDeps) error {
 	if sig == nil {
 		return fmt.Errorf("signal channel is required")
 	}
@@ -104,6 +120,11 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	if newProvider == nil {
 		newProvider = func(config openai.Config) (harness.Provider, error) {
 			return openai.NewClient(config)
+		}
+	}
+	if deps.newConversationCleaner == nil {
+		deps.newConversationCleaner = func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter {
+			return harness.NewConversationCleaner(store, retentionDays)
 		}
 	}
 
@@ -530,8 +551,8 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 	// Conversation persistence
 	convRetentionDays := envIntOrDefault("HARNESS_CONVERSATION_RETENTION_DAYS", 30)
 	var convStore harness.ConversationStore
-	var convCleanerCtx context.Context
-	var convCleanerCancel context.CancelFunc
+	convCleanerCtx, convCleanerCancel := context.WithCancel(context.Background())
+	defer convCleanerCancel()
 	if dbPath := getenv("HARNESS_CONVERSATION_DB"); dbPath != "" {
 		if !filepath.IsAbs(dbPath) {
 			dbPath = filepath.Join(workspace, dbPath)
@@ -551,8 +572,7 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		// Start retention cleaner background goroutine.
 		if convRetentionDays > 0 {
 			log.Printf("conversation retention policy: %d days", convRetentionDays)
-			convCleanerCtx, convCleanerCancel = context.WithCancel(context.Background())
-			cleaner := harness.NewConversationCleaner(store, convRetentionDays)
+			cleaner := deps.newConversationCleaner(store, convRetentionDays)
 			cleaner.Start(convCleanerCtx, 24*time.Hour)
 		}
 	}

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -72,6 +72,19 @@ func (p *scriptedHarnessdProvider) Complete(_ context.Context, _ harness.Complet
 	return result, nil
 }
 
+type recordingConversationCleaner struct {
+	started chan struct{}
+	done    chan struct{}
+}
+
+func (c *recordingConversationCleaner) Start(ctx context.Context, _ time.Duration) {
+	close(c.started)
+	go func() {
+		<-ctx.Done()
+		close(c.done)
+	}()
+}
+
 func TestMainDoesNotExitWhenRunSucceeds(t *testing.T) {
 	origRun := runMain
 	origExit := exitFunc
@@ -3891,6 +3904,61 @@ func TestShutdownConversationCleanerCancellation(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out: conversation cleaner cancellation may have hung")
+	}
+}
+
+func TestStartupFailureCancelsConversationCleaner(t *testing.T) {
+	t.Parallel()
+
+	cleaner := &recordingConversationCleaner{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("bind listener: %v", err)
+	}
+	defer ln.Close()
+
+	workspaceDir := t.TempDir()
+	env := map[string]string{
+		"OPENAI_API_KEY":                      "test-key",
+		"HARNESS_ADDR":                        ln.Addr().String(),
+		"HARNESS_MEMORY_MODE":                 "off",
+		"HARNESS_WORKSPACE":                   workspaceDir,
+		"HARNESS_CONVERSATION_DB":             filepath.Join(workspaceDir, "conv.db"),
+		"HARNESS_CONVERSATION_RETENTION_DAYS": "30",
+	}
+	getenv := func(key string) string { return env[key] }
+
+	err = runWithSignalsWithDeps(
+		make(chan os.Signal, 1),
+		getenv,
+		func(openai.Config) (harness.Provider, error) {
+			return &noopProvider{}, nil
+		},
+		"",
+		runDeps{
+			newConversationCleaner: func(harness.ConversationStore, int) conversationCleanerStarter {
+				return cleaner
+			},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected startup failure when port is already bound")
+	}
+
+	select {
+	case <-cleaner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("conversation cleaner was not started before startup failure")
+	}
+
+	select {
+	case <-cleaner.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected startup failure to cancel the conversation cleaner")
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -18,7 +18,19 @@
     - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
   - green phase:
     - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
+## 2026-03-25 (Issue #431 Startup Cleaner Cancellation)
 
+- Reproduced the `go vet` startup-leak warning in `cmd/harnessd/main.go` where `convCleanerCancel` was only reached from the normal shutdown path after the conversation cleaner had already been started.
+- Added a deterministic regression seam in `cmd/harnessd/main.go` so tests can supply a fake conversation cleaner without mutating package globals across parallel test runs.
+- Added `TestStartupFailureCancelsConversationCleaner` in `cmd/harnessd/main_test.go`:
+  - starts the cleaner
+  - forces a startup failure with a bound port
+  - asserts the cleaner context is cancelled before `runWithSignals(...)` returns
+- Tightened `runWithSignals(...)` cleanup so the cleaner cancel function is always deferred once startup begins, which preserves the existing clean-shutdown path while also covering early startup exits.
+- Verification:
+  - `go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
+  - `go test ./cmd/harnessd -count=1`
+  - `go vet ./internal/... ./cmd/...`
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -30,11 +30,18 @@
 - Followed up on the PR CI failure in `internal/training`:
   - the temporary Git repositories created in tests were still using Git's default branch name, while the regression helper and tests expect `main`
   - updated `initGitRepo(...)` to rename the freshly created branch to `main` after the initial commit so the regression suite behaves the same in CI, worktrees, and local runs
+- Followed up on the repo-wide coverage gate exposed by CI:
+  - added direct coverage for `newEmptyCommandRegistry()` in `cmd/harnesscli/tui`
+  - added direct coverage for `tooluse.New(...)`
+  - added direct coverage for `ListProfileSummaries()` tier precedence via explicit project/user dirs plus built-in fallback
 - Verification:
   - `go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
   - `go test ./cmd/harnessd -count=1`
   - `go vet ./internal/... ./cmd/...`
   - `go test ./internal/training -count=1`
+  - `go test ./cmd/harnesscli/tui -run TestNewEmptyCommandRegistryStartsEmpty -count=1`
+  - `go test ./cmd/harnesscli/tui/components/tooluse -run TestNewInitializesIdentityFields -count=1`
+  - `go test ./internal/profiles -run TestListProfileSummariesPrefersHigherPriorityDirs -count=1`
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -27,10 +27,14 @@
   - forces a startup failure with a bound port
   - asserts the cleaner context is cancelled before `runWithSignals(...)` returns
 - Tightened `runWithSignals(...)` cleanup so the cleaner cancel function is always deferred once startup begins, which preserves the existing clean-shutdown path while also covering early startup exits.
+- Followed up on the PR CI failure in `internal/training`:
+  - the temporary Git repositories created in tests were still using Git's default branch name, while the regression helper and tests expect `main`
+  - updated `initGitRepo(...)` to rename the freshly created branch to `main` after the initial commit so the regression suite behaves the same in CI, worktrees, and local runs
 - Verification:
   - `go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
   - `go test ./cmd/harnessd -count=1`
   - `go vet ./internal/... ./cmd/...`
+  - `go test ./internal/training -count=1`
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -61,6 +61,29 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
   - Whether the backend `list_models` tool should be discovery-aware now or in a follow-up once `/v1/models` and routing are stabilized.
 - Next verification step: add failing tests for discovery/cache/merge/routing, implement the minimal backend layer, then run targeted packages and the regression suite.
 
+## 2026-03-25 (Issue #431 Startup Cleaner Cancellation)
+
+- Command intent: Process GitHub issue `#431` end to end by fixing the `harnessd` conversation-cleaner startup leak, landing regression coverage, and getting a clean PR ready to merge.
+- User intent: Close one bounded backlog issue fully instead of stopping at analysis, with explicit TDD, issue updates, and CI-clean merge readiness.
+- Success definition:
+  - A failing regression test reproduces a startup failure after the conversation cleaner has already been started.
+  - `cmd/harnessd/main.go` guarantees the cleaner cancel function is used on all exit paths after initialization.
+  - Existing clean-shutdown behavior remains unchanged.
+  - `go test ./cmd/harnessd` passes.
+  - `go vet ./internal/... ./cmd/...` no longer reports the `convCleanerCancel` leak.
+  - The issue is updated and a PR is opened with passing checks.
+- Non-goals:
+  - Broad `harnessd` bootstrap decomposition.
+  - Behavior changes to conversation retention beyond correct cleanup.
+  - Fixing unrelated failing tests outside this issue.
+- Guardrails/constraints:
+  - Strict TDD with the regression test written first.
+  - Keep the production fix small and reviewable.
+  - Use repo-local Go caches in this sandbox so builds/tests stay writable.
+- Open questions:
+  - Whether repo-wide regression or CI will expose unrelated blockers after the targeted fix is green.
+- Next verification step: add the startup-failure regression test, run it red, apply the minimal cleanup fix, then rerun `go test ./cmd/harnessd` and `go vet ./internal/... ./cmd/...`.
+
 ## 2026-03-24 (Worktree Bootstrap Script)
 
 - Command intent: Build a reusable setup script that creates a fresh agent worktree and leaves it ready for local development and verification.

--- a/docs/plans/2026-03-25-issue-431-startup-cleaner-plan.md
+++ b/docs/plans/2026-03-25-issue-431-startup-cleaner-plan.md
@@ -1,0 +1,51 @@
+# Plan: Issue #431 startup cleaner cancellation
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` starts the conversation-retention cleaner with a cancelable context, but some startup-error returns can bypass the shutdown block that calls `convCleanerCancel()`.
+- User impact: background cleaner goroutines can outlive a failed startup attempt, and `go vet` already flags the path as a possible context leak.
+- Constraints: keep the bootstrap behavior unchanged aside from guaranteed cleanup, follow strict TDD, and verify with targeted `go test` plus `go vet`.
+
+## Scope
+
+- In scope:
+  - add a failing regression test for a startup failure after the cleaner is started
+  - implement the smallest `cmd/harnessd` cleanup fix that cancels the cleaner on all exit paths
+  - update logs/docs needed for the issue workflow
+- Out of scope:
+  - broader `harnessd` bootstrap refactors
+  - changing conversation retention semantics
+  - unrelated `go vet` findings outside this issue
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - a `cmd/harnessd` test that starts the conversation cleaner, forces a startup failure, and asserts the cleaner context is cancelled before `runWithSignals(...)` returns
+- Existing tests to update:
+  - keep the existing clean-shutdown cleaner test passing
+- Regression tests required:
+  - `go test ./cmd/harnessd`
+  - `go vet ./internal/... ./cmd/...`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue does not touch those surfaces, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: the regression test could become timing-sensitive if it depends on real goroutine behavior.
+- Mitigation: inject a tiny cleaner factory seam so the test can observe cancellation deterministically without waiting on the real background sweep loop.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -4,6 +4,7 @@
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
+- `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/internal/profiles/loader_coverage_test.go
+++ b/internal/profiles/loader_coverage_test.go
@@ -6,33 +6,33 @@ import (
 	"testing"
 )
 
+func writeTestProfile(t *testing.T, dir, name, description, model string, tools []string) {
+	t.Helper()
+	content := "[meta]\n" +
+		"name = \"" + name + "\"\n" +
+		"description = \"" + description + "\"\n" +
+		"version = 1\n" +
+		"created_at = \"2026-03-25\"\n" +
+		"created_by = \"test\"\n" +
+		"review_eligible = false\n\n" +
+		"[runner]\n" +
+		"model = \"" + model + "\"\n\n" +
+		"[tools]\n" +
+		"allow = [\"" + tools[0] + "\"]\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write profile %s: %v", name, err)
+	}
+}
+
 func TestListProfileSummariesPrefersHigherPriorityDirs(t *testing.T) {
 	t.Parallel()
 
 	projectDir := t.TempDir()
 	userDir := t.TempDir()
 
-	writeProfile := func(dir, name, description, model string, tools []string) {
-		t.Helper()
-		content := "[meta]\n" +
-			"name = \"" + name + "\"\n" +
-			"description = \"" + description + "\"\n" +
-			"version = 1\n" +
-			"created_at = \"2026-03-25\"\n" +
-			"created_by = \"test\"\n" +
-			"review_eligible = false\n\n" +
-			"[runner]\n" +
-			"model = \"" + model + "\"\n\n" +
-			"[tools]\n" +
-			"allow = [\"" + tools[0] + "\"]\n"
-		if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
-			t.Fatalf("write profile %s: %v", name, err)
-		}
-	}
-
-	writeProfile(projectDir, "shared", "project profile", "gpt-4.1", []string{"bash"})
-	writeProfile(userDir, "shared", "user profile", "gpt-4.1-mini", []string{"read"})
-	writeProfile(userDir, "user-only", "user only profile", "gpt-4.1-nano", []string{"edit"})
+	writeTestProfile(t, projectDir, "shared", "project profile", "gpt-4.1", []string{"bash"})
+	writeTestProfile(t, userDir, "shared", "user profile", "gpt-4.1-mini", []string{"read"})
+	writeTestProfile(t, userDir, "user-only", "user only profile", "gpt-4.1-nano", []string{"edit"})
 
 	summaries, err := ListProfileSummariesFromDirs(projectDir, userDir)
 	if err != nil {
@@ -72,5 +72,60 @@ func TestListProfileSummariesPrefersHigherPriorityDirs(t *testing.T) {
 
 	if !hasBuiltin {
 		t.Fatal("expected at least one built-in profile summary")
+	}
+}
+
+func TestListProfileSummariesUsesDefaultDirs(t *testing.T) {
+	projectRoot := t.TempDir()
+	projectProfilesDir := filepath.Join(projectRoot, ".harness", "profiles")
+	if err := os.MkdirAll(projectProfilesDir, 0o755); err != nil {
+		t.Fatalf("mkdir project profiles: %v", err)
+	}
+
+	homeDir := t.TempDir()
+	userProfilesDir := filepath.Join(homeDir, ".harness", "profiles")
+	if err := os.MkdirAll(userProfilesDir, 0o755); err != nil {
+		t.Fatalf("mkdir user profiles: %v", err)
+	}
+
+	writeTestProfile(t, projectProfilesDir, "wrapper-project", "wrapper project profile", "gpt-4.1", []string{"bash"})
+	writeTestProfile(t, userProfilesDir, "wrapper-user", "wrapper user profile", "gpt-4.1-mini", []string{"read"})
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+	t.Setenv("HOME", homeDir)
+
+	summaries, err := ListProfileSummaries()
+	if err != nil {
+		t.Fatalf("ListProfileSummaries: %v", err)
+	}
+
+	byName := make(map[string]ProfileSummary, len(summaries))
+	for _, summary := range summaries {
+		byName[summary.Name] = summary
+	}
+
+	projectSummary, ok := byName["wrapper-project"]
+	if !ok {
+		t.Fatal("wrapper-project summary missing")
+	}
+	if projectSummary.SourceTier != "project" {
+		t.Fatalf("wrapper-project SourceTier = %q, want project", projectSummary.SourceTier)
+	}
+
+	userSummary, ok := byName["wrapper-user"]
+	if !ok {
+		t.Fatal("wrapper-user summary missing")
+	}
+	if userSummary.SourceTier != "user" {
+		t.Fatalf("wrapper-user SourceTier = %q, want user", userSummary.SourceTier)
 	}
 }

--- a/internal/profiles/loader_coverage_test.go
+++ b/internal/profiles/loader_coverage_test.go
@@ -1,0 +1,76 @@
+package profiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListProfileSummariesPrefersHigherPriorityDirs(t *testing.T) {
+	t.Parallel()
+
+	projectDir := t.TempDir()
+	userDir := t.TempDir()
+
+	writeProfile := func(dir, name, description, model string, tools []string) {
+		t.Helper()
+		content := "[meta]\n" +
+			"name = \"" + name + "\"\n" +
+			"description = \"" + description + "\"\n" +
+			"version = 1\n" +
+			"created_at = \"2026-03-25\"\n" +
+			"created_by = \"test\"\n" +
+			"review_eligible = false\n\n" +
+			"[runner]\n" +
+			"model = \"" + model + "\"\n\n" +
+			"[tools]\n" +
+			"allow = [\"" + tools[0] + "\"]\n"
+		if err := os.WriteFile(filepath.Join(dir, name+".toml"), []byte(content), 0o644); err != nil {
+			t.Fatalf("write profile %s: %v", name, err)
+		}
+	}
+
+	writeProfile(projectDir, "shared", "project profile", "gpt-4.1", []string{"bash"})
+	writeProfile(userDir, "shared", "user profile", "gpt-4.1-mini", []string{"read"})
+	writeProfile(userDir, "user-only", "user only profile", "gpt-4.1-nano", []string{"edit"})
+
+	summaries, err := ListProfileSummariesFromDirs(projectDir, userDir)
+	if err != nil {
+		t.Fatalf("ListProfileSummariesFromDirs: %v", err)
+	}
+
+	byName := make(map[string]ProfileSummary, len(summaries))
+	hasBuiltin := false
+	for _, summary := range summaries {
+		byName[summary.Name] = summary
+		if summary.SourceTier == "built-in" {
+			hasBuiltin = true
+		}
+	}
+
+	shared, ok := byName["shared"]
+	if !ok {
+		t.Fatal("shared profile missing from summaries")
+	}
+	if shared.SourceTier != "project" {
+		t.Fatalf("shared.SourceTier = %q, want project", shared.SourceTier)
+	}
+	if shared.Description != "project profile" {
+		t.Fatalf("shared.Description = %q, want project profile", shared.Description)
+	}
+	if shared.AllowedToolCount != 1 || len(shared.AllowedTools) != 1 || shared.AllowedTools[0] != "bash" {
+		t.Fatalf("shared allowed tools = %#v (count=%d), want [bash]", shared.AllowedTools, shared.AllowedToolCount)
+	}
+
+	userOnly, ok := byName["user-only"]
+	if !ok {
+		t.Fatal("user-only profile missing from summaries")
+	}
+	if userOnly.SourceTier != "user" {
+		t.Fatalf("userOnly.SourceTier = %q, want user", userOnly.SourceTier)
+	}
+
+	if !hasBuiltin {
+		t.Fatal("expected at least one built-in profile summary")
+	}
+}

--- a/internal/training/applier_test.go
+++ b/internal/training/applier_test.go
@@ -30,6 +30,7 @@ func initGitRepo(t *testing.T, dir string) {
 	for _, args := range [][]string{
 		{"add", ".gitkeep"},
 		{"commit", "-m", "initial"},
+		{"branch", "-M", "main"},
 	} {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir


### PR DESCRIPTION
## Summary
- cancel the conversation cleaner context on all `harnessd` startup exit paths
- add a deterministic startup-failure regression test without relying on package-global overrides
- record the issue plan and verification trail in the repo docs/logs

## Testing
- `go test ./cmd/harnessd -run TestStartupFailureCancelsConversationCleaner -count=1`
- `go test ./cmd/harnessd -count=1`
- `go vet ./internal/... ./cmd/...`

Closes #431