### PR TITLE
Fix HTTP run persistence ownership

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,32 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Added red-to-green regression coverage for persistence ownership in the server layer:
+  - `internal/server/http_test.go`
+  - `internal/server/http_external_trigger_test.go`
+- Introduced a counting store wrapper in tests to prove duplicate `CreateRun` calls per run ID.
+- Reproduced the bug before implementation:
+  - `POST /v1/runs` called `CreateRun` twice for the same run.
+  - external-trigger `start` called `CreateRun` twice for the same run.
+  - external-trigger `continue` called `CreateRun` twice for the new continuation run.
+- Fixed the ownership boundary by removing HTTP-side duplicate `CreateRun` calls in:
+  - `internal/server/http.go`
+  - `internal/server/http_external_trigger.go`
+- Removed the now-unused `harnessRunToStore` helper after the ownership fix so this branch does not introduce a fresh zero-coverage function in the regression gate.
+- Preserved the existing behavior that the runner owns initial persistence and store failures remain non-fatal inside the runner layer.
+- Verification:
+  - Failing-first: `go test ./internal/server -run 'TestPostRunPersistsExactlyOnce|TestHandleExternalTrigger_StartPersistsExactlyOnce|TestHandleExternalTrigger_ContinuePersistsExactlyOnce'`
+  - Green focused server checks: `go test ./internal/server -run 'TestPostRunPersistsExactlyOnce|TestHandleExternalTrigger_StartPersistsExactlyOnce|TestHandleExternalTrigger_ContinuePersistsExactlyOnce|TestRunLifecycleEndpoints|TestContinueRunEndpointBasic|TestHandleExternalTrigger_StartNewRun|TestHandleExternalTrigger_ContinueCompletedRun'`
+  - Green touched packages: `go test ./internal/server ./internal/harness`
+  - Repo regression gate rerun in tmux via `./scripts/test-regression.sh`
+- Regression gate status:
+  - total statement coverage remained above threshold at `84.7%`
+  - the gate is still blocked by pre-existing zero-coverage functions outside this issue scope:
+    - `cmd/harnesscli/tui/cmd_parser.go:73` (`newEmptyCommandRegistry`)
+    - `cmd/harnesscli/tui/components/tooluse/model.go:44` (`New`)
+    - `internal/profiles/loader.go:101` (`ListProfileSummaries`)
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #422 Run Persistence Ownership)
+
+- Command intent: Process GitHub issue `#422` end to end by removing duplicate HTTP-side run-record inserts and making the runner the clear owner of initial run persistence.
+- User intent: Close one architecture-backlog issue cleanly with strict TDD so run creation/continuation semantics stay the same while persistence ownership stops being ambiguous.
+- Success definition:
+  - Failing tests first prove duplicate `CreateRun` behavior on `POST /v1/runs` and the external-trigger start/continue paths.
+  - The runner remains the only component that persists initial run records for `StartRun` and `ContinueRun`.
+  - HTTP response shapes and non-fatal store behavior remain unchanged.
+  - Targeted server/harness tests pass, then the repo regression gate is rerun and any unrelated blockers are reported explicitly.
+- Non-goals:
+  - Redesigning the store API.
+  - Refactoring unrelated HTTP handlers or store internals.
+  - Broad runner persistence changes beyond initial run ownership.
+- Guardrails/constraints:
+  - Strict TDD.
+  - Keep the fix small and reviewable.
+  - Do not change external API payloads or status codes.
+- Open questions:
+  - Whether the external-trigger HTTP surface should be covered in the same ownership fix even though the issue body calls out `POST /v1/runs` explicitly.
+- Next verification step: add failing duplicate-write tests for the HTTP run and external-trigger paths, implement the smallest fix, then rerun targeted packages and the regression script.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-422-run-persistence-ownership-plan.md
+++ b/docs/plans/2026-03-25-issue-422-run-persistence-ownership-plan.md
@@ -1,0 +1,53 @@
+# Plan: Issue #422 Run Persistence Ownership
+
+## Context
+
+- Problem: The runner already persists initial run records, but the HTTP layer duplicates `CreateRun` calls for direct run creation and external-trigger start/continue flows.
+- User impact: Persistence ownership is unclear, duplicate writes complicate store semantics, and future transports could repeat the same mistake.
+- Constraints: Keep the change narrow, preserve response contracts, and follow strict TDD with regression coverage.
+
+## Scope
+
+- In scope:
+  - Add failing tests for duplicate `CreateRun` calls on HTTP-backed run creation paths.
+  - Remove transport-layer duplicate inserts where the runner already persists the run.
+  - Keep store errors non-fatal in the same places they are today.
+- Out of scope:
+  - Store API redesign.
+  - Broader HTTP transport decomposition.
+  - Persistence behavior unrelated to initial run creation.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `POST /v1/runs` persists exactly once when a store is configured.
+  - External-trigger `start` persists exactly once.
+  - External-trigger `continue` persists exactly once.
+- Existing tests to update:
+  - Server persistence tests around run creation and trigger handling, if needed for current helpers.
+- Regression tests required:
+  - Targeted `go test ./internal/server ./internal/harness`.
+  - Repo regression script rerun before final handoff.
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue does not change provider/model flow behavior, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: Removing the HTTP-side insert could accidentally change behavior on a path where the runner does not actually persist yet.
+- Mitigation: Pin single-write behavior in failing tests for both direct HTTP and external-trigger flows before touching production code.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for making the runner the single owner of initial run persistence across HTTP entrypoints.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on additive backend OpenRouter discovery and provider/model routing safety.
+Current status: active implementation work is focused on issue #422 run persistence ownership.
 
-Current active plan: `2026-03-25-openrouter-backend-discovery-plan.md`
+Current active plan: `2026-03-25-issue-422-run-persistence-ownership-plan.md`
 
-Most recent completed plan: `2026-03-19-issue-361-golden-path-smoke-plan.md`
+Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -603,12 +603,6 @@ func (s *Server) handlePostRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Persist the initial run record to the store when configured.
-	if s.runStore != nil {
-		storeRun := harnessRunToStore(run)
-		_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-	}
-
 	writeJSON(w, http.StatusAccepted, map[string]any{
 		"run_id": run.ID,
 		"status": run.Status,
@@ -1560,25 +1554,6 @@ func (s *Server) handleDeleteConversation(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
-}
-
-// harnessRunToStore converts a harness.Run to a store.Run for initial persistence.
-// Usage/cost JSON fields are left empty; they are updated via UpdateRun later.
-func harnessRunToStore(run harness.Run) *store.Run {
-	return &store.Run{
-		ID:             run.ID,
-		ConversationID: run.ConversationID,
-		TenantID:       run.TenantID,
-		AgentID:        run.AgentID,
-		Model:          run.Model,
-		ProviderName:   run.ProviderName,
-		Prompt:         run.Prompt,
-		Status:         store.RunStatus(run.Status),
-		Output:         run.Output,
-		Error:          run.Error,
-		CreatedAt:      run.CreatedAt,
-		UpdatedAt:      run.UpdatedAt,
-	}
 }
 
 // storeRunToHarness converts a store.Run to a map suitable for JSON response.

--- a/internal/server/http_external_trigger.go
+++ b/internal/server/http_external_trigger.go
@@ -142,10 +142,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
 		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(run)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
-		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": run.ID,
 			"status": run.Status,
@@ -202,10 +198,6 @@ func (s *Server) dispatchTriggerEnvelope(w http.ResponseWriter, r *http.Request,
 			}
 			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
 			return
-		}
-		if s.runStore != nil {
-			storeRun := harnessRunToStore(newRun)
-			_ = s.runStore.CreateRun(r.Context(), storeRun) // best-effort
 		}
 		writeJSON(w, http.StatusAccepted, map[string]any{
 			"run_id": newRun.ID,

--- a/internal/server/http_external_trigger_test.go
+++ b/internal/server/http_external_trigger_test.go
@@ -151,6 +151,49 @@ func TestHandleExternalTrigger_StartNewRun(t *testing.T) {
 	}
 }
 
+func TestHandleExternalTrigger_StartPersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	countingStore := newCreateRunCountingStore()
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+		Store:        countingStore,
+	})
+	handler := NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        countingStore,
+		AuthDisabled: true,
+		Validators:   reg,
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	body, sig := buildTriggerRequest(t, "github", secret, "start", "build the feature", "PR#43", nil)
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+	if got := countingStore.createCount(resp.RunID); got != 1 {
+		t.Fatalf("CreateRun calls for trigger-start run %s = %d, want 1", resp.RunID, got)
+	}
+}
+
 // TestHandleExternalTrigger_SteerActiveRun verifies that action="steer" on an
 // active run returns 202.
 func TestHandleExternalTrigger_SteerActiveRun(t *testing.T) {
@@ -277,6 +320,64 @@ func TestHandleExternalTrigger_ContinueCompletedRun(t *testing.T) {
 	}
 	if resp.RunID == "" {
 		t.Error("expected non-empty run_id in continue response")
+	}
+}
+
+func TestHandleExternalTrigger_ContinuePersistsExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	const secret = "test-github-secret"
+	provider := &staticProvider{result: harness.CompletionResult{Content: "done"}}
+	reg := makeGitHubRegistry(secret)
+	countingStore := newCreateRunCountingStore()
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+		Store:        countingStore,
+	})
+	handler := NewWithOptions(ServerOptions{
+		Runner:       runner,
+		Store:        countingStore,
+		AuthDisabled: true,
+		Validators:   reg,
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	threadID := trigger.DeriveExternalThreadID("github", "org", "repo", "PR#199")
+
+	initialRun, err := runner.StartRun(harness.RunRequest{
+		Prompt:         "original prompt",
+		ConversationID: threadID.String(),
+		TenantID:       "default",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForRunStatus(t, ts, initialRun.ID, "completed", "failed")
+
+	body, sig := buildTriggerRequest(t, "github", secret, "continue", "follow up", "PR#199", map[string]string{
+		"repo_owner": "org",
+		"repo_name":  "repo",
+	})
+	res := sendTrigger(t, ts, body, sig)
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 202, got %d: %s", res.StatusCode, raw)
+	}
+	var resp struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.RunID == "" {
+		t.Fatal("expected non-empty run_id in continue response")
+	}
+	if got := countingStore.createCount(resp.RunID); got != 1 {
+		t.Fatalf("CreateRun calls for trigger-continue run %s = %d, want 1", resp.RunID, got)
 	}
 }
 

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -44,6 +44,34 @@ func (s *scriptedProvider) Complete(_ context.Context, _ harness.CompletionReque
 	return out, nil
 }
 
+type createRunCountingStore struct {
+	*store.MemoryStore
+	mu            sync.Mutex
+	totalCreates  int
+	createByRunID map[string]int
+}
+
+func newCreateRunCountingStore() *createRunCountingStore {
+	return &createRunCountingStore{
+		MemoryStore:   store.NewMemoryStore(),
+		createByRunID: make(map[string]int),
+	}
+}
+
+func (s *createRunCountingStore) CreateRun(ctx context.Context, run *store.Run) error {
+	s.mu.Lock()
+	s.totalCreates++
+	s.createByRunID[run.ID]++
+	s.mu.Unlock()
+	return s.MemoryStore.CreateRun(ctx, run)
+}
+
+func (s *createRunCountingStore) createCount(runID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.createByRunID[runID]
+}
+
 func TestRunLifecycleEndpoints(t *testing.T) {
 	t.Parallel()
 
@@ -2310,22 +2338,27 @@ func TestStoreRunFallback(t *testing.T) {
 	}
 }
 
-// TestHarnessRunToStore tests that POST /v1/runs persists the run to the store
-// when a runStore is configured (exercises harnessRunToStore).
-func TestHarnessRunToStore(t *testing.T) {
+// TestPostRunPersistsExactlyOnce verifies that POST /v1/runs relies on the
+// runner as the single owner of initial run persistence.
+func TestPostRunPersistsExactlyOnce(t *testing.T) {
 	t.Parallel()
 
-	memStore := store.NewMemoryStore()
+	memStore := newCreateRunCountingStore()
 	registry := harness.NewRegistry()
 	runner := harness.NewRunner(
 		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
 		registry,
-		harness.RunnerConfig{DefaultModel: "gpt-4.1-mini", DefaultSystemPrompt: "You are helpful.", MaxSteps: 1},
+		harness.RunnerConfig{
+			DefaultModel:        "gpt-4.1-mini",
+			DefaultSystemPrompt: "You are helpful.",
+			MaxSteps:            1,
+			Store:               memStore,
+		},
 	)
 	ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, Store: memStore, AuthDisabled: true}))
 	defer ts.Close()
 
-	// Start a run via the server — this should call harnessRunToStore internally.
+	// Start a run via the server — the runner should be the only initial persister.
 	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(`{"prompt":"Hello"}`))
 	if err != nil {
 		t.Fatalf("POST /v1/runs: %v", err)
@@ -2346,8 +2379,11 @@ func TestHarnessRunToStore(t *testing.T) {
 	if created.RunID == "" {
 		t.Fatal("expected non-empty run_id")
 	}
+	if got := memStore.createCount(created.RunID); got != 1 {
+		t.Fatalf("CreateRun calls for run %s = %d, want 1", created.RunID, got)
+	}
 
-	// The store should have a record for this run (best-effort write on POST /v1/runs).
+	// The store should have a record for this run.
 	ctx := context.Background()
 	// Poll briefly since the run is async.
 	var storeRun *store.Run


### PR DESCRIPTION
## Summary
- remove HTTP-side duplicate `CreateRun` inserts for direct run creation and external-trigger start/continue paths
- add red-to-green regression tests that count `CreateRun` calls per run ID
- document the issue plan and engineering verification for issue #422

## Testing
- `go test ./internal/server -run 'TestPostRunPersistsExactlyOnce|TestHandleExternalTrigger_StartPersistsExactlyOnce|TestHandleExternalTrigger_ContinuePersistsExactlyOnce'`
- `go test ./internal/server -run 'TestPostRunPersistsExactlyOnce|TestHandleExternalTrigger_StartPersistsExactlyOnce|TestHandleExternalTrigger_ContinuePersistsExactlyOnce|TestRunLifecycleEndpoints|TestContinueRunEndpointBasic|TestHandleExternalTrigger_StartNewRun|TestHandleExternalTrigger_ContinueCompletedRun'`
- `go test ./internal/server ./internal/harness`
- `./scripts/test-regression.sh` (blocked by pre-existing zero-coverage functions in `cmd/harnesscli/tui/cmd_parser.go`, `cmd/harnesscli/tui/components/tooluse/model.go`, and `internal/profiles/loader.go`)

Closes #422