### PR TITLE
Extract runner preflight orchestration

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -129,6 +129,32 @@
   - red step: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run 'TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation'`
   - green focused step: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server -run 'TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation|TestAgentsEndpoint_Timeout(Exceeded_Returns408|CancelsSpawnedRun)'`
   - package verification: `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness ./internal/server`
+## 2026-03-25 (Issue #423 Runner Preflight Extraction)
+
+- Extracted the `Runner.execute()` setup path into a focused `runPreflight(...)` helper in [`internal/harness/runner.go`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/internal/harness/runner.go):
+  - profile-driven workspace isolation fallback
+  - workspace provisioning and cleanup registration
+  - workspace-path system-prompt re-resolution
+  - provider/model setup and prompt events
+  - conversation preloading and per-run MCP registry setup
+- Added direct seam-level regression coverage in [`internal/harness/runner_preflight_test.go`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/internal/harness/runner_preflight_test.go) for:
+  - profile isolation fallback when `workspace_type` is unset
+  - `workspace.provision_failed` emission on provisioning errors
+  - prompt re-resolution against the provisioned workspace path
+  - per-run scoped MCP registry creation
+- Updated the plan/intent trail for the issue:
+  - [`docs/plans/2026-03-25-issue-423-runner-preflight-plan.md`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/docs/plans/2026-03-25-issue-423-runner-preflight-plan.md)
+  - [`docs/plans/active-plan.md`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/docs/plans/active-plan.md)
+  - [`docs/plans/INDEX.md`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/docs/plans/INDEX.md)
+  - [`docs/logs/long-term-thinking-log.md`](/Users/dennisonbertram/.codex/worktrees/a321/go-agent-harness/docs/logs/long-term-thinking-log.md)
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run 'TestRunPreflight_' -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -race -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -race -run TestWorkerPool_QueuedTransitionsToRunning -count=5`
+- Regression status:
+  - the repo-wide `./scripts/test-regression.sh` run reached the multi-package race phase cleanly but hit a timeout in `TestWorkerPool_QueuedTransitionsToRunning` during the full-package `go test ./internal/... ./cmd/... -race` invocation.
+  - that worker-pool race timeout did not reproduce in isolated reruns, so it currently looks like an unrelated pre-existing/full-suite flake rather than a deterministic issue-`#423` regression.
 
 ## 2026-03-25 (Harness Review Bug Tickets)
 

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -189,6 +189,26 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether repo-wide regression or CI will expose unrelated blockers after the targeted fix is green.
 - Next verification step: add the startup-failure regression test, run it red, apply the minimal cleanup fix, then rerun `go test ./cmd/harnessd` and `go vet ./internal/... ./cmd/...`.
+## 2026-03-25 (Issue #423 Runner Preflight Extraction)
+
+- Command intent: Complete GitHub issue `#423` by extracting the `Runner.execute()` preflight/setup path into an explicit helper without changing runtime behavior.
+- User intent: Make the first seam in the runner monolith concrete and test-backed so future workspace/profile/MCP changes are easier to review and safer to evolve.
+- Success definition:
+  - `execute()` delegates preflight responsibilities instead of inlining them.
+  - Direct tests cover workspace-type fallback, workspace provisioning failure, prompt re-resolution with the provisioned workspace path, and per-run MCP setup.
+  - `go test ./internal/harness` passes after the extraction.
+  - A PR is opened and reaches a clean mergeable state.
+- Non-goals:
+  - Extracting the event journal or step loop.
+  - Changing workspace/profile/MCP semantics beyond preserving current behavior.
+  - Broad server or provider refactors.
+- Guardrails/constraints:
+  - Strict TDD: failing characterization tests first.
+  - Keep event ordering and terminal behavior unchanged.
+  - Use the current dedicated automation worktree and a focused issue branch only.
+- Open questions:
+  - Whether the cleanest seam is a helper function, a small struct, or a pair of helpers split between workspace and MCP setup.
+- Next verification step: add the direct failing preflight tests, implement the minimal extraction, and rerun `go test ./internal/harness` before opening the PR.
 
 ## 2026-03-24 (Worktree Bootstrap Script)
 

--- a/docs/plans/2026-03-25-issue-423-runner-preflight-plan.md
+++ b/docs/plans/2026-03-25-issue-423-runner-preflight-plan.md
@@ -1,0 +1,54 @@
+# Plan: Issue #423 runner preflight extraction
+
+## Context
+
+- Problem: `internal/harness/runner.go` mixes profile loading, workspace provisioning, system-prompt re-resolution, and per-run MCP setup directly into `execute()`.
+- User impact: small runner setup changes are hard to review and regressions in workspace/profile behavior are easy to miss because the preflight contract is not explicit.
+- Constraints: preserve existing run behavior, follow strict TDD, keep the extraction narrow, and avoid touching later step-loop/event-journal concerns.
+
+## Scope
+
+- In scope:
+  - characterize the current preflight contract in tests
+  - extract the `execute()` preflight/setup path into a focused helper or small component
+  - keep profile isolation fallback, workspace events, prompt re-resolution, and per-run MCP setup behavior unchanged
+- Out of scope:
+  - event journal extraction
+  - step engine extraction
+  - transport or provider behavior changes outside current preflight flow
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - direct preflight characterization for workspace provisioning failure emitting `workspace.provision_failed`
+  - direct preflight characterization for profile-driven workspace fallback
+  - direct preflight characterization for system prompt re-resolution against a provisioned workspace path
+  - direct preflight characterization for per-run MCP registry setup
+- Existing tests to update:
+  - `internal/harness/workspace_selection_test.go`
+  - `internal/harness/profile_mcp_test.go`
+- Regression tests required:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -count=1`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This task does not change provider/model flow contracts, so no impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: the extraction could subtly change event ordering or run-state initialization.
+- Mitigation: pin current preflight behavior with direct tests before moving code and rerun the full `internal/harness` package after refactoring.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -8,9 +8,15 @@
 - `2026-03-25-issue-421-config-contract-plan.md`: Active plan for making merged harness config the authoritative runtime contract in `cmd/harnessd`.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
-- `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
+- `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
+- `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
+- `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
+- `2026-03-25-issue-421-config-contract-plan.md`: Active plan for making merged harness config the authoritative runtime contract in `cmd/harnessd`.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
+- `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
+- `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
+- `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on issue #422 run persistence ownership between the runner and HTTP transport.
+Current status: active implementation work is focused on issue `#423`, extracting runner preflight orchestration from `execute()` without changing behavior.
 
-Current active plan: `2026-03-25-issue-422-run-persistence-ownership-plan.md`
+Current active plan: `2026-03-25-issue-423-runner-preflight-plan.md`
 
-Most recent completed plan: `2026-03-25-issue-429-fork-result-failure-plan.md`
+Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -649,6 +649,235 @@ func (r *Runner) resolveSystemPrompt(req RunRequest, model, workspacePath string
 	return resolved.StaticPrompt, &resolved, nil
 }
 
+type runPreflightResult struct {
+	model                  string
+	primaryModel           string
+	activeProvider         Provider
+	providerName           string
+	systemPrompt           string
+	resolvedPrompt         *systemprompt.ResolvedPrompt
+	runStartedAt           time.Time
+	messages               []Message
+	effectiveWorkspaceType string
+}
+
+func (r *Runner) runPreflight(ctx context.Context, runID string, req RunRequest) (*runPreflightResult, error) {
+	// Per-run workspace provisioning (issue #324, extended by issue #414).
+	// Resolve the effective workspace type: RunRequest.WorkspaceType takes
+	// precedence; if unset, Profile.IsolationMode provides the fallback.
+	// Load the full profile now (if a profile is named) so we can extract
+	// IsolationMode. Profile loading errors are non-fatal for this field —
+	// a missing or unparseable profile falls back to no provisioning rather
+	// than failing the run at this early stage (the MCP loading path below
+	// already handles the authoritative profile error reporting).
+	var resolvedProfile *profiles.Profile
+	if req.ProfileName != "" {
+		profilesDir := r.config.ProfilesDir
+		if profilesDir == "" {
+			profilesDir = defaultProfilesDir()
+		}
+		if p, loadErr := profiles.LoadProfileFromUserDir(req.ProfileName, profilesDir); loadErr == nil && p != nil {
+			resolvedProfile = p
+		}
+	}
+	effectiveWorkspaceType := resolveWorkspaceType(req.WorkspaceType, resolvedProfile)
+
+	// If workspace_type is set (explicitly or via profile), provision it now
+	// and register cleanup in runState.
+	// The cleanup function is called by runWorkspaceCleanup() before each terminal
+	// event, ensuring workspace.destroyed is emitted before run.completed/failed.
+	if effectiveWorkspaceType != "" {
+		ws, provisionErr := provisionRunWorkspace(ctx, runID, effectiveWorkspaceType, r.config.WorkspaceBaseOptions)
+		if provisionErr != nil {
+			r.emit(runID, EventWorkspaceProvisionFailed, map[string]any{
+				"workspace_type": effectiveWorkspaceType,
+				"error":          provisionErr.Error(),
+			})
+			return nil, fmt.Errorf("workspace provisioning failed: %w", provisionErr)
+		}
+		wsPath := ws.WorkspacePath()
+		r.emit(runID, EventWorkspaceProvisioned, map[string]any{
+			"workspace_type": effectiveWorkspaceType,
+			"workspace_path": wsPath,
+		})
+		// Re-resolve system prompt with the provisioned workspace path so that
+		// AGENTS.md from the workspace is injected (overriding any AGENTS.md
+		// loaded from WorkspaceBaseOptions.RepoPath during StartRun). This is a
+		// no-op when the workspace path matches the repo path.
+		wsModel := req.Model
+		if wsModel == "" {
+			wsModel = r.config.DefaultModel
+		}
+		if wsPath != "" && r.config.PromptEngine != nil {
+			if wsSP, wsRP, wsErr := r.resolveSystemPrompt(req, wsModel, wsPath); wsErr == nil {
+				r.mu.Lock()
+				if st, ok := r.runs[runID]; ok {
+					st.staticSystemPrompt = wsSP
+					st.promptResolved = wsRP
+				}
+				r.mu.Unlock()
+			} else if r.config.Logger != nil {
+				r.config.Logger.Error("failed to re-resolve system prompt with workspace path",
+					"run_id", runID, "workspace_path", wsPath, "error", wsErr)
+			}
+		}
+		// Store cleanup function so completeRun/failRun/cancelledRun can call it
+		// before the terminal event, keeping workspace.destroyed before run.completed.
+		wsType := effectiveWorkspaceType
+		logger := r.config.Logger
+		cleanupFn := func() {
+			destroyErr := ws.Destroy(context.Background())
+			payload := map[string]any{
+				"workspace_type": wsType,
+				"workspace_path": wsPath,
+			}
+			if destroyErr != nil {
+				payload["error"] = destroyErr.Error()
+				if logger != nil {
+					logger.Error("workspace destroy failed", "run_id", runID, "error", destroyErr)
+				}
+			}
+			r.emit(runID, EventWorkspaceDestroyed, payload)
+		}
+		r.mu.Lock()
+		if st, ok := r.runs[runID]; ok {
+			st.workspaceCleanup = cleanupFn
+		}
+		r.mu.Unlock()
+	}
+
+	model := req.Model
+	if model == "" {
+		model = r.config.DefaultModel
+	}
+
+	// Resolve per-role model overrides. primaryModel is used in CompletionRequests
+	// for the main step loop. An empty Primary falls back to the base model.
+	roleModels := r.resolveRoleModels(req)
+	primaryModel := model
+	if roleModels.Primary != "" {
+		primaryModel = roleModels.Primary
+	}
+
+	activeProvider, providerName, err := r.resolveProvider(runID, model, req.ProviderName, req.AllowFallback)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set provider name and resolved role models on run state.
+	// resolvedRoleModels is stored so that autoCompactMessages can honour the
+	// per-request Summarizer override without needing the original RunRequest.
+	r.mu.Lock()
+	if state, ok := r.runs[runID]; ok {
+		state.run.ProviderName = providerName
+		state.resolvedRoleModels = roleModels
+	}
+	r.mu.Unlock()
+
+	r.emit(runID, EventProviderResolved, map[string]any{
+		"model":    model,
+		"provider": providerName,
+	})
+
+	systemPrompt, resolvedPrompt, runStartedAt := r.promptContext(runID)
+	if resolvedPrompt != nil {
+		r.emit(runID, EventPromptResolved, map[string]any{
+			"intent":            resolvedPrompt.ResolvedIntent,
+			"model_profile":     resolvedPrompt.ResolvedModelProfile,
+			"model_fallback":    resolvedPrompt.ModelFallback,
+			"applied_behaviors": append([]string(nil), resolvedPrompt.Behaviors...),
+			"applied_talents":   append([]string(nil), resolvedPrompt.Talents...),
+			"applied_skills":    append([]string(nil), resolvedPrompt.Skills...),
+			"has_warnings":      len(resolvedPrompt.Warnings) > 0,
+		})
+		for _, warning := range resolvedPrompt.Warnings {
+			r.emit(runID, EventPromptWarning, map[string]any{
+				"code":    warning.Code,
+				"message": warning.Message,
+			})
+		}
+	}
+
+	priorMessages := r.loadConversationHistory(runID)
+	messages := make([]Message, 0, len(priorMessages)+16)
+	messages = append(messages, priorMessages...)
+	messages = append(messages, Message{Role: "user", Content: req.Prompt})
+	r.snapshotRecordMessage(runID, "user", req.Prompt)
+
+	if len(priorMessages) > 0 {
+		r.emit(runID, EventConversationContinued, map[string]any{
+			"conversation_id":     r.conversationID(runID),
+			"prior_message_count": len(priorMessages),
+		})
+	}
+	r.setMessages(runID, messages)
+
+	// Build per-run MCP registry when profile and/or run-level MCP servers are configured.
+	// Profile servers shadow global server names (no error); run-level servers error on collision.
+	if req.ProfileName != "" || len(req.MCPServers) > 0 {
+		var profileMCPServers []MCPServerConfig
+
+		if req.ProfileName != "" {
+			// Resolve the profiles directory: use runner config value or fall back to default.
+			profilesDir := r.config.ProfilesDir
+			if profilesDir == "" {
+				profilesDir = defaultProfilesDir()
+			}
+			profileCfg, profileErr := loadProfileMCPServers(profilesDir, req.ProfileName)
+			if profileErr != nil {
+				// Non-fatal: log and continue without profile servers.
+				if r.config.Logger != nil {
+					r.config.Logger.Error("failed to load profile MCP servers",
+						"run_id", runID,
+						"profile", req.ProfileName,
+						"error", profileErr)
+				}
+			} else {
+				for name, srv := range profileCfg {
+					// Harness MCPServerConfig infers transport from Command/URL;
+					// the config.MCPServerConfig Transport field is not forwarded here.
+					profileMCPServers = append(profileMCPServers, MCPServerConfig{
+						Name:    name,
+						Command: srv.Command,
+						Args:    srv.Args,
+						URL:     srv.URL,
+					})
+				}
+			}
+		}
+
+		scopedReg, mcpErr := buildPerRunMCPRegistry(
+			r.config.GlobalMCPRegistry,
+			r.config.GlobalMCPServerNames,
+			profileMCPServers,
+			req.MCPServers,
+		)
+		if mcpErr != nil {
+			return nil, fmt.Errorf("build per-run MCP registry: %w", mcpErr)
+		}
+		r.mu.Lock()
+		if state, ok := r.runs[runID]; ok {
+			state.scopedMCPRegistry = scopedReg
+		} else {
+			// Run was cancelled before we could store the registry; clean up.
+			_ = scopedReg.Close()
+		}
+		r.mu.Unlock()
+	}
+
+	return &runPreflightResult{
+		model:                  model,
+		primaryModel:           primaryModel,
+		activeProvider:         activeProvider,
+		providerName:           providerName,
+		systemPrompt:           systemPrompt,
+		resolvedPrompt:         resolvedPrompt,
+		runStartedAt:           runStartedAt,
+		messages:               messages,
+		effectiveWorkspaceType: effectiveWorkspaceType,
+	}, nil
+}
+
 func mapPromptExtensions(input *PromptExtensions) systemprompt.Extensions {
 	if input == nil {
 		return systemprompt.Extensions{}
@@ -1292,212 +1521,19 @@ func (r *Runner) execute(runID string, req RunRequest) {
 		})
 	}
 
-	// Per-run workspace provisioning (issue #324, extended by issue #414).
-	// Resolve the effective workspace type: RunRequest.WorkspaceType takes
-	// precedence; if unset, Profile.IsolationMode provides the fallback.
-	// Load the full profile now (if a profile is named) so we can extract
-	// IsolationMode. Profile loading errors are non-fatal for this field —
-	// a missing or unparseable profile falls back to no provisioning rather
-	// than failing the run at this early stage (the MCP loading path below
-	// already handles the authoritative profile error reporting).
-	var resolvedProfile *profiles.Profile
-	if req.ProfileName != "" {
-		profilesDir := r.config.ProfilesDir
-		if profilesDir == "" {
-			profilesDir = defaultProfilesDir()
-		}
-		if p, loadErr := profiles.LoadProfileFromUserDir(req.ProfileName, profilesDir); loadErr == nil && p != nil {
-			resolvedProfile = p
-		}
-	}
-	effectiveWorkspaceType := resolveWorkspaceType(req.WorkspaceType, resolvedProfile)
-
-	// If workspace_type is set (explicitly or via profile), provision it now
-	// and register cleanup in runState.
-	// The cleanup function is called by runWorkspaceCleanup() before each terminal
-	// event, ensuring workspace.destroyed is emitted before run.completed/failed.
-	// Provisioning failure immediately fails the run (no LLM call is made).
-	if effectiveWorkspaceType != "" {
-		ws, provisionErr := provisionRunWorkspace(ctx, runID, effectiveWorkspaceType, r.config.WorkspaceBaseOptions)
-		if provisionErr != nil {
-			r.emit(runID, EventWorkspaceProvisionFailed, map[string]any{
-				"workspace_type": effectiveWorkspaceType,
-				"error":          provisionErr.Error(),
-			})
-			r.failRun(runID, fmt.Errorf("workspace provisioning failed: %w", provisionErr))
-			return
-		}
-		wsPath := ws.WorkspacePath()
-		r.emit(runID, EventWorkspaceProvisioned, map[string]any{
-			"workspace_type": effectiveWorkspaceType,
-			"workspace_path": wsPath,
-		})
-		// Re-resolve system prompt with the provisioned workspace path so that
-		// AGENTS.md from the workspace is injected (overriding any AGENTS.md
-		// loaded from WorkspaceBaseOptions.RepoPath during StartRun). This is a
-		// no-op when the workspace path matches the repo path.
-		wsModel := req.Model
-		if wsModel == "" {
-			wsModel = r.config.DefaultModel
-		}
-		if wsPath != "" && r.config.PromptEngine != nil {
-			if wsSP, wsRP, wsErr := r.resolveSystemPrompt(req, wsModel, wsPath); wsErr == nil {
-				r.mu.Lock()
-				if st, ok := r.runs[runID]; ok {
-					st.staticSystemPrompt = wsSP
-					st.promptResolved = wsRP
-				}
-				r.mu.Unlock()
-			} else if r.config.Logger != nil {
-				r.config.Logger.Error("failed to re-resolve system prompt with workspace path",
-					"run_id", runID, "workspace_path", wsPath, "error", wsErr)
-			}
-		}
-		// Store cleanup function so completeRun/failRun/cancelledRun can call it
-		// before the terminal event, keeping workspace.destroyed before run.completed.
-		wsType := effectiveWorkspaceType
-		logger := r.config.Logger
-		cleanupFn := func() {
-			destroyErr := ws.Destroy(context.Background())
-			payload := map[string]any{
-				"workspace_type": wsType,
-				"workspace_path": wsPath,
-			}
-			if destroyErr != nil {
-				payload["error"] = destroyErr.Error()
-				if logger != nil {
-					logger.Error("workspace destroy failed", "run_id", runID, "error", destroyErr)
-				}
-			}
-			r.emit(runID, EventWorkspaceDestroyed, payload)
-		}
-		r.mu.Lock()
-		if st, ok := r.runs[runID]; ok {
-			st.workspaceCleanup = cleanupFn
-		}
-		r.mu.Unlock()
-	}
-
-	model := req.Model
-	if model == "" {
-		model = r.config.DefaultModel
-	}
-
-	// Resolve per-role model overrides. primaryModel is used in CompletionRequests
-	// for the main step loop. An empty Primary falls back to the base model.
-	roleModels := r.resolveRoleModels(req)
-	primaryModel := model
-	if roleModels.Primary != "" {
-		primaryModel = roleModels.Primary
-	}
-
-	activeProvider, providerName, err := r.resolveProvider(runID, model, req.ProviderName, req.AllowFallback)
+	preflight, err := r.runPreflight(ctx, runID, req)
 	if err != nil {
 		r.failRun(runID, err)
 		return
 	}
 
-	// Set provider name and resolved role models on run state.
-	// resolvedRoleModels is stored so that autoCompactMessages can honour the
-	// per-request Summarizer override without needing the original RunRequest.
-	r.mu.Lock()
-	if state, ok := r.runs[runID]; ok {
-		state.run.ProviderName = providerName
-		state.resolvedRoleModels = roleModels
-	}
-	r.mu.Unlock()
-
-	r.emit(runID, EventProviderResolved, map[string]any{
-		"model":    model,
-		"provider": providerName,
-	})
-
-	systemPrompt, resolvedPrompt, runStartedAt := r.promptContext(runID)
-	if resolvedPrompt != nil {
-		r.emit(runID, EventPromptResolved, map[string]any{
-			"intent":            resolvedPrompt.ResolvedIntent,
-			"model_profile":     resolvedPrompt.ResolvedModelProfile,
-			"model_fallback":    resolvedPrompt.ModelFallback,
-			"applied_behaviors": append([]string(nil), resolvedPrompt.Behaviors...),
-			"applied_talents":   append([]string(nil), resolvedPrompt.Talents...),
-			"applied_skills":    append([]string(nil), resolvedPrompt.Skills...),
-			"has_warnings":      len(resolvedPrompt.Warnings) > 0,
-		})
-		for _, warning := range resolvedPrompt.Warnings {
-			r.emit(runID, EventPromptWarning, map[string]any{
-				"code":    warning.Code,
-				"message": warning.Message,
-			})
-		}
-	}
-
-	priorMessages := r.loadConversationHistory(runID)
-	messages := make([]Message, 0, len(priorMessages)+16)
-	messages = append(messages, priorMessages...)
-	messages = append(messages, Message{Role: "user", Content: req.Prompt})
-	r.snapshotRecordMessage(runID, "user", req.Prompt)
-
-	if len(priorMessages) > 0 {
-		r.emit(runID, EventConversationContinued, map[string]any{
-			"conversation_id":     r.conversationID(runID),
-			"prior_message_count": len(priorMessages),
-		})
-	}
-	r.setMessages(runID, messages)
-
-	// Build per-run MCP registry when profile and/or run-level MCP servers are configured.
-	// Profile servers shadow global server names (no error); run-level servers error on collision.
-	if req.ProfileName != "" || len(req.MCPServers) > 0 {
-		var profileMCPServers []MCPServerConfig
-
-		if req.ProfileName != "" {
-			// Resolve the profiles directory: use runner config value or fall back to default.
-			profilesDir := r.config.ProfilesDir
-			if profilesDir == "" {
-				profilesDir = defaultProfilesDir()
-			}
-			profileCfg, profileErr := loadProfileMCPServers(profilesDir, req.ProfileName)
-			if profileErr != nil {
-				// Non-fatal: log and continue without profile servers.
-				if r.config.Logger != nil {
-					r.config.Logger.Error("failed to load profile MCP servers",
-						"run_id", runID,
-						"profile", req.ProfileName,
-						"error", profileErr)
-				}
-			} else {
-				for name, srv := range profileCfg {
-					// Harness MCPServerConfig infers transport from Command/URL;
-					// the config.MCPServerConfig Transport field is not forwarded here.
-					profileMCPServers = append(profileMCPServers, MCPServerConfig{
-						Name:    name,
-						Command: srv.Command,
-						Args:    srv.Args,
-						URL:     srv.URL,
-					})
-				}
-			}
-		}
-
-		scopedReg, mcpErr := buildPerRunMCPRegistry(
-			r.config.GlobalMCPRegistry,
-			r.config.GlobalMCPServerNames,
-			profileMCPServers,
-			req.MCPServers,
-		)
-		if mcpErr != nil {
-			r.failRun(runID, fmt.Errorf("build per-run MCP registry: %w", mcpErr))
-			return
-		}
-		r.mu.Lock()
-		if state, ok := r.runs[runID]; ok {
-			state.scopedMCPRegistry = scopedReg
-		} else {
-			// Run was cancelled before we could store the registry; clean up.
-			_ = scopedReg.Close()
-		}
-		r.mu.Unlock()
-	}
+	model := preflight.model
+	primaryModel := preflight.primaryModel
+	activeProvider := preflight.activeProvider
+	systemPrompt := preflight.systemPrompt
+	resolvedPrompt := preflight.resolvedPrompt
+	runStartedAt := preflight.runStartedAt
+	messages := preflight.messages
 
 	// Resolve the effective step limit for this run.
 	// Priority: per-run request > runner config.

--- a/internal/harness/runner_preflight_test.go
+++ b/internal/harness/runner_preflight_test.go
@@ -1,0 +1,228 @@
+package harness
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/systemprompt"
+)
+
+func TestRunPreflight_UsesProfileIsolationModeFallback(t *testing.T) {
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+	profilesDir := t.TempDir()
+	profileTOML := `isolation_mode = "worktree"
+
+[meta]
+name = "isolated-worktree"
+description = "Test profile with worktree isolation"
+version = 1
+
+[runner]
+model = ""
+max_steps = 1
+
+[tools]
+allow = []
+`
+	if err := os.WriteFile(filepath.Join(profilesDir, "isolated-worktree.toml"), []byte(profileTOML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			DefaultModel: "gpt-5-nano",
+			MaxSteps:     1,
+			ProfilesDir:  profilesDir,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	runID := "run-preflight-profile"
+	runner.runs[runID] = newRunStateForPreflightTest(runID)
+
+	preflight, err := runner.runPreflight(context.Background(), runID, RunRequest{
+		Prompt:      "hello",
+		ProfileName: "isolated-worktree",
+	})
+	if err != nil {
+		t.Fatalf("runPreflight: %v", err)
+	}
+
+	if preflight.effectiveWorkspaceType != "worktree" {
+		t.Fatalf("effectiveWorkspaceType = %q, want worktree", preflight.effectiveWorkspaceType)
+	}
+	if got := preflight.messages[len(preflight.messages)-1].Content; got != "hello" {
+		t.Fatalf("last preflight message = %q, want hello", got)
+	}
+
+	provisioned := findEventByType(runner.runs[runID].events, EventWorkspaceProvisioned)
+	if provisioned == nil {
+		t.Fatal("expected workspace.provisioned event")
+	}
+	if got := provisioned.Payload["workspace_type"]; got != "worktree" {
+		t.Fatalf("workspace.provisioned workspace_type = %v, want worktree", got)
+	}
+	if runner.runs[runID].workspaceCleanup == nil {
+		t.Fatal("expected workspace cleanup to be registered")
+	}
+}
+
+func TestRunPreflight_ProvisionFailureEmitsWorkspaceProvisionFailed(t *testing.T) {
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			DefaultModel: "gpt-5-nano",
+			MaxSteps:     1,
+		},
+	)
+
+	runID := "run-preflight-failure"
+	runner.runs[runID] = newRunStateForPreflightTest(runID)
+
+	_, err := runner.runPreflight(context.Background(), runID, RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err == nil {
+		t.Fatal("expected workspace provisioning error")
+	}
+
+	failed := findEventByType(runner.runs[runID].events, EventWorkspaceProvisionFailed)
+	if failed == nil {
+		t.Fatal("expected workspace.provision_failed event")
+	}
+	if got := failed.Payload["workspace_type"]; got != "worktree" {
+		t.Fatalf("workspace.provision_failed workspace_type = %v, want worktree", got)
+	}
+}
+
+func TestRunPreflight_ReResolvesSystemPromptWithWorkspacePath(t *testing.T) {
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+	engine := &promptEngineStub{
+		resolved: systemprompt.ResolvedPrompt{
+			StaticPrompt:         "workspace-system",
+			ResolvedIntent:       "general",
+			ResolvedModelProfile: "default",
+		},
+	}
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			DefaultModel:       "gpt-5-nano",
+			DefaultAgentIntent: "general",
+			MaxSteps:           1,
+			PromptEngine:       engine,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	runID := "run-preflight-prompt"
+	state := newRunStateForPreflightTest(runID)
+	state.staticSystemPrompt = "initial-system"
+	state.promptResolved = &systemprompt.ResolvedPrompt{StaticPrompt: "initial-system"}
+	runner.runs[runID] = state
+
+	preflight, err := runner.runPreflight(context.Background(), runID, RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err != nil {
+		t.Fatalf("runPreflight: %v", err)
+	}
+
+	if preflight.systemPrompt != "workspace-system" {
+		t.Fatalf("systemPrompt = %q, want workspace-system", preflight.systemPrompt)
+	}
+	if state.staticSystemPrompt != "workspace-system" {
+		t.Fatalf("state.staticSystemPrompt = %q, want workspace-system", state.staticSystemPrompt)
+	}
+	provisioned := findEventByType(state.events, EventWorkspaceProvisioned)
+	if provisioned == nil {
+		t.Fatal("expected workspace.provisioned event")
+	}
+	if len(engine.resolveReqs) != 1 {
+		t.Fatalf("resolve calls = %d, want 1", len(engine.resolveReqs))
+	}
+	if got := engine.resolveReqs[0].WorkspacePath; got != provisioned.Payload["workspace_path"] {
+		t.Fatalf("resolve workspace path = %v, want %v", got, provisioned.Payload["workspace_path"])
+	}
+}
+
+func TestRunPreflight_BuildsScopedMCPRegistry(t *testing.T) {
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			DefaultModel: "gpt-5-nano",
+			MaxSteps:     1,
+		},
+	)
+
+	runID := "run-preflight-mcp"
+	state := newRunStateForPreflightTest(runID)
+	runner.runs[runID] = state
+
+	preflight, err := runner.runPreflight(context.Background(), runID, RunRequest{
+		Prompt: "hello",
+		MCPServers: []MCPServerConfig{{
+			Name: "run-srv",
+			URL:  "http://example.com/mcp",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("runPreflight: %v", err)
+	}
+
+	if preflight.model != "gpt-5-nano" {
+		t.Fatalf("model = %q, want gpt-5-nano", preflight.model)
+	}
+	if state.scopedMCPRegistry == nil {
+		t.Fatal("expected scoped MCP registry on run state")
+	}
+	if !state.scopedMCPRegistry.isPerRun("run-srv") {
+		t.Fatal("expected run-srv to be registered as a per-run MCP server")
+	}
+}
+
+func newRunStateForPreflightTest(runID string) *runState {
+	now := time.Now().UTC()
+	return &runState{
+		run: Run{
+			ID:             runID,
+			ConversationID: "conv-" + runID,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			Status:         RunStatusQueued,
+		},
+		messages:       make([]Message, 0, 16),
+		events:         make([]Event, 0, 16),
+		subscribers:    make(map[chan Event]struct{}),
+		steeringCh:     make(chan string, steeringBufferSize),
+		firedOnceRules: make(map[string]bool),
+	}
+}
+
+func findEventByType(events []Event, eventType EventType) *Event {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- extract the `Runner.execute()` setup path into a focused `runPreflight(...)` helper
- add direct seam-level regression tests for workspace/profile/prompt/MCP preflight behavior
- record the issue plan, intent, and engineering verification trail required by the repo workflow

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run 'TestRunPreflight_' -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -race -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -race -run TestWorkerPool_QueuedTransitionsToRunning -count=5`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build COVERPROFILE_PATH=$PWD/.tmp/issue-423-coverage.out ./scripts/test-regression.sh` *(full repo gate reached the multi-package race phase cleanly but hit a non-reproducing timeout in `TestWorkerPool_QueuedTransitionsToRunning` during the combined `go test ./internal/... ./cmd/... -race` run; isolated reruns of that test and `./internal/harness -race` passed)*

## Notes
- The extraction is behavior-preserving: it keeps workspace provisioning, prompt re-resolution, provider/model setup, conversation preload, and per-run MCP registry setup in the same order, but behind a narrower helper contract.
- The repo-wide race gate emitted repeated macOS linker warnings (`malformed LC_DYSYMTAB`) that did not fail the isolated harness package runs.

Closes #423