### PR TITLE
Make merged config authoritative for runner

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -66,6 +66,74 @@ func (a *callbackRunStarter) StartRun(prompt, conversationID string) error {
 
 type providerFactory func(cfg openai.Config) (harness.Provider, error)
 
+type runnerConfigInputs struct {
+	Model                string
+	SystemPrompt         string
+	DefaultAgentIntent   string
+	MaxSteps             int
+	AskUserTimeout       time.Duration
+	AskUserBroker        htools.AskUserQuestionBroker
+	MemoryManager        om.Manager
+	PromptEngine         systemprompt.Engine
+	ToolApprovalMode     harness.ToolApprovalMode
+	ProviderRegistry     *catalog.ProviderRegistry
+	ConversationStore    harness.ConversationStore
+	Store                istore.Store
+	Logger               harness.Logger
+	Activations          *harness.ActivationTracker
+	GlobalMCPRegistry    htools.MCPRegistry
+	GlobalMCPServerNames []string
+	RoleModels           harness.RoleModels
+	RolloutDir           string
+}
+
+func buildRunnerConfig(harnessCfg config.Config, inputs runnerConfigInputs) harness.RunnerConfig {
+	rolloutDir := strings.TrimSpace(inputs.RolloutDir)
+	if rolloutDir == "" {
+		rolloutDir = strings.TrimSpace(harnessCfg.Forensics.RolloutDir)
+	}
+
+	return harness.RunnerConfig{
+		DefaultModel:                  inputs.Model,
+		DefaultSystemPrompt:           inputs.SystemPrompt,
+		DefaultAgentIntent:            inputs.DefaultAgentIntent,
+		MaxSteps:                      inputs.MaxSteps,
+		AskUserTimeout:                inputs.AskUserTimeout,
+		AskUserBroker:                 inputs.AskUserBroker,
+		MemoryManager:                 inputs.MemoryManager,
+		PromptEngine:                  inputs.PromptEngine,
+		ToolApprovalMode:              inputs.ToolApprovalMode,
+		ProviderRegistry:              inputs.ProviderRegistry,
+		ConversationStore:             inputs.ConversationStore,
+		Store:                         inputs.Store,
+		Logger:                        inputs.Logger,
+		Activations:                   inputs.Activations,
+		RolloutDir:                    rolloutDir,
+		GlobalMCPRegistry:             inputs.GlobalMCPRegistry,
+		GlobalMCPServerNames:          inputs.GlobalMCPServerNames,
+		RoleModels:                    inputs.RoleModels,
+		AutoCompactEnabled:            harnessCfg.AutoCompact.Enabled,
+		AutoCompactMode:               harnessCfg.AutoCompact.Mode,
+		AutoCompactThreshold:          harnessCfg.AutoCompact.Threshold,
+		AutoCompactKeepLast:           harnessCfg.AutoCompact.KeepLast,
+		ModelContextWindow:            harnessCfg.AutoCompact.ModelContextWindow,
+		ErrorChainEnabled:             harnessCfg.Forensics.ErrorChainEnabled,
+		ErrorContextDepth:             harnessCfg.Forensics.ErrorContextDepth,
+		CaptureReasoning:              harnessCfg.Forensics.CaptureReasoning,
+		TraceToolDecisions:            harnessCfg.Forensics.TraceToolDecisions,
+		DetectAntiPatterns:            harnessCfg.Forensics.DetectAntiPatterns,
+		TraceHookMutations:            harnessCfg.Forensics.TraceHookMutations,
+		CaptureRequestEnvelope:        harnessCfg.Forensics.CaptureRequestEnvelope,
+		SnapshotMemorySnippet:         harnessCfg.Forensics.SnapshotMemorySnippet,
+		CostAnomalyDetectionEnabled:   harnessCfg.Forensics.CostAnomalyDetectionEnabled,
+		CostAnomalyStepMultiplier:     harnessCfg.Forensics.CostAnomalyStepMultiplier,
+		AuditTrailEnabled:             harnessCfg.Forensics.AuditTrailEnabled,
+		ContextWindowSnapshotEnabled:  harnessCfg.Forensics.ContextWindowSnapshotEnabled,
+		ContextWindowWarningThreshold: harnessCfg.Forensics.ContextWindowWarningThreshold,
+		CausalGraphEnabled:            harnessCfg.Forensics.CausalGraphEnabled,
+	}
+}
+
 // profileFlag is the --profile CLI flag. Registered at package level so it
 // integrates cleanly with Go's test infrastructure flags.
 var profileFlag = flag.String("profile", "", "named profile to load from ~/.harness/profiles/<name>.toml")
@@ -588,12 +656,9 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		MCPRegistry:       mcpRegistry,
 	}
 	tools := harness.NewDefaultRegistryWithOptions(workspace, baseRegistryOptions)
-	if rolloutDir != "" {
-		log.Printf("rollout recording enabled: %s", rolloutDir)
-	}
-	runnerCfg := harness.RunnerConfig{
-		DefaultModel:         model,
-		DefaultSystemPrompt:  systemPrompt,
+	runnerCfg := buildRunnerConfig(harnessCfg, runnerConfigInputs{
+		Model:                model,
+		SystemPrompt:         systemPrompt,
 		DefaultAgentIntent:   defaultAgentIntent,
 		MaxSteps:             maxSteps,
 		AskUserTimeout:       time.Duration(askUserTimeoutSeconds) * time.Second,
@@ -606,13 +671,16 @@ func runWithSignals(sig <-chan os.Signal, getenv func(string) string, newProvide
 		Store:                runStore,
 		Logger:               &stdLogger{},
 		Activations:          activations,
-		RolloutDir:           rolloutDir,
 		GlobalMCPRegistry:    mcpRegistry,
 		GlobalMCPServerNames: mcpManager.ListServers(),
 		RoleModels: harness.RoleModels{
 			Primary:    strings.TrimSpace(getenv("HARNESS_ROLE_MODEL_PRIMARY")),
 			Summarizer: strings.TrimSpace(getenv("HARNESS_ROLE_MODEL_SUMMARIZER")),
 		},
+		RolloutDir: rolloutDir,
+	})
+	if runnerCfg.RolloutDir != "" {
+		log.Printf("rollout recording enabled: %s", runnerCfg.RolloutDir)
 	}
 
 	// S3 backup: wire uploader when all required env vars are present.

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -174,6 +174,157 @@ func TestGetenvToolApprovalModeOrDefault(t *testing.T) {
 	}
 }
 
+func TestBuildRunnerConfigMapsMergedConfigRuntimeFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		AutoCompact: config.AutoCompactConfig{
+			Enabled:            true,
+			Mode:               "summarize",
+			Threshold:          0.72,
+			KeepLast:           5,
+			ModelContextWindow: 54321,
+		},
+		Forensics: config.ForensicsConfig{
+			TraceToolDecisions:            true,
+			DetectAntiPatterns:            true,
+			TraceHookMutations:            true,
+			CaptureRequestEnvelope:        true,
+			SnapshotMemorySnippet:         true,
+			ErrorChainEnabled:             true,
+			ErrorContextDepth:             17,
+			CaptureReasoning:              true,
+			CostAnomalyDetectionEnabled:   true,
+			CostAnomalyStepMultiplier:     4.25,
+			AuditTrailEnabled:             true,
+			ContextWindowSnapshotEnabled:  true,
+			ContextWindowWarningThreshold: 0.61,
+			CausalGraphEnabled:            true,
+			RolloutDir:                    "/tmp/from-config-rollouts",
+		},
+	}
+
+	broker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
+	activations := harness.NewActivationTracker()
+	roleModels := harness.RoleModels{Primary: "gpt-primary", Summarizer: "gpt-summarizer"}
+	serverNames := []string{"global-one", "global-two"}
+	logger := &stdLogger{}
+
+	runnerCfg := buildRunnerConfig(cfg, runnerConfigInputs{
+		Model:                "gpt-4.1-mini",
+		SystemPrompt:         "system",
+		DefaultAgentIntent:   "general",
+		MaxSteps:             11,
+		AskUserTimeout:       45 * time.Second,
+		AskUserBroker:        broker,
+		ToolApprovalMode:     harness.ToolApprovalModePermissions,
+		Logger:               logger,
+		Activations:          activations,
+		GlobalMCPServerNames: serverNames,
+		RoleModels:           roleModels,
+	})
+
+	if !runnerCfg.AutoCompactEnabled {
+		t.Fatalf("AutoCompactEnabled: got false, want true")
+	}
+	if runnerCfg.AutoCompactMode != "summarize" {
+		t.Fatalf("AutoCompactMode: got %q", runnerCfg.AutoCompactMode)
+	}
+	if runnerCfg.AutoCompactThreshold != 0.72 {
+		t.Fatalf("AutoCompactThreshold: got %f", runnerCfg.AutoCompactThreshold)
+	}
+	if runnerCfg.AutoCompactKeepLast != 5 {
+		t.Fatalf("AutoCompactKeepLast: got %d", runnerCfg.AutoCompactKeepLast)
+	}
+	if runnerCfg.ModelContextWindow != 54321 {
+		t.Fatalf("ModelContextWindow: got %d", runnerCfg.ModelContextWindow)
+	}
+	if !runnerCfg.TraceToolDecisions || !runnerCfg.DetectAntiPatterns || !runnerCfg.TraceHookMutations {
+		t.Fatalf("expected tool forensic flags to be true: %#v", runnerCfg)
+	}
+	if !runnerCfg.CaptureRequestEnvelope || !runnerCfg.SnapshotMemorySnippet {
+		t.Fatalf("expected request envelope forensic flags to be true: %#v", runnerCfg)
+	}
+	if !runnerCfg.ErrorChainEnabled {
+		t.Fatalf("ErrorChainEnabled: got false, want true")
+	}
+	if runnerCfg.ErrorContextDepth != 17 {
+		t.Fatalf("ErrorContextDepth: got %d", runnerCfg.ErrorContextDepth)
+	}
+	if !runnerCfg.CaptureReasoning {
+		t.Fatalf("CaptureReasoning: got false, want true")
+	}
+	if !runnerCfg.CostAnomalyDetectionEnabled {
+		t.Fatalf("CostAnomalyDetectionEnabled: got false, want true")
+	}
+	if runnerCfg.CostAnomalyStepMultiplier != 4.25 {
+		t.Fatalf("CostAnomalyStepMultiplier: got %f", runnerCfg.CostAnomalyStepMultiplier)
+	}
+	if !runnerCfg.AuditTrailEnabled {
+		t.Fatalf("AuditTrailEnabled: got false, want true")
+	}
+	if !runnerCfg.ContextWindowSnapshotEnabled {
+		t.Fatalf("ContextWindowSnapshotEnabled: got false, want true")
+	}
+	if runnerCfg.ContextWindowWarningThreshold != 0.61 {
+		t.Fatalf("ContextWindowWarningThreshold: got %f", runnerCfg.ContextWindowWarningThreshold)
+	}
+	if !runnerCfg.CausalGraphEnabled {
+		t.Fatalf("CausalGraphEnabled: got false, want true")
+	}
+	if runnerCfg.RolloutDir != "/tmp/from-config-rollouts" {
+		t.Fatalf("RolloutDir: got %q", runnerCfg.RolloutDir)
+	}
+	if runnerCfg.AskUserBroker != broker {
+		t.Fatalf("AskUserBroker: did not preserve injected broker")
+	}
+	if runnerCfg.ToolApprovalMode != harness.ToolApprovalModePermissions {
+		t.Fatalf("ToolApprovalMode: got %q", runnerCfg.ToolApprovalMode)
+	}
+	if runnerCfg.Logger != logger {
+		t.Fatalf("Logger: did not preserve injected logger")
+	}
+	if runnerCfg.Activations != activations {
+		t.Fatalf("Activations: did not preserve injected tracker")
+	}
+	if runnerCfg.RoleModels != roleModels {
+		t.Fatalf("RoleModels: got %#v", runnerCfg.RoleModels)
+	}
+	if len(runnerCfg.GlobalMCPServerNames) != len(serverNames) {
+		t.Fatalf("GlobalMCPServerNames length: got %d want %d", len(runnerCfg.GlobalMCPServerNames), len(serverNames))
+	}
+}
+
+func TestBuildRunnerConfigPrefersExplicitRuntimeOverrides(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		Forensics: config.ForensicsConfig{
+			RolloutDir: "/tmp/from-config-rollouts",
+		},
+	}
+
+	runnerCfg := buildRunnerConfig(cfg, runnerConfigInputs{
+		Model:        "gpt-4.1-mini",
+		SystemPrompt: "system",
+		MaxSteps:     8,
+		RolloutDir:   "/tmp/from-env-rollouts",
+	})
+
+	if runnerCfg.DefaultModel != "gpt-4.1-mini" {
+		t.Fatalf("DefaultModel: got %q", runnerCfg.DefaultModel)
+	}
+	if runnerCfg.DefaultSystemPrompt != "system" {
+		t.Fatalf("DefaultSystemPrompt: got %q", runnerCfg.DefaultSystemPrompt)
+	}
+	if runnerCfg.MaxSteps != 8 {
+		t.Fatalf("MaxSteps: got %d", runnerCfg.MaxSteps)
+	}
+	if runnerCfg.RolloutDir != "/tmp/from-env-rollouts" {
+		t.Fatalf("RolloutDir: got %q", runnerCfg.RolloutDir)
+	}
+}
+
 func TestRunDelegatesToRunWithSignals(t *testing.T) {
 	orig := runWithSignalsFunc
 	defer func() { runWithSignalsFunc = orig }()

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -19,6 +19,21 @@
   - green phase:
     - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
 
+## 2026-03-25 (Issue #421 Config Runtime Contract)
+
+- Claimed GitHub issue `#421` and created dedicated worktree branch `codex/issue-421-config-contract`.
+- Added focused projection coverage in `cmd/harnessd/main_test.go` to pin:
+  - merged `auto_compact` runtime mapping
+  - merged `forensics` runtime mapping, including rollout directory fallback
+  - explicit runtime override precedence for rollout directory
+- Refactored `cmd/harnessd/main.go` to route runner assembly through `buildRunnerConfig(...)` so merged `config.Config` is the authoritative source for supported runtime fields.
+- Verification:
+  - baseline: `go test ./cmd/harnessd ./internal/config`
+  - red: `go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Ma|Pr)'` failed before implementation because the projection helper did not exist
+  - green: `go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Ma|Pr)'`
+  - green: `go test ./cmd/harnessd ./internal/config`
+  - repo regression suite: `./scripts/test-regression.sh` still fails in this sandbox for unrelated transcript-export tests that write outside the workspace (`cmd/harnesscli/tui` and `cmd/harnesscli/tui/components/transcriptexport`)
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -36,6 +36,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
   - Whether other `ForkResult` consumers outside this issue already normalize `result.Error` consistently enough or should be audited in a later pass.
 - Next verification step: run the focused package suite, then the repo regression gate, then open a PR and verify CI completes cleanly.
 
+## 2026-03-25 (Issue #421 Config Runtime Contract)
+
+- Command intent: Take issue `#421` from backlog to merge by making merged `config.Config` the authoritative source for runtime `harness.RunnerConfig` wiring.
+- User intent: Close one backlog item end to end with strict TDD, clear issue/PR communication, and a mergeable PR with clean CI.
+- Success definition:
+  - `cmd/harnessd` uses one focused projection path to map merged config into runner runtime settings.
+  - Supported `auto_compact` and `forensics` fields stop being silently ignored at runtime.
+  - Focused regression tests fail before the fix and pass after it.
+  - Relevant package tests pass locally, PR is opened, and CI is green so the branch is mergeable.
+- Non-goals:
+  - Broad bootstrap modularization.
+  - New config features or API changes.
+  - Refactoring unrelated startup logic.
+- Guardrails/constraints:
+  - Strict TDD with failing tests first.
+  - Keep config/env precedence unchanged.
+  - Do not fix unrelated failing tests unless they block this issue directly.
+- Open questions:
+  - Whether any currently declared config fields should remain intentionally unsupported after the mapping helper lands.
+- Next verification step: add failing projection tests in `cmd/harnessd/main_test.go`, implement the smallest mapping helper, then rerun targeted packages and the regression gate.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-421-config-runtime-contract-plan.md
+++ b/docs/plans/2026-03-25-issue-421-config-runtime-contract-plan.md
@@ -1,0 +1,59 @@
+# Plan: Issue 421 Config Runtime Contract
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` only projects part of the merged `config.Config` into `harness.RunnerConfig`, so declared `auto_compact` and `forensics` settings can merge correctly but never affect the live runner.
+- User impact: operators can believe runtime controls are active when the harness silently ignores them, and future config growth risks more drift.
+- Constraints: keep the change narrow, preserve config/env precedence, use strict TDD, and avoid unrelated bootstrap refactors.
+
+## Scope
+
+- In scope:
+  - Add failing tests for config-to-runner projection in `cmd/harnessd/main_test.go`.
+  - Introduce one focused helper for projecting merged config into `harness.RunnerConfig`.
+  - Wire the currently supported `auto_compact` and `forensics` fields deliberately.
+  - Update docs/logs/indexes required by the repo process.
+- Out of scope:
+  - Broad `harnessd` bootstrap decomposition.
+  - Changing runner semantics beyond honoring already-declared config.
+  - New config fields or API shape changes.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - projection copies `auto_compact.enabled/mode/threshold/keep_last/model_context_window`
+  - projection copies core `forensics` runtime fields and rollout directory
+  - projection preserves explicit environment-derived runtime knobs alongside config-derived fields
+- Existing tests to update:
+  - `cmd/harnessd/main_test.go`
+- Regression tests required:
+  - `go test ./cmd/harnessd ./internal/config`
+  - relevant full-package regression after the fix lands
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- Create a one-page impact map from `IMPACT_MAP_TEMPLATE.md` covering:
+  - Config
+  - Server API
+  - TUI state
+  - Regression tests
+- A blank heading is a warning. Write `None` with rationale when a surface is truly unaffected.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: projecting fields incorrectly could change runtime behavior beyond the ignored-config bug.
+- Mitigation: pin the intended mapping in focused tests before introducing the helper, then keep the helper small and explicit.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -4,6 +4,7 @@
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
+- `2026-03-25-issue-421-config-runtime-contract-plan.md`: Active implementation plan for making merged harness config the authoritative runtime runner contract.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.


### PR DESCRIPTION
## Summary
- add focused `cmd/harnessd` regression tests for merged config to runner projection
- route runner assembly through a single `buildRunnerConfig(...)` helper
- make merged `auto_compact` and supported `forensics` settings flow into `harness.RunnerConfig`, including rollout-dir fallback

## Testing
- `go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Ma|Pr)'`
- `go test ./cmd/harnessd ./internal/config`
- `./scripts/test-regression.sh` started in tmux; non-race phase completed locally, while the race phase stalled in this sandbox after only linker warnings, so GitHub CI is the final mergeability check

## Issue
- Closes #421