### PR TITLE
Make merged harness config authoritative at runtime

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -74,6 +74,74 @@ type runDeps struct {
 	newConversationCleaner func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter
 }
 
+type runnerConfigOptions struct {
+	DefaultSystemPrompt  string
+	DefaultAgentIntent   string
+	AskUserTimeout       time.Duration
+	AskUserBroker        htools.AskUserQuestionBroker
+	MemoryManager        om.Manager
+	PromptEngine         systemprompt.Engine
+	ToolApprovalMode     harness.ToolApprovalMode
+	ProviderRegistry     *catalog.ProviderRegistry
+	ConversationStore    harness.ConversationStore
+	Store                istore.Store
+	Logger               harness.Logger
+	Activations          *harness.ActivationTracker
+	GlobalMCPRegistry    htools.MCPRegistry
+	GlobalMCPServerNames []string
+	RoleModels           harness.RoleModels
+	RolloutDirOverride   string
+}
+
+// buildRunnerConfig keeps config-driven runner behavior in one place so the
+// merged harness config is the authoritative runtime contract for harnessd.
+func buildRunnerConfig(harnessCfg config.Config, opts runnerConfigOptions) harness.RunnerConfig {
+	rolloutDir := strings.TrimSpace(opts.RolloutDirOverride)
+	if rolloutDir == "" {
+		rolloutDir = strings.TrimSpace(harnessCfg.Forensics.RolloutDir)
+	}
+
+	return harness.RunnerConfig{
+		DefaultModel:                  harnessCfg.Model,
+		DefaultSystemPrompt:           opts.DefaultSystemPrompt,
+		DefaultAgentIntent:            opts.DefaultAgentIntent,
+		MaxSteps:                      harnessCfg.MaxSteps,
+		AskUserTimeout:                opts.AskUserTimeout,
+		AskUserBroker:                 opts.AskUserBroker,
+		MemoryManager:                 opts.MemoryManager,
+		PromptEngine:                  opts.PromptEngine,
+		ToolApprovalMode:              opts.ToolApprovalMode,
+		ProviderRegistry:              opts.ProviderRegistry,
+		ConversationStore:             opts.ConversationStore,
+		Store:                         opts.Store,
+		Logger:                        opts.Logger,
+		Activations:                   opts.Activations,
+		RolloutDir:                    rolloutDir,
+		RoleModels:                    opts.RoleModels,
+		GlobalMCPRegistry:             opts.GlobalMCPRegistry,
+		GlobalMCPServerNames:          opts.GlobalMCPServerNames,
+		AutoCompactEnabled:            harnessCfg.AutoCompact.Enabled,
+		AutoCompactMode:               harnessCfg.AutoCompact.Mode,
+		AutoCompactThreshold:          harnessCfg.AutoCompact.Threshold,
+		AutoCompactKeepLast:           harnessCfg.AutoCompact.KeepLast,
+		ModelContextWindow:            harnessCfg.AutoCompact.ModelContextWindow,
+		TraceToolDecisions:            harnessCfg.Forensics.TraceToolDecisions,
+		DetectAntiPatterns:            harnessCfg.Forensics.DetectAntiPatterns,
+		TraceHookMutations:            harnessCfg.Forensics.TraceHookMutations,
+		CaptureRequestEnvelope:        harnessCfg.Forensics.CaptureRequestEnvelope,
+		SnapshotMemorySnippet:         harnessCfg.Forensics.SnapshotMemorySnippet,
+		ErrorChainEnabled:             harnessCfg.Forensics.ErrorChainEnabled,
+		ErrorContextDepth:             harnessCfg.Forensics.ErrorContextDepth,
+		CaptureReasoning:              harnessCfg.Forensics.CaptureReasoning,
+		CostAnomalyDetectionEnabled:   harnessCfg.Forensics.CostAnomalyDetectionEnabled,
+		CostAnomalyStepMultiplier:     harnessCfg.Forensics.CostAnomalyStepMultiplier,
+		AuditTrailEnabled:             harnessCfg.Forensics.AuditTrailEnabled,
+		ContextWindowSnapshotEnabled:  harnessCfg.Forensics.ContextWindowSnapshotEnabled,
+		ContextWindowWarningThreshold: harnessCfg.Forensics.ContextWindowWarningThreshold,
+		CausalGraphEnabled:            harnessCfg.Forensics.CausalGraphEnabled,
+	}
+}
+
 // profileFlag is the --profile CLI flag. Registered at package level so it
 // integrates cleanly with Go's test infrastructure flags.
 var profileFlag = flag.String("profile", "", "named profile to load from ~/.harness/profiles/<name>.toml")
@@ -210,6 +278,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	if maxSteps == 0 && getenv("HARNESS_MAX_STEPS") == "" {
 		maxSteps = 8
 	}
+	harnessCfg.MaxSteps = maxSteps
 
 	defaultSystemPrompt := "You are a practical coding assistant. Prefer using tools for file inspection and tests when needed."
 	if startupProfile != nil {
@@ -302,6 +371,9 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	sourcegraphEndpoint := strings.TrimSpace(getenv("HARNESS_SOURCEGRAPH_ENDPOINT"))
 	sourcegraphToken := strings.TrimSpace(getenv("HARNESS_SOURCEGRAPH_TOKEN"))
 	rolloutDir := strings.TrimSpace(getenv("HARNESS_ROLLOUT_DIR"))
+	if rolloutDir != "" {
+		harnessCfg.Forensics.RolloutDir = rolloutDir
+	}
 
 	var providerRegistry *catalog.ProviderRegistry
 	var modelCatalog *catalog.Catalog
@@ -611,11 +683,9 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	if rolloutDir != "" {
 		log.Printf("rollout recording enabled: %s", rolloutDir)
 	}
-	runnerCfg := harness.RunnerConfig{
-		DefaultModel:         model,
+	runnerCfg := buildRunnerConfig(harnessCfg, runnerConfigOptions{
 		DefaultSystemPrompt:  systemPrompt,
 		DefaultAgentIntent:   defaultAgentIntent,
-		MaxSteps:             maxSteps,
 		AskUserTimeout:       time.Duration(askUserTimeoutSeconds) * time.Second,
 		AskUserBroker:        askUserBroker,
 		MemoryManager:        memoryManager,
@@ -626,14 +696,14 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		Store:                runStore,
 		Logger:               &stdLogger{},
 		Activations:          activations,
-		RolloutDir:           rolloutDir,
 		GlobalMCPRegistry:    mcpRegistry,
 		GlobalMCPServerNames: mcpManager.ListServers(),
 		RoleModels: harness.RoleModels{
 			Primary:    strings.TrimSpace(getenv("HARNESS_ROLE_MODEL_PRIMARY")),
 			Summarizer: strings.TrimSpace(getenv("HARNESS_ROLE_MODEL_SUMMARIZER")),
 		},
-	}
+		RolloutDirOverride: rolloutDir,
+	})
 
 	// S3 backup: wire uploader when all required env vars are present.
 	if s3cfg, ok := s3backup.ConfigFromEnv(getenv); ok {

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -25,6 +25,7 @@ import (
 	"go-agent-harness/internal/provider/catalog"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/skills"
+	"go-agent-harness/internal/systemprompt"
 )
 
 type noopProvider struct{}
@@ -83,6 +84,16 @@ func (c *recordingConversationCleaner) Start(ctx context.Context, _ time.Duratio
 		<-ctx.Done()
 		close(c.done)
 	}()
+}
+
+type stubPromptEngine struct{}
+
+func (stubPromptEngine) Resolve(systemprompt.ResolveRequest) (systemprompt.ResolvedPrompt, error) {
+	return systemprompt.ResolvedPrompt{StaticPrompt: "static prompt"}, nil
+}
+
+func (stubPromptEngine) RuntimeContext(systemprompt.RuntimeContextInput) string {
+	return "runtime context"
 }
 
 func TestMainDoesNotExitWhenRunSucceeds(t *testing.T) {
@@ -364,6 +375,197 @@ func TestApplyProfileDefaultsAppliesProfileThenEnvOverrides(t *testing.T) {
 	}
 	if got.Cost.MaxPerRunUSD != 1.5 {
 		t.Fatalf("MaxPerRunUSD: got %v", got.Cost.MaxPerRunUSD)
+	}
+}
+
+func TestBuildRunnerConfigProjectsAutoCompactAndForensics(t *testing.T) {
+	t.Parallel()
+
+	askUserBroker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
+	memoryManager, err := newObservationalMemoryManager(observationalMemoryManagerOptions{Mode: om.ModeOff})
+	if err != nil {
+		t.Fatalf("newObservationalMemoryManager: %v", err)
+	}
+	cfg := config.Defaults()
+	cfg.Model = "runtime-model"
+	cfg.MaxSteps = 24
+	cfg.Cost.MaxPerRunUSD = 3.5
+	cfg.Memory.Enabled = true
+	cfg.AutoCompact = config.AutoCompactConfig{
+		Enabled:            true,
+		Mode:               "summarize",
+		Threshold:          0.72,
+		KeepLast:           5,
+		ModelContextWindow: 64000,
+	}
+	cfg.Forensics = config.ForensicsConfig{
+		TraceToolDecisions:            true,
+		DetectAntiPatterns:            true,
+		TraceHookMutations:            true,
+		CaptureRequestEnvelope:        true,
+		SnapshotMemorySnippet:         true,
+		ErrorChainEnabled:             true,
+		ErrorContextDepth:             14,
+		CaptureReasoning:              true,
+		CostAnomalyDetectionEnabled:   true,
+		CostAnomalyStepMultiplier:     4.25,
+		AuditTrailEnabled:             true,
+		ContextWindowSnapshotEnabled:  true,
+		ContextWindowWarningThreshold: 0.61,
+		CausalGraphEnabled:            true,
+		RolloutDir:                    "/tmp/config-rollouts",
+	}
+
+	got := buildRunnerConfig(cfg, runnerConfigOptions{
+		DefaultSystemPrompt: "system prompt",
+		DefaultAgentIntent:  "general",
+		AskUserTimeout:      45 * time.Second,
+		AskUserBroker:       askUserBroker,
+		MemoryManager:       memoryManager,
+		PromptEngine:        stubPromptEngine{},
+		ToolApprovalMode:    harness.ToolApprovalModePermissions,
+		Logger:              &stdLogger{},
+		GlobalMCPServerNames: []string{
+			"global-a",
+			"global-b",
+		},
+		RoleModels: harness.RoleModels{
+			Primary:    "primary-role",
+			Summarizer: "summary-role",
+		},
+	})
+
+	if got.DefaultModel != "runtime-model" {
+		t.Fatalf("DefaultModel: got %q", got.DefaultModel)
+	}
+	if got.MaxSteps != 24 {
+		t.Fatalf("MaxSteps: got %d", got.MaxSteps)
+	}
+	if got.MemoryManager == nil {
+		t.Fatal("expected MemoryManager to be preserved")
+	}
+	if !got.AutoCompactEnabled {
+		t.Fatal("expected AutoCompactEnabled")
+	}
+	if got.AutoCompactMode != "summarize" {
+		t.Fatalf("AutoCompactMode: got %q", got.AutoCompactMode)
+	}
+	if got.AutoCompactThreshold != 0.72 {
+		t.Fatalf("AutoCompactThreshold: got %v", got.AutoCompactThreshold)
+	}
+	if got.AutoCompactKeepLast != 5 {
+		t.Fatalf("AutoCompactKeepLast: got %d", got.AutoCompactKeepLast)
+	}
+	if got.ModelContextWindow != 64000 {
+		t.Fatalf("ModelContextWindow: got %d", got.ModelContextWindow)
+	}
+	if !got.TraceToolDecisions || !got.DetectAntiPatterns || !got.TraceHookMutations {
+		t.Fatal("expected tool-decision forensics flags to project")
+	}
+	if !got.CaptureRequestEnvelope || !got.SnapshotMemorySnippet {
+		t.Fatal("expected request-envelope forensics flags to project")
+	}
+	if !got.ErrorChainEnabled {
+		t.Fatal("expected ErrorChainEnabled")
+	}
+	if got.ErrorContextDepth != 14 {
+		t.Fatalf("ErrorContextDepth: got %d", got.ErrorContextDepth)
+	}
+	if !got.CaptureReasoning {
+		t.Fatal("expected CaptureReasoning")
+	}
+	if !got.CostAnomalyDetectionEnabled {
+		t.Fatal("expected CostAnomalyDetectionEnabled")
+	}
+	if got.CostAnomalyStepMultiplier != 4.25 {
+		t.Fatalf("CostAnomalyStepMultiplier: got %v", got.CostAnomalyStepMultiplier)
+	}
+	if !got.AuditTrailEnabled {
+		t.Fatal("expected AuditTrailEnabled")
+	}
+	if !got.ContextWindowSnapshotEnabled {
+		t.Fatal("expected ContextWindowSnapshotEnabled")
+	}
+	if got.ContextWindowWarningThreshold != 0.61 {
+		t.Fatalf("ContextWindowWarningThreshold: got %v", got.ContextWindowWarningThreshold)
+	}
+	if !got.CausalGraphEnabled {
+		t.Fatal("expected CausalGraphEnabled")
+	}
+	if got.RolloutDir != "/tmp/config-rollouts" {
+		t.Fatalf("RolloutDir: got %q", got.RolloutDir)
+	}
+}
+
+func TestBuildRunnerConfigPreservesExistingRuntimeDependencies(t *testing.T) {
+	t.Parallel()
+
+	askUserBroker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
+	memoryManager, err := newObservationalMemoryManager(observationalMemoryManagerOptions{Mode: om.ModeOff})
+	if err != nil {
+		t.Fatalf("newObservationalMemoryManager: %v", err)
+	}
+	promptEngine := stubPromptEngine{}
+	providerRegistry := catalog.NewProviderRegistryWithEnv(&catalog.Catalog{
+		CatalogVersion: "1.0.0",
+		Providers:      map[string]catalog.ProviderEntry{},
+	}, func(string) string { return "" })
+
+	got := buildRunnerConfig(config.Config{
+		Model:    "config-model",
+		MaxSteps: 8,
+	}, runnerConfigOptions{
+		DefaultSystemPrompt: "system prompt",
+		DefaultAgentIntent:  "debug",
+		AskUserTimeout:      2 * time.Minute,
+		AskUserBroker:       askUserBroker,
+		MemoryManager:       memoryManager,
+		PromptEngine:        promptEngine,
+		ToolApprovalMode:    harness.ToolApprovalModePermissions,
+		ProviderRegistry:    providerRegistry,
+		Logger:              &stdLogger{},
+		GlobalMCPServerNames: []string{
+			"server-1",
+		},
+		RoleModels: harness.RoleModels{
+			Primary:    "role-primary",
+			Summarizer: "role-summarizer",
+		},
+		RolloutDirOverride: "/tmp/override-rollouts",
+	})
+
+	if got.DefaultSystemPrompt != "system prompt" {
+		t.Fatalf("DefaultSystemPrompt: got %q", got.DefaultSystemPrompt)
+	}
+	if got.DefaultAgentIntent != "debug" {
+		t.Fatalf("DefaultAgentIntent: got %q", got.DefaultAgentIntent)
+	}
+	if got.AskUserTimeout != 2*time.Minute {
+		t.Fatalf("AskUserTimeout: got %v", got.AskUserTimeout)
+	}
+	if got.AskUserBroker != askUserBroker {
+		t.Fatal("expected AskUserBroker to be preserved")
+	}
+	if got.MemoryManager != memoryManager {
+		t.Fatal("expected MemoryManager to be preserved")
+	}
+	if got.PromptEngine != promptEngine {
+		t.Fatal("expected PromptEngine to be preserved")
+	}
+	if got.ToolApprovalMode != harness.ToolApprovalModePermissions {
+		t.Fatalf("ToolApprovalMode: got %q", got.ToolApprovalMode)
+	}
+	if got.ProviderRegistry != providerRegistry {
+		t.Fatal("expected ProviderRegistry to be preserved")
+	}
+	if got.RoleModels.Primary != "role-primary" || got.RoleModels.Summarizer != "role-summarizer" {
+		t.Fatalf("RoleModels: got %+v", got.RoleModels)
+	}
+	if got.RolloutDir != "/tmp/override-rollouts" {
+		t.Fatalf("RolloutDir override: got %q", got.RolloutDir)
+	}
+	if len(got.GlobalMCPServerNames) != 1 || got.GlobalMCPServerNames[0] != "server-1" {
+		t.Fatalf("GlobalMCPServerNames: got %+v", got.GlobalMCPServerNames)
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -39,6 +39,7 @@
     - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/server ./internal/harness/tools ./internal/harness/tools/core -run 'TestAgentsEndpoint_SkillForkResultErrorReturns500|TestFlatSkillForkForkedAgentRunnerResultError|TestSkillTool_Handler_ForkResultError'`
 ## 2026-03-25 (Issue #431 Startup Cleaner Cancellation)
 
+<<<<<<< HEAD
 - Reproduced the `go vet` startup-leak warning in `cmd/harnessd/main.go` where `convCleanerCancel` was only reached from the normal shutdown path after the conversation cleaner had already been started.
 - Added a deterministic regression seam in `cmd/harnessd/main.go` so tests can supply a fake conversation cleaner without mutating package globals across parallel test runs.
 - Added `TestStartupFailureCancelsConversationCleaner` in `cmd/harnessd/main_test.go`:
@@ -60,7 +61,31 @@
   - `go test ./internal/training -count=1`
   - `go test ./cmd/harnesscli/tui -run TestNewEmptyCommandRegistryStartsEmpty -count=1`
   - `go test ./cmd/harnesscli/tui/components/tooluse -run TestNewInitializesIdentityFields -count=1`
-  - `go test ./internal/profiles -run TestListProfileSummariesPrefersHigherPriorityDirs -count=1`
+- `go test ./internal/profiles -run TestListProfileSummariesPrefersHigherPriorityDirs -count=1`
+
+## 2026-03-25 (Issue #421 Config Runtime Contract)
+
+- Centralized `cmd/harnessd` runner wiring behind `buildRunnerConfig(...)` so merged `config.Config` is the authoritative source for projected runner behavior instead of scattered field assignment in `runWithSignals(...)`.
+- Projected the full currently-supported `auto_compact` and `forensics` surfaces into `harness.RunnerConfig`, including:
+  - `enabled`, `mode`, `threshold`, `keep_last`, `model_context_window`
+  - `trace_tool_decisions`, `detect_anti_patterns`, `trace_hook_mutations`
+  - `capture_request_envelope`, `snapshot_memory_snippet`
+  - `error_chain_enabled`, `error_context_depth`, `capture_reasoning`
+  - `cost_anomaly_detection_enabled`, `cost_anomaly_step_multiplier`
+  - `audit_trail_enabled`, `context_window_snapshot_enabled`, `context_window_warning_threshold`, `causal_graph_enabled`, `rollout_dir`
+- Preserved the existing runtime-only dependencies and behavior around prompt engine, ask-user broker, role models, MCP registry wiring, and the legacy rollout-dir env override by folding that override back into the resolved config before building `RunnerConfig`.
+- Added failing-first regression coverage in `cmd/harnessd/main_test.go` for:
+  - projection of all supported `auto_compact` and `forensics` fields
+  - preservation of existing runtime dependencies when using the new builder seam
+- Verification:
+  - Baseline before edits: `go test ./cmd/harnessd ./internal/config`
+  - Red first: `go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Project|Preserves)' -count=1`
+  - Green after fix:
+    - `go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Project|Preserves)' -count=1`
+    - `go test ./cmd/harnessd -count=1`
+    - `go test ./internal/config -count=1`
+  - Repo regression gate: `./scripts/test-regression.sh` launched in `tmux` (`issue421-regression`); final status recorded after completion.
+
 ## 2026-03-25 (Harness Review Bug Tickets)
 
 - Reviewed the harness runtime and transport paths with focus on cancellation propagation, forked-run failure reporting, tool-allowlist integrity, and bootstrap cleanup.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -58,6 +58,49 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
   - Whether other `ForkResult` consumers outside this issue already normalize `result.Error` consistently enough or should be audited in a later pass.
 - Next verification step: run the focused package suite, then the repo regression gate, then open a PR and verify CI completes cleanly.
 
+## 2026-03-25 (Issue #421 Config Runtime Contract)
+
+- Command intent: Complete GitHub issue `#421` by making the merged harness config the authoritative runtime contract for `harnessd`, with failing-first projection tests and the required docs/log updates.
+- User intent: Close one scoped backlog issue end to end so operators can trust that merged config values, especially `auto_compact` and `forensics`, actually affect live runner behavior instead of being silently ignored.
+- Success definition:
+  - `cmd/harnessd` builds `harness.RunnerConfig` through one authoritative projection path instead of scattered field assignment.
+  - Focused tests fail first and then pass for the currently-supported `auto_compact` fields:
+    - `enabled`
+    - `mode`
+    - `threshold`
+    - `keep_last`
+    - `model_context_window`
+  - Focused tests fail first and then pass for the currently-supported `forensics` fields:
+    - `trace_tool_decisions`
+    - `detect_anti_patterns`
+    - `trace_hook_mutations`
+    - `capture_request_envelope`
+    - `snapshot_memory_snippet`
+    - `error_chain_enabled`
+    - `error_context_depth`
+    - `capture_reasoning`
+    - `cost_anomaly_detection_enabled`
+    - `cost_anomaly_step_multiplier`
+    - `audit_trail_enabled`
+    - `context_window_snapshot_enabled`
+    - `context_window_warning_threshold`
+    - `causal_graph_enabled`
+    - `rollout_dir`
+  - Existing `model`, `max_steps`, default prompt, and role-model behavior remain unchanged.
+  - The issue branch has a PR with passing required checks and no merge conflicts.
+- Non-goals:
+  - Broad `harnessd` bootstrap decomposition beyond what is needed to centralize runner-config projection.
+  - Changing config precedence rules or profile/env semantics.
+  - Fixing unrelated pre-existing regression/coverage failures outside this issue's scope.
+- Guardrails/constraints:
+  - Strict TDD: write failing tests first.
+  - Keep the fix narrow and centered on config-to-runtime projection.
+  - Preserve existing runtime behavior except where config values are currently ignored.
+  - Do not weaken the repo regression gate; solve mergeability without papering over unrelated debt.
+- Open questions:
+  - Whether any runner-config fields besides `auto_compact` and `forensics` should move into the shared projection helper in this pass for consistency.
+- Next verification step: add failing projection tests in `cmd/harnessd/main_test.go`, introduce the minimal shared builder/helper, run targeted package tests, then run `./scripts/test-regression.sh`.
+
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 
 - Command intent: Implement a backend model discovery layer with OpenRouter live discovery, TTL caching, static-overlay merge behavior, runtime routing support, `/v1/models` integration, tests, and docs.

--- a/docs/plans/2026-03-25-issue-421-config-contract-plan.md
+++ b/docs/plans/2026-03-25-issue-421-config-contract-plan.md
@@ -1,0 +1,65 @@
+# Plan: Issue #421 Config Runtime Contract
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` manually assembles `harness.RunnerConfig` and currently drops merged `auto_compact` and `forensics` values that already exist in `internal/config.Config`.
+- User impact: Operators can configure these surfaces successfully in TOML/env/profile layers and still get runtime behavior that silently ignores them.
+- Constraints:
+  - Strict TDD.
+  - Keep the change narrow and behavior-preserving outside the config drift.
+  - Do not weaken existing config precedence or merge semantics.
+
+## Scope
+
+- In scope:
+  - Add failing tests for config-to-`RunnerConfig` projection.
+  - Introduce one authoritative helper/builder for runner config assembly in `cmd/harnessd`.
+  - Wire all currently-supported `auto_compact` and `forensics` fields deliberately.
+  - Update plan/log/index docs required by repo workflow.
+- Out of scope:
+  - Large bootstrap decomposition in `cmd/harnessd`.
+  - New config fields or new runtime behavior outside projection correctness.
+  - Unrelated coverage-gate cleanup unless it directly blocks this issue’s mergeability.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - projection of `auto_compact` fields into `harness.RunnerConfig`
+  - projection of `forensics` fields into `harness.RunnerConfig`
+  - preservation of existing defaults/role-model behavior in the new helper
+- Existing tests to update:
+  - `cmd/harnessd/main_test.go`
+- Regression tests required:
+  - `go test ./cmd/harnessd`
+  - `go test ./internal/config`
+  - `./scripts/test-regression.sh`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- Create a one-page impact map from `IMPACT_MAP_TEMPLATE.md` covering:
+  - Config
+  - Server API
+  - TUI state
+  - Regression tests
+- A blank heading is a warning. Write `None` with rationale when a surface is truly unaffected.
+
+This task does not change provider/model flow behavior, so no separate impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: The helper accidentally changes unrelated startup defaults while centralizing config projection.
+- Mitigation: Keep the helper small, preserve existing call sites, and assert unchanged core fields in focused tests.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,6 +5,7 @@
 - `active-plan.md`: Current active plan tracker.
 - `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
+- `2026-03-25-issue-421-config-contract-plan.md`: Active plan for making merged harness config the authoritative runtime contract in `cmd/harnessd`.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.


### PR DESCRIPTION
## Summary
- centralize `cmd/harnessd` runner wiring behind a single `buildRunnerConfig(...)` path
- project the full supported `auto_compact` and `forensics` config surfaces into `harness.RunnerConfig`
- add failing-first regression tests that pin both config projection and preservation of existing runtime dependencies

## Testing
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./cmd/harnessd -run 'TestBuildRunnerConfig(Project|Preserves)' -count=1`
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./cmd/harnessd ./internal/config -count=1`
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp COVERPROFILE_PATH=$PWD/.tmp/issue-421-coverage.out ./scripts/test-regression.sh` launched in `tmux` (`issue421-regression`) for the full repo gate; local package phase is green and GitHub CI is the final mergeability signal due the macOS race-wrapper ambiguity

Closes #421