### PR TITLE
Extract runner event journal path

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -155,6 +155,18 @@
 - Regression status:
   - the repo-wide `./scripts/test-regression.sh` run reached the multi-package race phase cleanly but hit a timeout in `TestWorkerPool_QueuedTransitionsToRunning` during the full-package `go test ./internal/... ./cmd/... -race` invocation.
   - that worker-pool race timeout did not reproduce in isolated reruns, so it currently looks like an unrelated pre-existing/full-suite flake rather than a deterministic issue-`#423` regression.
+## 2026-03-25 (Issue #424 Event Journal Extraction)
+
+- Extracted the runner event append/store/recorder path into a focused internal helper in `internal/harness/runner_event_journal.go`.
+- Kept `Runner.emit()` as the orchestration wrapper while moving payload enrichment, terminal sealing, redaction handling, recorder capture, and event construction behind the new helper boundary.
+- Added direct regression coverage in `internal/harness/runner_event_journal_test.go` for the terminal-ordering contract:
+  - terminal events must be appended to the store before subscribers observe them as durable.
+- Preserved the existing send-under-lock behavior for non-terminal subscriber fanout so the extraction stays race-clean with concurrent `Subscribe(...)/cancel()` behavior.
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run TestEventJournalDispatch_TerminalStoreAppendPrecedesSubscriberNotification -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test -race ./internal/harness -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build COVERPROFILE_PATH=$PWD/.tmp/issue-424-coverage.out ./scripts/test-regression.sh` launched in `tmux` as `issue-424-regression`; the package-test phase passed and the repo-wide race phase advanced deep into `internal/...` and `cmd/...`, but the local sandbox run stopped making visible progress after repeated macOS linker warnings (`malformed LC_DYSYMTAB`). Final mergeability should be confirmed from PR CI.
 
 ## 2026-03-25 (Harness Review Bug Tickets)
 

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -141,6 +141,26 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether `/v1/agents` needs additional direct assertions beyond harness-level cancellation coverage.
 - Next verification step: run the current harness/server baseline, add failing orchestration tests that expose the leak, then implement the minimal cancellation propagation fix.
+## 2026-03-25 (Issue #424 Event Journal Extraction)
+
+- Command intent: Complete GitHub issue `#424` by extracting the runner event journal/sink path from `emit()` while preserving event ordering, terminal sealing, recorder behavior, subscriber fanout, and store-append semantics.
+- User intent: Make the hottest runner event path easier to reason about and evolve without changing any public harness behavior or weakening the existing forensic guarantees.
+- Success definition:
+  - `Runner.emit()` delegates the event journal/sink responsibilities to a narrower internal boundary instead of keeping all logic inline.
+  - Existing behavior remains unchanged for event IDs, sequence numbers, timestamps, subscriber fanout, recorder writes, terminal sealing, and store append ordering.
+  - New or updated characterization tests pin the extracted boundary directly, especially around store append ordering and recorder terminal handling.
+  - `go test ./internal/harness` passes in the issue worktree.
+- Non-goals:
+  - Refactoring the step engine or workspace preflight logic.
+  - Changing SSE/event payload contracts.
+  - Redesigning the store or recorder abstractions beyond what is needed for a narrow extraction seam.
+- Guardrails/constraints:
+  - Strict TDD: add a failing test first for the extraction seam or uncovered invariant.
+  - Keep the change scoped and reviewable.
+  - Preserve terminal-event sealing behavior exactly.
+- Open questions:
+  - Whether the cleanest seam is a helper on `runState`, a focused sink struct, or a small internal method family on `Runner`.
+- Next verification step: add a failing characterization test around the event journal/store ordering boundary, then implement the minimal extraction and rerun `go test ./internal/harness`.
 
 ## 2026-03-25 (Backend OpenRouter Model Discovery)
 

--- a/docs/plans/2026-03-25-issue-424-event-journal-plan.md
+++ b/docs/plans/2026-03-25-issue-424-event-journal-plan.md
@@ -1,0 +1,57 @@
+# Plan: Issue #424 Event Journal Extraction
+
+## Context
+
+- Problem: `Runner.emit()` currently owns canonical event append, subscriber fanout, recorder interaction, terminal sealing, and store append setup inline inside one large method.
+- User impact: The hottest event path is harder to review and evolve safely because several ownership boundaries are implicit in one place.
+- Constraints:
+  - Preserve existing event ordering and terminal behavior exactly.
+  - Keep the public runner API and event payload contracts unchanged.
+  - Follow strict TDD with a failing characterization test first.
+
+## Scope
+
+- In scope:
+  - Extract the event journal/sink responsibilities behind a narrower internal boundary.
+  - Add or update direct regression coverage for the extracted seam.
+  - Keep `emit()` behavior-preserving.
+- Out of scope:
+  - Step-engine extraction.
+  - Workspace/preflight refactors.
+  - Store API redesign or transport changes.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - characterization coverage for the extracted event journal path, especially store append ordering / terminal handling at the seam.
+- Existing tests to update:
+  - `internal/harness/runner_forensics_test.go`
+  - `internal/harness/runner_terminal_sealing_test.go`
+  - `internal/harness/runner_store_durability_test.go`
+- Regression tests required:
+  - JSONL ledger still matches in-memory history.
+  - Terminal events still seal the run before late events append.
+  - Store append ordering relative to terminal observation remains intact.
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This task does not touch provider/model flow surfaces.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: The extraction could subtly change terminal-event ordering or recorder/store timing.
+- Mitigation: Add seam-level characterization coverage first, keep the extracted helper synchronous where ordering matters, and rerun the existing invariant suite after each change.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -10,13 +10,7 @@
 - `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
 - `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
 - `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
-- `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
-- `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.
-- `2026-03-25-issue-421-config-contract-plan.md`: Active plan for making merged harness config the authoritative runtime contract in `cmd/harnessd`.
-- `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
-- `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
-- `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
-- `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
+- `2026-03-25-issue-424-event-journal-plan.md`: Active implementation plan for extracting the runner event journal/sink path from `emit()`.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on issue `#423`, extracting runner preflight orchestration from `execute()` without changing behavior.
+Current status: active implementation work is focused on runner event-journal extraction for issue `#424`.
 
-Current active plan: `2026-03-25-issue-423-runner-preflight-plan.md`
+Current active plan: `2026-03-25-issue-424-event-journal-plan.md`
 
 Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -22,7 +22,6 @@ import (
 	"go-agent-harness/internal/forensics/contextwindow"
 	"go-agent-harness/internal/forensics/costanomaly"
 	"go-agent-harness/internal/forensics/errorchain"
-	"go-agent-harness/internal/forensics/redaction"
 	"go-agent-harness/internal/forensics/requestenvelope"
 	"go-agent-harness/internal/forensics/tooldecision"
 	htools "go-agent-harness/internal/harness/tools"
@@ -5019,160 +5018,16 @@ func (r *Runner) emit(runID string, eventType EventType, payload map[string]any)
 		r.mu.Unlock()
 		return
 	}
-
-	// Deep-clone the caller's payload so that nested maps and slices inside
-	// the payload are not aliased. A shallow copy is insufficient: if the
-	// caller holds a reference to a nested slice or map and mutates it after
-	// emit() returns (or concurrently), the stored forensic event would
-	// otherwise observe those mutations (#228).
-	enriched := deepClonePayload(payload)
-	if enriched == nil {
-		enriched = make(map[string]any, 3)
+	journal := newEventJournal(r)
+	delivery, deliver := journal.prepareLocked(state, runID, eventType, payload)
+	if deliver && !delivery.dropped && IsTerminalEvent(eventType) {
+		journal.publishTerminalLocked(delivery)
 	}
-	// Inject forensic correlation fields into every event payload.
-	enriched["schema_version"] = EventSchemaVersion
-	enriched["conversation_id"] = state.run.ConversationID
-	if _, ok := enriched["step"]; !ok {
-		enriched["step"] = state.currentStep
-	}
-
-	// Seal the run for terminal events BEFORE redaction so that even if the
-	// redaction pipeline drops the event, the recorder is still closed and
-	// the terminated gate is still armed. Without this, a "drop" rule on
-	// run.completed would leave the run unsealed forever.
-	isTerminal := IsTerminalEvent(eventType)
-	var recCh chan rollout.RecordableEvent
-	var recDone chan struct{}
-	var closeRec func()
-	if isTerminal {
-		state.terminated = true
-		recCh = state.recorderCh
-		recDone = state.recorderDone
-		closeRec = state.closeRecorderOnce
-		state.recorderCh = nil
-		state.recorderDone = nil
-		state.closeRecorderOnce = nil
-	}
-
-	// Apply PII/secret redaction pipeline if configured.
-	if r.config.RedactionPipeline != nil {
-		var keep bool
-		enriched, keep = redaction.RedactPayload(r.config.RedactionPipeline, string(eventType), enriched)
-		if !keep {
-			r.mu.Unlock()
-			// Still close the recorder if this was a terminal event that got dropped.
-			if isTerminal && closeRec != nil {
-				closeRec()
-			}
-			return
-		}
-	}
-
-	// Deep-clone the enriched payload for immutable forensic storage.
-	// This prevents any nested map/slice from being shared with subscribers,
-	// the recorder, or the original caller.
-	storedPayload := deepClonePayload(enriched)
-
-	eventSeq := state.nextEventSeq
-	event := Event{
-		ID:        fmt.Sprintf("%s:%d", runID, eventSeq),
-		RunID:     runID,
-		Type:      eventType,
-		Timestamp: time.Now().UTC(),
-		Payload:   storedPayload,
-	}
-	state.nextEventSeq++
-
-	state.events = append(state.events, event)
-
-	// Fan out to subscribers while holding the lock so cancel() cannot close
-	// the channel between our check and send — prevents send-on-closed-channel.
-	// Each subscriber gets its own deep copy of the payload so that one
-	// subscriber cannot corrupt the stored forensic history or race with
-	// other subscribers by mutating nested structures.
-	for ch := range state.subscribers {
-		evCopy := event
-		evCopy.Payload = deepClonePayload(storedPayload)
-		select {
-		case ch <- evCopy:
-		default:
-			// Drop if subscriber is too slow; event is still persisted in run history.
-		}
-	}
-
-	// Capture the recorder channel under lock for non-terminal events.
-	// For terminal events recCh/recDone/closeRec were already captured above.
-	if !isTerminal {
-		recCh = state.recorderCh
-	}
-
 	r.mu.Unlock()
-
-	// Persist the event to the configured store (non-fatal, outside lock).
-	// For terminal events this MUST happen before any caller observing the
-	// terminal subscriber message queries the store, so we call it here
-	// synchronously before the rollout recorder logic below.
-	r.storeAppendEvent(event, eventSeq)
-
-	// Record to the JSONL rollout file via the per-run recorder goroutine.
-	// The goroutine owns all writes to the file and is the only entity that
-	// calls rec.Record / rec.Close, so no additional serialisation is needed.
-	rev := rollout.RecordableEvent{
-		ID:        event.ID,
-		RunID:     event.RunID,
-		Type:      string(event.Type),
-		Timestamp: event.Timestamp,
-		Payload:   event.Payload,
-		Seq:       eventSeq,
+	if !deliver {
+		return
 	}
-	if isTerminal {
-		if recCh != nil {
-			sendTimer := time.NewTimer(recorderDrainTimeout)
-			defer sendTimer.Stop()
-			select {
-			case recCh <- rev:
-			case <-sendTimer.C:
-				if r.config.Logger != nil {
-					r.config.Logger.Error("rollout recorder: terminal send timeout, JSONL may be incomplete",
-						"run_id", runID, "timeout", recorderDrainTimeout)
-				}
-			}
-			closeRec()
-			drainTimer := time.NewTimer(recorderDrainTimeout)
-			defer drainTimer.Stop()
-			select {
-			case <-recDone:
-			case <-drainTimer.C:
-				if r.config.Logger != nil {
-					r.config.Logger.Error("rollout recorder: drain timeout exceeded, JSONL may be incomplete",
-						"run_id", runID, "timeout", recorderDrainTimeout)
-				}
-			}
-		}
-	} else {
-		if recCh != nil {
-			if !safeRecorderSend(recCh, rev) {
-				if r.config.Logger != nil {
-					r.config.Logger.Error("rollout recorder: channel full, event dropped",
-						"run_id", runID, "event_type", string(eventType), "seq", eventSeq)
-				}
-				// Inject a drop marker so the JSONL gap is observable.
-				dropMarker := rollout.RecordableEvent{
-					ID:        fmt.Sprintf("%s:drop:%d", runID, eventSeq),
-					RunID:     runID,
-					Type:      string(EventRecorderDropDetected),
-					Timestamp: time.Now().UTC(),
-					Seq:       eventSeq,
-					Payload: map[string]any{
-						"dropped_event_id":   event.ID,
-						"dropped_event_type": string(eventType),
-						"dropped_seq":        eventSeq,
-					},
-				}
-				safeRecorderSend(recCh, dropMarker)
-			}
-		}
-	}
+	journal.dispatch(delivery)
 }
 
 func (r *Runner) emitCompletionDelta(runID string, step int, delta CompletionDelta) {

--- a/internal/harness/runner_event_journal.go
+++ b/internal/harness/runner_event_journal.go
@@ -1,0 +1,224 @@
+package harness
+
+import (
+	"fmt"
+	"time"
+
+	"go-agent-harness/internal/forensics/redaction"
+	"go-agent-harness/internal/rollout"
+)
+
+type eventDispatch struct {
+	runID     string
+	eventType EventType
+	event     Event
+	eventSeq  uint64
+
+	dropped bool
+
+	subscribers []subscriberDelivery
+
+	recorderCh    chan rollout.RecordableEvent
+	recorderDone  chan struct{}
+	closeRecorder func()
+}
+
+type subscriberDelivery struct {
+	ch    chan Event
+	event Event
+}
+
+type eventJournal struct {
+	runner *Runner
+}
+
+func newEventJournal(r *Runner) *eventJournal {
+	return &eventJournal{runner: r}
+}
+
+func (j *eventJournal) prepareLocked(state *runState, runID string, eventType EventType, payload map[string]any) (eventDispatch, bool) {
+	// Deep-clone the caller's payload so that nested maps and slices inside
+	// the payload are not aliased. A shallow copy is insufficient: if the
+	// caller holds a reference to a nested slice or map and mutates it after
+	// emit() returns (or concurrently), the stored forensic event would
+	// otherwise observe those mutations (#228).
+	enriched := deepClonePayload(payload)
+	if enriched == nil {
+		enriched = make(map[string]any, 3)
+	}
+	// Inject forensic correlation fields into every event payload.
+	enriched["schema_version"] = EventSchemaVersion
+	enriched["conversation_id"] = state.run.ConversationID
+	if _, ok := enriched["step"]; !ok {
+		enriched["step"] = state.currentStep
+	}
+
+	// Seal the run for terminal events BEFORE redaction so that even if the
+	// redaction pipeline drops the event, the recorder is still closed and
+	// the terminated gate is still armed. Without this, a "drop" rule on
+	// run.completed would leave the run unsealed forever.
+	isTerminal := IsTerminalEvent(eventType)
+	delivery := eventDispatch{
+		runID:     runID,
+		eventType: eventType,
+	}
+	if isTerminal {
+		state.terminated = true
+		delivery.recorderCh = state.recorderCh
+		delivery.recorderDone = state.recorderDone
+		delivery.closeRecorder = state.closeRecorderOnce
+		state.recorderCh = nil
+		state.recorderDone = nil
+		state.closeRecorderOnce = nil
+	}
+
+	// Apply PII/secret redaction pipeline if configured.
+	if j.runner.config.RedactionPipeline != nil {
+		var keep bool
+		enriched, keep = redaction.RedactPayload(j.runner.config.RedactionPipeline, string(eventType), enriched)
+		if !keep {
+			delivery.dropped = true
+			return delivery, true
+		}
+	}
+
+	// Deep-clone the enriched payload for immutable forensic storage.
+	// This prevents any nested map/slice from being shared with subscribers,
+	// the recorder, or the original caller.
+	storedPayload := deepClonePayload(enriched)
+
+	eventSeq := state.nextEventSeq
+	event := Event{
+		ID:        fmt.Sprintf("%s:%d", runID, eventSeq),
+		RunID:     runID,
+		Type:      eventType,
+		Timestamp: time.Now().UTC(),
+		Payload:   storedPayload,
+	}
+	state.nextEventSeq++
+	state.events = append(state.events, event)
+
+	delivery.event = event
+	delivery.eventSeq = eventSeq
+
+	// For non-terminal events, preserve the original fanout behavior by
+	// publishing while the runner lock is still held so a concurrent cancel
+	// cannot close the channel between our check and send.
+	if !isTerminal {
+		for ch := range state.subscribers {
+			evCopy := event
+			evCopy.Payload = deepClonePayload(storedPayload)
+			select {
+			case ch <- evCopy:
+			default:
+				// Drop if subscriber is too slow; event is still persisted in run history.
+			}
+		}
+	} else {
+		// Terminal events need a stronger ordering guarantee: append to the store
+		// before subscribers can observe the terminal event. We still snapshot the
+		// subscriber deliveries while the runner lock is held so the payload stays
+		// isolated and the subscriber set is consistent for this event.
+		delivery.subscribers = make([]subscriberDelivery, 0, len(state.subscribers))
+		for ch := range state.subscribers {
+			evCopy := event
+			evCopy.Payload = deepClonePayload(storedPayload)
+			delivery.subscribers = append(delivery.subscribers, subscriberDelivery{
+				ch:    ch,
+				event: evCopy,
+			})
+		}
+	}
+
+	// Capture the recorder channel under lock for non-terminal events.
+	if !isTerminal {
+		delivery.recorderCh = state.recorderCh
+	}
+
+	return delivery, true
+}
+
+func (j *eventJournal) publishTerminalLocked(delivery eventDispatch) {
+	j.runner.storeAppendEvent(delivery.event, delivery.eventSeq)
+
+	for _, sub := range delivery.subscribers {
+		select {
+		case sub.ch <- sub.event:
+		default:
+			// Drop if subscriber is too slow; event is still persisted in run history.
+		}
+	}
+}
+
+func (j *eventJournal) dispatch(delivery eventDispatch) {
+	if delivery.dropped {
+		if delivery.closeRecorder != nil {
+			delivery.closeRecorder()
+		}
+		return
+	}
+
+	if !IsTerminalEvent(delivery.eventType) {
+		j.runner.storeAppendEvent(delivery.event, delivery.eventSeq)
+	}
+
+	// Record to the JSONL rollout file via the per-run recorder goroutine.
+	// The goroutine owns all writes to the file and is the only entity that
+	// calls rec.Record / rec.Close, so no additional serialisation is needed.
+	rev := rollout.RecordableEvent{
+		ID:        delivery.event.ID,
+		RunID:     delivery.event.RunID,
+		Type:      string(delivery.event.Type),
+		Timestamp: delivery.event.Timestamp,
+		Payload:   delivery.event.Payload,
+		Seq:       delivery.eventSeq,
+	}
+	if IsTerminalEvent(delivery.eventType) {
+		if delivery.recorderCh != nil {
+			sendTimer := time.NewTimer(recorderDrainTimeout)
+			defer sendTimer.Stop()
+			select {
+			case delivery.recorderCh <- rev:
+			case <-sendTimer.C:
+				if j.runner.config.Logger != nil {
+					j.runner.config.Logger.Error("rollout recorder: terminal send timeout, JSONL may be incomplete",
+						"run_id", delivery.runID, "timeout", recorderDrainTimeout)
+				}
+			}
+			delivery.closeRecorder()
+			drainTimer := time.NewTimer(recorderDrainTimeout)
+			defer drainTimer.Stop()
+			select {
+			case <-delivery.recorderDone:
+			case <-drainTimer.C:
+				if j.runner.config.Logger != nil {
+					j.runner.config.Logger.Error("rollout recorder: drain timeout exceeded, JSONL may be incomplete",
+						"run_id", delivery.runID, "timeout", recorderDrainTimeout)
+				}
+			}
+		}
+		return
+	}
+
+	if delivery.recorderCh != nil {
+		if !safeRecorderSend(delivery.recorderCh, rev) {
+			if j.runner.config.Logger != nil {
+				j.runner.config.Logger.Error("rollout recorder: channel full, event dropped",
+					"run_id", delivery.runID, "event_type", string(delivery.eventType), "seq", delivery.eventSeq)
+			}
+			dropMarker := rollout.RecordableEvent{
+				ID:        fmt.Sprintf("%s:drop:%d", delivery.runID, delivery.eventSeq),
+				RunID:     delivery.runID,
+				Type:      string(EventRecorderDropDetected),
+				Timestamp: time.Now().UTC(),
+				Seq:       delivery.eventSeq,
+				Payload: map[string]any{
+					"dropped_event_id":   delivery.event.ID,
+					"dropped_event_type": string(delivery.eventType),
+					"dropped_seq":        delivery.eventSeq,
+				},
+			}
+			safeRecorderSend(delivery.recorderCh, dropMarker)
+		}
+	}
+}

--- a/internal/harness/runner_event_journal_test.go
+++ b/internal/harness/runner_event_journal_test.go
@@ -1,0 +1,98 @@
+package harness
+
+import (
+	"context"
+	"testing"
+
+	"go-agent-harness/internal/store"
+)
+
+type terminalOrderingStore struct {
+	*store.MemoryStore
+	terminalAppendStarted chan struct{}
+	releaseTerminalAppend chan struct{}
+}
+
+func newTerminalOrderingStore() *terminalOrderingStore {
+	return &terminalOrderingStore{
+		MemoryStore:           store.NewMemoryStore(),
+		terminalAppendStarted: make(chan struct{}),
+		releaseTerminalAppend: make(chan struct{}),
+	}
+}
+
+func (s *terminalOrderingStore) AppendEvent(ctx context.Context, ev *store.Event) error {
+	if IsTerminalEvent(EventType(ev.EventType)) {
+		select {
+		case <-s.terminalAppendStarted:
+		default:
+			close(s.terminalAppendStarted)
+		}
+		<-s.releaseTerminalAppend
+	}
+	return s.MemoryStore.AppendEvent(ctx, ev)
+}
+
+func TestEventJournalDispatch_TerminalStoreAppendPrecedesSubscriberNotification(t *testing.T) {
+	t.Parallel()
+
+	st := newTerminalOrderingStore()
+	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		Store:        st,
+	})
+
+	sub := make(chan Event, 1)
+	state := &runState{
+		run: Run{
+			ID:             "run_terminal_order",
+			ConversationID: "conv_terminal_order",
+		},
+		subscribers: map[chan Event]struct{}{
+			sub: {},
+		},
+		nextEventSeq: 7,
+	}
+
+	journal := newEventJournal(runner)
+
+	runner.mu.Lock()
+	delivery, ok := journal.prepareLocked(state, state.run.ID, EventRunCompleted, map[string]any{
+		"output": "done",
+	})
+	runner.mu.Unlock()
+	if !ok {
+		t.Fatal("prepareLocked returned ok=false for terminal event")
+	}
+
+	delivered := make(chan Event, 1)
+	go func() {
+		delivered <- <-sub
+	}()
+
+	go func() {
+		runner.mu.Lock()
+		journal.publishTerminalLocked(delivery)
+		runner.mu.Unlock()
+		journal.dispatch(delivery)
+	}()
+
+	select {
+	case ev := <-delivered:
+		t.Fatalf("subscriber observed terminal event %q before store append started", ev.Type)
+	case <-st.terminalAppendStarted:
+	}
+
+	select {
+	case ev := <-delivered:
+		t.Fatalf("subscriber observed terminal event %q before terminal store append completed", ev.Type)
+	default:
+	}
+
+	close(st.releaseTerminalAppend)
+
+	ev := <-delivered
+	if ev.Type != EventRunCompleted {
+		t.Fatalf("subscriber event type = %q, want %q", ev.Type, EventRunCompleted)
+	}
+}


### PR DESCRIPTION
## Summary
- extract the runner event append/store/recorder path into a focused `eventJournal` helper
- keep `Runner.emit()` as the orchestration wrapper while preserving payload isolation, terminal sealing, redaction handling, and recorder capture behavior
- add direct regression coverage proving terminal events are appended to the store before subscribers observe them

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -run TestEventJournalDispatch_TerminalStoreAppendPrecedesSubscriberNotification -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/harness -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test -race ./internal/harness -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build COVERPROFILE_PATH=$PWD/.tmp/issue-424-coverage.out ./scripts/test-regression.sh` launched in `tmux` as `issue-424-regression`; the package-test phase passed and the repo-wide race phase advanced deep into `internal/...` and `cmd/...`, but the local sandbox run stopped making visible progress after repeated macOS linker warnings (`malformed LC_DYSYMTAB`)

## Notes
- The extraction preserves send-under-lock fanout for non-terminal events so the existing concurrent subscribe/cancel safety remains intact.
- Terminal events now append to the store before subscriber observation, which is the ordering contract pinned by the new test.

Closes #424