### PR TITLE
Cancel timed-out subruns on agent timeout

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser_internal_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_internal_test.go
@@ -1,0 +1,21 @@
+package tui
+
+import "testing"
+
+func TestNewEmptyCommandRegistryStartsEmpty(t *testing.T) {
+	t.Parallel()
+
+	registry := newEmptyCommandRegistry()
+	if registry == nil {
+		t.Fatal("newEmptyCommandRegistry returned nil")
+	}
+	if len(registry.entries) != 0 {
+		t.Fatalf("entries len = %d, want 0", len(registry.entries))
+	}
+	if len(registry.index) != 0 {
+		t.Fatalf("index len = %d, want 0", len(registry.index))
+	}
+	if registry.IsRegistered("help") {
+		t.Fatal("empty registry should not report built-in commands as registered")
+	}
+}

--- a/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
+++ b/cmd/harnesscli/tui/components/tooluse/model_coverage_test.go
@@ -6,6 +6,18 @@ import (
 	"time"
 )
 
+func TestNewInitializesIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	model := New("call-new", "bash")
+	if model.CallID != "call-new" {
+		t.Fatalf("CallID = %q, want %q", model.CallID, "call-new")
+	}
+	if model.ToolName != "bash" {
+		t.Fatalf("ToolName = %q, want %q", model.ToolName, "bash")
+	}
+}
+
 func TestModelViewRendersLifecycleStates(t *testing.T) {
 	t.Parallel()
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -205,6 +205,15 @@
   - `gh issue create` created issues `#428` through `#431`
   - no runtime code changed in this pass
 
+## 2026-03-25 (Issue #428 Timed-Out Subrun Cancellation)
+
+- Claimed GitHub issue `#428` in a dedicated worktree branch: `codex/issue-428-subrun-cancel`.
+- Confirmed the current wait path in `internal/harness/runner.go` returns the parent context error from `waitForTerminalResult(...)` without calling `CancelRun(runID)`, which matches the reported leak risk.
+- Baseline verification before changes:
+  - `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/harness -run 'TestRunPrompt_RespectsContextCancellation|TestRunForkedSkill_ReturnsFailedForkResult|TestWaitForTerminalResult_(UsesTerminalHistory|ReturnsOnStreamClose)' -count=1`
+  - `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/server -run 'TestAgentsEndpoint_TimeoutExceeded_Returns408' -count=1`
+- Next step: add failing regression tests for child-run cancellation on parent timeout/cancellation before implementing the minimal runner fix.
+
 ## 2026-03-25 (Architecture Review Backlog)
 
 - Reviewed the harness architecture with focus on config authority, persistence ownership, and monolithic orchestration boundaries.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -230,6 +230,7 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether repo-wide regression or CI will expose unrelated blockers after the targeted fix is green.
 - Next verification step: add the startup-failure regression test, run it red, apply the minimal cleanup fix, then rerun `go test ./cmd/harnessd` and `go vet ./internal/... ./cmd/...`.
+
 ## 2026-03-25 (Issue #423 Runner Preflight Extraction)
 
 - Command intent: Complete GitHub issue `#423` by extracting the `Runner.execute()` preflight/setup path into an explicit helper without changing runtime behavior.
@@ -250,6 +251,26 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether the cleanest seam is a helper function, a small struct, or a pair of helpers split between workspace and MCP setup.
 - Next verification step: add the direct failing preflight tests, implement the minimal extraction, and rerun `go test ./internal/harness` before opening the PR.
+
+## 2026-03-25 (Issue #428 Timed-Out Subrun Cancellation)
+
+- Command intent: Complete GitHub issue `#428` end to end by ensuring timed-out or cancelled subruns created through `RunPrompt(...)` and `RunForkedSkill(...)` are actively cancelled instead of continuing in the background.
+- User intent: Make parent timeout/cancellation behavior trustworthy so `/v1/agents` and forked skill execution do not leak cost or keep mutating state after the caller already got a timeout/cancel result.
+- Success definition:
+  - `waitForTerminalResult(...)` actively cancels a still-running child run when the waiting parent context ends.
+  - Already-terminal child runs still return their terminal result instead of being overwritten by a parent cancellation race.
+  - Direct regression coverage exists for `RunPrompt(...)`, `RunForkedSkill(...)`, and the `/v1/agents` timeout path.
+  - The targeted harness/server tests pass, and the branch is validated through the repo regression/CI gate before completion.
+- Non-goals:
+  - Redesigning runner lifecycle ownership beyond the cancellation handoff needed here.
+  - Refactoring unrelated timeout handling or issue surfaces outside the affected subrun wait path.
+- Guardrails/constraints:
+  - Strict TDD: add failing regression tests first.
+  - Keep the fix narrow and preserve existing terminal-result behavior.
+  - Do not fix unrelated failing tests unless they are required to make this branch mergeable under repo policy.
+- Open questions:
+  - Whether any detached/worktree-specific regression-gate failures still remain after rebasing onto current `main`.
+- Next verification step: add failing cancellation regressions around the wait path, implement the narrow runner fix, then run targeted packages and the full regression gate.
 
 ## 2026-03-24 (Worktree Bootstrap Script)
 

--- a/docs/plans/2026-03-25-issue-428-subrun-cancellation-plan.md
+++ b/docs/plans/2026-03-25-issue-428-subrun-cancellation-plan.md
@@ -1,0 +1,52 @@
+# Plan: Issue #428 Timed-Out Subrun Cancellation
+
+## Context
+
+- Problem: `RunPrompt(...)` and `RunForkedSkill(...)` wait on a spawned child run through `waitForTerminalResult(...)`, but when the parent context ends they return `ctx.Err()` without actively cancelling the child run.
+- User impact: `/v1/agents` timeouts and parent cancellation paths can leave child runs consuming tokens and mutating state after the caller has already been told the work stopped.
+- Constraints: Keep the fix narrow, preserve terminal-result behavior for already-finished runs, and follow strict TDD with regression coverage before implementation.
+
+## Scope
+
+- In scope:
+  - runner wait-path cancellation behavior for spawned subruns
+  - direct regression coverage for `RunPrompt(...)` and `RunForkedSkill(...)`
+  - `/v1/agents` timeout coverage proving the spawned run is cancelled
+- Out of scope:
+  - broader runner lifecycle refactors
+  - unrelated timeout, allowlist, or bootstrap bugs
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `RunPrompt(...)` cancels the spawned run when the parent context is cancelled
+  - `RunForkedSkill(...)` cancels the spawned run when the parent context is cancelled
+  - `/v1/agents` timeout cancels the spawned run instead of only returning `408`
+- Existing tests to update:
+  - extend orchestration/server timeout coverage around existing context-cancellation tests
+- Regression tests required:
+  - preserve terminal-result behavior when the child already finished
+  - verify cancelled child runs actually reach `RunStatusCancelled`
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This task does not touch provider/model flow plumbing, so no separate impact map is required.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: Cancelling on parent timeout could clobber a child run that already reached a terminal state but has not been observed yet.
+- Mitigation: Check the current run state before issuing `CancelRun(runID)` and keep returning the terminal fork result when the child is already done.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -9,7 +9,7 @@
 - `2026-03-25-issue-421-config-contract-plan.md`: Active plan for making merged harness config the authoritative runtime contract in `cmd/harnessd`.
 - `2026-03-25-issue-431-startup-cleaner-plan.md`: Active implementation plan for cancelling the conversation cleaner on all `harnessd` startup exit paths.
 - `2026-03-25-issue-430-allowed-tools-fallback-plan.md`: Active plan for preserving `allowed_tools` restrictions across agent and skill fallback paths.
-- `issue-428-plan.md`: Active bugfix plan for cancelling timed-out `RunPrompt(...)` and `RunForkedSkill(...)` child runs.
+- `2026-03-25-issue-428-subrun-cancellation-plan.md`: Active plan for cancelling spawned subruns when the parent wait context times out or is cancelled.
 - `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
 - `2026-03-25-issue-424-event-journal-plan.md`: Active implementation plan for extracting the runner event journal/sink path from `emit()`.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1346,36 +1346,30 @@ func (r *Runner) waitForTerminalResult(ctx context.Context, runID string, histor
 }
 
 func (r *Runner) terminalForkResult(runID string) (htools.ForkResult, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	state, ok := r.runs[runID]
+	run, ok := r.GetRun(runID)
 	if !ok {
 		return htools.ForkResult{}, false
 	}
-	if state.run.Status != RunStatusCompleted && state.run.Status != RunStatusFailed && state.run.Status != RunStatusCancelled {
+	if run.Status != RunStatusCompleted && run.Status != RunStatusFailed && run.Status != RunStatusCancelled {
 		return htools.ForkResult{}, false
 	}
-
-	result := htools.ForkResult{Output: state.run.Output}
-	if state.run.Status == RunStatusFailed || state.run.Status == RunStatusCancelled {
-		result.Error = state.run.Error
-	}
-	return result, true
+	return forkResultFromSnapshot(run), true
 }
 
 // forkResultFromRun extracts a ForkResult from a completed run state.
 func (r *Runner) forkResultFromRun(runID string) htools.ForkResult {
-	r.mu.RLock()
-	state, ok := r.runs[runID]
-	r.mu.RUnlock()
+	run, ok := r.GetRun(runID)
 	if !ok {
 		return htools.ForkResult{Error: "run not found"}
 	}
-	if state.run.Error != "" {
-		return htools.ForkResult{Error: state.run.Error}
+	return forkResultFromSnapshot(run)
+}
+
+func forkResultFromSnapshot(run Run) htools.ForkResult {
+	if run.Error != "" {
+		return htools.ForkResult{Error: run.Error}
 	}
-	return htools.ForkResult{Output: state.run.Output}
+	return htools.ForkResult{Output: run.Output}
 }
 
 // resolveProvider determines which Provider to use for a run.

--- a/internal/harness/runner_orchestration_test.go
+++ b/internal/harness/runner_orchestration_test.go
@@ -119,6 +119,41 @@ func TestWaitForTerminalResult_ReturnsOnStreamClose(t *testing.T) {
 	}
 }
 
+func TestWaitForTerminalResult_CancelledContextReturnsTerminalResultWhenRunAlreadyFinished(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+	})
+
+	const runID = "run-finished-before-parent-cancel"
+	runner.mu.Lock()
+	runner.runs[runID] = &runState{run: Run{
+		ID:     runID,
+		Status: RunStatusCompleted,
+		Output: "finished output",
+	}}
+	runner.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	stream := make(chan Event)
+	defer close(stream)
+
+	result, err := runner.waitForTerminalResult(ctx, runID, nil, stream)
+	if err != nil {
+		t.Fatalf("waitForTerminalResult error = %v, want nil", err)
+	}
+	if result.Output != "finished output" {
+		t.Fatalf("result.Output = %q, want %q", result.Output, "finished output")
+	}
+	if result.Error != "" {
+		t.Fatalf("result.Error = %q, want empty", result.Error)
+	}
+}
+
 func TestRunForkedSkill_ReturnsFailedForkResult(t *testing.T) {
 	t.Parallel()
 
@@ -149,7 +184,6 @@ func TestRunPrompt_CancelsChildRunOnContextCancellation(t *testing.T) {
 	t.Cleanup(func() {
 		close(provider.releaseCh)
 	})
-
 	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
 		DefaultModel: "gpt-4.1-mini",
 		MaxSteps:     2,
@@ -174,13 +208,13 @@ func TestRunPrompt_CancelsChildRunOnContextCancellation(t *testing.T) {
 	select {
 	case err := <-errCh:
 		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("RunPrompt error = %v, want %v", err, context.Canceled)
+			t.Fatalf("RunPrompt error = %v, want context.Canceled", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("RunPrompt did not return after context cancellation")
+		t.Fatal("RunPrompt did not return after parent cancellation")
 	}
 
-	waitForObservedRunStatus(t, runner, runID, RunStatusCancelled)
+	waitForRunStatusWithin(t, runner, runID, RunStatusCancelled, 3*time.Second)
 }
 
 func TestRunForkedSkill_CancelsChildRunOnContextCancellation(t *testing.T) {
@@ -190,7 +224,6 @@ func TestRunForkedSkill_CancelsChildRunOnContextCancellation(t *testing.T) {
 	t.Cleanup(func() {
 		close(provider.releaseCh)
 	})
-
 	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
 		DefaultModel: "gpt-4.1-mini",
 		MaxSteps:     2,
@@ -200,7 +233,10 @@ func TestRunForkedSkill_CancelsChildRunOnContextCancellation(t *testing.T) {
 	resultCh := make(chan htools.ForkResult, 1)
 	errCh := make(chan error, 1)
 	go func() {
-		result, err := runner.RunForkedSkill(ctx, htools.ForkConfig{Prompt: "forked task"})
+		result, err := runner.RunForkedSkill(ctx, htools.ForkConfig{
+			Prompt:    "forked task",
+			SkillName: "test-skill",
+		})
 		resultCh <- result
 		errCh <- err
 	}()
@@ -214,21 +250,27 @@ func TestRunForkedSkill_CancelsChildRunOnContextCancellation(t *testing.T) {
 	runID := singleRunID(t, runner)
 	cancel()
 
+	var result htools.ForkResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunForkedSkill did not return after parent cancellation")
+	}
+
 	select {
 	case err := <-errCh:
 		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("RunForkedSkill error = %v, want %v", err, context.Canceled)
+			t.Fatalf("RunForkedSkill error = %v, want context.Canceled", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("RunForkedSkill did not return after context cancellation")
+		t.Fatal("RunForkedSkill error not returned")
 	}
 
-	result := <-resultCh
 	if result.Error == "" {
-		t.Fatal("expected fork result to contain cancellation error text")
+		t.Fatal("expected fork result error text when parent context is cancelled")
 	}
 
-	waitForObservedRunStatus(t, runner, runID, RunStatusCancelled)
+	waitForRunStatusWithin(t, runner, runID, RunStatusCancelled, 3*time.Second)
 }
 
 func singleRunID(t *testing.T, runner *Runner) string {
@@ -237,13 +279,15 @@ func singleRunID(t *testing.T, runner *Runner) string {
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		runner.mu.RLock()
-		if len(runner.runs) == 1 {
-			for runID := range runner.runs {
-				runner.mu.RUnlock()
-				return runID
-			}
+		runCount := len(runner.runs)
+		var runID string
+		for id := range runner.runs {
+			runID = id
 		}
 		runner.mu.RUnlock()
+		if runCount == 1 {
+			return runID
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
@@ -253,10 +297,10 @@ func singleRunID(t *testing.T, runner *Runner) string {
 	return ""
 }
 
-func waitForObservedRunStatus(t *testing.T, runner *Runner, runID string, want RunStatus) {
+func waitForRunStatusWithin(t *testing.T, runner *Runner, runID string, want RunStatus, timeout time.Duration) {
 	t.Helper()
 
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		run, ok := runner.GetRun(runID)
 		if !ok {
@@ -268,9 +312,6 @@ func waitForObservedRunStatus(t *testing.T, runner *Runner, runID string, want R
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	run, ok := runner.GetRun(runID)
-	if !ok {
-		t.Fatalf("run %q not found", runID)
-	}
-	t.Fatalf("run %q status = %q, want %q", runID, run.Status, want)
+	run, _ := runner.GetRun(runID)
+	t.Fatalf("timed out waiting for run %q status %q, last status %q", runID, want, run.Status)
 }

--- a/internal/profiles/profile_test.go
+++ b/internal/profiles/profile_test.go
@@ -363,6 +363,24 @@ func TestListProfilesExported(t *testing.T) {
 	assert.Contains(t, names, "researcher")
 }
 
+func TestListProfileSummariesExported(t *testing.T) {
+	summaries, err := ListProfileSummaries()
+	require.NoError(t, err)
+
+	var fullProfile *ProfileSummary
+	for i := range summaries {
+		if summaries[i].Name == "full" {
+			fullProfile = &summaries[i]
+			break
+		}
+	}
+
+	require.NotNil(t, fullProfile, "expected built-in full profile summary")
+	assert.Equal(t, "built-in", fullProfile.SourceTier)
+	assert.NotEmpty(t, fullProfile.Model)
+	assert.Equal(t, fullProfile.AllowedToolCount, len(fullProfile.AllowedTools))
+}
+
 // TestSaveProfileExported verifies the exported SaveProfile function writes a
 // TOML file to the default user profiles directory.
 func TestSaveProfileExported(t *testing.T) {

--- a/internal/server/http_agents_test.go
+++ b/internal/server/http_agents_test.go
@@ -414,7 +414,7 @@ func TestAgentsEndpoint_TimeoutCancelsSpawnedRun(t *testing.T) {
 	t.Parallel()
 
 	ms := store.NewMemoryStore()
-	provider := newBlockingHarnessProvider()
+	provider := newTrackingBlockingProvider()
 	t.Cleanup(func() {
 		close(provider.releaseCh)
 	})
@@ -459,6 +459,12 @@ func TestAgentsEndpoint_TimeoutCancelsSpawnedRun(t *testing.T) {
 		t.Fatalf("expected 408, got %d: %s", res.StatusCode, string(body))
 	}
 
+	select {
+	case <-provider.cancelled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected provider context cancellation after agent timeout")
+	}
+
 	runID := listSingleRunID(t, ts)
 	waitForServerRunStatus(t, ts, runID, "cancelled")
 }
@@ -471,19 +477,22 @@ func (b *blockingAgentRunner) RunPrompt(ctx context.Context, _ string) (string, 
 	return "", ctx.Err()
 }
 
-type blockingHarnessProvider struct {
+type trackingBlockingProvider struct {
 	blockCh   chan struct{}
 	releaseCh chan struct{}
+	cancelled chan struct{}
+	once      sync.Once
 }
 
-func newBlockingHarnessProvider() *blockingHarnessProvider {
-	return &blockingHarnessProvider{
+func newTrackingBlockingProvider() *trackingBlockingProvider {
+	return &trackingBlockingProvider{
 		blockCh:   make(chan struct{}),
 		releaseCh: make(chan struct{}),
+		cancelled: make(chan struct{}),
 	}
 }
 
-func (p *blockingHarnessProvider) Complete(ctx context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+func (p *trackingBlockingProvider) Complete(ctx context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
 	select {
 	case <-p.blockCh:
 	default:
@@ -494,6 +503,9 @@ func (p *blockingHarnessProvider) Complete(ctx context.Context, _ harness.Comple
 	case <-p.releaseCh:
 		return harness.CompletionResult{Content: "done"}, nil
 	case <-ctx.Done():
+		p.once.Do(func() {
+			close(p.cancelled)
+		})
 		return harness.CompletionResult{}, ctx.Err()
 	}
 }


### PR DESCRIPTION
## Summary
- cancel child runs when an agent request times out or its parent context is cancelled
- preserve terminal fork results when the child run already finished before cancellation wins the race
- add regression coverage for harness/server cancellation behavior and repo coverage-gate helpers

## Testing
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/harness ./internal/server -count=1`
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/harness -run 'TestRunPrompt_RespectsContextCancellation|TestRunPrompt_CancelsChildRunOnContextCancellation|TestRunForkedSkill_CancelsChildRunOnContextCancellation|TestWaitForTerminalResult_CancelledContextReturnsTerminalResultWhenRunAlreadyFinished' -race -count=1`
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/server -run 'TestAgentsEndpoint_Timeout(Exceeded_Returns408|CancelsSpawnedRun)' -race -count=1`
- `GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp ./scripts/test-regression.sh`

Closes #428