### PR TITLE
Split harnessd bootstrap into modular helpers

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -1,0 +1,335 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/cron"
+	githubadapter "go-agent-harness/internal/github"
+	"go-agent-harness/internal/harness"
+	htools "go-agent-harness/internal/harness/tools"
+	linearadapter "go-agent-harness/internal/linear"
+	"go-agent-harness/internal/provider/anthropic"
+	"go-agent-harness/internal/provider/catalog"
+	openai "go-agent-harness/internal/provider/openai"
+	"go-agent-harness/internal/provider/pricing"
+	"go-agent-harness/internal/server"
+	slackadapter "go-agent-harness/internal/slack"
+	istore "go-agent-harness/internal/store"
+	"go-agent-harness/internal/subagents"
+	"go-agent-harness/internal/trigger"
+)
+
+type catalogBootstrapOptions struct {
+	workspace   string
+	getenv      func(string) string
+	newProvider providerFactory
+	logger      func(string, ...any)
+}
+
+type catalogBootstrap struct {
+	modelCatalog     *catalog.Catalog
+	providerRegistry *catalog.ProviderRegistry
+	pricingResolver  pricing.Resolver
+	lookupModelAPI   func(providerName, modelID string) string
+}
+
+func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, error) {
+	if opts.getenv == nil {
+		opts.getenv = os.Getenv
+	}
+	if opts.logger == nil {
+		opts.logger = func(string, ...any) {}
+	}
+
+	pricingCatalogPath := strings.TrimSpace(opts.getenv("HARNESS_PRICING_CATALOG_PATH"))
+	modelCatalogPath := strings.TrimSpace(opts.getenv("HARNESS_MODEL_CATALOG_PATH"))
+	if modelCatalogPath == "" {
+		candidates := []string{
+			filepath.Join(opts.workspace, "catalog", "models.json"),
+			"catalog/models.json",
+		}
+		for _, candidate := range candidates {
+			if _, err := os.Stat(candidate); err == nil {
+				modelCatalogPath = candidate
+				break
+			}
+		}
+	}
+
+	var bootstrap catalogBootstrap
+	if modelCatalogPath != "" {
+		cat, err := catalog.LoadCatalog(modelCatalogPath)
+		if err != nil {
+			opts.logger("warning: failed to load model catalog from %s: %v (continuing without catalog)", modelCatalogPath, err)
+		} else {
+			bootstrap.modelCatalog = cat
+			bootstrap.providerRegistry = catalog.NewProviderRegistryWithEnv(cat, opts.getenv)
+			opts.logger("loaded model catalog with %d providers", len(cat.Providers))
+		}
+	}
+
+	bootstrap.lookupModelAPI = func(providerName, modelID string) string {
+		if bootstrap.modelCatalog == nil {
+			return ""
+		}
+		entry, ok := bootstrap.modelCatalog.Providers[providerName]
+		if !ok {
+			return ""
+		}
+		resolved := modelID
+		if target, ok := entry.Aliases[modelID]; ok {
+			if _, exists := entry.Models[target]; exists {
+				resolved = target
+			}
+		}
+		model, ok := entry.Models[resolved]
+		if !ok {
+			return ""
+		}
+		return model.API
+	}
+
+	if pricingCatalogPath != "" {
+		resolver, err := pricing.NewFileResolver(pricingCatalogPath)
+		if err != nil {
+			return catalogBootstrap{}, fmt.Errorf("load pricing catalog from %s: %w", pricingCatalogPath, err)
+		}
+		bootstrap.pricingResolver = resolver
+	}
+
+	if bootstrap.providerRegistry != nil {
+		if _, ok := bootstrap.modelCatalog.Providers["openrouter"]; ok {
+			bootstrap.providerRegistry.SetOpenRouterDiscovery(catalog.NewOpenRouterDiscovery(catalog.OpenRouterDiscoveryOptions{
+				TTL: 5 * time.Minute,
+			}))
+		}
+		bootstrap.providerRegistry.SetClientFactory(func(apiKey, baseURL, providerName string) (catalog.ProviderClient, error) {
+			if providerName == "anthropic" {
+				return anthropic.NewClient(anthropic.Config{
+					APIKey:          apiKey,
+					BaseURL:         baseURL,
+					ProviderName:    providerName,
+					PricingResolver: bootstrap.pricingResolver,
+				})
+			}
+			return opts.newProvider(openai.Config{
+				APIKey:          apiKey,
+				BaseURL:         baseURL,
+				ProviderName:    providerName,
+				PricingResolver: bootstrap.pricingResolver,
+				ModelAPILookup:  bootstrap.lookupModelAPI,
+				NoParallelTools: providerName == "gemini",
+				ModelIDPrefix: func() string {
+					if providerName == "gemini" {
+						return "models/"
+					}
+					return ""
+				}(),
+			})
+		})
+	}
+
+	return bootstrap, nil
+}
+
+type cronBootstrap struct {
+	client    htools.CronClient
+	store     cron.Store
+	scheduler *cron.Scheduler
+}
+
+func buildCronBootstrap(workspace, cronURL string, logger func(string, ...any)) (cronBootstrap, error) {
+	if logger == nil {
+		logger = func(string, ...any) {}
+	}
+	if strings.TrimSpace(cronURL) != "" {
+		return cronBootstrap{
+			client: &cronClientAdapter{client: cron.NewClient(strings.TrimSpace(cronURL))},
+		}, nil
+	}
+
+	cronDBPath := filepath.Join(workspace, ".harness", "cron.db")
+	store, err := cron.NewSQLiteStore(cronDBPath)
+	if err != nil {
+		return cronBootstrap{}, fmt.Errorf("create cron store: %w", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		store.Close()
+		return cronBootstrap{}, fmt.Errorf("migrate cron store: %w", err)
+	}
+	clock := cron.RealClock{}
+	scheduler := cron.NewScheduler(store, &cron.ShellExecutor{}, clock, cron.SchedulerConfig{MaxConcurrent: 5})
+	if err := scheduler.Start(context.Background()); err != nil {
+		store.Close()
+		return cronBootstrap{}, fmt.Errorf("start cron scheduler: %w", err)
+	}
+	logger("embedded cron scheduler started (db: %s)", cronDBPath)
+	return cronBootstrap{
+		client:    &embeddedCronAdapter{store: store, scheduler: scheduler, clock: clock},
+		store:     store,
+		scheduler: scheduler,
+	}, nil
+}
+
+type persistenceBootstrapOptions struct {
+	workspace         string
+	getenv            func(string) string
+	convRetentionDays int
+	logger            func(string, ...any)
+	newCleaner        func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter
+}
+
+type persistenceBootstrap struct {
+	runStore          istore.Store
+	conversationStore harness.ConversationStore
+	convCleanerCancel context.CancelFunc
+}
+
+func buildPersistenceBootstrap(opts persistenceBootstrapOptions) (_ persistenceBootstrap, err error) {
+	if opts.getenv == nil {
+		opts.getenv = os.Getenv
+	}
+	if opts.logger == nil {
+		opts.logger = func(string, ...any) {}
+	}
+	if opts.newCleaner == nil {
+		opts.newCleaner = func(store harness.ConversationStore, retentionDays int) conversationCleanerStarter {
+			return harness.NewConversationCleaner(store, retentionDays)
+		}
+	}
+
+	var bootstrap persistenceBootstrap
+	defer func() {
+		if err == nil {
+			return
+		}
+		if bootstrap.convCleanerCancel != nil {
+			bootstrap.convCleanerCancel()
+		}
+		if bootstrap.conversationStore != nil {
+			_ = bootstrap.conversationStore.Close()
+		}
+		if bootstrap.runStore != nil {
+			_ = bootstrap.runStore.Close()
+		}
+	}()
+
+	if runDBPath := strings.TrimSpace(opts.getenv("HARNESS_RUN_DB")); runDBPath != "" {
+		if !filepath.IsAbs(runDBPath) {
+			runDBPath = filepath.Join(opts.workspace, runDBPath)
+		}
+		runStore, openErr := istore.NewSQLiteStore(runDBPath)
+		if openErr != nil {
+			err = fmt.Errorf("create run store: %w", openErr)
+			return persistenceBootstrap{}, err
+		}
+		if migrateErr := runStore.Migrate(context.Background()); migrateErr != nil {
+			_ = runStore.Close()
+			err = fmt.Errorf("migrate run store: %w", migrateErr)
+			return persistenceBootstrap{}, err
+		}
+		bootstrap.runStore = runStore
+		opts.logger("run persistence enabled: %s", runDBPath)
+	}
+
+	if dbPath := strings.TrimSpace(opts.getenv("HARNESS_CONVERSATION_DB")); dbPath != "" {
+		if !filepath.IsAbs(dbPath) {
+			dbPath = filepath.Join(opts.workspace, dbPath)
+		}
+		convStore, openErr := harness.NewSQLiteConversationStore(dbPath)
+		if openErr != nil {
+			err = fmt.Errorf("create conversation store: %w", openErr)
+			return persistenceBootstrap{}, err
+		}
+		if migrateErr := convStore.Migrate(context.Background()); migrateErr != nil {
+			_ = convStore.Close()
+			err = fmt.Errorf("migrate conversation store: %w", migrateErr)
+			return persistenceBootstrap{}, err
+		}
+		bootstrap.conversationStore = convStore
+		opts.logger("conversation persistence enabled: %s", dbPath)
+
+		if opts.convRetentionDays > 0 {
+			opts.logger("conversation retention policy: %d days", opts.convRetentionDays)
+			cleanerCtx, cleanerCancel := context.WithCancel(context.Background())
+			opts.newCleaner(convStore, opts.convRetentionDays).Start(cleanerCtx, 24*time.Hour)
+			bootstrap.convCleanerCancel = cleanerCancel
+		}
+	}
+
+	return bootstrap, nil
+}
+
+type triggerRuntime struct {
+	validators *trigger.ValidatorRegistry
+	github     *githubadapter.GitHubAdapter
+	slack      *slackadapter.SlackAdapter
+	linear     *linearadapter.LinearAdapter
+}
+
+func buildTriggerRuntime(getenv func(string) string, logger func(string, ...any)) triggerRuntime {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	if logger == nil {
+		logger = func(string, ...any) {}
+	}
+
+	runtime := triggerRuntime{
+		validators: trigger.NewValidatorRegistry(),
+	}
+	if secret := strings.TrimSpace(getenv("GITHUB_WEBHOOK_SECRET")); secret != "" {
+		runtime.validators.Register("github", &trigger.GitHubValidator{Secret: secret})
+		runtime.github = githubadapter.NewGitHubAdapter(secret)
+		logger("registered GitHub webhook validator")
+		logger("registered GitHub webhook adapter for /v1/webhooks/github")
+	}
+	if secret := strings.TrimSpace(getenv("SLACK_SIGNING_SECRET")); secret != "" {
+		runtime.validators.Register("slack", &trigger.SlackValidator{Secret: secret})
+		runtime.slack = slackadapter.NewSlackAdapter()
+		logger("registered Slack webhook validator")
+		logger("registered Slack webhook adapter for /v1/webhooks/slack")
+	}
+	if secret := strings.TrimSpace(getenv("LINEAR_WEBHOOK_SECRET")); secret != "" {
+		runtime.validators.Register("linear", &trigger.LinearValidator{Secret: secret})
+		runtime.linear = linearadapter.NewLinearAdapter()
+		logger("registered Linear webhook validator")
+		logger("registered Linear webhook adapter for /v1/webhooks/linear")
+	}
+	return runtime
+}
+
+type serverBootstrapOptions struct {
+	runner           *harness.Runner
+	modelCatalog     *catalog.Catalog
+	skillLister      htools.SkillLister
+	skillManager     server.SkillManager
+	cronClient       htools.CronClient
+	subagentManager  subagents.Manager
+	providerRegistry *catalog.ProviderRegistry
+	runStore         istore.Store
+	triggers         triggerRuntime
+}
+
+func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
+	return server.ServerOptions{
+		Runner:           opts.runner,
+		Catalog:          opts.modelCatalog,
+		AgentRunner:      opts.runner,
+		SkillLister:      opts.skillLister,
+		Skills:           opts.skillManager,
+		CronClient:       opts.cronClient,
+		SubagentManager:  opts.subagentManager,
+		ProviderRegistry: opts.providerRegistry,
+		Store:            opts.runStore,
+		Validators:       opts.triggers.validators,
+		GitHubAdapter:    opts.triggers.github,
+		SlackAdapter:     opts.triggers.slack,
+		LinearAdapter:    opts.triggers.linear,
+	}
+}

--- a/cmd/harnessd/bootstrap_helpers_test.go
+++ b/cmd/harnessd/bootstrap_helpers_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/provider/catalog"
+	openai "go-agent-harness/internal/provider/openai"
+)
+
+func TestBuildCatalogBootstrapFallsBackToWorkspaceCatalog(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(workspace+"/catalog", 0o755); err != nil {
+		t.Fatalf("mkdir catalog: %v", err)
+	}
+	if err := os.WriteFile(workspace+"/catalog/models.json", []byte(`{
+  "catalog_version": "1.0.0",
+  "providers": {
+    "openrouter": {
+      "display_name": "OpenRouter",
+      "base_url": "https://openrouter.ai/api/v1",
+      "api_key_env": "OPENROUTER_API_KEY",
+      "models": {
+        "openai/gpt-4.1-mini": {
+          "display_name": "GPT-4.1 mini",
+          "context_window": 128000,
+          "modalities": ["text"],
+          "tool_calling": true,
+          "streaming": true,
+          "api": "responses"
+        }
+      }
+    }
+  }
+}`), 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+
+	bootstrap, err := buildCatalogBootstrap(catalogBootstrapOptions{
+		workspace: workspace,
+		getenv:    func(string) string { return "" },
+		newProvider: func(openai.Config) (harness.Provider, error) {
+			return &noopProvider{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildCatalogBootstrap: %v", err)
+	}
+	if bootstrap.modelCatalog == nil {
+		t.Fatal("expected model catalog")
+	}
+	if bootstrap.providerRegistry == nil {
+		t.Fatal("expected provider registry")
+	}
+	if got := bootstrap.lookupModelAPI("openrouter", "openai/gpt-4.1-mini"); got != "responses" {
+		t.Fatalf("lookupModelAPI: got %q", got)
+	}
+}
+
+func TestBuildTriggerRuntimeHonorsSecrets(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"GITHUB_WEBHOOK_SECRET": "gh-secret",
+		"SLACK_SIGNING_SECRET":  "slack-secret",
+	}
+	var logs []string
+	runtime := buildTriggerRuntime(func(key string) string { return env[key] }, func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	})
+
+	if runtime.validators == nil {
+		t.Fatal("expected validator registry")
+	}
+	if validator, ok := runtime.validators.Get("github"); !ok {
+		t.Fatal("expected github validator")
+	} else if got := fmt.Sprintf("%T", validator); !strings.HasSuffix(got, ".GitHubValidator") {
+		t.Fatalf("github validator type: got %q", got)
+	}
+	if validator, ok := runtime.validators.Get("slack"); !ok {
+		t.Fatal("expected slack validator")
+	} else if got := fmt.Sprintf("%T", validator); !strings.HasSuffix(got, ".SlackValidator") {
+		t.Fatalf("slack validator type: got %q", got)
+	}
+	if _, ok := runtime.validators.Get("linear"); ok {
+		t.Fatal("did not expect linear validator")
+	}
+
+	if got := fmt.Sprintf("%T", runtime.github); !strings.HasSuffix(got, ".GitHubAdapter") {
+		t.Fatalf("expected github adapter, got %q", got)
+	}
+	if got := fmt.Sprintf("%T", runtime.slack); !strings.HasSuffix(got, ".SlackAdapter") {
+		t.Fatalf("expected slack adapter, got %q", got)
+	}
+	if runtime.linear != nil {
+		t.Fatal("did not expect linear adapter")
+	}
+
+	logText := strings.Join(logs, "\n")
+	for _, want := range []string{
+		"registered GitHub webhook validator",
+		"registered Slack webhook validator",
+		"registered GitHub webhook adapter for /v1/webhooks/github",
+		"registered Slack webhook adapter for /v1/webhooks/slack",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("expected log %q in %q", want, logText)
+		}
+	}
+}
+
+func TestBuildServerOptionsForwardsBootstrapRuntime(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(&noopProvider{}, harness.NewDefaultRegistry(t.TempDir()), harness.RunnerConfig{})
+	cat := &catalog.Catalog{}
+	runtime := buildTriggerRuntime(func(key string) string {
+		switch key {
+		case "GITHUB_WEBHOOK_SECRET":
+			return "gh-secret"
+		case "LINEAR_WEBHOOK_SECRET":
+			return "linear-secret"
+		default:
+			return ""
+		}
+	}, nil)
+
+	opts := buildServerOptions(serverBootstrapOptions{
+		runner:           runner,
+		modelCatalog:     cat,
+		providerRegistry: catalog.NewProviderRegistryWithEnv(cat, func(string) string { return "" }),
+		triggers:         runtime,
+	})
+
+	if opts.Runner != runner {
+		t.Fatal("expected runner")
+	}
+	if opts.AgentRunner != runner {
+		t.Fatal("expected agent runner to match runner")
+	}
+	if opts.Catalog != cat {
+		t.Fatal("expected model catalog")
+	}
+	if opts.ProviderRegistry == nil {
+		t.Fatal("expected provider registry")
+	}
+	if opts.Validators == nil {
+		t.Fatal("expected validators")
+	}
+	if opts.GitHubAdapter == nil {
+		t.Fatal("expected github adapter")
+	}
+	if opts.LinearAdapter == nil {
+		t.Fatal("expected linear adapter")
+	}
+	if opts.SlackAdapter != nil {
+		t.Fatal("did not expect slack adapter")
+	}
+}
+
+func TestBuildPersistenceBootstrapInitializesStoresAndCleaner(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	getenv := func(key string) string {
+		switch key {
+		case "HARNESS_RUN_DB":
+			return ".harness/runs.db"
+		case "HARNESS_CONVERSATION_DB":
+			return ".harness/conversations.db"
+		default:
+			return ""
+		}
+	}
+
+	bootstrap, err := buildPersistenceBootstrap(persistenceBootstrapOptions{
+		workspace:         workspace,
+		getenv:            getenv,
+		convRetentionDays: 14,
+	})
+	if err != nil {
+		t.Fatalf("buildPersistenceBootstrap: %v", err)
+	}
+	defer func() {
+		if bootstrap.convCleanerCancel != nil {
+			bootstrap.convCleanerCancel()
+		}
+		if bootstrap.conversationStore != nil {
+			_ = bootstrap.conversationStore.Close()
+		}
+		if bootstrap.runStore != nil {
+			_ = bootstrap.runStore.Close()
+		}
+	}()
+
+	if bootstrap.runStore == nil {
+		t.Fatal("expected run store")
+	}
+	if bootstrap.conversationStore == nil {
+		t.Fatal("expected conversation store")
+	}
+	if bootstrap.convCleanerCancel == nil {
+		t.Fatal("expected conversation cleaner cancel func")
+	}
+
+	if _, err := os.Stat(workspace + "/.harness/runs.db"); err != nil {
+		t.Fatalf("expected run db to exist: %v", err)
+	}
+	if _, err := os.Stat(workspace + "/.harness/conversations.db"); err != nil {
+		t.Fatalf("expected conversation db to exist: %v", err)
+	}
+}
+
+func TestBuildPersistenceBootstrapClosesRunStoreWhenConversationSetupFails(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(workspace+"/blocked.db", 0o755); err != nil {
+		t.Fatalf("mkdir blocked path: %v", err)
+	}
+
+	bootstrap, err := buildPersistenceBootstrap(persistenceBootstrapOptions{
+		workspace: workspace,
+		getenv: func(key string) string {
+			switch key {
+			case "HARNESS_RUN_DB":
+				return ".harness/runs.db"
+			case "HARNESS_CONVERSATION_DB":
+				return "blocked.db"
+			default:
+				return ""
+			}
+		},
+	})
+	if err == nil {
+		if bootstrap.runStore != nil {
+			_ = bootstrap.runStore.Close()
+		}
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "create conversation store") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if bootstrap.runStore != nil {
+		t.Fatal("expected run store to be cleaned up on failure")
+	}
+}

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -19,25 +19,20 @@ import (
 	"github.com/google/uuid"
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/cron"
-	githubadapter "go-agent-harness/internal/github"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
-	linearadapter "go-agent-harness/internal/linear"
 	"go-agent-harness/internal/mcp"
 	om "go-agent-harness/internal/observationalmemory"
 	"go-agent-harness/internal/profiles"
-	anthropic "go-agent-harness/internal/provider/anthropic"
 	"go-agent-harness/internal/provider/catalog"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/provider/pricing"
 	"go-agent-harness/internal/server"
 	"go-agent-harness/internal/skills"
-	slackadapter "go-agent-harness/internal/slack"
 	istore "go-agent-harness/internal/store"
 	"go-agent-harness/internal/store/s3backup"
 	"go-agent-harness/internal/subagents"
 	"go-agent-harness/internal/systemprompt"
-	"go-agent-harness/internal/trigger"
 	"go-agent-harness/internal/watcher"
 	conclusionwatcher "go-agent-harness/plugins/conclusion-watcher"
 )
@@ -342,21 +337,6 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	if memoryLLMAPIKey == "" {
 		memoryLLMAPIKey = strings.TrimSpace(getenv("OPENAI_API_KEY"))
 	}
-	pricingCatalogPath := strings.TrimSpace(getenv("HARNESS_PRICING_CATALOG_PATH"))
-	modelCatalogPath := strings.TrimSpace(getenv("HARNESS_MODEL_CATALOG_PATH"))
-	// Auto-discover catalog from workspace when env var not set.
-	if modelCatalogPath == "" {
-		candidates := []string{
-			filepath.Join(workspace, "catalog", "models.json"),
-			"catalog/models.json",
-		}
-		for _, p := range candidates {
-			if _, statErr := os.Stat(p); statErr == nil {
-				modelCatalogPath = p
-				break
-			}
-		}
-	}
 	skillsEnabled := envBoolOrDefault("HARNESS_SKILLS_ENABLED", true)
 	watchEnabled := envBoolOrDefault("HARNESS_WATCH_ENABLED", true)
 	watchIntervalSeconds := envIntOrDefault("HARNESS_WATCH_INTERVAL_SECONDS", 5)
@@ -375,93 +355,25 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		harnessCfg.Forensics.RolloutDir = rolloutDir
 	}
 
-	var providerRegistry *catalog.ProviderRegistry
-	var modelCatalog *catalog.Catalog
-	if modelCatalogPath != "" {
-		cat, err := catalog.LoadCatalog(modelCatalogPath)
-		if err != nil {
-			log.Printf("warning: failed to load model catalog from %s: %v (continuing without catalog)", modelCatalogPath, err)
-		} else {
-			modelCatalog = cat
-			providerRegistry = catalog.NewProviderRegistryWithEnv(cat, getenv)
-			log.Printf("loaded model catalog with %d providers", len(cat.Providers))
-		}
+	catalogBootstrap, err := buildCatalogBootstrap(catalogBootstrapOptions{
+		workspace:   workspace,
+		getenv:      getenv,
+		newProvider: newProvider,
+		logger:      log.Printf,
+	})
+	if err != nil {
+		return err
 	}
-
-	// lookupModelAPI routes models to the correct API endpoint (e.g. "responses" for Codex models).
-	// Returns the catalog's "api" field value for the given model, or "" for standard chat/completions.
-	lookupModelAPI := func(providerName, modelID string) string {
-		if modelCatalog == nil {
-			return ""
-		}
-		entry, ok := modelCatalog.Providers[providerName]
-		if !ok {
-			return ""
-		}
-		// Resolve alias if needed.
-		resolved := modelID
-		if target, ok := entry.Aliases[modelID]; ok {
-			if _, exists := entry.Models[target]; exists {
-				resolved = target
-			}
-		}
-		m, ok := entry.Models[resolved]
-		if !ok {
-			return ""
-		}
-		return m.API
-	}
-
-	var pricingResolver pricing.Resolver
-	if pricingCatalogPath != "" {
-		resolver, err := pricing.NewFileResolver(pricingCatalogPath)
-		if err != nil {
-			return fmt.Errorf("load pricing catalog from %s: %w", pricingCatalogPath, err)
-		}
-		pricingResolver = resolver
-	}
-
-	if providerRegistry != nil {
-		if _, ok := modelCatalog.Providers["openrouter"]; ok {
-			providerRegistry.SetOpenRouterDiscovery(catalog.NewOpenRouterDiscovery(catalog.OpenRouterDiscoveryOptions{
-				TTL: 5 * time.Minute,
-			}))
-		}
-		providerRegistry.SetClientFactory(func(apiKey, baseURL, providerName string) (catalog.ProviderClient, error) {
-			if providerName == "anthropic" {
-				return anthropic.NewClient(anthropic.Config{
-					APIKey:          apiKey,
-					BaseURL:         baseURL,
-					ProviderName:    providerName,
-					PricingResolver: pricingResolver,
-				})
-			}
-			return newProvider(openai.Config{
-				APIKey:          apiKey,
-				BaseURL:         baseURL,
-				ProviderName:    providerName,
-				PricingResolver: pricingResolver,
-				ModelAPILookup:  lookupModelAPI,
-				// Gemini quirks: parallel tool calls cause streaming index bugs;
-				// API requires "models/" prefix for all model IDs.
-				NoParallelTools: providerName == "gemini",
-				ModelIDPrefix: func() string {
-					if providerName == "gemini" {
-						return "models/"
-					}
-					return ""
-				}(),
-			})
-		})
-	}
+	providerRegistry := catalogBootstrap.providerRegistry
+	modelCatalog := catalogBootstrap.modelCatalog
 
 	provider, err := resolveDefaultProvider(resolveDefaultProviderOptions{
 		getenv:          getenv,
 		newProvider:     newProvider,
 		registry:        providerRegistry,
-		pricingResolver: pricingResolver,
+		pricingResolver: catalogBootstrap.pricingResolver,
 		model:           model,
-		lookupModelAPI:  lookupModelAPI,
+		lookupModelAPI:  catalogBootstrap.lookupModelAPI,
 	})
 	if err != nil {
 		return fmt.Errorf("create provider: %w", err)
@@ -530,29 +442,13 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	var cronStore cron.Store
 	var cronScheduler *cron.Scheduler
 
-	if cronURL != "" {
-		cronClient = &cronClientAdapter{client: cron.NewClient(cronURL)}
-	} else {
-		cronDBPath := filepath.Join(workspace, ".harness", "cron.db")
-		st, err := cron.NewSQLiteStore(cronDBPath)
-		if err != nil {
-			return fmt.Errorf("create cron store: %w", err)
-		}
-		if err := st.Migrate(context.Background()); err != nil {
-			st.Close()
-			return fmt.Errorf("migrate cron store: %w", err)
-		}
-		clock := cron.RealClock{}
-		sched := cron.NewScheduler(st, &cron.ShellExecutor{}, clock, cron.SchedulerConfig{MaxConcurrent: 5})
-		if err := sched.Start(context.Background()); err != nil {
-			st.Close()
-			return fmt.Errorf("start cron scheduler: %w", err)
-		}
-		cronStore = st
-		cronScheduler = sched
-		cronClient = &embeddedCronAdapter{store: st, scheduler: sched, clock: clock}
-		log.Printf("embedded cron scheduler started (db: %s)", cronDBPath)
+	cronBootstrap, err := buildCronBootstrap(workspace, cronURL, log.Printf)
+	if err != nil {
+		return err
 	}
+	cronClient = cronBootstrap.client
+	cronStore = cronBootstrap.store
+	cronScheduler = cronBootstrap.scheduler
 
 	// Delayed callbacks
 	var callbackStarter *callbackRunStarter
@@ -602,52 +498,26 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	// HARNESS_RUN_DB configures the SQLite path for run/event/message records.
 	// When S3_BUCKET is set but HARNESS_RUN_DB is not, we default to a
 	// sibling file next to HARNESS_CONVERSATION_DB (or a temp location).
-	var runStore istore.Store
-	if runDBPath := getenv("HARNESS_RUN_DB"); runDBPath != "" {
-		if !filepath.IsAbs(runDBPath) {
-			runDBPath = filepath.Join(workspace, runDBPath)
-		}
-		rs, err := istore.NewSQLiteStore(runDBPath)
-		if err != nil {
-			return fmt.Errorf("create run store: %w", err)
-		}
-		if err := rs.Migrate(context.Background()); err != nil {
-			rs.Close()
-			return fmt.Errorf("migrate run store: %w", err)
-		}
-		defer rs.Close()
-		runStore = rs
-		log.Printf("run persistence enabled: %s", runDBPath)
-	}
-
-	// Conversation persistence
 	convRetentionDays := envIntOrDefault("HARNESS_CONVERSATION_RETENTION_DAYS", 30)
-	var convStore harness.ConversationStore
-	convCleanerCtx, convCleanerCancel := context.WithCancel(context.Background())
-	defer convCleanerCancel()
-	if dbPath := getenv("HARNESS_CONVERSATION_DB"); dbPath != "" {
-		if !filepath.IsAbs(dbPath) {
-			dbPath = filepath.Join(workspace, dbPath)
-		}
-		store, err := harness.NewSQLiteConversationStore(dbPath)
-		if err != nil {
-			return fmt.Errorf("create conversation store: %w", err)
-		}
-		if err := store.Migrate(context.Background()); err != nil {
-			store.Close()
-			return fmt.Errorf("migrate conversation store: %w", err)
-		}
-		convStore = store
-		defer store.Close()
-		log.Printf("conversation persistence enabled: %s", dbPath)
-
-		// Start retention cleaner background goroutine.
-		if convRetentionDays > 0 {
-			log.Printf("conversation retention policy: %d days", convRetentionDays)
-			cleaner := deps.newConversationCleaner(store, convRetentionDays)
-			cleaner.Start(convCleanerCtx, 24*time.Hour)
-		}
+	persistenceBootstrap, err := buildPersistenceBootstrap(persistenceBootstrapOptions{
+		workspace:         workspace,
+		getenv:            getenv,
+		convRetentionDays: convRetentionDays,
+		logger:            log.Printf,
+		newCleaner:        deps.newConversationCleaner,
+	})
+	if err != nil {
+		return err
 	}
+	runStore := persistenceBootstrap.runStore
+	if runStore != nil {
+		defer runStore.Close()
+	}
+	convStore := persistenceBootstrap.conversationStore
+	if convStore != nil {
+		defer convStore.Close()
+	}
+	convCleanerCancel := persistenceBootstrap.convCleanerCancel
 
 	askUserBroker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
 	activations := harness.NewActivationTracker()
@@ -807,59 +677,19 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	// Build the external-trigger validator registry from webhook secrets (issue #411).
 	// Validators are only registered when the corresponding env var is non-empty;
 	// missing secrets mean the source is simply unavailable (fail-closed).
-	triggerValidators := trigger.NewValidatorRegistry()
-	if s := strings.TrimSpace(getenv("GITHUB_WEBHOOK_SECRET")); s != "" {
-		triggerValidators.Register("github", &trigger.GitHubValidator{Secret: s})
-		log.Printf("registered GitHub webhook validator")
-	}
-	if s := strings.TrimSpace(getenv("SLACK_SIGNING_SECRET")); s != "" {
-		triggerValidators.Register("slack", &trigger.SlackValidator{Secret: s})
-		log.Printf("registered Slack webhook validator")
-	}
-	if s := strings.TrimSpace(getenv("LINEAR_WEBHOOK_SECRET")); s != "" {
-		triggerValidators.Register("linear", &trigger.LinearValidator{Secret: s})
-		log.Printf("registered Linear webhook validator")
-	}
+	triggerRuntime := buildTriggerRuntime(getenv, log.Printf)
 
-	// Build the GitHub webhook adapter for POST /v1/webhooks/github (issue #412).
-	// Uses the same GITHUB_WEBHOOK_SECRET as the generic trigger validator.
-	var ghAdapter *githubadapter.GitHubAdapter
-	if s := strings.TrimSpace(getenv("GITHUB_WEBHOOK_SECRET")); s != "" {
-		ghAdapter = githubadapter.NewGitHubAdapter(s)
-		log.Printf("registered GitHub webhook adapter for /v1/webhooks/github")
-	}
-
-	// Build the Slack webhook adapter for POST /v1/webhooks/slack (issue #413).
-	// Signature validation uses SLACK_SIGNING_SECRET (already in triggerValidators).
-	var slAdapter *slackadapter.SlackAdapter
-	if strings.TrimSpace(getenv("SLACK_SIGNING_SECRET")) != "" {
-		slAdapter = slackadapter.NewSlackAdapter()
-		log.Printf("registered Slack webhook adapter for /v1/webhooks/slack")
-	}
-
-	// Build the Linear webhook adapter for POST /v1/webhooks/linear (issue #413).
-	// Signature validation uses LINEAR_WEBHOOK_SECRET (already in triggerValidators).
-	var linAdapter *linearadapter.LinearAdapter
-	if strings.TrimSpace(getenv("LINEAR_WEBHOOK_SECRET")) != "" {
-		linAdapter = linearadapter.NewLinearAdapter()
-		log.Printf("registered Linear webhook adapter for /v1/webhooks/linear")
-	}
-
-	handler := server.NewWithOptions(server.ServerOptions{
-		Runner:           runner,
-		Catalog:          modelCatalog,
-		AgentRunner:      runner,
-		SkillLister:      skillLister,
-		Skills:           skillManager,
-		CronClient:       cronClient,
-		SubagentManager:  subagentMgr,
-		ProviderRegistry: providerRegistry,
-		Store:            runStore,
-		Validators:       triggerValidators,
-		GitHubAdapter:    ghAdapter,
-		SlackAdapter:     slAdapter,
-		LinearAdapter:    linAdapter,
-	})
+	handler := server.NewWithOptions(buildServerOptions(serverBootstrapOptions{
+		runner:           runner,
+		modelCatalog:     modelCatalog,
+		skillLister:      skillLister,
+		skillManager:     skillManager,
+		cronClient:       cronClient,
+		subagentManager:  subagentMgr,
+		providerRegistry: providerRegistry,
+		runStore:         runStore,
+		triggers:         triggerRuntime,
+	}))
 	httpServer := &http.Server{
 		Addr:              addr,
 		Handler:           handler,

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -518,6 +518,9 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		defer convStore.Close()
 	}
 	convCleanerCancel := persistenceBootstrap.convCleanerCancel
+	if convCleanerCancel != nil {
+		defer convCleanerCancel()
+	}
 
 	askUserBroker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
 	activations := harness.NewActivationTracker()

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,31 @@
 # Engineering Log
 
+## 2026-03-25 (Issue #426 Bootstrap Wiring)
+
+- Extracted focused `harnessd` bootstrap helpers in `cmd/harnessd/bootstrap_helpers.go` for:
+  - catalog/pricing/provider-registry bootstrap
+  - cron bootstrap
+  - persistence + conversation-cleaner bootstrap
+  - trigger/webhook adapter bootstrap
+  - HTTP server option assembly
+- Slimmed `cmd/harnessd/main.go` so `runWithSignals(...)` delegates those wiring concerns instead of inlining each subsystem's setup.
+- Added direct failing-first coverage in `cmd/harnessd/bootstrap_helpers_test.go` for:
+  - workspace catalog fallback and model API lookup behavior
+  - secret-driven trigger validator/adapter registration
+  - server option forwarding of the extracted runtime dependencies
+  - persistence bootstrap setup and failure cleanup behavior
+- Verification:
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run 'TestBuild(CatalogBootstrapFallsBackToWorkspaceCatalog|TriggerRuntimeHonorsSecrets|ServerOptionsForwardsBootstrapRuntime|PersistenceBootstrapInitializesStoresAndCleaner|PersistenceBootstrapClosesRunStoreWhenConversationSetupFails)' -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -race -count=1`
+  - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build COVERPROFILE_PATH=$PWD/.tmp/issue-426-coverage.out ./scripts/test-regression.sh`
+- Regression status:
+  - `cmd/harnessd` package tests and race tests passed after the extraction.
+  - The repo-wide regression script is blocked locally by unrelated existing transcript-export tests that attempt to write under `~/Library/Caches`, which this sandbox forbids:
+    - `cmd/harnesscli/tui: TestExportCommandWritesOutsideWorkingDirectory`
+    - `cmd/harnesscli/tui/components/transcriptexport: TestTUI059_ExportDefaultOutputDirCreatesFileOutsideWorkingDirectory`
+  - The issue-`#426` change itself did not introduce a package-level failure outside that pre-existing sandbox-specific blocker.
+
 ## 2026-03-25 (Issue #422 Run Persistence Ownership)
 
 - Added focused HTTP persistence-ownership regressions in `internal/server/http_persistence_ownership_test.go` to prove that:
@@ -180,6 +206,7 @@
 - Regression status:
   - the repo-wide `./scripts/test-regression.sh` run reached the multi-package race phase cleanly but hit a timeout in `TestWorkerPool_QueuedTransitionsToRunning` during the full-package `go test ./internal/... ./cmd/... -race` invocation.
   - that worker-pool race timeout did not reproduce in isolated reruns, so it currently looks like an unrelated pre-existing/full-suite flake rather than a deterministic issue-`#423` regression.
+
 ## 2026-03-25 (Issue #424 Event Journal Extraction)
 
 - Extracted the runner event append/store/recorder path into a focused internal helper in `internal/harness/runner_event_journal.go`.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -15,6 +15,27 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
 - Next verification step:
 
+## 2026-03-25 (Issue #426 Bootstrap Wiring)
+
+- Command intent: Complete GitHub issue `#426` by splitting `harnessd` bootstrap assembly into focused helpers while preserving startup/shutdown behavior.
+- User intent: Make the `harnessd` entrypoint easier to evolve and review by moving subsystem wiring out of the monolithic `runWithSignals(...)` flow.
+- Success definition:
+  - `cmd/harnessd/main.go` becomes more orchestration-focused and delegates bootstrap assembly to smaller helpers.
+  - The extracted seams cover provider/catalog startup, persistence/cron startup, and webhook/server assembly without changing runtime behavior.
+  - New failing-first tests pin the extracted behavior directly.
+  - `go test ./cmd/harnessd` passes.
+  - The repo regression gate and PR CI pass so the PR is mergeable.
+- Non-goals:
+  - Changing runtime behavior or public API contracts.
+  - Refactoring unrelated runner or transport code.
+- Guardrails/constraints:
+  - Strict TDD.
+  - Keep changes narrow and reviewable.
+  - Preserve existing env/config-driven optional subsystem behavior.
+- Open questions:
+  - Which bootstrap slices can be extracted most cleanly without forcing broad new seams into already-tested startup behavior.
+- Next verification step: run the new helper tests red, implement the missing helper layer, then rerun `go test ./cmd/harnessd` before the full regression gate.
+
 ## 2026-03-25 (Issue #422 Run Persistence Ownership)
 
 - Command intent: Complete GitHub issue `#422` by consolidating run-record persistence ownership into the runner boundary and removing duplicate HTTP-side `CreateRun` calls.

--- a/docs/plans/2026-03-25-issue-426-bootstrap-wiring-plan.md
+++ b/docs/plans/2026-03-25-issue-426-bootstrap-wiring-plan.md
@@ -1,0 +1,52 @@
+# Plan: Issue #426 harnessd bootstrap wiring
+
+## Context
+
+- Problem: `cmd/harnessd/main.go` still assembles provider/catalog startup, persistence, cron, webhook adapters, and server wiring in one large `runWithSignals(...)` flow.
+- User impact: Startup wiring is harder to review and extend safely because unrelated bootstrap concerns are interleaved in one function.
+- Constraints: Preserve existing startup and shutdown behavior, follow strict TDD, and keep the extraction scoped to bootstrap composition rather than changing runtime features.
+
+## Scope
+
+- In scope:
+  - Extract focused helpers for `harnessd` bootstrap assembly.
+  - Add failing-first tests around the extracted seams.
+  - Keep `runWithSignals(...)` as orchestration glue instead of detailed subsystem assembly.
+- Out of scope:
+  - Provider/model behavior changes.
+  - HTTP API contract changes.
+  - Runner loop redesign.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - Catalog bootstrap coverage for workspace catalog discovery and API lookup behavior.
+  - Trigger/bootstrap helper coverage for secret-driven validator and adapter registration.
+  - Server-options helper coverage for forwarding the extracted runtime dependencies.
+- Existing tests to update:
+  - `cmd/harnessd/main_test.go` assertions that interact with the extracted seams.
+- Regression tests required:
+  - `go test ./cmd/harnessd -count=1`
+  - `./scripts/test-regression.sh`
+
+## Cross-Surface Impact Map
+
+- None. This task is bootstrap decomposition only and does not change provider/model flow contracts, TUI state, or API behavior.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [ ] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: Refactoring bootstrap assembly could subtly change which optional subsystems start under a given env/config combination.
+- Mitigation: Extract only well-bounded helpers and pin the env-driven seams with direct tests before moving code.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -12,6 +12,7 @@
 - `2026-03-25-issue-428-subrun-cancellation-plan.md`: Active plan for cancelling spawned subruns when the parent wait context times out or is cancelled.
 - `2026-03-25-issue-423-runner-preflight-plan.md`: Active plan for extracting runner preflight orchestration from `execute()` while preserving workspace/profile/MCP behavior.
 - `2026-03-25-issue-424-event-journal-plan.md`: Active implementation plan for extracting the runner event journal/sink path from `emit()`.
+- `2026-03-25-issue-426-bootstrap-wiring-plan.md`: Active implementation plan for modular `harnessd` bootstrap wiring extraction for issue `#426`.
 - `2026-03-25-openrouter-backend-discovery-plan.md`: Active plan for additive backend OpenRouter discovery, runtime routing, and merged `/v1/models` behavior.
 - `2026-03-25-openrouter-backend-discovery-impact-map.md`: One-page impact map for backend OpenRouter discovery and provider/model routing changes.
 - `2026-03-19-issue-361-golden-path-smoke-plan.md`: Active plan for the supported local deployment profile contract and live smoke suite.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on runner event-journal extraction for issue `#424`.
+Current status: active implementation work is focused on modular `harnessd` bootstrap wiring for issue `#426`.
 
-Current active plan: `2026-03-25-issue-424-event-journal-plan.md`
+Current active plan: `2026-03-25-issue-426-bootstrap-wiring-plan.md`
 
 Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`


### PR DESCRIPTION
## Summary
- extract focused `cmd/harnessd` bootstrap helpers for catalog/provider, cron, persistence, trigger, and server wiring
- keep `runWithSignals(...)` orchestration-focused while preserving the existing startup/shutdown behavior
- add direct regression coverage for the extracted helper seams before moving the wiring

## Testing
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -run 'TestBuild(CatalogBootstrapFallsBackToWorkspaceCatalog|TriggerRuntimeHonorsSecrets|ServerOptionsForwardsBootstrapRuntime|PersistenceBootstrapInitializesStoresAndCleaner|PersistenceBootstrapClosesRunStoreWhenConversationSetupFails)' -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnessd -race -count=1`
- `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build COVERPROFILE_PATH=$PWD/.tmp/issue-426-coverage.out ./scripts/test-regression.sh` *(blocked locally by pre-existing transcript-export tests that attempt to write under `~/Library/Caches`, which this sandbox denies: `cmd/harnesscli/tui: TestExportCommandWritesOutsideWorkingDirectory` and `cmd/harnesscli/tui/components/transcriptexport: TestTUI059_ExportDefaultOutputDirCreatesFileOutsideWorkingDirectory`)*

## Notes
- The repo-wide non-race phase completed locally before the sandbox-only transcript-export failures stopped the full gate.
- `cmd/harnessd` package tests and race tests are green on this branch.

Closes #426