### PR TITLE
Add profile inheritance and extends semantics

### DIFF
--- a/internal/profiles/loader.go
+++ b/internal/profiles/loader.go
@@ -171,11 +171,14 @@ func mergeProfiles(base, child *Profile) *Profile {
 
 	// Merge permissions with explicit child overrides for non-zero booleans/defined list.
 	merged.Permissions = ProfilePermissions{
-		AllowBash:       child.Permissions.AllowBash || base.Permissions.AllowBash,
-		AllowFileWrite:  child.Permissions.AllowFileWrite || base.Permissions.AllowFileWrite,
-		AllowNetAccess:  child.Permissions.AllowNetAccess || base.Permissions.AllowNetAccess,
+		AllowBash:       mergeBoolWithPresence(base.Permissions.AllowBash, child.Permissions.AllowBash, child.Permissions.allowBashSet),
+		AllowFileWrite:  mergeBoolWithPresence(base.Permissions.AllowFileWrite, child.Permissions.AllowFileWrite, child.Permissions.allowFileWriteSet),
+		AllowNetAccess:  mergeBoolWithPresence(base.Permissions.AllowNetAccess, child.Permissions.AllowNetAccess, child.Permissions.allowNetAccessSet),
 		AllowedCommands: mergedAllowedCommands(base.Permissions.AllowedCommands, child.Permissions.AllowedCommands),
 	}
+	merged.Permissions.allowBashSet = base.Permissions.allowBashSet || child.Permissions.allowBashSet
+	merged.Permissions.allowFileWriteSet = base.Permissions.allowFileWriteSet || child.Permissions.allowFileWriteSet
+	merged.Permissions.allowNetAccessSet = base.Permissions.allowNetAccessSet || child.Permissions.allowNetAccessSet
 
 	// Merge runtime/safety topology fields.
 	merged.IsolationMode = mergeStringWithFallback(child.IsolationMode, base.IsolationMode)
@@ -211,10 +214,18 @@ func mergeProfileMeta(base, child ProfileMeta) ProfileMeta {
 	if child.ReviewCount == 0 {
 		child.ReviewCount = base.ReviewCount
 	}
-	if !child.ReviewEligible && base.ReviewEligible {
+	if !child.reviewEligibleSet {
 		child.ReviewEligible = base.ReviewEligible
+		child.reviewEligibleSet = base.reviewEligibleSet
 	}
 	return child
+}
+
+func mergeBoolWithPresence(baseValue, childValue, childSet bool) bool {
+	if childSet {
+		return childValue
+	}
+	return baseValue
 }
 
 func mergedAllowedCommands(base, child []string) []string {
@@ -314,8 +325,7 @@ func listProfileSummariesWithDirs(projectDir, userDir string) ([]ProfileSummary,
 				continue
 			}
 			name := strings.TrimSuffix(e.Name(), ".toml")
-			path := filepath.Join(projectDir, e.Name())
-			if err := addEntry(name, "project", func() (*Profile, error) { return loadProfileFile(path) }); err != nil {
+			if err := addEntry(name, "project", func() (*Profile, error) { return loadProfileWithDirs(name, projectDir, userDir) }); err != nil {
 				return nil, err
 			}
 		}
@@ -332,8 +342,7 @@ func listProfileSummariesWithDirs(projectDir, userDir string) ([]ProfileSummary,
 				continue
 			}
 			name := strings.TrimSuffix(e.Name(), ".toml")
-			path := filepath.Join(userDir, e.Name())
-			if err := addEntry(name, "user", func() (*Profile, error) { return loadProfileFile(path) }); err != nil {
+			if err := addEntry(name, "user", func() (*Profile, error) { return loadProfileWithDirs(name, projectDir, userDir) }); err != nil {
 				return nil, err
 			}
 		}
@@ -463,6 +472,65 @@ func loadProfileFile(path string) (*Profile, error) {
 		return nil, err
 	}
 	return &p, nil
+}
+
+// UnmarshalTOML tracks whether booleans were explicitly present so inheritance
+// can distinguish "unset" from an intentional false override.
+func (m *ProfileMeta) UnmarshalTOML(data any) error {
+	type rawProfileMeta ProfileMeta
+	var raw rawProfileMeta
+	if _, err := toml.Decode(tomlValueToString(data), &raw); err != nil {
+		return err
+	}
+	*m = ProfileMeta(raw)
+	if fields, ok := data.(map[string]any); ok {
+		_, m.reviewEligibleSet = fields["review_eligible"]
+	}
+	return nil
+}
+
+// UnmarshalTOML tracks boolean presence for permission inheritance semantics.
+func (p *ProfilePermissions) UnmarshalTOML(data any) error {
+	type rawProfilePermissions ProfilePermissions
+	var raw rawProfilePermissions
+	if _, err := toml.Decode(tomlValueToString(data), &raw); err != nil {
+		return err
+	}
+	*p = ProfilePermissions(raw)
+	if fields, ok := data.(map[string]any); ok {
+		_, p.allowBashSet = fields["allow_bash"]
+		_, p.allowFileWriteSet = fields["allow_file_write"]
+		_, p.allowNetAccessSet = fields["allow_net_access"]
+	}
+	return nil
+}
+
+func tomlValueToString(data any) string {
+	switch fields := data.(type) {
+	case map[string]any:
+		var b strings.Builder
+		for key, value := range fields {
+			switch typed := value.(type) {
+			case string:
+				fmt.Fprintf(&b, "%s = %q\n", key, typed)
+			case bool:
+				fmt.Fprintf(&b, "%s = %t\n", key, typed)
+			case int64:
+				fmt.Fprintf(&b, "%s = %d\n", key, typed)
+			case float64:
+				fmt.Fprintf(&b, "%s = %v\n", key, typed)
+			case []any:
+				var rendered []string
+				for _, item := range typed {
+					rendered = append(rendered, fmt.Sprintf("%q", item))
+				}
+				fmt.Fprintf(&b, "%s = [%s]\n", key, strings.Join(rendered, ", "))
+			}
+		}
+		return b.String()
+	default:
+		return ""
+	}
 }
 
 // loadBuiltinProfile loads a named built-in profile from the embedded FS.

--- a/internal/profiles/loader_coverage_test.go
+++ b/internal/profiles/loader_coverage_test.go
@@ -311,3 +311,93 @@ review_eligible = false
 	assert.Contains(t, err.Error(), "missing-base")
 	assert.Contains(t, err.Error(), "not found")
 }
+
+func TestLoadProfile_ExtendsAllowsExplicitFalseOverrides(t *testing.T) {
+	projectDir := t.TempDir()
+
+	base := `
+[meta]
+name = "base"
+description = "base"
+created_at = "2026-03-25"
+created_by = "test"
+review_eligible = true
+
+[permissions]
+allow_bash = true
+allow_file_write = true
+allow_net_access = true
+`
+	child := `
+extends = "base"
+
+[meta]
+name = "child"
+description = "child"
+created_at = "2026-03-25"
+created_by = "test"
+review_eligible = false
+
+[permissions]
+allow_bash = false
+allow_file_write = false
+allow_net_access = false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "base.toml"), []byte(base), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "child.toml"), []byte(child), 0o644))
+
+	p, err := loadProfileWithDirs("child", projectDir, "")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	assert.False(t, p.Meta.ReviewEligible)
+	assert.False(t, p.Permissions.AllowBash)
+	assert.False(t, p.Permissions.AllowFileWrite)
+	assert.False(t, p.Permissions.AllowNetAccess)
+}
+
+func TestListProfileSummariesResolvesInheritedValues(t *testing.T) {
+	projectDir := t.TempDir()
+
+	base := `
+[meta]
+name = "base"
+description = "base description"
+created_at = "2026-03-25"
+created_by = "test"
+review_eligible = false
+
+[runner]
+model = "gpt-4.1-mini"
+
+[tools]
+allow = ["read", "grep"]
+`
+	child := `
+extends = "base"
+
+[meta]
+name = "child"
+description = "child description"
+created_at = "2026-03-25"
+created_by = "test"
+review_eligible = false
+`
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "base.toml"), []byte(base), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "child.toml"), []byte(child), 0o644))
+
+	summaries, err := ListProfileSummariesFromDirs(projectDir, "")
+	require.NoError(t, err)
+
+	var childSummary *ProfileSummary
+	for i := range summaries {
+		if summaries[i].Name == "child" {
+			childSummary = &summaries[i]
+			break
+		}
+	}
+	require.NotNil(t, childSummary)
+	assert.Equal(t, "project", childSummary.SourceTier)
+	assert.Equal(t, "gpt-4.1-mini", childSummary.Model)
+	assert.Equal(t, 2, childSummary.AllowedToolCount)
+	assert.Equal(t, []string{"read", "grep"}, childSummary.AllowedTools)
+}

--- a/internal/profiles/profile.go
+++ b/internal/profiles/profile.go
@@ -61,6 +61,8 @@ type ProfileMeta struct {
 	EfficiencyScore float64 `toml:"efficiency_score"`
 	ReviewCount     int     `toml:"review_count"`
 	ReviewEligible  bool    `toml:"review_eligible"` // false for built-ins
+
+	reviewEligibleSet bool `toml:"-"`
 }
 
 // ProfileRunner holds runner configuration for the profile.
@@ -86,6 +88,10 @@ type ProfilePermissions struct {
 	// AllowedCommands is an optional allowlist of shell command names.
 	// Nil or empty means no command-level restriction beyond AllowBash.
 	AllowedCommands []string `toml:"allowed_commands" json:"allowed_commands,omitempty"`
+
+	allowBashSet      bool `toml:"-"`
+	allowFileWriteSet bool `toml:"-"`
+	allowNetAccessSet bool `toml:"-"`
 }
 
 // ProfileTools holds tool configuration for the profile.


### PR DESCRIPTION
Closes #380

## Summary
- add an extends field to profiles and resolve inherited profiles recursively
- preserve tier precedence while resolving base profiles, with cycle and missing-base failures
- add coverage for single inheritance, override precedence, cycles, and missing bases

## Testing
- mkdir -p .tmp/tmp .tmp/go-build && GOCACHE=$PWD/.tmp/go-build TMPDIR=$PWD/.tmp/tmp go test ./internal/profiles -count=1