### PR TITLE
Add parent context handoff bundles for subagents

### DIFF
--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -865,3 +865,25 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether additional command-backed tools should share the same bounded output helper immediately.
 - Next verification step: Add failing tests for oversized output in both foreground/background flows, implement bounded buffer, then run `./scripts/test-regression.sh`.
+
+## 2026-03-25 (Issue #384 Parent Context Handoff Bundles)
+
+- Command intent: Complete GitHub issue `#384` by replacing ad hoc parent-to-child prompt stuffing with a typed, size-bounded context handoff bundle for delegated subagent and forked executions.
+- User intent: Make delegated runs inspectable, replayable, and safely bounded so child prompts get the right parent context without silent loss or runaway prompt growth.
+- Success definition:
+  - A typed `ParentContextHandoff` contract exists in the tools/harness layer and serializes deterministically.
+  - Parent context extraction is bounded by message count, per-message size, and total serialized size, with pinned truncation behavior.
+  - `run_agent`, `spawn_agent`, and fork-context skills render the handoff before the child task content in a consistent order.
+  - The runner and subagent manager propagate/store the handoff on child runs for debugging and replay.
+  - Focused delegation/handoff package tests pass after failing-first coverage is added.
+- Non-goals:
+  - Redesigning task-complete or child-result payloads.
+  - Broad profile/runtime isolation changes unrelated to handoff propagation.
+  - Passing the full unbounded parent transcript into child prompts.
+- Guardrails/constraints:
+  - Strict TDD: failing tests first for serialization, truncation, and prompt order.
+  - Keep the handoff deterministic and reviewable.
+  - Preserve current behavior when no parent context is available.
+- Open questions:
+  - Whether the `spawn_agent` system prompt should continue duplicating the task text while the typed handoff block becomes the canonical parent-context contract.
+- Next verification step: add failing handoff tests in tools/subagents/harness packages, implement the shared handoff helpers and propagation fields, then rerun focused suites and broader relevant tests.

--- a/docs/plans/2026-03-25-issue-384-context-handoff-plan.md
+++ b/docs/plans/2026-03-25-issue-384-context-handoff-plan.md
@@ -1,0 +1,61 @@
+# Plan: Issue #384 Parent Context Handoff Bundles
+
+## Context
+
+- Problem: delegated child runs currently rely on ad hoc prompt assembly, so parent context is not carried in a typed, inspectable, size-bounded way across `run_agent`, `spawn_agent`, and forked skills.
+- User impact: subagent delegation is harder to debug and replay, and large parent context can either disappear or bloat child prompts unpredictably.
+- Constraints:
+  - Strict TDD with failing tests first.
+  - Keep the change scoped to delegation handoff and storage surfaces.
+  - Preserve behavior when no parent context is available.
+
+## Scope
+
+- In scope:
+  - Add a typed parent-context handoff contract in the tools layer.
+  - Bound and serialize parent transcript metadata/messages deterministically.
+  - Render the handoff before child task prompts for `run_agent`, `spawn_agent`, and fork-context skills.
+  - Propagate/store the handoff through subagent manager and runner child-run requests.
+  - Add regression coverage for truncation markers, prompt ordering, and omitted-large-context behavior.
+- Out of scope:
+  - Redesigning child-result payloads.
+  - Broad profile/runtime isolation refactors.
+  - Carrying the full unbounded parent transcript into child prompts.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `internal/harness/tools/types_context_test.go` for handoff serialization, truncation, and prompt rendering order.
+  - `internal/harness/tools/deferred/run_agent_test.go` and `internal/harness/tools/deferred/spawn_agent_test.go` for forwarding/rendering the handoff.
+  - `internal/harness/tools/core/skill_test.go` for forked skill prompt/handoff propagation.
+  - `internal/subagents/system_prompt_test.go` and `internal/harness/runner_profile_propagation_test.go` for manager/runner propagation and storage.
+- Existing tests to update:
+  - delegation-path tests that currently assume plain task-only prompts.
+- Regression tests required:
+  - truncation markers on oversized messages
+  - message ordering after byte-count bounding
+  - omission of oversized older messages
+  - child prompt ordering: handoff block before task boundary/body
+
+## Cross-Surface Impact Map
+
+- Required when the task touches provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing.
+- This issue does not touch those surfaces directly.
+
+## Implementation Checklist
+
+- [ ] Define acceptance criteria in tests.
+- [ ] For provider/model flow work, add or update the one-page impact map before implementation.
+- [x] Write failing tests first.
+- [ ] Review ownership/copy semantics for exported or state-storing types when mutable fields cross boundaries.
+- [ ] Implement minimal code changes.
+- [ ] Refactor while tests remain green.
+- [ ] Update docs and indexes.
+- [ ] Update engineering/system/observational logs as needed.
+- [ ] Run full test suite.
+- [ ] Merge branch back to `main` after tests pass.
+
+## Risks and Mitigations
+
+- Risk: prompt rendering or runner propagation may diverge between `run_agent`, `spawn_agent`, and skill forks.
+- Mitigation: pin the shared ordering/propagation contract with tests across all three call sites plus the runner/subagent seams.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-03-25-issue-384-context-handoff-plan.md`: Active plan for introducing typed, bounded parent-to-child context handoff bundles for delegated runs.
 - `2026-03-25-issue-422-run-persistence-ownership-plan.md`: Active plan for consolidating initial run-record persistence ownership into the runner boundary.
 - `2026-03-25-issue-427-http-feature-decomposition-plan.md`: Active plan for extracting run and conversation transport logic out of `internal/server/http.go`.
 - `2026-03-25-issue-429-fork-result-failure-plan.md`: Active plan for treating `ForkResult.Error` as a real failure across `/v1/agents` and fork-context skill tools.

--- a/docs/plans/active-plan.md
+++ b/docs/plans/active-plan.md
@@ -1,7 +1,7 @@
 # Active Plan
 
-Current status: active implementation work is focused on runner step-engine extraction for issue `#425`.
+Current status: active implementation work is focused on parent context handoff bundles for issue `#384`.
 
-Current active plan: `2026-03-25-issue-425-step-engine-plan.md`
+Current active plan: `2026-03-25-issue-384-context-handoff-plan.md`
 
-Most recent completed plan: `2026-03-25-openrouter-backend-discovery-plan.md`
+Most recent completed plan: `2026-03-25-issue-425-step-engine-plan.md`

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -450,16 +450,17 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		agentID = "default"
 	}
 	run := Run{
-		ID:          r.nextID("run"),
-		Prompt:      req.Prompt,
-		Model:       model,
-		Status:      RunStatusQueued,
-		UsageTotals: &RunUsageTotals{},
-		CostTotals:  &RunCostTotals{CostStatus: CostStatusPending},
-		TenantID:    tenantID,
-		AgentID:     agentID,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID:                   r.nextID("run"),
+		Prompt:               req.Prompt,
+		Model:                model,
+		Status:               RunStatusQueued,
+		UsageTotals:          &RunUsageTotals{},
+		CostTotals:           &RunCostTotals{CostStatus: CostStatusPending},
+		TenantID:             tenantID,
+		AgentID:              agentID,
+		ParentContextHandoff: req.ParentContextHandoff,
+		CreatedAt:            now,
+		UpdatedAt:            now,
 	}
 	run.ConversationID = strings.TrimSpace(req.ConversationID)
 	if run.ConversationID == "" {
@@ -1276,12 +1277,21 @@ func (r *Runner) runPromptWithRequest(ctx context.Context, req RunRequest, op st
 // embedded in ctx). AllowedTools from ForkConfig is forwarded as RunRequest.AllowedTools.
 // The fork depth from ctx is propagated to the child run via RunRequest.ForkDepth.
 func (r *Runner) RunForkedSkill(ctx context.Context, config htools.ForkConfig) (htools.ForkResult, error) {
+	requestHandoff := config.ParentContextHandoff
+	if requestHandoff == nil {
+		if fromContext, ok := htools.BuildParentContextHandoffFromContext(ctx); ok {
+			copied := fromContext
+			requestHandoff = &copied
+		}
+	}
+
 	// Build the sub-run request, forwarding AllowedTools from the fork config.
 	// Propagate fork depth from context so the child knows its nesting level.
 	req := RunRequest{
-		Prompt:       config.Prompt,
-		AllowedTools: config.AllowedTools,
-		ForkDepth:    htools.ForkDepthFromContext(ctx),
+		Prompt:               config.Prompt,
+		AllowedTools:         config.AllowedTools,
+		ForkDepth:            htools.ForkDepthFromContext(ctx),
+		ParentContextHandoff: requestHandoff,
 	}
 	// Apply optional model and max_steps overrides from ForkConfig.
 	// Empty/zero values mean "use runner defaults" (inherit from parent run).

--- a/internal/harness/runner_profile_propagation_test.go
+++ b/internal/harness/runner_profile_propagation_test.go
@@ -7,6 +7,19 @@ import (
 	htools "go-agent-harness/internal/harness/tools"
 )
 
+type profilePropagationTranscriptReaderStub struct{}
+
+func (profilePropagationTranscriptReaderStub) Snapshot(limit int, includeTools bool) htools.TranscriptSnapshot {
+	return htools.TranscriptSnapshot{
+		RunID: "run_parent",
+		Messages: []htools.TranscriptMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: "Parent note to preserve in child context.",
+		}},
+	}
+}
+
 // TestRunForkedSkill_InheritsParentProfileName verifies that RunForkedSkill
 // propagates the parent run's ProfileName to the child RunRequest.
 // This ensures profile MCP servers (loaded by StartRun from the profile file)
@@ -173,5 +186,75 @@ func TestRunState_StoresProfileName(t *testing.T) {
 
 	if state.profileName != "test-profile" {
 		t.Errorf("expected profileName %q in runState, got %q", "test-profile", state.profileName)
+	}
+}
+
+func TestRunForkedSkill_StoresParentContextHandoff(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{
+		turns: []CompletionResult{
+			{Content: "parent done"},
+			{Content: "child done"},
+		},
+	}
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     2,
+	})
+
+	parentRun, err := runner.StartRun(RunRequest{
+		Prompt: "parent task",
+	})
+	if err != nil {
+		t.Fatalf("start parent run: %v", err)
+	}
+	_, err = collectRunEvents(t, runner, parentRun.ID)
+	if err != nil {
+		t.Fatalf("collect parent run events: %v", err)
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, htools.ContextKeyRunMetadata, htools.RunMetadata{
+		RunID:          parentRun.ID,
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+	})
+	ctx = context.WithValue(ctx, htools.ContextKeyTranscriptReader, profilePropagationTranscriptReaderStub{})
+
+	_, err = runner.RunForkedSkill(ctx, htools.ForkConfig{
+		Prompt:    "child task",
+		SkillName: "test-skill",
+	})
+	if err != nil {
+		t.Fatalf("RunForkedSkill: %v", err)
+	}
+
+	runner.mu.RLock()
+	var forkedRunState *runState
+	var loadedRun Run
+	for id, state := range runner.runs {
+		if id == parentRun.ID {
+			continue
+		}
+		forkedRunState = state
+		loadedRun = state.run
+		break
+	}
+	runner.mu.RUnlock()
+
+	if forkedRunState == nil {
+		t.Fatal("no forked run state found")
+	}
+	if forkedRunState.run.ParentContextHandoff == nil {
+		t.Fatal("expected ParentContextHandoff on child run state")
+	}
+	if forkedRunState.run.ParentContextHandoff.ParentRunID != parentRun.ID {
+		t.Fatalf("expected child run ParentRunID %q, got %q", parentRun.ID, forkedRunState.run.ParentContextHandoff.ParentRunID)
+	}
+	if loadedRun.ParentContextHandoff == nil {
+		t.Fatal("expected ParentContextHandoff on stored run")
 	}
 }

--- a/internal/harness/tools/core/skill.go
+++ b/internal/harness/tools/core/skill.go
@@ -137,14 +137,22 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 	forkCtx = tools.WithForkDepth(forkCtx, currentDepth+1)
 	// Keep the legacy forked skill marker for backward compatibility.
 	forkCtx = context.WithValue(forkCtx, tools.ContextKeyForkedSkill, info.Name)
+	childHandoff, hasHandoff := tools.BuildParentContextHandoffFromContext(forkCtx)
+	effectivePrompt := tools.RenderPromptWithParentContext(content, childHandoff)
+	var handoffRef *tools.ParentContextHandoff
+	if hasHandoff {
+		copyHandoff := childHandoff
+		handoffRef = &copyHandoff
+	}
 
 	// Check if runner implements ForkedAgentRunner for richer invocation
 	if forkedRunner, ok := runner.(tools.ForkedAgentRunner); ok {
 		config := tools.ForkConfig{
-			Prompt:       content,
-			SkillName:    info.Name,
-			Agent:        info.Agent,
-			AllowedTools: info.AllowedTools,
+			Prompt:               effectivePrompt,
+			ParentContextHandoff: handoffRef,
+			SkillName:            info.Name,
+			Agent:                info.Agent,
+			AllowedTools:         info.AllowedTools,
 		}
 		result, err := forkedRunner.RunForkedSkill(forkCtx, config)
 		if err != nil {
@@ -169,7 +177,7 @@ func handleForkSkill(ctx context.Context, runner tools.AgentRunner, info tools.S
 	}
 
 	// Fallback: basic AgentRunner.RunPrompt
-	output, err := runPromptWithAllowedTools(forkCtx, runner, content, info.AllowedTools)
+	output, err := runPromptWithAllowedTools(forkCtx, runner, effectivePrompt, info.AllowedTools)
 	if err != nil {
 		return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 	}

--- a/internal/harness/tools/core/skill_test.go
+++ b/internal/harness/tools/core/skill_test.go
@@ -11,6 +11,19 @@ import (
 	tools "go-agent-harness/internal/harness/tools"
 )
 
+type skillTranscriptReaderStub struct{}
+
+func (skillTranscriptReaderStub) Snapshot(limit int, includeTools bool) tools.TranscriptSnapshot {
+	return tools.TranscriptSnapshot{
+		RunID: "run_parent",
+		Messages: []tools.TranscriptMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: "Prior finding: keep the task specific.",
+		}},
+	}
+}
+
 // ---------- mock types ----------
 
 type mockSkillLister struct {
@@ -840,6 +853,46 @@ func TestSkillTool_Handler_ForkContextCanceled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "context canceled") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillTool_Handler_ForkInjectsParentContextHandoffIntoPrompt(t *testing.T) {
+	t.Parallel()
+	lister := newForkSkillLister()
+	runner := &mockForkedRunner{
+		forkOutput: tools.ForkResult{Output: "done"},
+	}
+	tool := SkillTool(lister, runner)
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, tools.ContextKeyRunMetadata, tools.RunMetadata{
+		RunID:          "run_parent",
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+	})
+	ctx = context.WithValue(ctx, tools.ContextKeyTranscriptReader, skillTranscriptReaderStub{})
+
+	_, err := tool.Handler(ctx, json.RawMessage(`{"command":"research topic"}`))
+	if err != nil {
+		t.Fatalf("fork failed: %v", err)
+	}
+
+	if runner.lastForkConfig.ParentContextHandoff == nil {
+		t.Fatal("expected ParentContextHandoff in ForkConfig")
+	}
+	if runner.lastForkConfig.ParentContextHandoff.ParentRunID != "run_parent" {
+		t.Fatalf("ParentRunID = %q, want %q", runner.lastForkConfig.ParentContextHandoff.ParentRunID, "run_parent")
+	}
+	prompt := runner.lastForkConfig.Prompt
+	handoffIdx := strings.Index(prompt, "# Parent context handoff")
+	taskHeaderIdx := strings.Index(prompt, "# Task")
+	taskIdx := strings.LastIndex(prompt, "Research the topic thoroughly.")
+	if handoffIdx == -1 || taskHeaderIdx == -1 || taskIdx == -1 {
+		t.Fatalf("expected rendered parent handoff order markers, got prompt: %q", prompt)
+	}
+	if !(handoffIdx < taskHeaderIdx && taskHeaderIdx < taskIdx) {
+		t.Fatalf("unexpected prompt order: handoff=%d taskHeader=%d task=%d", handoffIdx, taskHeaderIdx, taskIdx)
 	}
 }
 

--- a/internal/harness/tools/deferred/run_agent.go
+++ b/internal/harness/tools/deferred/run_agent.go
@@ -49,7 +49,7 @@ func RunAgentTool(manager tools.SubagentManager, profilesDir string) tools.Tool 
 		if manager == nil {
 			return "", fmt.Errorf("run_agent: subagent manager is not configured")
 		}
-		req, err := parseSubagentProfileRequest("run_agent", raw, profilesDir)
+		req, err := parseSubagentProfileRequest(ctx, "run_agent", raw, profilesDir)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/deferred/run_agent_test.go
+++ b/internal/harness/tools/deferred/run_agent_test.go
@@ -6,11 +6,26 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tools "go-agent-harness/internal/harness/tools"
 )
+
+type runAgentTranscriptReaderStub struct{}
+
+func (runAgentTranscriptReaderStub) Snapshot(limit int, includeTools bool) tools.TranscriptSnapshot {
+	return tools.TranscriptSnapshot{
+		RunID: "run_parent",
+		Messages: []tools.TranscriptMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: "Please investigate the parser failure before editing.",
+		}},
+		GeneratedAt: time.Now().UTC(),
+	}
+}
 
 // mockSubagentManager implements tools.SubagentManager for testing.
 type mockSubagentManager struct {
@@ -174,6 +189,30 @@ allow = ["bash", "read"]
 	assert.Equal(t, "worktree", manager.lastReq.IsolationMode)
 	assert.Equal(t, "delete_on_success", manager.lastReq.CleanupPolicy)
 	assert.Equal(t, "release/test-base", manager.lastReq.BaseRef)
+}
+
+func TestRunAgentTool_ForwardsParentContextHandoff(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{Status: "completed", Output: "done"},
+	}
+	tool := RunAgentTool(manager, "")
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, tools.ContextKeyRunMetadata, tools.RunMetadata{
+		RunID:          "run_parent",
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+	})
+	ctx = context.WithValue(ctx, tools.ContextKeyTranscriptReader, runAgentTranscriptReaderStub{})
+
+	raw, _ := json.Marshal(map[string]any{"task": "Fix the parser"})
+	_, err := tool.Handler(ctx, raw)
+	require.NoError(t, err)
+
+	require.NotNil(t, manager.lastReq.ParentContextHandoff)
+	assert.Equal(t, "run_parent", manager.lastReq.ParentContextHandoff.ParentRunID)
+	assert.Contains(t, manager.lastReq.Prompt, "# Parent context handoff")
 }
 
 func TestRunAgentTool_OverridesProfileModel(t *testing.T) {

--- a/internal/harness/tools/deferred/spawn_agent.go
+++ b/internal/harness/tools/deferred/spawn_agent.go
@@ -127,15 +127,25 @@ func SpawnAgentTool(runner tools.AgentRunner, profilesDir string) tools.Tool {
 		// runner can enforce task_complete visibility (depth > 0) and the next
 		// level's depth limit.
 		childCtx := tools.WithForkDepth(ctx, currentDepth+1)
+		childHandoff, hasHandoff := tools.BuildParentContextHandoffFromContext(childCtx)
+		var handoffRef *tools.ParentContextHandoff
+		if hasHandoff {
+			copyHandoff := childHandoff
+			handoffRef = &copyHandoff
+		}
 
 		// Build a system prompt that instructs the child to call task_complete.
 		childSystemPrompt := buildSubagentSystemPrompt(args.Task, maxSteps)
+		childPrompt := tools.RenderPromptWithParentContext(
+			childSystemPrompt+"\n\n# Task\n\n"+args.Task,
+			childHandoff,
+		)
 
 		// Check whether the runner supports ForkedAgentRunner (RunForkedSkill).
 		forkedRunner, ok := runner.(tools.ForkedAgentRunner)
 		if !ok {
 			// Fallback: use RunPrompt directly (no structured result).
-			output, err := runner.RunPrompt(childCtx, childSystemPrompt+"\n\n"+args.Task)
+			output, err := runner.RunPrompt(childCtx, childPrompt)
 			if err != nil {
 				return "", fmt.Errorf("spawn_agent: child run failed: %w", err)
 			}
@@ -147,11 +157,12 @@ func SpawnAgentTool(runner tools.AgentRunner, profilesDir string) tools.Tool {
 		}
 
 		config := tools.ForkConfig{
-			Prompt:       childSystemPrompt + "\n\n# Task\n\n" + args.Task,
-			SkillName:    "spawn_agent",
-			AllowedTools: args.AllowedTools,
-			Model:        model,
-			MaxSteps:     maxSteps,
+			Prompt:               childPrompt,
+			ParentContextHandoff: handoffRef,
+			SkillName:            "spawn_agent",
+			AllowedTools:         args.AllowedTools,
+			Model:                model,
+			MaxSteps:             maxSteps,
 		}
 
 		result, err := forkedRunner.RunForkedSkill(childCtx, config)

--- a/internal/harness/tools/deferred/spawn_agent_test.go
+++ b/internal/harness/tools/deferred/spawn_agent_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	tools "go-agent-harness/internal/harness/tools"
 )
@@ -38,6 +40,20 @@ func (m *mockSpawnForkedRunner) RunForkedSkill(ctx context.Context, config tools
 	m.lastConfig = config
 	m.lastCtx = ctx
 	return m.output, m.err
+}
+
+type spawnAgentTranscriptReaderStub struct{}
+
+func (spawnAgentTranscriptReaderStub) Snapshot(limit int, includeTools bool) tools.TranscriptSnapshot {
+	return tools.TranscriptSnapshot{
+		RunID: "run_parent",
+		Messages: []tools.TranscriptMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: strings.Repeat("child-context ", 50),
+		}},
+		GeneratedAt: time.Now().UTC(),
+	}
 }
 
 // --- SpawnAgentTool tests ---
@@ -171,6 +187,51 @@ func TestSpawnAgentTool_PropagatesDepthToChild(t *testing.T) {
 	childDepth := tools.ForkDepthFromContext(runner.lastCtx)
 	if childDepth != 3 {
 		t.Fatalf("expected child depth 3, got %d", childDepth)
+	}
+}
+
+func TestSpawnAgentTool_ForwardsParentContextHandoff(t *testing.T) {
+	t.Parallel()
+	runner := &mockSpawnForkedRunner{
+		output: tools.ForkResult{Output: "done"},
+	}
+	tool := SpawnAgentTool(runner, "")
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, tools.ContextKeyRunMetadata, tools.RunMetadata{
+		RunID:          "run_parent",
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+	})
+	ctx = context.WithValue(ctx, tools.ContextKeyTranscriptReader, spawnAgentTranscriptReaderStub{})
+
+	_, err := tool.Handler(ctx, json.RawMessage(`{"task":"do something"}`))
+	if err != nil {
+		t.Fatalf("spawn_agent failed: %v", err)
+	}
+
+	if runner.lastConfig.ParentContextHandoff == nil {
+		t.Fatal("expected ParentContextHandoff in ForkConfig")
+	}
+	if runner.lastConfig.ParentContextHandoff.ParentRunID != "run_parent" {
+		t.Fatalf("expected ParentRunID %q, got %q", "run_parent", runner.lastConfig.ParentContextHandoff.ParentRunID)
+	}
+	if utf8.RuneCountInString(runner.lastConfig.ParentContextHandoff.Messages[0].Content) > 400 {
+		t.Fatalf("expected parent context message to be truncated to <=400 runes, got %d", utf8.RuneCountInString(runner.lastConfig.ParentContextHandoff.Messages[0].Content))
+	}
+	prompt := runner.lastConfig.Prompt
+	if !strings.Contains(prompt, "# Parent context handoff") {
+		t.Fatalf("expected prompt to include parent context handoff header, got %q", prompt)
+	}
+	handoffIdx := strings.Index(prompt, "# Parent context handoff")
+	taskHeaderIdx := strings.Index(prompt, "# Task")
+	taskBodyIdx := strings.LastIndex(prompt, "do something")
+	if handoffIdx == -1 || taskHeaderIdx == -1 || taskBodyIdx == -1 {
+		t.Fatalf("expected prompt order markers, got %q", prompt)
+	}
+	if !(handoffIdx < taskHeaderIdx && taskHeaderIdx < taskBodyIdx) {
+		t.Fatalf("unexpected prompt order: handoff=%d taskHeader=%d task=%d", handoffIdx, taskHeaderIdx, taskBodyIdx)
 	}
 }
 

--- a/internal/harness/tools/deferred/subagent_tools.go
+++ b/internal/harness/tools/deferred/subagent_tools.go
@@ -47,7 +47,7 @@ func StartSubagentTool(manager tools.SubagentManager, profilesDir string) tools.
 	}
 
 	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
-		req, err := parseSubagentProfileRequest("start_subagent", raw, profilesDir)
+		req, err := parseSubagentProfileRequest(ctx, "start_subagent", raw, profilesDir)
 		if err != nil {
 			return "", err
 		}
@@ -240,7 +240,7 @@ type subagentProfileArgs struct {
 	BaseRef         string   `json:"base_ref,omitempty"`
 }
 
-func parseSubagentProfileRequest(toolName string, rawJSON json.RawMessage, profilesDir string) (tools.SubagentRequest, error) {
+func parseSubagentProfileRequest(ctx context.Context, toolName string, rawJSON json.RawMessage, profilesDir string) (tools.SubagentRequest, error) {
 	var args subagentProfileArgs
 	if err := json.Unmarshal(rawJSON, &args); err != nil {
 		return tools.SubagentRequest{}, fmt.Errorf("parse %s args: %w", toolName, err)
@@ -300,19 +300,26 @@ func parseSubagentProfileRequest(toolName string, rawJSON json.RawMessage, profi
 	if strings.TrimSpace(args.BaseRef) != "" {
 		baseRef = strings.TrimSpace(args.BaseRef)
 	}
+	childHandoff, hasHandoff := tools.BuildParentContextHandoffFromContext(ctx)
+	var handoffRef *tools.ParentContextHandoff
+	if hasHandoff {
+		copyHandoff := childHandoff
+		handoffRef = &copyHandoff
+	}
 
 	return tools.SubagentRequest{
-		Prompt:          args.Task,
-		Model:           model,
-		SystemPrompt:    vals.SystemPrompt,
-		MaxSteps:        maxSteps,
-		MaxCostUSD:      maxCostUSD,
-		AllowedTools:    allowedTools,
-		ProfileName:     profileName,
-		ReasoningEffort: reasoningEffort,
-		IsolationMode:   isolationMode,
-		CleanupPolicy:   cleanupPolicy,
-		BaseRef:         baseRef,
-		ResultMode:      vals.ResultMode,
+		Prompt:               tools.RenderPromptWithParentContext(args.Task, childHandoff),
+		Model:                model,
+		SystemPrompt:         vals.SystemPrompt,
+		MaxSteps:             maxSteps,
+		MaxCostUSD:           maxCostUSD,
+		AllowedTools:         allowedTools,
+		ProfileName:          profileName,
+		ReasoningEffort:      reasoningEffort,
+		IsolationMode:        isolationMode,
+		CleanupPolicy:        cleanupPolicy,
+		BaseRef:              baseRef,
+		ResultMode:           vals.ResultMode,
+		ParentContextHandoff: handoffRef,
 	}, nil
 }

--- a/internal/harness/tools/skill.go
+++ b/internal/harness/tools/skill.go
@@ -81,13 +81,21 @@ func flatSkillFork(ctx context.Context, runner AgentRunner, info SkillInfo, cont
 	forkCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
 	forkCtx = context.WithValue(forkCtx, ContextKeyForkedSkill, info.Name)
+	childHandoff, hasHandoff := BuildParentContextHandoffFromContext(forkCtx)
+	effectivePrompt := RenderPromptWithParentContext(content, childHandoff)
+	var handoffRef *ParentContextHandoff
+	if hasHandoff {
+		copyHandoff := childHandoff
+		handoffRef = &copyHandoff
+	}
 
 	if forkedRunner, ok := runner.(ForkedAgentRunner); ok {
 		config := ForkConfig{
-			Prompt:       content,
-			SkillName:    info.Name,
-			Agent:        info.Agent,
-			AllowedTools: info.AllowedTools,
+			Prompt:               effectivePrompt,
+			ParentContextHandoff: handoffRef,
+			SkillName:            info.Name,
+			Agent:                info.Agent,
+			AllowedTools:         info.AllowedTools,
 		}
 		result, err := forkedRunner.RunForkedSkill(forkCtx, config)
 		if err != nil {
@@ -108,7 +116,7 @@ func flatSkillFork(ctx context.Context, runner AgentRunner, info SkillInfo, cont
 		})
 	}
 
-	output, err := runPromptWithAllowedTools(forkCtx, runner, content, info.AllowedTools)
+	output, err := runPromptWithAllowedTools(forkCtx, runner, effectivePrompt, info.AllowedTools)
 	if err != nil {
 		return "", fmt.Errorf("forked skill %q failed: %w", info.Name, err)
 	}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	om "go-agent-harness/internal/observationalmemory"
@@ -208,6 +209,8 @@ type ForkConfig struct {
 	Agent        string            // agent type hint (e.g., "Explore")
 	AllowedTools []string          // tool restrictions for the subagent
 	Metadata     map[string]string // arbitrary metadata (parent run ID, etc.)
+	// ParentContextHandoff carries serialized context from the parent run.
+	ParentContextHandoff *ParentContextHandoff
 	// Model optionally overrides the runner's default model for the child run.
 	// An empty string means use the runner's configured default.
 	Model string
@@ -251,6 +254,8 @@ type SubagentRequest struct {
 	MaxCostUSD   float64
 	AllowedTools []string
 	ProfileName  string
+	// ParentContextHandoff carries serialized context from the parent run.
+	ParentContextHandoff *ParentContextHandoff
 
 	// New runtime and safety policy fields sourced from profile.ApplyValues().
 	// All fields are backward-compatible: zero value = inherit from defaults.
@@ -280,6 +285,152 @@ type SubagentResult struct {
 	Status string // "queued" | "running" | "completed" | "failed" | "cancelled"
 	Output string
 	Error  string
+}
+
+// ParentContextMessage is a single transcript message included in a handoff bundle.
+type ParentContextMessage struct {
+	Index      int64  `json:"index"`
+	Role       string `json:"role"`
+	Name       string `json:"name,omitempty"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+	Content    string `json:"content"`
+}
+
+// ParentContextHandoff contains a bounded, typed summary of parent-run context.
+type ParentContextHandoff struct {
+	ParentRunID          string                 `json:"parent_run_id"`
+	ParentTenantID       string                 `json:"parent_tenant_id,omitempty"`
+	ParentConversationID string                 `json:"parent_conversation_id,omitempty"`
+	ParentAgentID        string                 `json:"parent_agent_id,omitempty"`
+	Messages             []ParentContextMessage `json:"messages"`
+}
+
+const (
+	defaultParentContextMaxMessages     = 16
+	defaultParentContextMaxMessageRunes = 400
+	defaultParentContextHandoffMaxBytes = 8192
+	parentContextTaskHeader             = "# Task"
+	parentContextHandoffHeader          = "# Parent context handoff"
+)
+
+// BuildParentContextHandoffFromContext extracts a bounded parent handoff bundle
+// from context keys (RunMetadata and TranscriptReader).
+func BuildParentContextHandoffFromContext(ctx context.Context) (ParentContextHandoff, bool) {
+	handoff := ParentContextHandoff{}
+	meta, hasMeta := RunMetadataFromContext(ctx)
+	hasAny := false
+	if hasMeta {
+		handoff.ParentRunID = strings.TrimSpace(meta.RunID)
+		handoff.ParentTenantID = strings.TrimSpace(meta.TenantID)
+		handoff.ParentConversationID = strings.TrimSpace(meta.ConversationID)
+		handoff.ParentAgentID = strings.TrimSpace(meta.AgentID)
+		hasAny = strings.TrimSpace(meta.RunID) != ""
+	}
+
+	reader, ok := TranscriptReaderFromContext(ctx)
+	if ok {
+		snapshot := reader.Snapshot(0, true)
+		handoff.Messages = append([]ParentContextMessage{}, reduceAndTruncateMessages(snapshot.Messages)...)
+		hasAny = hasAny || len(handoff.Messages) > 0
+	}
+
+	boundParentContextHandoff(&handoff)
+	if !hasAny {
+		return ParentContextHandoff{}, false
+	}
+	return handoff, true
+}
+
+func boundParentContextHandoff(handoff *ParentContextHandoff) {
+	if handoff == nil {
+		return
+	}
+	msgs := handoff.Messages
+	if len(msgs) > defaultParentContextMaxMessages {
+		msgs = append([]ParentContextMessage{}, msgs[len(msgs)-defaultParentContextMaxMessages:]...)
+	}
+
+	bounded := make([]ParentContextMessage, 0, len(msgs))
+	for _, msg := range msgs {
+		bounded = append(bounded, ParentContextMessage{
+			Index:      msg.Index,
+			Role:       strings.TrimSpace(msg.Role),
+			Name:       strings.TrimSpace(msg.Name),
+			ToolCallID: strings.TrimSpace(msg.ToolCallID),
+			Content:    truncateRunes(msg.Content, defaultParentContextMaxMessageRunes),
+		})
+	}
+	handoff.Messages = bounded
+
+	for {
+		payload := mustJSONPayload(handoff)
+		if len(payload) <= defaultParentContextHandoffMaxBytes {
+			return
+		}
+		if len(handoff.Messages) == 0 {
+			return
+		}
+		handoff.Messages = append([]ParentContextMessage{}, handoff.Messages[1:]...)
+	}
+}
+
+func reduceAndTruncateMessages(messages []TranscriptMessage) []ParentContextMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	bounded := make([]ParentContextMessage, 0, len(messages))
+	for _, msg := range messages {
+		bounded = append(bounded, ParentContextMessage{
+			Index:      msg.Index,
+			Role:       msg.Role,
+			Name:       msg.Name,
+			ToolCallID: msg.ToolCallID,
+			Content:    truncateRunes(msg.Content, defaultParentContextMaxMessageRunes),
+		})
+	}
+	return bounded
+}
+
+func truncateRunes(value string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(strings.TrimSpace(value))
+	if len(runes) <= maxRunes {
+		return string(runes)
+	}
+	if maxRunes <= 1 {
+		return "…"
+	}
+	truncated := append([]rune{}, runes[:maxRunes-1]...)
+	truncated = append(truncated, '…')
+	return string(truncated)
+}
+
+// RenderParentContextHandoffBlock renders a markdown block for prompt insertion.
+func RenderParentContextHandoffBlock(handoff ParentContextHandoff) string {
+	if len(handoff.Messages) == 0 && strings.TrimSpace(handoff.ParentRunID) == "" {
+		return ""
+	}
+	payload := mustJSONPayload(handoff)
+	return parentContextHandoffHeader + "\n```json\n" + string(payload) + "\n```"
+}
+
+// RenderPromptWithParentContext prepends the handoff block before the task.
+func RenderPromptWithParentContext(task string, handoff ParentContextHandoff) string {
+	section := RenderParentContextHandoffBlock(handoff)
+	if section == "" {
+		return strings.TrimSpace(task)
+	}
+	return strings.TrimSpace(section) + "\n\n" + parentContextTaskHeader + "\n\n" + strings.TrimSpace(task)
+}
+
+func mustJSONPayload(v any) []byte {
+	encoded, err := json.Marshal(v)
+	if err != nil {
+		return []byte("{}")
+	}
+	return encoded
 }
 
 // SubagentManager is the interface for creating and polling subagents.

--- a/internal/harness/tools/types_context_test.go
+++ b/internal/harness/tools/types_context_test.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -61,5 +63,140 @@ func TestContextHelpers(t *testing.T) {
 	snap := gotReader.Snapshot(7, true)
 	if snap.RunID != "run_1" || len(snap.Messages) != 1 {
 		t.Fatalf("unexpected snapshot: %+v", snap)
+	}
+}
+
+type largeTranscriptReaderStub struct {
+	messages []TranscriptMessage
+}
+
+func (s largeTranscriptReaderStub) Snapshot(limit int, includeTools bool) TranscriptSnapshot {
+	return TranscriptSnapshot{
+		RunID:          "run_parent",
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+		Messages:       append([]TranscriptMessage(nil), s.messages...),
+		GeneratedAt:    time.Now().UTC(),
+	}
+}
+
+func TestBuildParentContextHandoffFromContext_TruncatesByMessagesRunesAndBytes(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("abcdef", 90)
+	messages := make([]TranscriptMessage, 0, 20)
+	for i := 0; i < 20; i++ {
+		messages = append(messages, TranscriptMessage{
+			Index:   int64(i),
+			Role:    "user",
+			Content: long,
+		})
+	}
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ContextKeyRunMetadata, RunMetadata{
+		RunID:          "run_parent",
+		TenantID:       "tenant_1",
+		ConversationID: "conv_1",
+		AgentID:        "agent_1",
+	})
+	ctx = context.WithValue(ctx, ContextKeyTranscriptReader, largeTranscriptReaderStub{messages: messages})
+
+	handoff, ok := BuildParentContextHandoffFromContext(ctx)
+	if !ok {
+		t.Fatal("expected non-empty handoff")
+	}
+	if got := handoff.ParentRunID; got != "run_parent" {
+		t.Fatalf("ParentRunID = %q, want %q", got, "run_parent")
+	}
+	if got := handoff.ParentTenantID; got != "tenant_1" {
+		t.Fatalf("ParentTenantID = %q, want %q", got, "tenant_1")
+	}
+	if got := handoff.ParentConversationID; got != "conv_1" {
+		t.Fatalf("ParentConversationID = %q, want %q", got, "conv_1")
+	}
+	if got := handoff.ParentAgentID; got != "agent_1" {
+		t.Fatalf("ParentAgentID = %q, want %q", got, "agent_1")
+	}
+	if len(handoff.Messages) != defaultParentContextMaxMessages {
+		t.Fatalf("messages len = %d, want %d", len(handoff.Messages), defaultParentContextMaxMessages)
+	}
+	for _, msg := range handoff.Messages {
+		if len([]rune(msg.Content)) > defaultParentContextMaxMessageRunes {
+			t.Fatalf("message content len = %d runes, want <= %d", len([]rune(msg.Content)), defaultParentContextMaxMessageRunes)
+		}
+		if !strings.HasSuffix(msg.Content, "…") {
+			t.Fatalf("expected truncated content marker in %q", msg.Content)
+		}
+	}
+	payload, err := json.Marshal(handoff)
+	if err != nil {
+		t.Fatalf("marshal handoff: %v", err)
+	}
+	if len(payload) > defaultParentContextHandoffMaxBytes {
+		t.Fatalf("serialized handoff = %d bytes, want <= %d", len(payload), defaultParentContextHandoffMaxBytes)
+	}
+	if handoff.Messages[0].Index != 4 {
+		t.Fatalf("first message index = %d, want 4", handoff.Messages[0].Index)
+	}
+}
+
+func TestRenderPromptWithParentContext_PrependsHandoffBeforeTask(t *testing.T) {
+	t.Parallel()
+
+	handoff := ParentContextHandoff{
+		ParentRunID: "run_parent",
+		Messages: []ParentContextMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: "Investigate the failing integration path.",
+		}},
+	}
+
+	prompt := RenderPromptWithParentContext("child task", handoff)
+	handoffIdx := strings.Index(prompt, parentContextHandoffHeader)
+	taskHeaderIdx := strings.Index(prompt, parentContextTaskHeader)
+	taskBodyIdx := strings.LastIndex(prompt, "child task")
+	if handoffIdx == -1 || taskHeaderIdx == -1 || taskBodyIdx == -1 {
+		t.Fatalf("expected handoff + task markers in prompt, got %q", prompt)
+	}
+	if !(handoffIdx < taskHeaderIdx && taskHeaderIdx < taskBodyIdx) {
+		t.Fatalf("unexpected order in prompt: handoff=%d taskHeader=%d taskBody=%d", handoffIdx, taskHeaderIdx, taskBodyIdx)
+	}
+
+	trimmed := RenderPromptWithParentContext("  child task  ", ParentContextHandoff{})
+	if trimmed != "child task" {
+		t.Fatalf("expected trimmed task when no handoff, got %q", trimmed)
+	}
+}
+
+func TestRenderParentContextHandoffBlock_SerializesJSON(t *testing.T) {
+	t.Parallel()
+
+	handoff := ParentContextHandoff{
+		ParentRunID: "run_parent",
+		Messages: []ParentContextMessage{{
+			Index:   2,
+			Role:    "assistant",
+			Content: "Summary",
+		}},
+	}
+
+	block := RenderParentContextHandoffBlock(handoff)
+	if !strings.HasPrefix(block, parentContextHandoffHeader) {
+		t.Fatalf("expected handoff header prefix, got %q", block)
+	}
+	jsonStart := strings.Index(block, "{")
+	jsonEnd := strings.LastIndex(block, "}")
+	if jsonStart == -1 || jsonEnd == -1 || jsonEnd < jsonStart {
+		t.Fatalf("expected JSON block, got %q", block)
+	}
+	var decoded ParentContextHandoff
+	if err := json.Unmarshal([]byte(block[jsonStart:jsonEnd+1]), &decoded); err != nil {
+		t.Fatalf("unmarshal handoff block JSON: %v", err)
+	}
+	if decoded.ParentRunID != "run_parent" {
+		t.Fatalf("decoded ParentRunID = %q, want %q", decoded.ParentRunID, "run_parent")
 	}
 }

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -241,6 +241,7 @@ type Run struct {
 	Status         RunStatus       `json:"status"`
 	Output         string          `json:"output,omitempty"`
 	Error          string          `json:"error,omitempty"`
+	ParentContextHandoff *htools.ParentContextHandoff `json:"parent_context_handoff,omitempty"`
 	UsageTotals    *RunUsageTotals `json:"usage_totals,omitempty"`
 	CostTotals     *RunCostTotals  `json:"cost_totals,omitempty"`
 	TenantID       string          `json:"tenant_id,omitempty"`
@@ -333,6 +334,8 @@ type RunRequest struct {
 	// Profile files are read from the runner's ProfilesDir (default: ~/.harness/profiles/).
 	// An empty string means no profile is applied.
 	ProfileName string `json:"profile,omitempty"`
+	// ParentContextHandoff carries a bounded parent-to-child context summary.
+	ParentContextHandoff *htools.ParentContextHandoff `json:"parent_context_handoff,omitempty"`
 	// Permissions configures the two-axis permission model for this run.
 	// If nil, DefaultPermissionConfig() is used (unrestricted sandbox, no approval).
 	Permissions *PermissionConfig `json:"permissions,omitempty"`

--- a/internal/subagents/inline_manager.go
+++ b/internal/subagents/inline_manager.go
@@ -52,17 +52,18 @@ func (im *InlineManager) Start(ctx context.Context, req tools.SubagentRequest) (
 	}
 
 	saReq := Request{
-		Prompt:          req.Prompt,
-		Model:           req.Model,
-		SystemPrompt:    req.SystemPrompt,
-		MaxSteps:        req.MaxSteps,
-		MaxCostUSD:      req.MaxCostUSD,
-		ReasoningEffort: req.ReasoningEffort,
-		AllowedTools:    append([]string(nil), req.AllowedTools...),
-		ProfileName:     req.ProfileName,
-		Isolation:       isolation,
-		CleanupPolicy:   cleanupPolicy,
-		BaseRef:         req.BaseRef,
+		Prompt:               req.Prompt,
+		Model:                req.Model,
+		SystemPrompt:         req.SystemPrompt,
+		MaxSteps:             req.MaxSteps,
+		MaxCostUSD:           req.MaxCostUSD,
+		ReasoningEffort:      req.ReasoningEffort,
+		AllowedTools:         append([]string(nil), req.AllowedTools...),
+		ProfileName:          req.ProfileName,
+		ParentContextHandoff: req.ParentContextHandoff,
+		Isolation:            isolation,
+		CleanupPolicy:        cleanupPolicy,
+		BaseRef:              req.BaseRef,
 	}
 
 	sa, err := im.m.Create(ctx, saReq)

--- a/internal/subagents/manager.go
+++ b/internal/subagents/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"go-agent-harness/internal/harness"
+	tools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/workspace"
 )
 
@@ -56,6 +57,7 @@ type Request struct {
 	CleanupPolicy   CleanupPolicy             `json:"cleanup_policy,omitempty"`
 	WorktreeRoot    string                    `json:"worktree_root,omitempty"`
 	BaseRef         string                    `json:"base_ref,omitempty"`
+	ParentContextHandoff *tools.ParentContextHandoff `json:"parent_context_handoff,omitempty"`
 }
 
 type Subagent struct {
@@ -212,18 +214,19 @@ func (m *manager) Create(ctx context.Context, req Request) (Subagent, error) {
 	}
 
 	runReq := harness.RunRequest{
-		Prompt:          prompt,
-		Model:           strings.TrimSpace(req.Model),
-		ProviderName:    strings.TrimSpace(req.ProviderName),
-		AllowFallback:   req.AllowFallback,
-		SystemPrompt:    strings.TrimSpace(req.SystemPrompt),
-		MaxSteps:        req.MaxSteps,
-		MaxCostUSD:      req.MaxCostUSD,
-		ReasoningEffort: strings.TrimSpace(req.ReasoningEffort),
-		AllowedTools:    append([]string(nil), req.AllowedTools...),
-		ProfileName:     strings.TrimSpace(req.ProfileName),
-		Permissions:     req.Permissions,
-		AgentID:         id,
+		Prompt:               prompt,
+		Model:                strings.TrimSpace(req.Model),
+		ProviderName:         strings.TrimSpace(req.ProviderName),
+		AllowFallback:        req.AllowFallback,
+		SystemPrompt:         strings.TrimSpace(req.SystemPrompt),
+		MaxSteps:             req.MaxSteps,
+		MaxCostUSD:           req.MaxCostUSD,
+		ReasoningEffort:      strings.TrimSpace(req.ReasoningEffort),
+		AllowedTools:         append([]string(nil), req.AllowedTools...),
+		ProfileName:          strings.TrimSpace(req.ProfileName),
+		Permissions:          req.Permissions,
+		AgentID:              id,
+		ParentContextHandoff: req.ParentContextHandoff,
 	}
 
 	switch isolation {

--- a/internal/subagents/system_prompt_test.go
+++ b/internal/subagents/system_prompt_test.go
@@ -210,6 +210,31 @@ func TestInlineManagerCreateAndWaitSystemPrompt(t *testing.T) {
 	assert.Equal(t, "Be specialized.", engine.lastReq.SystemPrompt)
 }
 
+func TestInlineManagerCreateAndWaitForwardsParentContextHandoff(t *testing.T) {
+	engine := &captureRunEngine{}
+	mgr, err := NewManager(Options{InlineRunner: engine})
+	require.NoError(t, err)
+
+	im := NewInlineManager(mgr)
+	handoff := &tools.ParentContextHandoff{
+		ParentRunID: "run_parent",
+		Messages: []tools.ParentContextMessage{{
+			Index:   1,
+			Role:    "user",
+			Content: "Important parent context",
+		}},
+	}
+
+	_, err = im.CreateAndWait(context.Background(), tools.SubagentRequest{
+		Prompt:               "Do a thing",
+		ParentContextHandoff: handoff,
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, engine.lastReq.ParentContextHandoff)
+	assert.Equal(t, "run_parent", engine.lastReq.ParentContextHandoff.ParentRunID)
+}
+
 func TestInlineManagerGet(t *testing.T) {
 	engine := &statefulRunEngine{
 		status: harness.RunStatusCompleted,


### PR DESCRIPTION
## Summary
- add a typed `ParentContextHandoff` bundle with message-count, rune, and byte bounds
- propagate handoff bundles through deferred subagent tools, skill forks, subagent manager requests, and runner child runs
- add regression coverage for serialization, truncation markers, prompt ordering, forwarding, and stored child-run handoff state

## Validation
- `GOCACHE="$PWD/.tmp/go-cache" GOMODCACHE="$PWD/.tmp/go-mod-cache" go test ./internal/harness/tools/deferred ./internal/subagents ./internal/harness -run 'TestSpawnAgentTool|TestRunAgentTool|TestInlineManager|TestRunForkedSkill|TestSkillTool_Handler_Fork|TestBuildParentContextHandoff|TestRenderParentContext'`\n- `GOCACHE="$PWD/.tmp/go-cache" GOMODCACHE="$PWD/.tmp/go-mod-cache" go test ./internal/harness/tools/deferred ./internal/harness/tools/core ./internal/subagents ./internal/harness ./internal/harness/tools -run 'Test(BuildParentContextHandoffFromContext_TruncatesByMessagesRunesAndBytes|RenderPromptWithParentContext_PrependsHandoffBeforeTask|RenderParentContextHandoffBlock_SerializesJSON|RunAgentTool_ForwardsParentContextHandoff|SpawnAgentTool_ForwardsParentContextHandoff|SkillTool_Handler_ForkInjectsParentContextHandoffIntoPrompt|InlineManagerCreateAndWaitForwardsParentContextHandoff|RunForkedSkill_StoresParentContextHandoff)'`\n- `GOCACHE="$PWD/.tmp/go-cache" GOMODCACHE="$PWD/.tmp/go-mod-cache" go test ./internal/harness/tools/deferred ./internal/harness/tools/core ./internal/subagents ./internal/harness ./internal/harness/tools`\n- `HOME="$PWD/.tmp/home" XDG_CACHE_HOME="$PWD/.tmp/home/.cache" TMPDIR="$PWD/.tmp/tmp" GOCACHE="$PWD/.tmp/go-cache" GOMODCACHE="$PWD/.tmp/go-mod-cache" COVERPROFILE_PATH="$PWD/.tmp/issue-384-coverage.out" ./scripts/test-regression.sh`\n\nCloses #384