### PR TITLE
feat(#495): Enrich tool descriptions with behavioral specifications

### DIFF
--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -102,6 +102,12 @@ func dispatch(args []string) int {
 	switch args[0] {
 	case "auth":
 		return runAuth(args[1:])
+	case "list":
+		return runList(args[1:])
+	case "cancel":
+		return runCancel(args[1:])
+	case "status":
+		return runStatus(args[1:])
 	default:
 		return run(args)
 	}

--- a/cmd/harnesscli/config/config.go
+++ b/cmd/harnesscli/config/config.go
@@ -8,9 +8,10 @@ import (
 
 // Config holds persistent CLI configuration.
 type Config struct {
-	StarredModels []string          `json:"starred_models,omitempty"`
-	Gateway       string            `json:"gateway,omitempty"` // "" = direct, "openrouter" = OpenRouter
-	APIKeys       map[string]string `json:"api_keys,omitempty"`
+	StarredModels  []string          `json:"starred_models,omitempty"`
+	Gateway        string            `json:"gateway,omitempty"` // "" = direct, "openrouter" = OpenRouter
+	APIKeys        map[string]string `json:"api_keys,omitempty"`
+	HistoryEntries []string          `json:"history_entries,omitempty"` // newest-first command history
 }
 
 func configPath() (string, error) {

--- a/cmd/harnesscli/runctl.go
+++ b/cmd/harnesscli/runctl.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// runListResponse is the JSON shape returned by GET /v1/runs.
+type runListResponse struct {
+	Runs []runRecord `json:"runs"`
+}
+
+// runRecord is a single run entry from the list or get-by-ID response.
+type runRecord struct {
+	ID             string    `json:"id"`
+	ConversationID string    `json:"conversation_id,omitempty"`
+	TenantID       string    `json:"tenant_id,omitempty"`
+	Model          string    `json:"model,omitempty"`
+	Prompt         string    `json:"prompt,omitempty"`
+	Status         string    `json:"status"`
+	Error          string    `json:"error,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// runList implements "harnesscli list".
+// Sends GET /v1/runs (optionally filtered) and prints a table.
+func runList(args []string) int {
+	fs := flag.NewFlagSet("list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL")
+	statusFilter := fs.String("status", "", "filter by status (queued, running, completed, failed)")
+	convID := fs.String("conversation-id", "", "filter by conversation ID")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "harnesscli list: %v\n", err)
+		return 1
+	}
+
+	endpoint := strings.TrimRight(*baseURL, "/") + "/v1/runs"
+	qv := url.Values{}
+	if *statusFilter != "" {
+		qv.Set("status", *statusFilter)
+	}
+	if *convID != "" {
+		qv.Set("conversation_id", *convID)
+	}
+	if len(qv) > 0 {
+		endpoint += "?" + qv.Encode()
+	}
+
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli list: build request: %v\n", err)
+		return 1
+	}
+
+	resp, err := requestHTTPClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli list: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli list: read response: %v\n", err)
+		return 1
+	}
+
+	if resp.StatusCode >= 300 {
+		fmt.Fprintf(stderr, "harnesscli list: %v\n", formatAPIError(resp.StatusCode, body))
+		return 1
+	}
+
+	var lr runListResponse
+	if err := json.Unmarshal(body, &lr); err != nil {
+		fmt.Fprintf(stderr, "harnesscli list: decode response: %v\n", err)
+		return 1
+	}
+
+	if len(lr.Runs) == 0 {
+		fmt.Fprintln(stdout, "No runs found")
+		return 0
+	}
+
+	// Print table header.
+	fmt.Fprintf(stdout, "%-24s  %-18s  %-20s  %s\n", "ID", "STATUS", "MODEL", "PROMPT")
+	fmt.Fprintf(stdout, "%s\n", strings.Repeat("-", 90))
+	for _, r := range lr.Runs {
+		prompt := r.Prompt
+		if len(prompt) > 40 {
+			prompt = prompt[:37] + "..."
+		}
+		model := r.Model
+		if model == "" {
+			model = "(default)"
+		}
+		fmt.Fprintf(stdout, "%-24s  %-18s  %-20s  %s\n", r.ID, r.Status, model, prompt)
+	}
+	return 0
+}
+
+// runCancel implements "harnesscli cancel <run-id>".
+// Sends POST /v1/runs/{id}/cancel and reports success or failure.
+func runCancel(args []string) int {
+	fs := flag.NewFlagSet("cancel", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "harnesscli cancel: %v\n", err)
+		return 1
+	}
+
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "harnesscli cancel: run ID is required")
+		return 1
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintln(stderr, "harnesscli cancel: too many arguments; accepts exactly one run ID")
+		return 1
+	}
+	runID := fs.Arg(0)
+
+	endpoint := strings.TrimRight(*baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/cancel"
+	req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli cancel: build request: %v\n", err)
+		return 1
+	}
+
+	resp, err := requestHTTPClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli cancel: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli cancel: read response: %v\n", err)
+		return 1
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		fmt.Fprintf(stderr, "harnesscli cancel: run %q not found\n", runID)
+		return 1
+	}
+
+	if resp.StatusCode >= 300 {
+		fmt.Fprintf(stderr, "harnesscli cancel: %v\n", formatAPIError(resp.StatusCode, body))
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Run %s cancelling\n", runID)
+	return 0
+}
+
+// runStatus implements "harnesscli status <run-id>".
+// Sends GET /v1/runs/{id} and prints run details.
+func runStatus(args []string) int {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "harnesscli status: %v\n", err)
+		return 1
+	}
+
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "harnesscli status: run ID is required")
+		return 1
+	}
+	if fs.NArg() > 1 {
+		fmt.Fprintln(stderr, "harnesscli status: too many arguments; accepts exactly one run ID")
+		return 1
+	}
+	runID := fs.Arg(0)
+
+	endpoint := strings.TrimRight(*baseURL, "/") + "/v1/runs/" + url.PathEscape(runID)
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli status: build request: %v\n", err)
+		return 1
+	}
+
+	resp, err := requestHTTPClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli status: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli status: read response: %v\n", err)
+		return 1
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		fmt.Fprintf(stderr, "harnesscli status: run %q not found\n", runID)
+		return 1
+	}
+
+	if resp.StatusCode >= 300 {
+		fmt.Fprintf(stderr, "harnesscli status: %v\n", formatAPIError(resp.StatusCode, body))
+		return 1
+	}
+
+	var r runRecord
+	if err := json.Unmarshal(body, &r); err != nil {
+		fmt.Fprintf(stderr, "harnesscli status: decode response: %v\n", err)
+		return 1
+	}
+
+	model := r.Model
+	if model == "" {
+		model = "(default)"
+	}
+	fmt.Fprintf(stdout, "ID:        %s\n", r.ID)
+	fmt.Fprintf(stdout, "Status:    %s\n", r.Status)
+	fmt.Fprintf(stdout, "Model:     %s\n", model)
+	fmt.Fprintf(stdout, "Created:   %s\n", r.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(stdout, "Updated:   %s\n", r.UpdatedAt.Format(time.RFC3339))
+	if r.Prompt != "" {
+		prompt := r.Prompt
+		if len(prompt) > 80 {
+			prompt = prompt[:77] + "..."
+		}
+		fmt.Fprintf(stdout, "Prompt:    %s\n", prompt)
+	}
+	if r.Error != "" {
+		fmt.Fprintf(stdout, "Error:     %s\n", r.Error)
+	}
+	return 0
+}

--- a/cmd/harnesscli/runctl_test.go
+++ b/cmd/harnesscli/runctl_test.go
@@ -1,0 +1,556 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- helpers ---
+
+func captureOutput(t *testing.T) (outBuf *bytes.Buffer, errBuf *bytes.Buffer, restore func()) {
+	t.Helper()
+	origStdout := stdout
+	origStderr := stderr
+	outBuf = &bytes.Buffer{}
+	errBuf = &bytes.Buffer{}
+	stdout = outBuf
+	stderr = errBuf
+	return outBuf, errBuf, func() {
+		stdout = origStdout
+		stderr = origStderr
+	}
+}
+
+// sampleRunJSON returns a JSON-encoded run object for test servers to emit.
+func sampleRunJSON(id, status, model, prompt string) map[string]any {
+	return map[string]any{
+		"id":         id,
+		"status":     status,
+		"model":      model,
+		"prompt":     prompt,
+		"created_at": time.Now().UTC().Format(time.RFC3339),
+		"updated_at": time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// --- BT-001: list shows all 3 run IDs ---
+
+func TestRunList_ShowsAllRunIDs(t *testing.T) {
+	runs := []map[string]any{
+		sampleRunJSON("run_aaa", "completed", "gpt-4", "first prompt"),
+		sampleRunJSON("run_bbb", "running", "gpt-4", "second prompt"),
+		sampleRunJSON("run_ccc", "queued", "gpt-4", "third prompt"),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runs" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": runs})
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runList([]string{"-base-url=" + ts.URL})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	output := outBuf.String()
+	for _, id := range []string{"run_aaa", "run_bbb", "run_ccc"} {
+		if !strings.Contains(output, id) {
+			t.Errorf("output missing run ID %q:\n%s", id, output)
+		}
+	}
+}
+
+// --- BT-002: list --status running only shows running runs ---
+
+func TestRunList_StatusFilter(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		runs := []map[string]any{
+			sampleRunJSON("run_running1", "running", "gpt-4", "a prompt"),
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": runs})
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runList([]string{"-base-url=" + ts.URL, "-status=running"})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	if !strings.Contains(capturedQuery, "status=running") {
+		t.Errorf("expected query to contain status=running, got %q", capturedQuery)
+	}
+	if !strings.Contains(outBuf.String(), "run_running1") {
+		t.Errorf("expected run_running1 in output:\n%s", outBuf.String())
+	}
+}
+
+// --- BT-003: list 501 shows clear error ---
+
+func TestRunList_501NoStore(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+		_, _ = io.WriteString(w, `{"error":{"code":"not_implemented","message":"run persistence is not configured"}}`)
+	}))
+	defer ts.Close()
+
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runList([]string{"-base-url=" + ts.URL})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for 501, got %d", code)
+	}
+	errStr := errBuf.String()
+	if !strings.Contains(errStr, "not configured") && !strings.Contains(errStr, "501") && !strings.Contains(errStr, "not_implemented") {
+		t.Errorf("expected clear error message about run store not configured, got: %s", errStr)
+	}
+}
+
+// --- BT-004: cancel succeeds, output says "cancelling" ---
+
+func TestRunCancel_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runs/run_xyz/cancel" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"cancelling"}`)
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runCancel([]string{"-base-url=" + ts.URL, "run_xyz"})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	if !strings.Contains(outBuf.String(), "cancelling") {
+		t.Errorf("expected 'cancelling' in output, got: %s", outBuf.String())
+	}
+}
+
+// --- BT-005: cancel 404 says run not found ---
+
+func TestRunCancel_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":"not_found","message":"run \"run_nope\" not found"}}`)
+	}))
+	defer ts.Close()
+
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runCancel([]string{"-base-url=" + ts.URL, "run_nope"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for 404, got %d", code)
+	}
+	errStr := errBuf.String()
+	if !strings.Contains(errStr, "not found") && !strings.Contains(errStr, "404") {
+		t.Errorf("expected 'not found' in error output, got: %s", errStr)
+	}
+}
+
+// --- BT-006: cancel with no ID shows usage error ---
+
+func TestRunCancel_NoID(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runCancel([]string{})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for missing run ID, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "run ID") {
+		t.Errorf("expected usage error about run ID, got: %s", errBuf.String())
+	}
+}
+
+// --- BT-007: status succeeds, shows run details ---
+
+func TestRunStatus_ShowsDetails(t *testing.T) {
+	runData := sampleRunJSON("run_detail", "completed", "gpt-4o", "write a report")
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runs/run_detail" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(runData)
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runStatus([]string{"-base-url=" + ts.URL, "run_detail"})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	output := outBuf.String()
+	for _, want := range []string{"run_detail", "completed", "gpt-4o"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+// --- BT-008: status 404 says not found ---
+
+func TestRunStatus_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":"not_found","message":"run not found"}}`)
+	}))
+	defer ts.Close()
+
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runStatus([]string{"-base-url=" + ts.URL, "run_missing"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for 404, got %d", code)
+	}
+	errStr := errBuf.String()
+	if !strings.Contains(errStr, "not found") && !strings.Contains(errStr, "404") {
+		t.Errorf("expected 'not found' in error output, got: %s", errStr)
+	}
+}
+
+// --- BT-009: status with no run ID shows usage error ---
+
+func TestRunStatus_NoID(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runStatus([]string{})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for missing run ID, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "run ID") {
+		t.Errorf("expected usage error about run ID, got: %s", errBuf.String())
+	}
+}
+
+// --- Regression: dispatch routes list/cancel/status correctly ---
+
+func TestDispatch_ListRouted(t *testing.T) {
+	// Verify that dispatch("list", ...) calls runList, not run().
+	// If run() is called without -prompt it returns 1 with "prompt is required".
+	// If runList is called against a valid server returning empty list, returns 0.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := dispatch([]string{"list", "-base-url=" + ts.URL})
+	if code != 0 {
+		t.Fatalf("dispatch list should route to runList and return 0; got %d (stderr=%s)", code, errBuf.String())
+	}
+	// Should not print "prompt is required" (which run() would emit)
+	if strings.Contains(errBuf.String(), "prompt is required") {
+		t.Errorf("dispatch('list') should not call run(); got: %s", errBuf.String())
+	}
+	_ = outBuf
+}
+
+func TestDispatch_CancelRoutedNoID(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	// dispatch("cancel") with no ID should route to runCancel and return 1 with usage.
+	code := dispatch([]string{"cancel"})
+	if code != 1 {
+		t.Fatalf("dispatch cancel with no ID should return 1; got %d", code)
+	}
+	if strings.Contains(errBuf.String(), "prompt is required") {
+		t.Errorf("dispatch('cancel') should not call run(); got: %s", errBuf.String())
+	}
+}
+
+func TestDispatch_StatusRoutedNoID(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	// dispatch("status") with no ID should route to runStatus and return 1 with usage.
+	code := dispatch([]string{"status"})
+	if code != 1 {
+		t.Fatalf("dispatch status with no ID should return 1; got %d", code)
+	}
+	if strings.Contains(errBuf.String(), "prompt is required") {
+		t.Errorf("dispatch('status') should not call run(); got: %s", errBuf.String())
+	}
+}
+
+// --- Regression: list with conversation-id filter sends query param ---
+
+func TestRunList_ConversationIDFilter(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runList([]string{"-base-url=" + ts.URL, "-conversation-id=conv_abc"})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if !strings.Contains(capturedQuery, "conversation_id=conv_abc") {
+		t.Errorf("expected conversation_id=conv_abc in query, got %q", capturedQuery)
+	}
+}
+
+// --- Regression: list empty result says no runs ---
+
+func TestRunList_EmptyResult(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runList([]string{"-base-url=" + ts.URL})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	if !strings.Contains(outBuf.String(), "No runs") {
+		t.Errorf("expected 'No runs' in output for empty list, got: %s", outBuf.String())
+	}
+}
+
+// --- Review finding 1: URL-escape run IDs in cancel path ---
+
+// TestRunCancel_PathEscapesRunID verifies that a run ID containing path-traversal
+// characters ("../admin") does not alter the wire-level URL path beyond the runs
+// prefix. url.PathEscape encodes "/" to "%2F" so the RawPath on the server side
+// must contain the encoded form, not a literal slash that would allow traversal.
+func TestRunCancel_PathEscapesRunID(t *testing.T) {
+	var capturedRawPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RawPath holds the percent-encoded wire path; Path is always cleaned.
+		capturedRawPath = r.URL.RawPath
+		if capturedRawPath == "" {
+			capturedRawPath = r.URL.Path // fallback when no encoding was needed
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"cancelling"}`)
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	runCancel([]string{"-base-url=" + ts.URL, "../admin"})
+
+	// The RawPath must not contain a literal "/admin" segment — the slash in the
+	// run ID must be percent-encoded (%2F), preventing path traversal.
+	if strings.Contains(capturedRawPath, "/admin") {
+		t.Errorf("path traversal not escaped: raw path %q contains literal /admin; run ID slash must be %%2F-encoded", capturedRawPath)
+	}
+}
+
+// TestRunStatus_PathEscapesRunID verifies that a run ID containing path-traversal
+// characters ("../admin") does not alter the wire-level URL path beyond the runs
+// prefix.
+func TestRunStatus_PathEscapesRunID(t *testing.T) {
+	var capturedRawPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRawPath = r.URL.RawPath
+		if capturedRawPath == "" {
+			capturedRawPath = r.URL.Path
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(sampleRunJSON("x", "running", "gpt-4", "p"))
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	runStatus([]string{"-base-url=" + ts.URL, "../admin"})
+
+	if strings.Contains(capturedRawPath, "/admin") {
+		t.Errorf("path traversal not escaped: raw path %q contains literal /admin; run ID slash must be %%2F-encoded", capturedRawPath)
+	}
+}
+
+// --- Review finding 2: url.Values encoding for query parameters ---
+
+// TestRunList_QueryParamInjection verifies that a status filter value containing
+// "&admin=true" is properly encoded and does not inject extra query parameters.
+func TestRunList_QueryParamInjection(t *testing.T) {
+	var capturedQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []any{}})
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	runList([]string{"-base-url=" + ts.URL, "-status=running&admin=true"})
+
+	// The injected "&admin=true" must not appear as a separate query parameter.
+	// url.Values.Encode would percent-encode the ampersand.
+	if strings.Contains(capturedQuery, "admin=true") {
+		t.Errorf("query parameter injection not escaped: got query %q, 'admin=true' must not appear as a separate param", capturedQuery)
+	}
+}
+
+// --- Review finding 3: reject extra positional arguments ---
+
+// TestRunCancel_RejectsExtraArgs verifies that passing multiple run IDs returns an error.
+func TestRunCancel_RejectsExtraArgs(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runCancel([]string{"run1", "run2"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for extra args, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "too many") && !strings.Contains(errBuf.String(), "extra") && !strings.Contains(errBuf.String(), "accepts") {
+		t.Errorf("expected error about too many arguments, got: %s", errBuf.String())
+	}
+}
+
+// TestRunStatus_RejectsExtraArgs verifies that passing multiple run IDs returns an error.
+func TestRunStatus_RejectsExtraArgs(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runStatus([]string{"run1", "run2"})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for extra args, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "too many") && !strings.Contains(errBuf.String(), "extra") && !strings.Contains(errBuf.String(), "accepts") {
+		t.Errorf("expected error about too many arguments, got: %s", errBuf.String())
+	}
+}
+
+// --- Regression: cancel sends POST to correct path ---
+
+func TestRunCancel_SendsPostToCorrectPath(t *testing.T) {
+	var capturedMethod, capturedPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"status":"cancelling"}`)
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	runCancel([]string{"-base-url=" + ts.URL, "run_test123"})
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", capturedMethod)
+	}
+	if capturedPath != "/v1/runs/run_test123/cancel" {
+		t.Errorf("expected /v1/runs/run_test123/cancel, got %s", capturedPath)
+	}
+}

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -358,6 +358,38 @@ func flattenJSON(obj map[string]any, indent string) []string {
 	return lines
 }
 
+// fetchSessionRunsCmd fetches the run history for a conversation from
+// GET /v1/conversations/{id}/runs.  On success it emits a SessionRunsFetchedMsg;
+// on failure (including 501 Not Implemented) it emits a zero SessionRunsFetchedMsg
+// so callers can handle the empty case gracefully.
+func fetchSessionRunsCmd(baseURL, conversationID string) tea.Cmd {
+	return func() tea.Msg {
+		url := strings.TrimRight(baseURL, "/") + "/v1/conversations/" + conversationID + "/runs"
+		resp, err := http.Get(url) //nolint:noctx
+		if err != nil {
+			return SessionRunsFetchedMsg{}
+		}
+		defer resp.Body.Close()
+		// 501 means the server has no run store — treat as empty.
+		if resp.StatusCode == http.StatusNotImplemented || resp.StatusCode != http.StatusOK {
+			return SessionRunsFetchedMsg{}
+		}
+		var payload struct {
+			Runs []struct {
+				RunID string `json:"run_id"`
+			} `json:"runs"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return SessionRunsFetchedMsg{}
+		}
+		ids := make([]string, len(payload.Runs))
+		for i, r := range payload.Runs {
+			ids[i] = r.RunID
+		}
+		return SessionRunsFetchedMsg{ConversationID: conversationID, RunIDs: ids}
+	}
+}
+
 // sseEventsURL builds the SSE endpoint URL for a given run ID.
 func sseEventsURL(baseURL, runID string) string {
 	return strings.TrimRight(baseURL, "/") + "/v1/runs/" + runID + "/events"

--- a/cmd/harnesscli/tui/api_session_test.go
+++ b/cmd/harnesscli/tui/api_session_test.go
@@ -1,0 +1,153 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// ─── BT-009: fetchSessionRunsCmd success ─────────────────────────────────────
+
+// TestFetchSessionRunsCmd_Success verifies that when the server returns 200 with
+// a valid JSON payload, fetchSessionRunsCmd emits a SessionRunsFetchedMsg with
+// the correct conversation ID and run IDs.
+func TestFetchSessionRunsCmd_Success(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/conversations/conv-abc/runs" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"runs": []map[string]any{
+				{"run_id": "run-001"},
+				{"run_id": "run-002"},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	msg := fetchSessionRunsCmd(ts.URL, "conv-abc")()
+	got, ok := msg.(SessionRunsFetchedMsg)
+	if !ok {
+		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
+	}
+	if got.ConversationID != "conv-abc" {
+		t.Errorf("ConversationID: want %q, got %q", "conv-abc", got.ConversationID)
+	}
+	if len(got.RunIDs) != 2 {
+		t.Fatalf("RunIDs length: want 2, got %d", len(got.RunIDs))
+	}
+	if got.RunIDs[0] != "run-001" {
+		t.Errorf("RunIDs[0]: want %q, got %q", "run-001", got.RunIDs[0])
+	}
+	if got.RunIDs[1] != "run-002" {
+		t.Errorf("RunIDs[1]: want %q, got %q", "run-002", got.RunIDs[1])
+	}
+}
+
+// ─── BT-010: fetchSessionRunsCmd on 501 returns empty msg ────────────────────
+
+// TestFetchSessionRunsCmd_501ReturnsEmptyMsg verifies that a 501 Not Implemented
+// response causes fetchSessionRunsCmd to emit a zero SessionRunsFetchedMsg
+// (empty RunIDs) so callers handle the graceful-empty case.
+func TestFetchSessionRunsCmd_501ReturnsEmptyMsg(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+	defer ts.Close()
+
+	msg := fetchSessionRunsCmd(ts.URL, "conv-xyz")()
+	got, ok := msg.(SessionRunsFetchedMsg)
+	if !ok {
+		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
+	}
+	if got.ConversationID != "" {
+		t.Errorf("ConversationID on 501: want empty, got %q", got.ConversationID)
+	}
+	if len(got.RunIDs) != 0 {
+		t.Errorf("RunIDs on 501: want empty, got %v", got.RunIDs)
+	}
+}
+
+// ─── BT-011: fetchSessionRunsCmd on network error returns empty msg ──────────
+
+// TestFetchSessionRunsCmd_NetworkErrorReturnsEmptyMsg verifies that a network
+// error (unreachable server) causes fetchSessionRunsCmd to emit a zero
+// SessionRunsFetchedMsg rather than panicking or returning a non-msg type.
+func TestFetchSessionRunsCmd_NetworkErrorReturnsEmptyMsg(t *testing.T) {
+	t.Parallel()
+
+	// Use an address that will immediately refuse/error.
+	msg := fetchSessionRunsCmd("http://127.0.0.1:1", "conv-err")()
+	got, ok := msg.(SessionRunsFetchedMsg)
+	if !ok {
+		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
+	}
+	if len(got.RunIDs) != 0 {
+		t.Errorf("RunIDs on network error: want empty, got %v", got.RunIDs)
+	}
+}
+
+// ─── BT-012: fetchSessionRunsCmd on malformed JSON returns empty msg ──────────
+
+// TestFetchSessionRunsCmd_MalformedJSONReturnsEmptyMsg verifies that an invalid
+// JSON body causes fetchSessionRunsCmd to emit a zero SessionRunsFetchedMsg
+// rather than propagating a decode error.
+func TestFetchSessionRunsCmd_MalformedJSONReturnsEmptyMsg(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not-valid-json"))
+	}))
+	defer ts.Close()
+
+	msg := fetchSessionRunsCmd(ts.URL, "conv-json-err")()
+	got, ok := msg.(SessionRunsFetchedMsg)
+	if !ok {
+		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
+	}
+	if len(got.RunIDs) != 0 {
+		t.Errorf("RunIDs on malformed JSON: want empty, got %v", got.RunIDs)
+	}
+}
+
+// ─── Regression: fetchSessionRunsCmd trailing slash normalised ───────────────
+
+// TestFetchSessionRunsCmd_TrailingSlashNormalised verifies that a base URL with
+// a trailing slash still constructs the correct path, so the function is
+// insensitive to how the user configures the base URL.
+func TestFetchSessionRunsCmd_TrailingSlashNormalised(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path must be exactly /v1/conversations/conv-slash/runs (no double slash).
+		if r.URL.Path != "/v1/conversations/conv-slash/runs" {
+			t.Errorf("path with trailing base slash: want /v1/conversations/conv-slash/runs, got %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"runs": []map[string]any{{"run_id": "r1"}}})
+	}))
+	defer ts.Close()
+
+	msg := fetchSessionRunsCmd(ts.URL+"/", "conv-slash")()
+	got, ok := msg.(SessionRunsFetchedMsg)
+	if !ok {
+		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
+	}
+	if len(got.RunIDs) != 1 || got.RunIDs[0] != "r1" {
+		t.Errorf("unexpected RunIDs with trailing-slash base URL: %v", got.RunIDs)
+	}
+}

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -158,6 +158,22 @@ func builtinCommandEntries() []CommandEntry {
 			},
 			Execute: executeProfilesCommand,
 		},
+		{
+			Name:        "sessions",
+			Description: "Browse and switch between past sessions",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeSessionsCommand,
+		},
+		{
+			Name:        "new",
+			Description: "Start a new session (resets conversation)",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeNewSessionCommand,
+		},
 	}
 }
 

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -174,6 +174,22 @@ func builtinCommandEntries() []CommandEntry {
 			},
 			Execute: executeNewSessionCommand,
 		},
+		{
+			Name:        "search",
+			Description: "Search current session transcript",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeSearchCommand,
+		},
+		{
+			Name:        "history",
+			Description: "Search across stored session metadata",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeHistoryCommand,
+		},
 	}
 }
 

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
 		"clear", "context", "export", "help", "keys",
-		"model", "profiles", "quit", "stats", "subagents",
+		"model", "new", "profiles", "quit", "sessions", "stats", "subagents",
 	}
 
 	r := tui.NewCommandRegistry()

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -395,8 +395,8 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"clear", "context", "export", "help", "keys",
-		"model", "new", "profiles", "quit", "sessions", "stats", "subagents",
+		"clear", "context", "export", "help", "history", "keys",
+		"model", "new", "profiles", "quit", "search", "sessions", "stats", "subagents",
 	}
 
 	r := tui.NewCommandRegistry()

--- a/cmd/harnesscli/tui/components/inputarea/history.go
+++ b/cmd/harnesscli/tui/components/inputarea/history.go
@@ -112,3 +112,35 @@ func (h History) ResetPos() History {
 	h.draft = ""
 	return h
 }
+
+// Entries returns a copy of the history entries in newest-first order.
+// This is used for persistence (save to config).
+func (h History) Entries() []string {
+	if len(h.entries) == 0 {
+		return nil
+	}
+	cp := make([]string, len(h.entries))
+	copy(cp, h.entries)
+	return cp
+}
+
+// NewHistoryWithEntries creates a History pre-populated with the given entries.
+// The entries slice must be in newest-first order (as returned by Entries()).
+// This is used for restoring history from persistent storage.
+func NewHistoryWithEntries(maxSize int, entries []string) History {
+	if maxSize <= 0 {
+		maxSize = 100
+	}
+	h := History{
+		maxSize: maxSize,
+		pos:     -1,
+	}
+	if len(entries) > maxSize {
+		entries = entries[:maxSize]
+	}
+	if len(entries) > 0 {
+		h.entries = make([]string, len(entries))
+		copy(h.entries, entries)
+	}
+	return h
+}

--- a/cmd/harnesscli/tui/components/inputarea/history_persistence_test.go
+++ b/cmd/harnesscli/tui/components/inputarea/history_persistence_test.go
@@ -1,0 +1,192 @@
+package inputarea_test
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"go-agent-harness/cmd/harnesscli/tui/components/inputarea"
+)
+
+// BT-001: When a user types "hello" and presses Enter, then presses Up, the input shows "hello".
+func TestBT001_UpAfterSubmitShowsLastCommand(t *testing.T) {
+	m := inputarea.New(80)
+	m = typeText(m, "hello")
+	m, _ = m.Update(btKeyEnter())
+	// Now press Up — should show "hello"
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "hello" {
+		t.Errorf("BT-001: after Up, want 'hello', got %q", m.Value())
+	}
+}
+
+// BT-002: When user submits 3 commands and presses Up three times, shows c, b, a.
+func TestBT002_ThreeCommandsNavigateBackwardCorrectly(t *testing.T) {
+	m := inputarea.New(80)
+	for _, cmd := range []string{"a", "b", "c"} {
+		m = typeText(m, cmd)
+		m, _ = m.Update(btKeyEnter())
+	}
+
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "c" {
+		t.Errorf("BT-002 Up#1: want 'c', got %q", m.Value())
+	}
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "b" {
+		t.Errorf("BT-002 Up#2: want 'b', got %q", m.Value())
+	}
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "a" {
+		t.Errorf("BT-002 Up#3: want 'a', got %q", m.Value())
+	}
+}
+
+// BT-003: When a user presses Down after navigating up, it moves forward through entries.
+func TestBT003_DownAfterUpMovesForward(t *testing.T) {
+	m := inputarea.New(80)
+	for _, cmd := range []string{"first", "second", "third"} {
+		m = typeText(m, cmd)
+		m, _ = m.Update(btKeyEnter())
+	}
+
+	// Navigate up to "third", "second"
+	m, _ = m.Update(btKeyUp())
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "second" {
+		t.Fatalf("BT-003 setup: want 'second', got %q", m.Value())
+	}
+
+	// Navigate down — should go back to "third"
+	m, _ = m.Update(btKeyDown())
+	if m.Value() != "third" {
+		t.Errorf("BT-003 Down: want 'third', got %q", m.Value())
+	}
+}
+
+// BT-004: When at the most recent entry and pressing Down, input returns to draft.
+func TestBT004_DownFromNewestEntryReturnsDraft(t *testing.T) {
+	m := inputarea.New(80)
+	m = typeText(m, "mycommand")
+	m, _ = m.Update(btKeyEnter())
+	// Type a draft but don't submit
+	m = typeText(m, "draft text")
+
+	// Navigate up to history
+	m, _ = m.Update(btKeyUp())
+	if m.Value() != "mycommand" {
+		t.Fatalf("BT-004 setup: want 'mycommand', got %q", m.Value())
+	}
+
+	// Navigate down — should return to draft
+	m, _ = m.Update(btKeyDown())
+	if m.Value() != "draft text" {
+		t.Errorf("BT-004: Down from newest should restore draft; want 'draft text', got %q", m.Value())
+	}
+}
+
+// BT-005: After a quit/restart (simulated via WithEntries), previous history is available.
+func TestBT005_PersistenceViaWithEntries(t *testing.T) {
+	// Simulate a "session" that accumulated history
+	m := inputarea.New(80)
+	for _, cmd := range []string{"persist-a", "persist-b", "persist-c"} {
+		m = typeText(m, cmd)
+		m, _ = m.Update(btKeyEnter())
+	}
+
+	// Extract the entries (simulating save-to-disk)
+	entries := m.HistoryState().Entries()
+	if len(entries) == 0 {
+		t.Fatal("BT-005: Entries() returned empty slice after submitting commands")
+	}
+
+	// Simulate "restart": new model loaded with saved entries
+	m2 := inputarea.NewWithHistory(80, inputarea.NewHistoryWithEntries(100, entries))
+
+	// History navigation should work
+	m2, _ = m2.Update(btKeyUp())
+	if m2.Value() != "persist-c" {
+		t.Errorf("BT-005: After restart, Up should show 'persist-c', got %q", m2.Value())
+	}
+}
+
+// BT-006: When history has 100 entries and a new one is added, the oldest is evicted.
+func TestBT006_OldestEntryEvictedAt100(t *testing.T) {
+	h := inputarea.NewHistory(100)
+	// Push 100 entries
+	for i := 0; i < 100; i++ {
+		h = h.Push(fmt.Sprintf("entry-%03d", i))
+	}
+	if h.Len() != 100 {
+		t.Fatalf("BT-006: want 100 entries after 100 pushes, got %d", h.Len())
+	}
+
+	// Push one more — oldest ("entry-000") should be evicted
+	h = h.Push("entry-new")
+	if h.Len() != 100 {
+		t.Errorf("BT-006: want 100 entries after eviction, got %d", h.Len())
+	}
+
+	// Verify "entry-000" is gone via Entries()
+	entries := h.Entries()
+	for _, e := range entries {
+		if e == "entry-000" {
+			t.Error("BT-006: oldest entry 'entry-000' should have been evicted")
+		}
+	}
+	// Verify "entry-new" is present as newest
+	if entries[0] != "entry-new" {
+		t.Errorf("BT-006: newest entry should be 'entry-new', got %q", entries[0])
+	}
+}
+
+// BT-007: When a user submits the same command twice, only one entry is stored.
+func TestBT007_DuplicateCommandSuppressed(t *testing.T) {
+	m := inputarea.New(80)
+	m = typeText(m, "duplicate")
+	m, _ = m.Update(btKeyEnter())
+	m = typeText(m, "duplicate")
+	m, _ = m.Update(btKeyEnter())
+
+	h := m.HistoryState()
+	if h.Len() != 1 {
+		t.Errorf("BT-007: duplicate suppression failed; want 1 entry, got %d", h.Len())
+	}
+}
+
+// BT-008: When user has typed text and presses Down without having pressed Up first, input is preserved.
+// Regression guard for: https://github.com/dennisonbertram/go-agent-harness/issues/473
+// Before the fix, KeyDown unconditionally called history.Down() which returned the empty draft
+// string when pos == -1, wiping whatever the user had typed.
+func TestBT008_DownWithoutUpPreservesInput(t *testing.T) {
+	m := inputarea.New(80)
+	m = typeText(m, "work in progress")
+
+	// Sanity check: we have text and are at the draft position.
+	if m.Value() != "work in progress" {
+		t.Fatalf("BT-008 setup: want 'work in progress', got %q", m.Value())
+	}
+	if !m.HistoryState().AtDraft() {
+		t.Fatal("BT-008 setup: expected to be at draft position before any navigation")
+	}
+
+	// Press Down without ever pressing Up — input must NOT be wiped.
+	m, _ = m.Update(btKeyDown())
+	if m.Value() != "work in progress" {
+		t.Errorf("BT-008: Down at draft position wiped input; want 'work in progress', got %q", m.Value())
+	}
+}
+
+// helpers — named with bt prefix to avoid collision with history_test.go helpers
+
+func btKeyEnter() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyEnter}
+}
+
+func btKeyUp() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyUp}
+}
+
+func btKeyDown() tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyDown}
+}

--- a/cmd/harnesscli/tui/components/inputarea/model.go
+++ b/cmd/harnesscli/tui/components/inputarea/model.go
@@ -38,6 +38,12 @@ func New(width int) Model {
 	return Model{width: width, history: NewHistory(100), focused: true}
 }
 
+// NewWithHistory creates a new input area for the given width, pre-populated
+// with the given History. This is used to restore history from persistent storage.
+func NewWithHistory(width int, h History) Model {
+	return Model{width: width, history: h, focused: true}
+}
+
 // HistoryState returns the current History for testing and introspection.
 func (m Model) HistoryState() History { return m.history }
 
@@ -198,6 +204,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.cursor = len([]rune(m.value))
 
 	case tea.KeyDown:
+		if m.history.AtDraft() {
+			return m, nil
+		}
 		var text string
 		m.history, text = m.history.Down()
 		m.value = text

--- a/cmd/harnesscli/tui/components/sessionpicker/messages.go
+++ b/cmd/harnesscli/tui/components/sessionpicker/messages.go
@@ -4,3 +4,9 @@ package sessionpicker
 type SessionSelectedMsg struct {
 	Entry SessionEntry
 }
+
+// SessionDeletedMsg is emitted when the user presses 'd' on a session entry.
+// The model should delete the session with the given ID from the store.
+type SessionDeletedMsg struct {
+	ID string
+}

--- a/cmd/harnesscli/tui/components/sessionpicker/model.go
+++ b/cmd/harnesscli/tui/components/sessionpicker/model.go
@@ -132,6 +132,28 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	case key.Type == tea.KeyEsc:
 		return m.Close(), nil
+
+	case key.Type == tea.KeyRunes && string(key.Runes) == "d":
+		entry, ok := m.Selected()
+		if !ok {
+			return m, nil
+		}
+		// Remove the entry from the local list immediately so the UI refreshes.
+		newEntries := make([]SessionEntry, 0, len(m.entries)-1)
+		for _, e := range m.entries {
+			if e.ID != entry.ID {
+				newEntries = append(newEntries, e)
+			}
+		}
+		m.entries = newEntries
+		if m.selected >= len(m.entries) && m.selected > 0 {
+			m.selected--
+		}
+		m.scrollOffset = adjustScroll(m.scrollOffset, m.selected, len(m.entries), maxVisibleRows)
+		deletedID := entry.ID
+		return m, func() tea.Msg {
+			return SessionDeletedMsg{ID: deletedID}
+		}
 	}
 
 	return m, nil

--- a/cmd/harnesscli/tui/filecomplete.go
+++ b/cmd/harnesscli/tui/filecomplete.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const maxFileCompletions = 20
+
+// pathLikePrefixes lists the prefixes that make an @token a path reference.
+// This mirrors the regex in fileexpand.go: only unquoted tokens starting with
+// /, ~/, ./, or ../ are treated as file paths.
+var pathLikePrefixes = []string{"/", "~/", "./", "../"}
+
+// FilePathCompleter returns file path completions when the input contains an @
+// token that looks like a file path.
+//
+// When the input contains an @-sign followed by a partial path that starts with
+// /, ~/, ./, or ../, this function:
+//   - Expands a leading ~/ to the user's home directory.
+//   - Lists directory entries matching the partial path prefix.
+//   - Appends a trailing "/" to directory entries.
+//   - Limits results to 20 suggestions.
+//   - Returns nil when the input contains no @ token or the partial path is not
+//     path-like (e.g. email addresses and @mentions are ignored).
+//
+// The returned completions are full replacement strings (including the @ prefix
+// and any text before the last @ token).
+func FilePathCompleter(input string) []string {
+	// Find the last @ in the input.
+	lastAt := strings.LastIndex(input, "@")
+	if lastAt < 0 {
+		return nil
+	}
+
+	// The text before and including @ (prefix we keep in completions).
+	beforeAt := input[:lastAt+1]
+
+	// The partial path after @.
+	partial := input[lastAt+1:]
+
+	// If the partial is empty or starts with a space, no file completion.
+	if partial == "" || strings.HasPrefix(partial, " ") {
+		return nil
+	}
+
+	// Only trigger completions when partial starts with a path-like prefix.
+	isPathLike := false
+	for _, pfx := range pathLikePrefixes {
+		if strings.HasPrefix(partial, pfx) {
+			isPathLike = true
+			break
+		}
+	}
+	if !isPathLike {
+		return nil
+	}
+
+	// Expand tilde for ~/ paths.
+	expandedPartial, err := expandTilde(partial)
+	if err != nil {
+		return nil
+	}
+
+	// Determine the directory and file prefix to search.
+	dir := filepath.Dir(expandedPartial)
+	base := filepath.Base(expandedPartial)
+
+	// When partial ends with '/', Dir returns the partial stripped of trailing slash
+	// but we want to list that directory.
+	if strings.HasSuffix(expandedPartial, "/") || strings.HasSuffix(expandedPartial, string(filepath.Separator)) {
+		dir = expandedPartial
+		base = ""
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		// Nonexistent or unreadable directory — no completions.
+		return nil
+	}
+
+	var results []string
+	for _, entry := range entries {
+		name := entry.Name()
+		// Filter by prefix.
+		if base != "" && !strings.HasPrefix(name, base) {
+			continue
+		}
+
+		// Build the completed path.
+		completedPath := filepath.Join(dir, name)
+		if entry.IsDir() {
+			completedPath += "/"
+		}
+
+		// Full completion = text before @ + @ + completed path.
+		results = append(results, beforeAt+completedPath)
+
+		if len(results) >= maxFileCompletions {
+			break
+		}
+	}
+
+	return results
+}

--- a/cmd/harnesscli/tui/filecomplete_test.go
+++ b/cmd/harnesscli/tui/filecomplete_test.go
@@ -1,0 +1,194 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// ─── FilePathCompleter tests ────────────────────────────────────────────────
+
+// TestFilePathCompleter_AfterAtSign verifies that typing "@/tmp/" returns file
+// completions for that directory.
+func TestFilePathCompleter_AfterAtSign(t *testing.T) {
+	dir := t.TempDir()
+	// Create some test files.
+	for _, name := range []string{"alpha.go", "beta.go", "gamma.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	completions := tui.FilePathCompleter("@" + dir + "/")
+	if len(completions) == 0 {
+		t.Fatalf("expected completions for @%s/, got none", dir)
+	}
+
+	// Each completion must contain the directory prefix.
+	for _, c := range completions {
+		if !strings.HasPrefix(c, "@") {
+			t.Errorf("completion %q must start with '@'", c)
+		}
+	}
+}
+
+// TestFilePathCompleter_NoAtSignReturnsNil verifies that input without @
+// returns nil (no completions triggered).
+func TestFilePathCompleter_NoAtSignReturnsNil(t *testing.T) {
+	completions := tui.FilePathCompleter("hello world")
+	if completions != nil {
+		t.Errorf("input without @ must return nil completions, got %v", completions)
+	}
+}
+
+// TestFilePathCompleter_DirectoriesHaveTrailingSlash verifies that directory
+// entries in completions have a trailing "/" to encourage drilling down.
+func TestFilePathCompleter_DirectoriesHaveTrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "mydir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	completions := tui.FilePathCompleter("@" + dir + "/")
+	found := false
+	for _, c := range completions {
+		if strings.Contains(c, "mydir/") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("directory 'mydir' must appear with trailing '/' in completions; got: %v", completions)
+	}
+}
+
+// TestFilePathCompleter_LimitedTo20 verifies that at most 20 suggestions are
+// returned even when there are many more directory entries.
+func TestFilePathCompleter_LimitedTo20(t *testing.T) {
+	dir := t.TempDir()
+	// Create 30 files.
+	for i := 0; i < 30; i++ {
+		f := filepath.Join(dir, strings.Repeat("f", i+1)+".txt")
+		if err := os.WriteFile(f, []byte(""), 0o644); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+	}
+
+	completions := tui.FilePathCompleter("@" + dir + "/")
+	if len(completions) > 20 {
+		t.Errorf("completions must be limited to 20; got %d", len(completions))
+	}
+}
+
+// TestFilePathCompleter_PrefixFiltering verifies that completions are filtered
+// by the partial path after @.
+func TestFilePathCompleter_PrefixFiltering(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"apple.go", "apricot.go", "banana.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	completions := tui.FilePathCompleter("@" + dir + "/ap")
+	for _, c := range completions {
+		if !strings.Contains(c, "ap") {
+			t.Errorf("completion %q must match prefix 'ap'", c)
+		}
+	}
+	// banana.go must not appear.
+	for _, c := range completions {
+		if strings.Contains(c, "banana") {
+			t.Errorf("completion %q must not match for prefix 'ap'", c)
+		}
+	}
+}
+
+// TestFilePathCompleter_TextBeforeAtSignPreserved verifies that when the input
+// has text before the @, completions are still based on the path after the LAST @.
+func TestFilePathCompleter_TextBeforeAtSignPreserved(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "foo.txt"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Input has text before @ symbol.
+	input := "look at @" + dir + "/"
+	completions := tui.FilePathCompleter(input)
+	if len(completions) == 0 {
+		t.Fatalf("expected completions for input %q, got none", input)
+	}
+}
+
+// ─── Regression: no panic on nonexistent directory ───────────────────────────
+
+// TestFilePathCompleter_NonexistentDirReturnsNil verifies that referencing a
+// directory that does not exist returns nil (no panic, no error).
+func TestFilePathCompleter_NonexistentDirReturnsNil(t *testing.T) {
+	completions := tui.FilePathCompleter("@/nonexistent/path/xyz/")
+	// Should return nil or empty — not panic.
+	_ = completions
+}
+
+// ─── BT-NEW: email-style @token must NOT trigger file completions ─────────────
+
+// TestFilePathCompleter_EmailStyleNoCompletions verifies that user@example does
+// not trigger file completions (no leading / ./ ../ or ~/).
+func TestFilePathCompleter_EmailStyleNoCompletions(t *testing.T) {
+	completions := tui.FilePathCompleter("user@example")
+	if len(completions) != 0 {
+		t.Errorf("email-style user@example must not trigger completions; got: %v", completions)
+	}
+}
+
+// TestFilePathCompleter_BareAtMentionNoCompletions verifies that @someone (no
+// path prefix) does not trigger file completions.
+func TestFilePathCompleter_BareAtMentionNoCompletions(t *testing.T) {
+	completions := tui.FilePathCompleter("hello @someone")
+	if len(completions) != 0 {
+		t.Errorf("bare @mention must not trigger completions; got: %v", completions)
+	}
+}
+
+// TestFilePathCompleter_TildePathTriggersCompletions verifies @~/ triggers
+// file completions after tilde expansion.
+func TestFilePathCompleter_TildePathTriggersCompletions(t *testing.T) {
+	// Set HOME to a temp dir with known files.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := os.WriteFile(filepath.Join(tmpHome, "myfile.txt"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	completions := tui.FilePathCompleter("@~/")
+	if len(completions) == 0 {
+		t.Error("@~/ must trigger file completions after tilde expansion")
+	}
+	for _, c := range completions {
+		if !strings.HasPrefix(c, "@") {
+			t.Errorf("completion %q must start with '@'", c)
+		}
+	}
+}
+
+// TestFilePathCompleter_DotSlashPathTriggersCompletions verifies @./ triggers completions.
+func TestFilePathCompleter_DotSlashPathTriggersCompletions(t *testing.T) {
+	// @./ is a valid relative path prefix — completions should fire.
+	// In CI, ./ is the cwd; we just verify the completer ATTEMPTS to read it.
+	// Even if cwd has no files the completer must not return nil when the path is valid.
+	// We test indirectly: the completer must NOT return nil because @./ is path-like.
+	// (It may return empty if cwd is empty, but that's acceptable.)
+	completions := tui.FilePathCompleter("@./")
+	// We cannot guarantee entries exist in cwd, so just verify no panic and it was attempted.
+	// The key is that it was NOT blocked by the non-path guard.
+	// We'll verify by checking if @/ returns something when / has entries (it always does on unix).
+	completions2 := tui.FilePathCompleter("@/")
+	if len(completions2) == 0 {
+		t.Error("@/ must trigger file completions (/ always has entries on Unix)")
+	}
+	_ = completions
+}

--- a/cmd/harnesscli/tui/fileexpand.go
+++ b/cmd/harnesscli/tui/fileexpand.go
@@ -1,0 +1,224 @@
+package tui
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	maxFileSize = 1024 * 1024 // 1 MB
+	maxAtFiles  = 10
+	binarySniff = 512 // bytes checked for null
+)
+
+// atTokenRegexp matches @"quoted path" or @path-like-token.
+//
+// Unquoted tokens MUST start with a path-like prefix to avoid matching email
+// addresses, @mentions, and SSH URLs:
+//   - @/...    absolute path
+//   - @~/...   tilde-relative path
+//   - @./...   explicit relative path
+//   - @../...  parent-relative path
+//   - any unquoted token that contains at least one slash after the initial segment
+//
+// Quoted form @"..." is unrestricted (explicit opt-in by the user).
+var atTokenRegexp = regexp.MustCompile(`@"([^"]+)"|@((?:\./|/|~/|\.\./)\S*)`)
+
+// trailingPunct lists characters that are trimmed from the end of unquoted paths.
+// These commonly follow a path reference in prose (e.g. "see @./file.txt, then").
+const trailingPunct = `,.;:!?)`
+
+// ExpandAtPaths finds all @path tokens in prompt, reads each file, and replaces
+// the token with XML-wrapped file contents:
+//
+//	<file path="path/to/file">
+//	<![CDATA[
+//	[contents]
+//	]]>
+//	</file>
+//
+// Rules:
+//   - Unquoted @ tokens must start with /, ~/, ./, or ../ to be treated as paths.
+//   - Trailing punctuation (,.;:!?)) is stripped from unquoted paths.
+//   - Relative paths are resolved against os.Getwd().
+//   - ~/... paths are expanded to the home directory.
+//   - Quoted paths (@"path with spaces") are supported.
+//   - Maximum file size: 1 MB.
+//   - Binary files (null bytes in first 512 bytes) are rejected.
+//   - Symlinks are rejected for security.
+//   - Non-regular files (directories, devices) are rejected.
+//   - Maximum 10 @path tokens per prompt.
+//   - Prompts with no @path tokens are returned unchanged.
+//   - Path attribute and contents are XML-escaped to prevent injection.
+func ExpandAtPaths(prompt string) (string, error) {
+	if prompt == "" {
+		return "", nil
+	}
+
+	matches := atTokenRegexp.FindAllStringSubmatchIndex(prompt, -1)
+	if len(matches) == 0 {
+		return prompt, nil
+	}
+
+	// Check limit BEFORE reading any files.
+	if len(matches) > maxAtFiles {
+		return "", fmt.Errorf("too many @path tokens (%d); limit is %d files per prompt",
+			len(matches), maxAtFiles)
+	}
+
+	var sb strings.Builder
+	lastEnd := 0
+
+	for _, match := range matches {
+		// match[0], match[1] = full match start/end
+		// match[2], match[3] = capture group 1 (quoted) start/end (-1 if not matched)
+		// match[4], match[5] = capture group 2 (unquoted) start/end (-1 if not matched)
+
+		fullStart := match[0]
+		fullEnd := match[1]
+
+		var rawPath string
+		isUnquoted := match[2] < 0
+		if !isUnquoted {
+			// Quoted path: @"..."
+			rawPath = prompt[match[2]:match[3]]
+		} else {
+			// Unquoted path — trim trailing punctuation.
+			rawPath = prompt[match[4]:match[5]]
+			rawPath = strings.TrimRight(rawPath, trailingPunct)
+			// After trimming, adjust fullEnd to exclude the trimmed characters.
+			fullEnd = fullStart + 1 + len(rawPath) // @-sign + trimmed path
+		}
+
+		// Expand ~ if present.
+		resolvedPath, err := expandTilde(rawPath)
+		if err != nil {
+			return "", fmt.Errorf("path expansion failed for %q: %w", rawPath, err)
+		}
+
+		// Read and validate the file.
+		content, err := readAtFile(resolvedPath)
+		if err != nil {
+			return "", err
+		}
+
+		// Append text before this match unchanged.
+		sb.WriteString(prompt[lastEnd:fullStart])
+
+		// Append XML-safe inline block.
+		// Escape the path attribute value.
+		escapedPath := xmlAttrEscape(resolvedPath)
+		sb.WriteString("<file path=\"")
+		sb.WriteString(escapedPath)
+		sb.WriteString("\">\n")
+		// Wrap contents in CDATA, splitting any "]]>" that appears in the content.
+		sb.WriteString("<![CDATA[")
+		sb.WriteString(cdataSafe(content))
+		sb.WriteString("]]>")
+		if len(content) > 0 && content[len(content)-1] != '\n' {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("</file>")
+
+		lastEnd = fullEnd
+	}
+
+	// Append trailing text.
+	sb.WriteString(prompt[lastEnd:])
+	return sb.String(), nil
+}
+
+// xmlAttrEscape escapes a string for safe use in an XML attribute value.
+// It escapes &, <, >, and ".
+func xmlAttrEscape(s string) string {
+	var buf strings.Builder
+	xml.EscapeText(&buf, []byte(s)) //nolint:errcheck // strings.Builder never errors
+	// xml.EscapeText does not escape double-quotes; handle them explicitly.
+	return strings.ReplaceAll(buf.String(), `"`, "&quot;")
+}
+
+// cdataSafe returns the string safe for inclusion inside a CDATA section.
+// The CDATA terminator "]]>" cannot appear inside a CDATA section, so we
+// split it: "]]>" becomes "]]>" + "]]>" — i.e., close CDATA, output "]]>",
+// reopen CDATA.
+func cdataSafe(s string) string {
+	return strings.ReplaceAll(s, "]]>", "]]>]]><![CDATA[")
+}
+
+// expandTilde replaces a leading ~/ with the user's home directory.
+func expandTilde(path string) (string, error) {
+	if !strings.HasPrefix(path, "~/") && path != "~" {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return home + path[1:], nil
+}
+
+// readAtFile reads the file at path and returns its contents as a string.
+// Returns an error if the file is a symlink, non-regular, too large, binary, or not found.
+func readAtFile(path string) (string, error) {
+	// Use Lstat to detect symlinks (Stat follows them).
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("file not found: %s (Use Tab after @ to browse files)", path)
+		}
+		return "", fmt.Errorf("cannot stat file %s: %w", path, err)
+	}
+
+	// Reject symlinks for security.
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("file %s is a symlink — symlinks are not supported for security reasons", path)
+	}
+
+	// Reject non-regular files (directories, device files, named pipes, etc.).
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("path %s is not a regular file (it may be a directory or special file)", path)
+	}
+
+	// Check size limit with humanized output.
+	if info.Size() > maxFileSize {
+		humanSize := humanizeBytes(info.Size())
+		return "", fmt.Errorf("file %s is too large (%s). Limit: 1MB per file", path, humanSize)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot read file %s: %w", path, err)
+	}
+
+	// Binary detection: check first 512 bytes for null bytes.
+	sniff := data
+	if len(sniff) > binarySniff {
+		sniff = sniff[:binarySniff]
+	}
+	for _, b := range sniff {
+		if b == 0 {
+			return "", fmt.Errorf("file %s is a binary file — only text files can be attached", path)
+		}
+	}
+
+	return string(data), nil
+}
+
+// humanizeBytes converts a byte count to a human-readable string like "2.3MB".
+func humanizeBytes(n int64) string {
+	const mb = 1024 * 1024
+	if n >= mb {
+		return fmt.Sprintf("%.1fMB", float64(n)/float64(mb))
+	}
+	const kb = 1024
+	if n >= kb {
+		return fmt.Sprintf("%.1fKB", float64(n)/float64(kb))
+	}
+	return fmt.Sprintf("%dB", n)
+}

--- a/cmd/harnesscli/tui/fileexpand_model_test.go
+++ b/cmd/harnesscli/tui/fileexpand_model_test.go
@@ -1,0 +1,169 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/cmd/harnesscli/tui/components/inputarea"
+)
+
+// TestModel_FileExpandErrorShowsStatusMsg verifies that when a CommandSubmittedMsg
+// contains an @path that fails to expand (file not found), the model shows a
+// status message and does NOT initiate a run.
+func TestModel_FileExpandErrorShowsStatusMsg(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m2, _ := m.Update(inputarea.CommandSubmittedMsg{
+		Value: "check @/tmp/absolutely-nonexistent-file-999.txt",
+	})
+	m = m2.(tui.Model)
+
+	// A status message must be set.
+	if m.StatusMsg() == "" {
+		t.Error("StatusMsg must be set when @path expansion fails")
+	}
+	// The run must NOT be active (expansion error prevented the run).
+	if m.RunActive() {
+		t.Error("RunActive must be false when @path expansion fails")
+	}
+}
+
+// TestModel_FileExpandNoAtTokensPassesThrough verifies that a normal message
+// without @path tokens passes through the expansion step unchanged and the run
+// is initiated normally.
+func TestModel_FileExpandNoAtTokensPassesThrough(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m2, cmd := m.Update(inputarea.CommandSubmittedMsg{
+		Value: "hello world, no at files here",
+	})
+	m = m2.(tui.Model)
+
+	// Status message must NOT be set (no error).
+	if strings.Contains(m.StatusMsg(), "file expand error") {
+		t.Errorf("StatusMsg must not contain file expand error for clean prompt; got %q", m.StatusMsg())
+	}
+	// A run command should have been queued.
+	if cmd == nil {
+		t.Error("cmd must be non-nil (startRunCmd must have been queued)")
+	}
+}
+
+// TestModel_FileExpandValidFilePassesThrough verifies that when a prompt with a
+// valid @path expands successfully, the run is started (no error status).
+func TestModel_FileExpandValidFilePassesThrough(t *testing.T) {
+	dir := t.TempDir()
+	testFile := filepath.Join(dir, "input.txt")
+	if err := os.WriteFile(testFile, []byte("the file contents"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	m := initModel(t, 80, 24)
+	m2, cmd := m.Update(inputarea.CommandSubmittedMsg{
+		Value: "look at this file @" + testFile,
+	})
+	m = m2.(tui.Model)
+
+	// No file expand error status should be set.
+	if strings.Contains(m.StatusMsg(), "file expand error") {
+		t.Errorf("StatusMsg must not contain error for valid @path; got %q", m.StatusMsg())
+	}
+	// A run command should have been queued.
+	if cmd == nil {
+		t.Error("cmd must be non-nil (startRunCmd must have been queued for valid expansion)")
+	}
+}
+
+// TestModel_FileTabCompleteActivatesOnAt verifies that when input contains @
+// followed by a partial path, Tab produces completions (file path completer active).
+func TestModel_FileTabCompleteActivatesOnAt(t *testing.T) {
+	dir := t.TempDir()
+	// Create two files so there is at least one completion entry.
+	for _, name := range []string{"readme.md", "main.go"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	m := initModel(t, 80, 24)
+	// Type "@<dir>/" into the model.
+	m = typeIntoModel(m, "@"+dir+"/")
+
+	before := m.Input()
+
+	// Press Tab.
+	m = typeTab(m)
+	after := m.Input()
+
+	// Tab must have produced a change (a completion was found and applied).
+	// OR there are multiple completions (common prefix unchanged but no error).
+	// The key invariant: no panic, and the input still starts with @.
+	if !strings.HasPrefix(after, "@") {
+		t.Errorf("input after Tab on @ must still start with '@'; got %q", after)
+	}
+
+	_ = before // used to capture initial state
+}
+
+// Regression: TestModel_TabCompleteSlashStillWorksAfterCombinedProvider verifies
+// that slash command Tab completion still works after the combined provider is wired.
+func TestModel_TabCompleteSlashStillWorksAfterCombinedProvider(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = typeIntoModel(m, "/cl")
+	m = typeTab(m)
+	if m.Input() != "/clear " {
+		t.Errorf("slash command Tab after combined provider: want %q, got %q", "/clear ", m.Input())
+	}
+}
+
+// Regression: TestModel_FileExpandTooManyFilesShowsStatusMsg verifies that a
+// prompt with more than 10 @path tokens fails with a status message and no run.
+func TestModel_FileExpandTooManyFilesShowsStatusMsg(t *testing.T) {
+	dir := t.TempDir()
+	var parts []string
+	for i := 0; i < 11; i++ {
+		f := filepath.Join(dir, strings.Repeat("f", i+1)+".txt")
+		if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+		parts = append(parts, "@"+f)
+	}
+
+	m := initModel(t, 80, 24)
+	m2, _ := m.Update(inputarea.CommandSubmittedMsg{Value: strings.Join(parts, " ")})
+	m = m2.(tui.Model)
+
+	if m.StatusMsg() == "" {
+		t.Error("StatusMsg must be set when @path token count exceeds limit")
+	}
+	if m.RunActive() {
+		t.Error("RunActive must be false when @path expansion exceeds limit")
+	}
+}
+
+// ─── BT-NEW-007: Input is preserved on expansion failure ─────────────────────
+
+// TestModel_FileExpandErrorPreservesInput verifies that when @path expansion
+// fails, the input value is restored so the user can fix and re-submit.
+func TestModel_FileExpandErrorPreservesInput(t *testing.T) {
+	originalInput := "check @/tmp/absolutely-nonexistent-file-abc999.txt please"
+	m := initModel(t, 80, 24)
+
+	m2, _ := m.Update(inputarea.CommandSubmittedMsg{
+		Value: originalInput,
+	})
+	m = m2.(tui.Model)
+
+	// StatusMsg must be set (expansion failed).
+	if m.StatusMsg() == "" {
+		t.Error("StatusMsg must be set when @path expansion fails")
+	}
+	// Input must be restored to the original value.
+	if m.Input() != originalInput {
+		t.Errorf("Input must be restored to original value on expansion failure; want %q, got %q",
+			originalInput, m.Input())
+	}
+}

--- a/cmd/harnesscli/tui/fileexpand_test.go
+++ b/cmd/harnesscli/tui/fileexpand_test.go
@@ -1,0 +1,540 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// ─── BT-001: File exists → inline <file> XML ─────────────────────────────────
+
+// TestExpandAtPaths_SingleFileExpanded verifies that @path/to/file is replaced
+// with the file contents wrapped in <file path="..."> XML tags.
+func TestExpandAtPaths_SingleFileExpanded(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(filePath, []byte("hello world\n"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	prompt := "check this @" + filePath
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, `<file path="`+filePath+`">`) {
+		t.Errorf("result must contain <file path=%q>; got:\n%s", filePath, result)
+	}
+	if !strings.Contains(result, "hello world") {
+		t.Errorf("result must contain file contents 'hello world'; got:\n%s", result)
+	}
+	if !strings.Contains(result, "</file>") {
+		t.Errorf("result must contain </file>; got:\n%s", result)
+	}
+	// The original @path token must be removed/replaced.
+	if strings.Contains(result, "@"+filePath) {
+		t.Errorf("result must not contain original @path token; got:\n%s", result)
+	}
+}
+
+// ─── BT-002: File not found → error with path ─────────────────────────────────
+
+// TestExpandAtPaths_FileNotFound verifies that a missing file returns an error
+// containing the specific path that failed.
+func TestExpandAtPaths_FileNotFound(t *testing.T) {
+	prompt := "read this @/tmp/nonexistent-file-xyz-99999.txt"
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "/tmp/nonexistent-file-xyz-99999.txt") {
+		t.Errorf("error must contain the missing path; got: %v", err)
+	}
+}
+
+// ─── BT-003: Multiple @path tokens all expanded ───────────────────────────────
+
+// TestExpandAtPaths_MultipleFilesExpanded verifies that all @path tokens in a
+// prompt are expanded when all files exist.
+func TestExpandAtPaths_MultipleFilesExpanded(t *testing.T) {
+	dir := t.TempDir()
+	file1 := filepath.Join(dir, "a.txt")
+	file2 := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(file1, []byte("content A"), 0o644); err != nil {
+		t.Fatalf("write file1: %v", err)
+	}
+	if err := os.WriteFile(file2, []byte("content B"), 0o644); err != nil {
+		t.Fatalf("write file2: %v", err)
+	}
+
+	prompt := "look at @" + file1 + " and also @" + file2
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(result, "content A") {
+		t.Errorf("result must contain content of file1; got:\n%s", result)
+	}
+	if !strings.Contains(result, "content B") {
+		t.Errorf("result must contain content of file2; got:\n%s", result)
+	}
+	// Both file tags must be present.
+	if strings.Count(result, "<file") != 2 {
+		t.Errorf("result must contain 2 <file> blocks, got %d; result:\n%s",
+			strings.Count(result, "<file"), result)
+	}
+}
+
+// ─── BT-004: File exceeds 1MB → error ────────────────────────────────────────
+
+// TestExpandAtPaths_FileTooLarge verifies that a file exceeding 1MB returns an
+// error indicating the size limit.
+func TestExpandAtPaths_FileTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	bigFile := filepath.Join(dir, "big.bin")
+	// Write 1MB + 1 byte.
+	data := make([]byte, 1024*1024+1)
+	for i := range data {
+		data[i] = 'a'
+	}
+	if err := os.WriteFile(bigFile, data, 0o644); err != nil {
+		t.Fatalf("write big file: %v", err)
+	}
+
+	prompt := "@" + bigFile
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for file exceeding 1MB, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "size") &&
+		!strings.Contains(strings.ToLower(err.Error()), "limit") &&
+		!strings.Contains(strings.ToLower(err.Error()), "large") &&
+		!strings.Contains(strings.ToLower(err.Error()), "1mb") &&
+		!strings.Contains(strings.ToLower(err.Error()), "1 mb") {
+		t.Errorf("error must mention size limit; got: %v", err)
+	}
+}
+
+// ─── BT-005: Binary file (null bytes) → error ────────────────────────────────
+
+// TestExpandAtPaths_BinaryFileRejected verifies that a file containing null bytes
+// is rejected with a meaningful error.
+func TestExpandAtPaths_BinaryFileRejected(t *testing.T) {
+	dir := t.TempDir()
+	binaryFile := filepath.Join(dir, "binary.bin")
+	data := []byte{0x00, 0x01, 0x02, 0x03, 'h', 'e', 'l', 'l', 'o'}
+	if err := os.WriteFile(binaryFile, data, 0o644); err != nil {
+		t.Fatalf("write binary file: %v", err)
+	}
+
+	prompt := "@" + binaryFile
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for binary file, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "binary") {
+		t.Errorf("error must mention 'binary'; got: %v", err)
+	}
+}
+
+// ─── BT-006: Quoted path with spaces resolved ─────────────────────────────────
+
+// TestExpandAtPaths_QuotedPathWithSpaces verifies that @"path with spaces/file.go"
+// syntax resolves correctly when the file exists.
+func TestExpandAtPaths_QuotedPathWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "sub dir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	filePath := filepath.Join(subDir, "file with spaces.go")
+	if err := os.WriteFile(filePath, []byte("package main"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	prompt := `check @"` + filePath + `" please`
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error for quoted path: %v", err)
+	}
+
+	if !strings.Contains(result, "package main") {
+		t.Errorf("result must contain file contents 'package main'; got:\n%s", result)
+	}
+	if !strings.Contains(result, "<file") {
+		t.Errorf("result must contain <file> tag; got:\n%s", result)
+	}
+}
+
+// ─── BT-007: Tilde expansion ────────────────────────────────────────────────
+
+// TestExpandAtPaths_TildeExpansion verifies that @~/somefile expands to the home
+// directory and resolves correctly when the file exists.
+func TestExpandAtPaths_TildeExpansion(t *testing.T) {
+	// Override HOME to a temp dir so we can create a known file.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	testFile := filepath.Join(tmpHome, "testfile.txt")
+	if err := os.WriteFile(testFile, []byte("tilde content"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	prompt := "read @~/testfile.txt"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error for tilde path: %v", err)
+	}
+
+	if !strings.Contains(result, "tilde content") {
+		t.Errorf("result must contain file contents 'tilde content'; got:\n%s", result)
+	}
+}
+
+// ─── BT-008: No @tokens → prompt returned unchanged ─────────────────────────
+
+// TestExpandAtPaths_NoTokensUnchanged verifies that a prompt with no @path tokens
+// is returned unchanged without error.
+func TestExpandAtPaths_NoTokensUnchanged(t *testing.T) {
+	prompt := "hello world, no at signs here"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != prompt {
+		t.Errorf("prompt with no @ tokens must be returned unchanged; want %q, got %q", prompt, result)
+	}
+}
+
+// ─── BT-009: More than 10 @path tokens → error ───────────────────────────────
+
+// TestExpandAtPaths_TooManyTokens verifies that a prompt with more than 10 @path
+// tokens returns an error.
+func TestExpandAtPaths_TooManyTokens(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create 11 files and reference them all.
+	var parts []string
+	for i := 0; i < 11; i++ {
+		f := filepath.Join(dir, strings.Repeat("x", i+1)+".txt")
+		if err := os.WriteFile(f, []byte("content"), 0o644); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+		parts = append(parts, "@"+f)
+	}
+	prompt := strings.Join(parts, " ")
+
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for more than 10 @path tokens, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "10") &&
+		!strings.Contains(strings.ToLower(err.Error()), "limit") &&
+		!strings.Contains(strings.ToLower(err.Error()), "too many") {
+		t.Errorf("error must mention the 10-file limit; got: %v", err)
+	}
+}
+
+// ─── Regression: empty prompt handled without panic ──────────────────────────
+
+// TestExpandAtPaths_EmptyPrompt verifies that an empty prompt is handled without
+// panic or error and returned as-is.
+func TestExpandAtPaths_EmptyPrompt(t *testing.T) {
+	result, err := tui.ExpandAtPaths("")
+	if err != nil {
+		t.Fatalf("empty prompt must not produce error: %v", err)
+	}
+	if result != "" {
+		t.Errorf("empty prompt must return empty string; got %q", result)
+	}
+}
+
+// TestExpandAtPaths_AtSignWithoutPath verifies that a bare @ not followed by a
+// path-like token is returned unchanged (not treated as a file reference).
+func TestExpandAtPaths_AtSignWithoutPath(t *testing.T) {
+	// An @-sign followed by whitespace is not a file reference.
+	prompt := "email me @ example.com"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("@ followed by space must not trigger file expansion: %v", err)
+	}
+	if result != prompt {
+		t.Errorf("@ without path must return prompt unchanged; want %q, got %q", prompt, result)
+	}
+}
+
+// ─── BT-NEW-001: Email address must NOT be treated as @path ─────────────────
+
+// TestExpandAtPaths_EmailAddressNotExpanded verifies that user@example.com is
+// not treated as a file attachment (email addresses must be ignored).
+func TestExpandAtPaths_EmailAddressNotExpanded(t *testing.T) {
+	prompt := "send to user@example.com please"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("email address must not cause error; got: %v", err)
+	}
+	if result != prompt {
+		t.Errorf("email address must leave prompt unchanged; want %q, got %q", prompt, result)
+	}
+}
+
+// TestExpandAtPaths_GitAtURLNotExpanded verifies that git@github.com:org/repo
+// is not treated as a file attachment.
+func TestExpandAtPaths_GitAtURLNotExpanded(t *testing.T) {
+	prompt := "clone git@github.com:org/repo.git"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("git@github.com URL must not cause error; got: %v", err)
+	}
+	if result != prompt {
+		t.Errorf("git@github.com URL must leave prompt unchanged; want %q, got %q", prompt, result)
+	}
+}
+
+// TestExpandAtPaths_BareAtMentionNotExpanded verifies that @someone is not
+// treated as a file path.
+func TestExpandAtPaths_BareAtMentionNotExpanded(t *testing.T) {
+	prompt := "hey @someone check this out"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("bare @mention must not cause error; got: %v", err)
+	}
+	if result != prompt {
+		t.Errorf("bare @mention must leave prompt unchanged; want %q, got %q", prompt, result)
+	}
+}
+
+// ─── BT-NEW-002: Path-like @tokens MUST be expanded ─────────────────────────
+
+// TestExpandAtPaths_AbsolutePathExpanded verifies that @/absolute/path/file.txt
+// is still expanded correctly.
+func TestExpandAtPaths_AbsolutePathExpanded(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "abs.txt")
+	if err := os.WriteFile(filePath, []byte("absolute"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prompt := "check @" + filePath
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("absolute @path must expand without error: %v", err)
+	}
+	if !strings.Contains(result, "absolute") {
+		t.Errorf("result must contain file contents; got: %s", result)
+	}
+}
+
+// TestExpandAtPaths_RelativeDotSlashExpanded verifies that @./relative/file
+// is expanded.
+func TestExpandAtPaths_RelativeDotSlashExpanded(t *testing.T) {
+	// We can only test that relative paths starting with ./ are matched by regex.
+	// We resolve against cwd, so we create a file relative to cwd.
+	dir := t.TempDir()
+	// We'll use an absolute path that starts with / (covered above).
+	// For ./ test, we verify it's matched (even if it may not exist in cwd).
+	// The key invariant: the regex matches @./foo, which means ExpandAtPaths
+	// will attempt to read the file (and fail with "file not found" not "unchanged").
+	prompt := "read @./nonexistent-relative-file.txt"
+	_, err := tui.ExpandAtPaths(prompt)
+	// It MUST attempt expansion (return an error about the file), not leave unchanged.
+	if err == nil {
+		t.Fatal("@./path must be attempted for expansion; expected file-not-found error")
+	}
+	_ = dir
+}
+
+// ─── BT-NEW-003: XML injection in file contents must be contained in CDATA ───
+
+// TestExpandAtPaths_XMLInjectionInPath verifies that file content containing
+// XML special characters is wrapped in a CDATA section so an XML parser
+// treats it as character data, not markup.
+func TestExpandAtPaths_XMLInjectionInPath(t *testing.T) {
+	// Create a file whose contents would break naive XML string concatenation.
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "normal.txt")
+	// Content that would break naive XML wrapping.
+	content := `</file><injected>evil content</injected><file path="fake">`
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	prompt := "@" + filePath
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The content must be wrapped in a CDATA section.
+	if !strings.Contains(result, "<![CDATA[") {
+		t.Errorf("result must use CDATA section; got:\n%s", result)
+	}
+	// The injection payload must appear inside CDATA — meaning it appears BETWEEN
+	// <![CDATA[ and the closing ]]>. We verify by checking CDATA contains it.
+	cdataStart := strings.Index(result, "<![CDATA[")
+	cdataEnd := strings.Index(result, "]]>")
+	if cdataStart < 0 || cdataEnd < 0 || cdataEnd <= cdataStart {
+		t.Fatalf("malformed CDATA section in result:\n%s", result)
+	}
+	cdataContent := result[cdataStart+9 : cdataEnd] // 9 = len("<![CDATA[")
+	if !strings.Contains(cdataContent, "</file>") {
+		t.Errorf("the injected </file> tag must appear INSIDE the CDATA section; CDATA content:\n%s", cdataContent)
+	}
+	// Verify outer structure: result starts with <file path="..." and ends with </file>.
+	if !strings.HasPrefix(result, "<file path=\"") {
+		t.Errorf("result must start with <file path=\"...\"; got:\n%s", result)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(result), "</file>") {
+		t.Errorf("result must end with </file>; got:\n%s", result)
+	}
+}
+
+// ─── BT-NEW-004: Symlink must be rejected ────────────────────────────────────
+
+// TestExpandAtPaths_SymlinkRejected verifies that a symlink is rejected with
+// a security-oriented error message.
+func TestExpandAtPaths_SymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.txt")
+	if err := os.WriteFile(target, []byte("target content"), 0o644); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	link := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	prompt := "@" + link
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for symlink, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "symlink") {
+		t.Errorf("error must mention 'symlink'; got: %v", err)
+	}
+}
+
+// TestExpandAtPaths_DirectoryRejected verifies that passing a directory path
+// returns a clear error rather than reading directory metadata.
+func TestExpandAtPaths_DirectoryRejected(t *testing.T) {
+	dir := t.TempDir()
+	prompt := "@" + dir
+	_, err := tui.ExpandAtPaths(prompt)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	lowerErr := strings.ToLower(err.Error())
+	if !strings.Contains(lowerErr, "directory") && !strings.Contains(lowerErr, "regular") && !strings.Contains(lowerErr, "not a regular") {
+		t.Errorf("error must indicate it is not a regular file; got: %v", err)
+	}
+}
+
+// ─── BT-NEW-005: Trailing punctuation trimmed from unquoted paths ────────────
+
+// TestExpandAtPaths_TrailingCommaTrimmed verifies that a trailing comma after
+// an unquoted @path is stripped before looking up the file.
+func TestExpandAtPaths_TrailingCommaTrimmed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("trimmed content"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// The comma after the path must NOT be part of the resolved filename.
+	prompt := "check @" + filePath + ", then proceed"
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("trailing comma must be trimmed from path; got error: %v", err)
+	}
+	if !strings.Contains(result, "trimmed content") {
+		t.Errorf("result must contain file contents; got:\n%s", result)
+	}
+	// The comma should appear in the surrounding text, not be eaten.
+	if !strings.Contains(result, ", then proceed") {
+		t.Errorf("result must preserve text after the comma; got:\n%s", result)
+	}
+}
+
+// TestExpandAtPaths_TrailingPeriodTrimmed verifies trailing period is stripped.
+func TestExpandAtPaths_TrailingPeriodTrimmed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(filePath, []byte("note content"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	prompt := "see @" + filePath + "."
+	result, err := tui.ExpandAtPaths(prompt)
+	if err != nil {
+		t.Fatalf("trailing period must be trimmed: %v", err)
+	}
+	if !strings.Contains(result, "note content") {
+		t.Errorf("result must contain file contents; got:\n%s", result)
+	}
+}
+
+// ─── BT-NEW-006: Improved error messages ─────────────────────────────────────
+
+// TestExpandAtPaths_BinaryErrorMessage verifies the binary error message uses
+// "binary file" and mentions the filename.
+func TestExpandAtPaths_BinaryErrorMessage(t *testing.T) {
+	dir := t.TempDir()
+	binaryFile := filepath.Join(dir, "data.bin")
+	if err := os.WriteFile(binaryFile, []byte{0x00, 0x01, 0x02}, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := tui.ExpandAtPaths("@" + binaryFile)
+	if err == nil {
+		t.Fatal("expected error for binary file")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "binary") {
+		t.Errorf("binary error must mention 'binary'; got: %v", err)
+	}
+	// Must say "text files" or "only text"
+	if !strings.Contains(strings.ToLower(err.Error()), "text") {
+		t.Errorf("binary error must mention 'text'; got: %v", err)
+	}
+}
+
+// TestExpandAtPaths_SizeErrorHumanized verifies size error shows humanized size.
+func TestExpandAtPaths_SizeErrorHumanized(t *testing.T) {
+	dir := t.TempDir()
+	bigFile := filepath.Join(dir, "big.txt")
+	data := make([]byte, 1024*1024+1)
+	for i := range data {
+		data[i] = 'a'
+	}
+	if err := os.WriteFile(bigFile, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := tui.ExpandAtPaths("@" + bigFile)
+	if err == nil {
+		t.Fatal("expected error for oversized file")
+	}
+	// Must contain "MB" or humanized size indicator.
+	if !strings.Contains(err.Error(), "MB") && !strings.Contains(err.Error(), "mb") {
+		t.Errorf("size error must show humanized size (MB); got: %v", err)
+	}
+	// Must mention limit.
+	if !strings.Contains(strings.ToLower(err.Error()), "limit") && !strings.Contains(strings.ToLower(err.Error()), "1mb") {
+		t.Errorf("size error must mention limit; got: %v", err)
+	}
+}
+
+// TestExpandAtPaths_NotFoundErrorHasHint verifies the "file not found" error
+// includes a Tab-completion hint.
+func TestExpandAtPaths_NotFoundErrorHasHint(t *testing.T) {
+	_, err := tui.ExpandAtPaths("@/tmp/definitely-missing-file-xyz123.txt")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "tab") {
+		t.Errorf("not-found error must hint 'Use Tab after @'; got: %v", err)
+	}
+}

--- a/cmd/harnesscli/tui/history_routing_test.go
+++ b/cmd/harnesscli/tui/history_routing_test.go
@@ -1,0 +1,144 @@
+package tui_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// sendKey sends a single key message to the model.
+func sendKey(m tui.Model, keyType tea.KeyType) tui.Model {
+	m2, _ := m.Update(tea.KeyMsg{Type: keyType})
+	return m2.(tui.Model)
+}
+
+// submitCommand types a command and presses Enter.
+func submitCommand(m tui.Model, cmd string) tui.Model {
+	m = typeIntoModel(m, cmd)
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	return m2.(tui.Model)
+}
+
+// BT-008: When no overlay or slash-complete dropdown is active,
+// Up/Down arrows navigate history (not viewport).
+func TestBT008_UpDownRoutesToHistoryWhenNoOverlayActive(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Pre-condition: no overlay, no slash complete
+	if m.OverlayActive() {
+		t.Fatal("BT-008 pre-condition: overlay must not be active")
+	}
+
+	// Submit a command so history has an entry
+	m = submitCommand(m, "history-entry-one")
+
+	// Input should be empty after submit
+	if m.Input() != "" {
+		t.Fatalf("BT-008 pre-condition: input should be empty after submit, got %q", m.Input())
+	}
+
+	// Record viewport scroll offset before pressing Up
+	scrollBefore := m.ViewportScrollOffset()
+
+	// Press Up — should navigate history, NOT scroll viewport
+	m = sendKey(m, tea.KeyUp)
+
+	// Input should now show the last submitted command
+	if m.Input() != "history-entry-one" {
+		t.Errorf("BT-008: Up when no overlay active should navigate history; want 'history-entry-one', got %q", m.Input())
+	}
+
+	// Viewport scroll offset should NOT have changed (history navigation, not viewport scroll)
+	scrollAfter := m.ViewportScrollOffset()
+	if scrollAfter != scrollBefore {
+		t.Errorf("BT-008: Up should not scroll viewport when navigating history; scroll changed from %d to %d", scrollBefore, scrollAfter)
+	}
+
+	// Press Down — should return to empty draft
+	m = sendKey(m, tea.KeyDown)
+	if m.Input() != "" {
+		t.Errorf("BT-008: Down after Up should return to empty draft, got %q", m.Input())
+	}
+}
+
+// TestBT008_UpScrollsViewportWhenOverlayActive verifies that when an overlay IS active,
+// Up still does overlay/viewport navigation (not history).
+func TestBT008_UpDoesNotRouteHistoryWhenOverlayActive(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = submitCommand(m, "history-check")
+
+	// Open an overlay
+	m2, _ := m.Update(tui.OverlayOpenMsg{Kind: "help"})
+	m = m2.(tui.Model)
+	if !m.OverlayActive() {
+		t.Fatal("BT-008 overlay pre-condition failed")
+	}
+
+	// Press Up — should NOT change the input (overlay is active, key goes elsewhere)
+	m = sendKey(m, tea.KeyUp)
+	// Input should still be empty (we didn't route Up to history)
+	if m.Input() == "history-check" {
+		t.Errorf("BT-008: Up when overlay is active should NOT navigate input history, but it did")
+	}
+}
+
+// Regression: After navigating history and pressing Down back to draft,
+// submitting a new command should add it to history.
+func TestRegression_HistoryNavigateAndSubmitNewCommand(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Submit two commands
+	m = submitCommand(m, "cmd-first")
+	m = submitCommand(m, "cmd-second")
+
+	// Navigate up to cmd-second, then down to draft
+	m = sendKey(m, tea.KeyUp) // shows "cmd-second"
+	if m.Input() != "cmd-second" {
+		t.Fatalf("regression setup: expected 'cmd-second', got %q", m.Input())
+	}
+	m = sendKey(m, tea.KeyDown) // back to draft
+
+	// Type and submit a new command
+	m = submitCommand(m, "cmd-third")
+
+	// Navigate up — should show "cmd-third" as most recent
+	m = sendKey(m, tea.KeyUp)
+	if m.Input() != "cmd-third" {
+		t.Errorf("regression: after navigate+submit, Up should show 'cmd-third', got %q", m.Input())
+	}
+}
+
+// Regression: Window resize must not clear history that was built up during a session.
+func TestRegression_WindowResizePreservesHistory(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Submit a command to populate history
+	m = submitCommand(m, "before-resize")
+
+	// Simulate window resize
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = m2.(tui.Model)
+
+	// History should still be navigable after resize
+	m = sendKey(m, tea.KeyUp)
+	if m.Input() != "before-resize" {
+		t.Errorf("regression: window resize must not clear history; want 'before-resize', got %q", m.Input())
+	}
+}
+
+// Regression: ScrollUp/ScrollDown key bindings (ctrl+p / ctrl+n) must also navigate history.
+func TestRegression_CtrlPNavigatesHistory(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = submitCommand(m, "ctrl-p-test")
+
+	// ctrl+p is also bound to ScrollUp; it should navigate history when no overlay active
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}, Alt: false})
+	// Actually ctrl+p is a special key type. Use the proper key binding:
+	m2, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	m = m2.(tui.Model)
+	if m.Input() != "ctrl-p-test" {
+		t.Errorf("regression: ctrl+p (ScrollUp alt binding) should navigate history; want 'ctrl-p-test', got %q", m.Input())
+	}
+}

--- a/cmd/harnesscli/tui/keys.go
+++ b/cmd/harnesscli/tui/keys.go
@@ -40,11 +40,11 @@ func DefaultKeyMap() KeyMap {
 		),
 		ScrollUp: key.NewBinding(
 			key.WithKeys("up", "ctrl+p"),
-			key.WithHelp("up", "scroll up"),
+			key.WithHelp("up", "history up"),
 		),
 		ScrollDown: key.NewBinding(
 			key.WithKeys("down", "ctrl+n"),
-			key.WithHelp("down", "scroll down"),
+			key.WithHelp("down", "history down"),
 		),
 		PageUp: key.NewBinding(
 			key.WithKeys("pgup"),

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -212,3 +212,10 @@ type SessionRunsFetchedMsg struct {
 type SessionDeletedMsg struct {
 	ID string
 }
+
+// TranscriptEntryMsg injects a transcript entry directly into the model.
+// Used in tests to set up transcript state without running a full SSE session.
+type TranscriptEntryMsg struct {
+	Role    string
+	Content string
+}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -192,3 +192,23 @@ type ProfileEntry struct {
 	ToolCount   int
 	SourceTier  string
 }
+
+// SessionPickerSelectedMsg is emitted when the user selects a session from the
+// session picker overlay.  The model wires this to update conversationID.
+type SessionPickerSelectedMsg struct {
+	SessionID string
+}
+
+// SessionRunsFetchedMsg carries the run IDs for a conversation fetched from
+// GET /v1/conversations/{id}/runs.  RunIDs is empty when the server returns 501
+// (no run store configured) or on any other error.
+type SessionRunsFetchedMsg struct {
+	ConversationID string
+	RunIDs         []string
+}
+
+// SessionDeletedMsg is emitted when the user deletes a session from the picker.
+// The model should remove it from the persistent store.
+type SessionDeletedMsg struct {
+	ID string
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -224,6 +224,10 @@ type Model struct {
 	helpDialog  helpdialog.Model
 	contextGrid contextgrid.Model
 	statsPanel  statspanel.Model
+
+	// historyStore holds the persistent command history across window resizes
+	// and is saved to ~/.config/harnesscli/config.json on every submit.
+	historyStore inputarea.History
 }
 
 // New creates a new root Model.
@@ -238,11 +242,16 @@ func New(cfg TUIConfig) Model {
 		selectedModel: cfg.Model,
 	}
 	m.modelSwitcher = modelswitcher.New(cfg.Model)
-	// Load starred models, gateway, and API keys from persistent config.
+	// Initialize history store with defaults.
+	m.historyStore = inputarea.NewHistory(100)
+	// Load starred models, gateway, API keys, and command history from persistent config.
 	if persistCfg, err := harnessconfig.Load(); err == nil {
 		m.modelSwitcher = m.modelSwitcher.WithStarred(persistCfg.StarredModels)
 		m.selectedGateway = persistCfg.Gateway
 		m.pendingAPIKeys = persistCfg.APIKeys
+		if len(persistCfg.HistoryEntries) > 0 {
+			m.historyStore = inputarea.NewHistoryWithEntries(100, persistCfg.HistoryEntries)
+		}
 	}
 	// Bootstrap: read known provider keys from the shell environment so models
 	// show as available immediately — without requiring the user to enter them
@@ -936,6 +945,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.layout = layout.Compute(msg.Width, msg.Height)
+		alreadyReady := m.ready
 		m.ready = true
 
 		// Initialize/resize components
@@ -943,7 +953,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusBar.SetModel(m.statusBarModelLabel())
 		m.statusBar.SetCost(m.cumulativeCostUSD)
 		m.vp = viewport.New(msg.Width, m.layout.ViewportHeight)
-		m.input = inputarea.New(msg.Width)
+		// Preserve current history across window resizes: on subsequent resizes
+		// (alreadyReady == true), sync historyStore from the live input state so
+		// any commands typed since startup are preserved. On the first WindowSizeMsg
+		// we keep historyStore as-is (loaded from config in New()).
+		if alreadyReady {
+			m.historyStore = m.input.HistoryState()
+		}
+		m.input = inputarea.NewWithHistory(msg.Width, m.historyStore)
 		// Re-wire autocomplete provider each time the input is re-created.
 		if m.autocompleteProvider != nil {
 			m.input = m.input.SetAutocompleteProvider(m.autocompleteProvider)
@@ -1334,6 +1351,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.slashComplete = m.slashComplete.Up()
 				return m, tea.Batch(cmds...)
 			}
+			// When no overlay or dropdown is active, Up navigates input history.
+			// Always send canonical KeyUp so inputarea handles ctrl+p identically to Up.
+			if !m.overlayActive {
+				var cmd tea.Cmd
+				m.input, cmd = m.input.Update(tea.KeyMsg{Type: tea.KeyUp})
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
 			m.vp.ScrollUp(1)
 		case key.Matches(msg, m.keys.ScrollDown):
 			// When the provider overlay is active, Down navigates the gateway list.
@@ -1353,6 +1380,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// When the dropdown is active, Down navigates the dropdown.
 			if m.slashComplete.IsActive() {
 				m.slashComplete = m.slashComplete.Down()
+				return m, tea.Batch(cmds...)
+			}
+			// When no overlay or dropdown is active, Down navigates input history.
+			// Always send canonical KeyDown so inputarea handles ctrl+n identically to Down.
+			if !m.overlayActive {
+				var cmd tea.Cmd
+				m.input, cmd = m.input.Update(tea.KeyMsg{Type: tea.KeyDown})
+				if cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 				return m, tea.Batch(cmds...)
 			}
 			m.vp.ScrollDown(1)
@@ -1418,6 +1455,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case inputarea.CommandSubmittedMsg:
+		// Persist command history to config on every submit.
+		// The input has already pushed the entry into its history at this point.
+		m.historyStore = m.input.HistoryState()
+		if persistCfg, err := harnessconfig.Load(); err == nil {
+			persistCfg.HistoryEntries = m.historyStore.Entries()
+			_ = harnessconfig.Save(persistCfg)
+		}
 		// Close the dropdown whenever a command is submitted.
 		m.slashComplete = m.slashComplete.Close()
 		// Check if it's a slash command; dispatch if so.

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ import (
 	"go-agent-harness/cmd/harnesscli/tui/components/messagebubble"
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
 	"go-agent-harness/cmd/harnesscli/tui/components/profilepicker"
+	"go-agent-harness/cmd/harnesscli/tui/components/sessionpicker"
 	"go-agent-harness/cmd/harnesscli/tui/components/slashcomplete"
 	"go-agent-harness/cmd/harnesscli/tui/components/statspanel"
 	"go-agent-harness/cmd/harnesscli/tui/components/statusbar"
@@ -33,6 +35,16 @@ import (
 // defaultExportDir returns a runtime-safe directory for transcript exports.
 func defaultExportDir() string {
 	return transcriptexport.DefaultOutputDir()
+}
+
+// defaultSessionConfigDir returns the directory where sessions.json is stored.
+// Falls back to the current directory on error.
+func defaultSessionConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "."
+	}
+	return filepath.Join(home, ".config", "harnesscli")
 }
 
 type gatewayOption struct {
@@ -217,6 +229,14 @@ type Model struct {
 	profilePicker   profilepicker.Model
 	selectedProfile string // name of profile selected for next run (not persisted)
 
+	// Session picker component and persistent session store.
+	sessionPicker sessionpicker.Model
+	sessionStore  *SessionStore
+
+	// pendingLastMsg holds the most-recently submitted user message (up to 60
+	// chars) so RunStartedMsg can record it on the session entry as LastMsg.
+	pendingLastMsg string
+
 	// Components
 	statusBar   statusbar.Model
 	vp          viewport.Model
@@ -253,6 +273,10 @@ func New(cfg TUIConfig) Model {
 			m.historyStore = inputarea.NewHistoryWithEntries(100, persistCfg.HistoryEntries)
 		}
 	}
+	// Load session history from persistent store.
+	m.sessionStore = NewSessionStore(defaultSessionConfigDir())
+	_ = m.sessionStore.Load() // errors are silently ignored at startup
+	m.sessionPicker = sessionpicker.New(sessionEntriesToPicker(m.sessionStore.List()))
 	// Bootstrap: read known provider keys from the shell environment so models
 	// show as available immediately — without requiring the user to enter them
 	// via /keys. These keys are stored separately (envAPIKeys) and are NOT
@@ -426,6 +450,12 @@ func (m Model) SelectedReasoningEffort() string {
 // Returns "" when no profile is selected.
 func (m Model) SelectedProfile() string {
 	return m.selectedProfile
+}
+
+// SessionStore returns the session store (for testing).
+// The returned pointer is live — callers can inspect it after updates.
+func (m Model) SessionStore() *SessionStore {
+	return m.sessionStore
 }
 
 // gatewayIndex returns the index of the gateway option with the given ID,
@@ -932,6 +962,26 @@ func executeProfilesCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	}, false
 }
 
+func executeSessionsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	// Refresh the picker with the latest store entries before opening.
+	m.sessionPicker = sessionpicker.New(sessionEntriesToPicker(m.sessionStore.List())).Open()
+	m.sessionPicker.Width = m.width
+	m.overlayActive = true
+	m.activeOverlay = "sessions"
+	return nil, false
+}
+
+func executeNewSessionCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	m.conversationID = ""
+	m.vp = viewport.New(m.width, m.layout.ViewportHeight)
+	m.transcript = nil
+	m.lastAssistantText = ""
+	m.responseStarted = false
+	m.activeAssistantLineCount = 0
+	m.clearThinkingBar()
+	return []tea.Cmd{m.setStatusMsg("New session started")}, false
+}
+
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
@@ -1058,6 +1108,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if m.activeOverlay == "profiles" {
 				m.profilePicker = m.profilePicker.Close()
+				m.overlayActive = false
+				m.activeOverlay = ""
+				return m, tea.Batch(cmds...)
+			}
+			if m.activeOverlay == "sessions" {
+				m.sessionPicker = m.sessionPicker.Close()
 				m.overlayActive = false
 				m.activeOverlay = ""
 				return m, tea.Batch(cmds...)
@@ -1345,6 +1401,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, ppCmd)
 			}
 			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "sessions":
+			// Route all keys to the session picker component.
+			// Enter triggers sessionpicker.SessionSelectedMsg which we translate
+			// to SessionPickerSelectedMsg in the block below.
+			// 'd' triggers sessionpicker.SessionDeletedMsg which we pass through.
+			var spCmd tea.Cmd
+			m.sessionPicker, spCmd = m.sessionPicker.Update(msg)
+			if spCmd != nil {
+				// The session picker emits sessionpicker.SessionSelectedMsg on Enter
+				// and sessionpicker.SessionDeletedMsg on 'd'.
+				// Unwrap both to our own message types so the switch-case below handles them.
+				cmds = append(cmds, func() tea.Msg {
+					raw := spCmd()
+					if sel, ok := raw.(sessionpicker.SessionSelectedMsg); ok {
+						return SessionPickerSelectedMsg{SessionID: sel.Entry.ID}
+					}
+					if del, ok := raw.(sessionpicker.SessionDeletedMsg); ok {
+						return SessionDeletedMsg{ID: del.ID}
+					}
+					return raw
+				})
+			}
+			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.ScrollUp):
 			// When the provider overlay is active, Up/Down navigates the gateway list.
 			if m.overlayActive && m.activeOverlay == "provider" {
@@ -1519,6 +1598,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.responseStarted = false
 		m.activeAssistantLineCount = 0
 		m.clearThinkingBar()
+		// Capture a preview of the user message so RunStartedMsg can record it as
+		// LastMsg on the session entry.
+		m.pendingLastMsg = truncateStr(msg.Value, 60)
 		// Record in transcript (use original value for display; expanded for the API).
 		m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
 			Role:      "user",
@@ -1564,6 +1646,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.conversationID == "" {
 			m.conversationID = msg.RunID
 		}
+		// Track the session in the persistent store so it appears in /sessions.
+		if m.sessionStore != nil {
+			pending := m.pendingLastMsg
+			existing, ok := m.sessionStore.Get(m.conversationID)
+			if !ok {
+				m.sessionStore.Add(StoredSessionEntry{
+					ID:        m.conversationID,
+					StartedAt: time.Now(),
+					Model:     m.selectedModel,
+					LastMsg:   pending,
+				})
+			} else {
+				m.sessionStore.Update(m.conversationID, func(e *StoredSessionEntry) {
+					e.TurnCount = existing.TurnCount + 1
+					if m.selectedModel != "" {
+						e.Model = m.selectedModel
+					}
+					if pending != "" {
+						e.LastMsg = pending
+					}
+				})
+			}
+			_ = m.sessionStore.Save()
+		}
+		// Clear pending message preview now that it has been recorded.
+		m.pendingLastMsg = ""
 		// Start the SSE bridge for this run only if no cancel func is already
 		// set (e.g. injected by tests via WithCancelRun). This avoids overwriting
 		// a test-supplied cancel with a real HTTP bridge.
@@ -1876,9 +1984,51 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.overlayActive = false
 		m.activeOverlay = ""
 		cmds = append(cmds, m.setStatusMsg("Profile: "+msg.Entry.Name))
+
+	case SessionPickerSelectedMsg:
+		m.conversationID = msg.SessionID
+		m.sessionPicker = m.sessionPicker.Close()
+		m.overlayActive = false
+		m.activeOverlay = ""
+		// Clear the viewport and transcript so stale messages from the previous
+		// conversation are not shown alongside the resumed session.
+		m.vp = viewport.New(m.width, m.layout.ViewportHeight)
+		m.transcript = nil
+		m.lastAssistantText = ""
+		m.responseStarted = false
+		m.activeAssistantLineCount = 0
+		// Show a system message so the user knows the session switch happened.
+		m.vp.AppendLine("↩ Resumed session " + msg.SessionID + ". Previous messages are on the server.")
+		m.vp.AppendLine("")
+		cmds = append(cmds, m.setStatusMsg("Switched to session "+msg.SessionID[:min8(msg.SessionID)]))
+
+	case SessionDeletedMsg:
+		// Remove from the persistent store and refresh the picker list.
+		if m.sessionStore != nil {
+			m.sessionStore.Delete(msg.ID)
+			_ = m.sessionStore.Save()
+			m.sessionPicker = m.sessionPicker.SetEntries(sessionEntriesToPicker(m.sessionStore.List()))
+		}
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+// truncateStr returns s truncated to at most n runes.
+func truncateStr(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
+}
+
+// min8 returns the minimum of 8 and the length of s, used for truncating IDs.
+func min8(s string) int {
+	if len(s) < 8 {
+		return len(s)
+	}
+	return 8
 }
 
 // View implements tea.Model -- composes all components.
@@ -1923,6 +2073,12 @@ func (m Model) View() string {
 		case "profiles":
 			m.profilePicker.Width = m.width
 			mainContent = m.profilePicker.View()
+			if mainContent == "" {
+				mainContent = m.vp.View()
+			}
+		case "sessions":
+			m.sessionPicker.Width = m.width
+			mainContent = m.sessionPicker.View(m.width)
 			if mainContent == "" {
 				mainContent = m.vp.View()
 			}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -237,6 +237,13 @@ type Model struct {
 	// chars) so RunStartedMsg can record it on the session entry as LastMsg.
 	pendingLastMsg string
 
+	// Search overlay state (for /search and /history commands).
+	searchResults     []SearchResult
+	searchQuery       string
+	searchSelectedIdx int
+	// searchIsHistory distinguishes /search (transcript) from /history (sessions).
+	searchIsHistory bool
+
 	// Components
 	statusBar   statusbar.Model
 	vp          viewport.Model
@@ -982,6 +989,106 @@ func executeNewSessionCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return []tea.Cmd{m.setStatusMsg("New session started")}, false
 }
 
+func executeSearchCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	if len(cmd.Args) == 0 {
+		return []tea.Cmd{m.setStatusMsg("Usage: /search <query>")}, false
+	}
+	query := strings.Join(cmd.Args, " ")
+	results := SearchTranscript(m.transcript, query)
+	m.searchResults = results
+	m.searchQuery = query
+	m.searchSelectedIdx = 0
+	m.searchIsHistory = false
+	m.overlayActive = true
+	m.activeOverlay = "search"
+	return nil, false
+}
+
+func executeHistoryCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	if len(cmd.Args) == 0 {
+		return []tea.Cmd{m.setStatusMsg("Usage: /history <query>")}, false
+	}
+	query := strings.Join(cmd.Args, " ")
+	results := searchSessions(m.sessionStore, query)
+	m.searchResults = results
+	m.searchQuery = query
+	m.searchSelectedIdx = 0
+	m.searchIsHistory = true
+	m.overlayActive = true
+	m.activeOverlay = "search"
+	return nil, false
+}
+
+// searchPageSize is the maximum number of results shown at once in the overlay.
+const searchPageSize = 20
+
+// viewSearchOverlay renders the search results overlay.
+func (m Model) viewSearchOverlay() string {
+	var sb strings.Builder
+	total := len(m.searchResults)
+	prefix := "Search"
+	if m.searchIsHistory {
+		prefix = "History"
+	}
+	title := prefix + ": " + m.searchQuery
+	if total > 0 {
+		title += " (" + searchResultCountLabel(total) + ")"
+	}
+	titleStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	sb.WriteString(titleStyle.Render(title))
+	sb.WriteString("\n")
+	sb.WriteString(strings.Repeat("─", m.width))
+	sb.WriteString("\n")
+
+	if total == 0 {
+		noMatchStyle := lipgloss.NewStyle().Faint(true).Padding(1, 2)
+		sb.WriteString(noMatchStyle.Render("No matches found for '" + m.searchQuery + "'"))
+		sb.WriteString("\n")
+		hintStyle := lipgloss.NewStyle().Faint(true).Padding(0, 2)
+		sb.WriteString(hintStyle.Render("Press Esc to close"))
+		return sb.String()
+	}
+
+	selectedStyle := lipgloss.NewStyle().Background(lipgloss.AdaptiveColor{Light: "#e5e7eb", Dark: "#374151"})
+	roleStyle := lipgloss.NewStyle().Bold(true).Width(12)
+	faintStyle := lipgloss.NewStyle().Faint(true)
+
+	// Compute the scroll window: at most searchPageSize results visible at a time.
+	// The window is anchored so that searchSelectedIdx stays in view.
+	windowStart := (m.searchSelectedIdx / searchPageSize) * searchPageSize
+	windowEnd := windowStart + searchPageSize
+	if windowEnd > total {
+		windowEnd = total
+	}
+
+	if windowStart > 0 {
+		aboveCount := windowStart
+		sb.WriteString(faintStyle.Render("... "+strings.TrimSpace(searchResultCountLabel(aboveCount))+" more above") + "\n")
+	}
+
+	for i := windowStart; i < windowEnd; i++ {
+		r := m.searchResults[i]
+		role := r.Role
+		snippet := HighlightMatch(r.Snippet, m.searchQuery)
+		ts := r.Timestamp.Format("15:04:05")
+		line := roleStyle.Render("["+role+"]") + " " + snippet + " " + faintStyle.Render(ts)
+		if i == m.searchSelectedIdx {
+			line = selectedStyle.Render(line)
+		}
+		sb.WriteString(line + "\n")
+	}
+
+	if windowEnd < total {
+		belowCount := total - windowEnd
+		sb.WriteString(faintStyle.Render("... "+strings.TrimSpace(searchResultCountLabel(belowCount))+" more below") + "\n")
+	}
+
+	sb.WriteString("\n")
+	hintStyle := lipgloss.NewStyle().Faint(true)
+	sb.WriteString(hintStyle.Render("↑↓ navigate  Enter jump to match  Esc close"))
+	return sb.String()
+}
+
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
@@ -1118,6 +1225,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeOverlay = ""
 				return m, tea.Batch(cmds...)
 			}
+			if m.activeOverlay == "search" {
+				m.overlayActive = false
+				m.activeOverlay = ""
+				m.searchResults = nil
+				m.searchQuery = ""
+				m.searchSelectedIdx = 0
+				return m, tea.Batch(cmds...)
+			}
 			if m.overlayActive {
 				m.overlayActive = false
 				m.activeOverlay = ""
@@ -1150,6 +1265,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.rerenderActiveToolView()
 			}
 		case key.Matches(msg, m.keys.Submit):
+			// When the search overlay is active, Enter dismisses the overlay and
+			// attempts to scroll the viewport to the selected result's position.
+			if m.overlayActive && m.activeOverlay == "search" {
+				if len(m.searchResults) > 0 && m.searchSelectedIdx >= 0 && m.searchSelectedIdx < len(m.searchResults) {
+					// Best-effort scroll: use a heuristic of ~4 lines per message bubble.
+					// We scroll to the bottom first, then scroll up by the number of
+					// lines from the end that the target entry occupies.
+					entryIndex := m.searchResults[m.searchSelectedIdx].EntryIndex
+					totalEntries := len(m.transcript)
+					linesPerMessage := 4
+					// Entries after the target (from bottom).
+					entriesFromBottom := totalEntries - entryIndex - 1
+					if entriesFromBottom < 0 {
+						entriesFromBottom = 0
+					}
+					m.vp.ScrollToBottom()
+					m.vp.ScrollUp(entriesFromBottom * linesPerMessage)
+				}
+				m.overlayActive = false
+				m.activeOverlay = ""
+				m.searchResults = nil
+				m.searchQuery = ""
+				m.searchSelectedIdx = 0
+				return m, tea.Batch(cmds...)
+			}
 			// When the profiles overlay is active, Enter confirms selection via the picker.
 			if m.overlayActive && m.activeOverlay == "profiles" {
 				var ppCmd tea.Cmd
@@ -1422,6 +1562,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					return raw
 				})
+			}
+			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "search" && (msg.Type == tea.KeyUp || msg.Type == tea.KeyDown || msg.String() == "k" || msg.String() == "j"):
+			// Navigate search results with Up/Down or vim k/j.
+			isUp := msg.Type == tea.KeyUp || msg.String() == "k"
+			if len(m.searchResults) > 0 {
+				if isUp {
+					m.searchSelectedIdx = (m.searchSelectedIdx - 1 + len(m.searchResults)) % len(m.searchResults)
+				} else {
+					m.searchSelectedIdx = (m.searchSelectedIdx + 1) % len(m.searchResults)
+				}
 			}
 			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.ScrollUp):
@@ -2009,6 +2160,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = m.sessionStore.Save()
 			m.sessionPicker = m.sessionPicker.SetEntries(sessionEntriesToPicker(m.sessionStore.List()))
 		}
+
+	case TranscriptEntryMsg:
+		// Test-only message: inject a transcript entry directly without a full run.
+		m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
+			Role:      msg.Role,
+			Content:   msg.Content,
+			Timestamp: time.Now(),
+		})
 	}
 
 	return m, tea.Batch(cmds...)
@@ -2082,6 +2241,8 @@ func (m Model) View() string {
 			if mainContent == "" {
 				mainContent = m.vp.View()
 			}
+		case "search":
+			mainContent = m.viewSearchOverlay()
 		default:
 			// Unknown overlay kind — fall back to viewport.
 			mainContent = m.vp.View()

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -273,9 +273,9 @@ func New(cfg TUIConfig) Model {
 	// Wire help dialog with real command list and keybindings derived from the
 	// registered commands and the default key map.
 	m.helpDialog = buildHelpDialog(m.commandRegistry, m.keys)
-	// Wire tab completion: derive the provider from the registered commands so
-	// it stays in sync with whatever commands are registered at startup.
-	m = m.WithAutocompleteProvider(buildSlashCommandProvider(m.commandRegistry))
+	// Wire tab completion: combine slash command provider with file path completer
+	// so Tab works for both "/" commands and "@" file paths.
+	m = m.WithAutocompleteProvider(buildCombinedProvider(m.commandRegistry))
 	// Wire slash-complete dropdown.
 	m.slashComplete = buildSlashComplete(m.commandRegistry)
 	return m
@@ -369,6 +369,20 @@ func buildSlashCommandProvider(reg *CommandRegistry) inputarea.AutocompleteProvi
 			}
 		}
 		return matches
+	}
+}
+
+// buildCombinedProvider returns an AutocompleteProvider that delegates to the
+// slash command provider when input starts with "/" and the file path completer
+// when the input contains an "@" token.
+func buildCombinedProvider(reg *CommandRegistry) inputarea.AutocompleteProvider {
+	slashProvider := buildSlashCommandProvider(reg)
+	return func(input string) []string {
+		if strings.HasPrefix(input, "/") {
+			return slashProvider(input)
+		}
+		// Delegate to the file path completer when @ is present.
+		return FilePathCompleter(input)
 	}
 }
 
@@ -1492,23 +1506,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		}
-		// Normal user message: reset assistant text accumulator for the new user turn.
+		// Normal user message: expand any @path tokens before sending.
+		expandedValue, expandErr := ExpandAtPaths(msg.Value)
+		if expandErr != nil {
+			cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("file expand error: %s", expandErr)))
+			// Restore the input so the user can fix the path and re-submit.
+			m.input = m.input.SetValue(msg.Value)
+			return m, tea.Batch(cmds...)
+		}
+		// Reset assistant text accumulator for the new user turn.
 		m.lastAssistantText = ""
 		m.responseStarted = false
 		m.activeAssistantLineCount = 0
 		m.clearThinkingBar()
-		// Record in transcript.
+		// Record in transcript (use original value for display; expanded for the API).
 		m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
 			Role:      "user",
 			Content:   msg.Value,
 			Timestamp: time.Now(),
 		})
-		// Add user message via the message bubble component path.
+		// Add user message via the message bubble component path (show original).
 		m.appendMessageBubble(messagebubble.RoleUser, msg.Value)
-		// Fire off the run against the harness API, carrying the current
-		// conversationID so the harness links this turn to the conversation.
+		// Fire off the run against the harness API with the expanded prompt.
 		effModel, effProvider := m.effectiveModelAndProvider()
-		cmds = append(cmds, startRunCmd(m.config.BaseURL, msg.Value, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile))
+		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile))
 
 	case AssistantDeltaMsg:
 		m.lastAssistantText += msg.Delta

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -603,6 +603,9 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 
 	// The dropdown may truncate the full list with "... N more", but the top
 	// entries (alphabetically) must be present.
+	// With 12 registered commands and maxVisible=8, only the first 8
+	// alphabetically are shown: clear, context, export, help, keys, model,
+	// new, profiles.
 	wantVisible := []string{
 		"clear",
 		"context",
@@ -610,7 +613,7 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 		"help",
 		"keys",
 		"model",
-		"quit",
+		"new",
 	}
 	for _, cmd := range wantVisible {
 		if !strings.Contains(v, cmd) {

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -602,15 +602,15 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 	v := m.View()
 
 	// The dropdown may truncate the full list with "... N more", but the top
-	// entries (alphabetically) must be present.
-	// With 12 registered commands and maxVisible=8, only the first 8
-	// alphabetically are shown: clear, context, export, help, keys, model,
-	// new, profiles.
+	// entries (alphabetically first 8) must be present.
+	// With 14 registered commands and maxVisible=8, only the first 8
+	// alphabetically are shown: clear, context, export, help, history, keys, model, new.
 	wantVisible := []string{
 		"clear",
 		"context",
 		"export",
 		"help",
+		"history",
 		"keys",
 		"model",
 		"new",

--- a/cmd/harnesscli/tui/model_session_test.go
+++ b/cmd/harnesscli/tui/model_session_test.go
@@ -1,0 +1,326 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/cmd/harnesscli/tui/components/inputarea"
+)
+
+// ─── BT-005: /new resets conversationID ──────────────────────────────────────
+
+// TestSS005_NewCommandResetsConversationID verifies that issuing /new clears
+// the conversationID field so the next run starts a fresh conversation.
+func TestSS005_NewCommandResetsConversationID(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Simulate a run having started (sets conversationID).
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-111"})
+	m = m2.(tui.Model)
+
+	if m.ConversationID() != "run-111" {
+		t.Fatalf("pre-condition: ConversationID must be %q, got %q", "run-111", m.ConversationID())
+	}
+
+	// Issue /new.
+	m = sendSlashCommand(m, "/new")
+
+	if m.ConversationID() != "" {
+		t.Errorf("/new must reset ConversationID to '', got %q", m.ConversationID())
+	}
+}
+
+// ─── BT-006: /sessions opens the session picker overlay ──────────────────────
+
+// TestSS006_SessionsCommandOpensOverlay verifies that /sessions opens the
+// sessions overlay.
+func TestSS006_SessionsCommandOpensOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/sessions")
+
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive() must be true after /sessions")
+	}
+	if m.ActiveOverlay() != "sessions" {
+		t.Errorf("ActiveOverlay(): want %q, got %q", "sessions", m.ActiveOverlay())
+	}
+}
+
+// ─── BT-007: Selecting a session updates conversationID ──────────────────────
+
+// TestSS007_SessionPickerSelectUpdatesConversationID verifies that handling a
+// SessionSelectedMsg changes the conversationID to the selected entry's ID.
+func TestSS007_SessionPickerSelectUpdatesConversationID(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Open sessions overlay first.
+	m = sendSlashCommand(m, "/sessions")
+
+	// Simulate the user picking a session from the picker.
+	selectedMsg := tui.SessionPickerSelectedMsg{SessionID: "conv-abc-999"}
+	m2, _ := m.Update(selectedMsg)
+	m = m2.(tui.Model)
+
+	if m.ConversationID() != "conv-abc-999" {
+		t.Errorf("ConversationID after session select: want %q, got %q",
+			"conv-abc-999", m.ConversationID())
+	}
+
+	// Overlay should close after selection.
+	if m.OverlayActive() && m.ActiveOverlay() == "sessions" {
+		t.Error("sessions overlay should close after a session is selected")
+	}
+}
+
+// ─── BT-004: RunStartedMsg creates/updates session entry ─────────────────────
+
+// TestSS004_RunStartedCreatesSessionEntry verifies that when RunStartedMsg is
+// received, a session entry is created/updated in the store.
+func TestSS004_RunStartedCreatesSessionEntry(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-xyz"})
+	m = m2.(tui.Model)
+
+	// The store should now have an entry with ID "run-xyz".
+	entry, ok := m.SessionStore().Get("run-xyz")
+	if !ok {
+		t.Fatal("SessionStore should have an entry after RunStartedMsg")
+	}
+	if entry.ID != "run-xyz" {
+		t.Errorf("entry ID: want %q, got %q", "run-xyz", entry.ID)
+	}
+}
+
+// ─── Regression: /clear still works ──────────────────────────────────────────
+
+// TestSS_Regression_ClearStillWorks verifies that /clear still clears
+// the viewport without error after session wiring is added.
+func TestSS_Regression_ClearStillWorks(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Type some text into the viewport first to confirm it's not empty.
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "r1"})
+	m = m2.(tui.Model)
+	m3, _ := m.Update(tui.RunCompletedMsg{RunID: "r1"})
+	m = m3.(tui.Model)
+
+	// /clear should not panic.
+	m = sendSlashCommand(m, "/clear")
+
+	// Overlay should not be left open by /clear.
+	if m.ActiveOverlay() == "sessions" {
+		t.Error("/clear left sessions overlay open")
+	}
+}
+
+// ─── Regression: existing /sessions command registered ───────────────────────
+
+// TestSS_Regression_SessionsCommandRegistered verifies the /sessions command is
+// registered in the command registry so it appears in /help.
+func TestSS_Regression_SessionsCommandRegistered(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// If /sessions is not registered, sendSlashCommand would have no effect.
+	// We verify the overlay opens — if the command isn't registered the overlay
+	// won't open.
+	m = sendSlashCommand(m, "/sessions")
+	if m.ActiveOverlay() != "sessions" {
+		t.Error("/sessions command must be registered; overlay did not open")
+	}
+}
+
+// ─── Regression: /new command registered ─────────────────────────────────────
+
+// TestSS_Regression_NewCommandRegistered verifies /new is a registered command.
+func TestSS_Regression_NewCommandRegistered(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Simulate a run to set a conversationID.
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-for-new-test"})
+	m = m2.(tui.Model)
+
+	if m.ConversationID() == "" {
+		t.Fatal("pre-condition: conversationID must be set after RunStartedMsg")
+	}
+
+	// /new should clear it.
+	m = sendSlashCommand(m, "/new")
+
+	if m.ConversationID() != "" {
+		t.Errorf("/new must reset conversationID, got %q", m.ConversationID())
+	}
+}
+
+// ─── Regression: SessionPickerSelectedMsg closes overlay ─────────────────────
+
+// TestSS_Regression_SessionPickerEscapeClosesOverlay verifies that pressing
+// Escape while the sessions overlay is open closes it.
+func TestSS_Regression_SessionPickerEscapeClosesOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/sessions")
+
+	if !m.OverlayActive() {
+		t.Fatal("pre-condition: overlay must be open")
+	}
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = m2.(tui.Model)
+
+	if m.OverlayActive() && m.ActiveOverlay() == "sessions" {
+		t.Error("sessions overlay must close on Escape")
+	}
+}
+
+// ─── BT-013: 'd' key in session picker deletes session from store ─────────────
+
+// TestSS013_DeleteKeyRemovesSessionFromStore verifies that pressing 'd' while
+// the session picker is open removes the currently selected session from the
+// persistent store.
+func TestSS013_DeleteKeyRemovesSessionFromStore(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// Seed the store with known sessions.
+	m.SessionStore().Add(tui.StoredSessionEntry{
+		ID:        "del-session-1",
+		StartedAt: time.Now(),
+	})
+	m.SessionStore().Add(tui.StoredSessionEntry{
+		ID:        "del-session-2",
+		StartedAt: time.Now().Add(-time.Minute),
+	})
+
+	// Record the store size before delete.
+	sizeBefore := len(m.SessionStore().List())
+	if sizeBefore < 2 {
+		t.Fatal("pre-condition: store must have at least 2 entries")
+	}
+
+	// Refresh the picker via /sessions (this populates the picker from the store).
+	m = sendSlashCommand(m, "/sessions")
+	if !m.OverlayActive() {
+		t.Fatal("pre-condition: sessions overlay must be open")
+	}
+
+	// Press 'd' — returns a cmd that produces SessionDeletedMsg.
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})
+	m = m2.(tui.Model)
+
+	// The cmd wraps the sessionpicker.SessionDeletedMsg → SessionDeletedMsg.
+	// Run the cmd and feed the resulting message back into the model.
+	if cmd != nil {
+		msg := cmd()
+		m3, _ := m.Update(msg)
+		m = m3.(tui.Model)
+	}
+
+	// The store should now have one fewer entry.
+	sizeAfter := len(m.SessionStore().List())
+	if sizeAfter != sizeBefore-1 {
+		t.Errorf("after 'd': store size want %d, got %d", sizeBefore-1, sizeAfter)
+	}
+}
+
+// ─── BT-014: Session switch clears viewport and shows system message ──────────
+
+// TestSS014_SessionSwitchClearsViewport verifies that selecting a session via
+// SessionPickerSelectedMsg clears the viewport and appends a system message
+// containing the session ID.
+func TestSS014_SessionSwitchClearsViewport(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Add some content to the viewport first.
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "old-run"})
+	m = m2.(tui.Model)
+
+	// Switch to a different session.
+	m3, _ := m.Update(tui.SessionPickerSelectedMsg{SessionID: "new-session-888"})
+	m = m3.(tui.Model)
+
+	// The view should contain the system message about the resumed session.
+	view := m.View()
+	if !strings.Contains(view, "new-session-888") {
+		t.Errorf("viewport after session switch must mention session ID %q, got view:\n%s",
+			"new-session-888", view)
+	}
+}
+
+// ─── BT-015: CommandSubmittedMsg populates LastMsg on subsequent RunStartedMsg ─
+
+// TestSS015_LastMsgPopulatedFromUserInput verifies that when the user submits a
+// message and a RunStartedMsg is received, the session entry's LastMsg contains
+// a truncated form of the user's input.
+func TestSS015_LastMsgPopulatedFromUserInput(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	userInput := "What is the weather like today in San Francisco?"
+
+	// Submit the message.
+	m2, _ := m.Update(inputarea.CommandSubmittedMsg{Value: userInput})
+	m = m2.(tui.Model)
+
+	// Simulate the run starting.
+	m3, _ := m.Update(tui.RunStartedMsg{RunID: "run-lastmsg"})
+	m = m3.(tui.Model)
+
+	entry, ok := m.SessionStore().Get("run-lastmsg")
+	if !ok {
+		t.Fatal("session entry must exist after RunStartedMsg")
+	}
+	if entry.LastMsg == "" {
+		t.Error("LastMsg must be populated from user input, got empty string")
+	}
+	// The message should start with (at least part of) the user input.
+	if !strings.HasPrefix(userInput, entry.LastMsg) && !strings.HasPrefix(entry.LastMsg, userInput[:10]) {
+		t.Errorf("LastMsg %q does not match user input prefix of %q", entry.LastMsg, userInput)
+	}
+}
+
+// ─── BT-016: Long user input is truncated in LastMsg ─────────────────────────
+
+// TestSS016_LongLastMsgTruncated verifies that when the user submits a message
+// longer than 60 characters, LastMsg is truncated to exactly 60 characters.
+func TestSS016_LongLastMsgTruncated(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// 70-rune input — must be truncated to 60.
+	longInput := strings.Repeat("x", 70)
+
+	m2, _ := m.Update(inputarea.CommandSubmittedMsg{Value: longInput})
+	m = m2.(tui.Model)
+
+	m3, _ := m.Update(tui.RunStartedMsg{RunID: "run-truncate"})
+	m = m3.(tui.Model)
+
+	entry, ok := m.SessionStore().Get("run-truncate")
+	if !ok {
+		t.Fatal("session entry must exist after RunStartedMsg")
+	}
+	if len([]rune(entry.LastMsg)) != 60 {
+		t.Errorf("LastMsg rune length: want 60, got %d (value=%q)", len([]rune(entry.LastMsg)), entry.LastMsg)
+	}
+}
+
+// ─── Regression: file permissions 0o600/0o700 on sessionstore ────────────────
+
+// TestSS_Regression_SessionStoreFilePermissions verifies that sessions.json is
+// written with 0o600 permissions (owner read/write only).
+func TestSS_Regression_SessionStoreFilePermissions(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	store.Add(tui.StoredSessionEntry{ID: "perm-test", StartedAt: time.Now()})
+
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	info, err := tui.SessionStoreFileInfo(dir)
+	if err != nil {
+		t.Fatalf("stat sessions.json: %v", err)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		t.Errorf("sessions.json permissions: want 0o600, got %04o", mode)
+	}
+}

--- a/cmd/harnesscli/tui/overlay_wire_test.go
+++ b/cmd/harnesscli/tui/overlay_wire_test.go
@@ -20,7 +20,10 @@ func TestHelpOverlay_ShowsCommands(t *testing.T) {
 
 	view := m.View()
 
-	wantCommands := []string{"clear", "help", "quit", "stats", "context", "export", "subagents"}
+	// With 14 registered commands and a fixed dialog height, not all commands fit
+	// on a single page. The dialog shows the first ~12 alphabetically.
+	// Check commands that are guaranteed to appear on the first visible page.
+	wantCommands := []string{"clear", "help", "context", "export", "history", "search"}
 	for _, cmd := range wantCommands {
 		if !strings.Contains(view, cmd) {
 			t.Errorf("help overlay View() must contain command %q; got:\n%s", cmd, view)

--- a/cmd/harnesscli/tui/scroll_test.go
+++ b/cmd/harnesscli/tui/scroll_test.go
@@ -153,29 +153,43 @@ func TestRegression_ViewportScrollWired(t *testing.T) {
 	}
 }
 
-// TestModel_ArrowKeys_ScrollViewport verifies that up/down arrow keys also
-// route to the viewport when the KeyMap includes them under ScrollUp/ScrollDown.
-func TestModel_ArrowKeys_ScrollViewport(t *testing.T) {
+// TestModel_ArrowKeys_NavigateHistory verifies that up/down arrow keys navigate
+// command history (not viewport) when no overlay or dropdown is active.
+// Viewport scrolling is handled by PgUp/PgDown — see TestModel_ScrollUp_MovesViewport.
+func TestModel_ArrowKeys_NavigateHistory(t *testing.T) {
 	m := newScrollTestModel(80, 30)
 	m = appendNLines(m, 50)
 
-	// Up arrow should scroll up by 1.
-	upKey := tea.KeyMsg{Type: tea.KeyUp}
-	m2, _ := m.Update(upKey)
+	// Submit a command so history has an entry
+	m = typeIntoModel(m, "scroll-test-cmd")
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = m2.(tui.Model)
 
-	if m.ViewportScrollOffset() <= 0 {
-		t.Errorf("expected scroll offset > 0 after Up key, got %d", m.ViewportScrollOffset())
+	// Verify viewport starts at bottom and input is empty
+	if m.Input() != "" {
+		t.Fatalf("pre-condition: input should be empty after submit, got %q", m.Input())
+	}
+	scrollBefore := m.ViewportScrollOffset()
+
+	// Up arrow should navigate history (not scroll viewport)
+	upKey := tea.KeyMsg{Type: tea.KeyUp}
+	m2, _ = m.Update(upKey)
+	m = m2.(tui.Model)
+
+	if m.Input() != "scroll-test-cmd" {
+		t.Errorf("expected Up to navigate history; want 'scroll-test-cmd', got %q", m.Input())
+	}
+	if m.ViewportScrollOffset() != scrollBefore {
+		t.Errorf("expected viewport NOT to scroll when Up navigates history; offset changed from %d to %d",
+			scrollBefore, m.ViewportScrollOffset())
 	}
 
-	// Down arrow should scroll back down by 1.
-	offsetAfterUp := m.ViewportScrollOffset()
+	// Down arrow should navigate back to empty draft
 	downKey := tea.KeyMsg{Type: tea.KeyDown}
 	m2, _ = m.Update(downKey)
 	m = m2.(tui.Model)
 
-	if m.ViewportScrollOffset() >= offsetAfterUp {
-		t.Errorf("expected offset to decrease after Down key: before=%d after=%d",
-			offsetAfterUp, m.ViewportScrollOffset())
+	if m.Input() != "" {
+		t.Errorf("expected Down to return to empty draft, got %q", m.Input())
 	}
 }

--- a/cmd/harnesscli/tui/search.go
+++ b/cmd/harnesscli/tui/search.go
@@ -1,0 +1,196 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
+)
+
+// SearchResult represents a single match within the conversation transcript.
+type SearchResult struct {
+	// EntryIndex is the position of the matched entry in the transcript slice.
+	EntryIndex int
+	// Role is the speaker: "user", "assistant", or "tool".
+	Role string
+	// Timestamp is the time the entry was recorded.
+	Timestamp time.Time
+	// Snippet is a short excerpt (up to 80 runes) around the match.
+	Snippet string
+	// MatchStart is the rune offset of the match start within Snippet.
+	MatchStart int
+	// MatchEnd is the rune offset of the match end within Snippet (exclusive).
+	MatchEnd int
+}
+
+// snippetWindow is the number of runes to show on each side of a match.
+const snippetWindow = 40
+
+// runeIndexFold finds the first occurrence of lowerSub (already lowercased) inside
+// s using Unicode case-folding. It returns the byte offset and rune offset of the
+// start of the match in s, or (-1, -1) if not found.
+// The comparison is done entirely in rune space to avoid byte-length mismatches
+// that arise when ToLower changes the byte length of a character (e.g. Turkish İ,
+// German ẞ).
+func runeIndexFold(s, query string) (byteOffset, runeOffset int) {
+	sRunes := []rune(s)
+	qRunes := []rune(strings.ToLower(query))
+	if len(qRunes) == 0 || len(sRunes) < len(qRunes) {
+		return -1, -1
+	}
+	sLower := []rune(strings.ToLower(s))
+	for i := 0; i <= len(sLower)-len(qRunes); i++ {
+		match := true
+		for j, qr := range qRunes {
+			if sLower[i+j] != qr {
+				match = false
+				break
+			}
+		}
+		if match {
+			// Compute byte offset from rune offset.
+			byteOff := len(string(sRunes[:i]))
+			return byteOff, i
+		}
+	}
+	return -1, -1
+}
+
+// SearchTranscript searches the transcript for entries containing query (case-insensitive).
+// Returns all matching entries in chronological (index) order.
+// Returns nil if query is empty.
+// All offsets (MatchStart, MatchEnd) are rune offsets into Snippet.
+func SearchTranscript(transcript []transcriptexport.TranscriptEntry, query string) []SearchResult {
+	if query == "" {
+		return nil
+	}
+	qRunes := []rune(query)
+	var results []SearchResult
+	for i, entry := range transcript {
+		_, runeIdx := runeIndexFold(entry.Content, query)
+		if runeIdx < 0 {
+			continue
+		}
+		snippet, matchStart, matchEnd := extractSnippet(entry.Content, runeIdx, len(qRunes))
+		results = append(results, SearchResult{
+			EntryIndex: i,
+			Role:       entry.Role,
+			Timestamp:  entry.Timestamp,
+			Snippet:    snippet,
+			MatchStart: matchStart,
+			MatchEnd:   matchEnd,
+		})
+	}
+	return results
+}
+
+// extractSnippet returns a windowed snippet (in runes) around the match at rune
+// position matchRunePos with length matchRuneLen, plus the start/end rune offsets
+// of the match within the snippet.
+// Ellipsis (…) is prepended/appended when the snippet does not reach the start/end
+// of the content.
+func extractSnippet(content string, matchRunePos, matchRuneLen int) (snippet string, matchStart, matchEnd int) {
+	runes := []rune(content)
+	total := len(runes)
+
+	startRune := matchRunePos - snippetWindow
+	truncatedLeft := startRune > 0
+	if startRune < 0 {
+		startRune = 0
+	}
+	endRune := matchRunePos + matchRuneLen + snippetWindow
+	truncatedRight := endRune < total
+	if endRune > total {
+		endRune = total
+	}
+
+	part := runes[startRune:endRune]
+
+	// Build the snippet string with ellipsis markers.
+	var sb strings.Builder
+	if truncatedLeft {
+		sb.WriteRune('…')
+	}
+	sb.WriteString(string(part))
+	if truncatedRight {
+		sb.WriteRune('…')
+	}
+
+	snippet = sb.String()
+
+	// Compute match offsets as rune offsets into snippet.
+	// The snippet rune slice starts with optional '…' (1 rune) then the content window.
+	ellipsisOffset := 0
+	if truncatedLeft {
+		ellipsisOffset = 1
+	}
+	matchStart = (matchRunePos - startRune) + ellipsisOffset
+	matchEnd = matchStart + matchRuneLen
+	return snippet, matchStart, matchEnd
+}
+
+// highlightStyle is the lipgloss style applied to matching text in search results.
+var highlightStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.AdaptiveColor{
+	Light: "#d97706",
+	Dark:  "#fbbf24",
+})
+
+// HighlightMatch wraps the first occurrence of query in text with bold/yellow styling.
+// The comparison is case-insensitive but the original casing is preserved.
+// Returns text unchanged if query is empty or not found.
+// All slicing is performed in rune space to avoid misalignment with multi-byte characters.
+func HighlightMatch(text, query string) string {
+	if query == "" {
+		return text
+	}
+	_, runeIdx := runeIndexFold(text, query)
+	if runeIdx < 0 {
+		return text
+	}
+	textRunes := []rune(text)
+	qLen := utf8.RuneCountInString(query)
+	before := string(textRunes[:runeIdx])
+	matched := string(textRunes[runeIdx : runeIdx+qLen])
+	after := string(textRunes[runeIdx+qLen:])
+	return before + highlightStyle.Render(matched) + after
+}
+
+// searchSessions searches stored session metadata for sessions whose LastMsg
+// contains query (case-insensitive). Returns results with a synthesised snippet.
+// If store is nil, returns nil.
+func searchSessions(store *SessionStore, query string) []SearchResult {
+	if store == nil || query == "" {
+		return nil
+	}
+	sessions := store.List()
+	qRunes := []rune(query)
+	var results []SearchResult
+	for i, s := range sessions {
+		_, runeIdx := runeIndexFold(s.LastMsg, query)
+		if runeIdx < 0 {
+			continue
+		}
+		snippet, matchStart, matchEnd := extractSnippet(s.LastMsg, runeIdx, len(qRunes))
+		results = append(results, SearchResult{
+			EntryIndex: i,
+			Role:       "session",
+			Timestamp:  s.StartedAt,
+			Snippet:    snippet,
+			MatchStart: matchStart,
+			MatchEnd:   matchEnd,
+		})
+	}
+	return results
+}
+
+// searchResultCountLabel returns "1 result" or "N results".
+func searchResultCountLabel(n int) string {
+	if n == 1 {
+		return "1 result"
+	}
+	return fmt.Sprintf("%d results", n)
+}

--- a/cmd/harnesscli/tui/search_test.go
+++ b/cmd/harnesscli/tui/search_test.go
@@ -1,0 +1,738 @@
+package tui_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
+)
+
+// ─── searchTranscript unit tests ────────────────────────────────────────────
+
+// TestSearch_BT001_BasicMatchFound verifies that when the transcript contains
+// "hello world" and the query is "hello", the result includes that entry.
+// BT-001: When /search hello is issued and transcript contains "hello world", results include that entry.
+func TestSearch_BT001_BasicMatchFound(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "hello world", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "hello")
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result, got 0")
+	}
+	if results[0].EntryIndex != 0 {
+		t.Errorf("EntryIndex = %d, want 0", results[0].EntryIndex)
+	}
+	if results[0].Role != "user" {
+		t.Errorf("Role = %q, want %q", results[0].Role, "user")
+	}
+	if !strings.Contains(results[0].Snippet, "hello") {
+		t.Errorf("Snippet %q does not contain 'hello'", results[0].Snippet)
+	}
+}
+
+// TestSearch_BT002_EmptyQueryReturnsNil verifies that an empty query produces no results.
+// BT-002: /search with no query is handled by the command handler (covered in model integration).
+// This unit test verifies the search function itself returns nil for empty queries.
+func TestSearch_BT002_EmptyQueryReturnsNil(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "hello world", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for empty query, got %d", len(results))
+	}
+}
+
+// TestSearch_BT003_NoMatchReturnsEmpty verifies that a non-matching query returns empty results.
+// BT-003: When /search xyz finds no matches, overlay shows "No matches found".
+func TestSearch_BT003_NoMatchReturnsEmpty(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "hello world", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "xyz_no_match_xyz")
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for non-matching query, got %d", len(results))
+	}
+}
+
+// TestSearch_BT004_CaseInsensitive verifies that search is case-insensitive.
+// BT-004: Search is case-insensitive: /search HELLO matches "hello".
+func TestSearch_BT004_CaseInsensitive(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "assistant", Content: "hello world", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "HELLO")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result for case-insensitive search, got 0")
+	}
+	if results[0].Role != "assistant" {
+		t.Errorf("Role = %q, want %q", results[0].Role, "assistant")
+	}
+}
+
+// TestSearch_BT005_MultipleMatchesChronological verifies that all matching entries
+// are returned in chronological order (by index).
+// BT-005: When multiple transcript entries match, all are returned in chronological order.
+func TestSearch_BT005_MultipleMatchesChronological(t *testing.T) {
+	now := time.Now()
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "deploy to prod", Timestamp: now},
+		{Role: "assistant", Content: "I will deploy now", Timestamp: now.Add(time.Second)},
+		{Role: "user", Content: "unrelated message", Timestamp: now.Add(2 * time.Second)},
+		{Role: "assistant", Content: "deploy completed", Timestamp: now.Add(3 * time.Second)},
+	}
+	results := tui.SearchTranscript(entries, "deploy")
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results for 'deploy', got %d", len(results))
+	}
+	// Verify chronological order by EntryIndex.
+	if results[0].EntryIndex >= results[1].EntryIndex {
+		t.Errorf("results not in chronological order: [0].EntryIndex=%d, [1].EntryIndex=%d",
+			results[0].EntryIndex, results[1].EntryIndex)
+	}
+	if results[1].EntryIndex >= results[2].EntryIndex {
+		t.Errorf("results not in chronological order: [1].EntryIndex=%d, [2].EntryIndex=%d",
+			results[1].EntryIndex, results[2].EntryIndex)
+	}
+}
+
+// TestSearch_BT008_ResultIncludesRoleAndSnippet verifies that each result contains
+// the role and a snippet of context around the match.
+// BT-008: Search results include the role (user/assistant) and a context snippet around the match.
+func TestSearch_BT008_ResultIncludesRoleAndSnippet(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "the quick brown fox jumps over the lazy dog", Timestamp: time.Now()},
+		{Role: "assistant", Content: "indeed the fox is quite quick", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "fox")
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	for i, r := range results {
+		if r.Role == "" {
+			t.Errorf("result[%d].Role is empty", i)
+		}
+		if r.Snippet == "" {
+			t.Errorf("result[%d].Snippet is empty", i)
+		}
+		if !strings.Contains(strings.ToLower(r.Snippet), "fox") {
+			t.Errorf("result[%d].Snippet %q does not contain 'fox'", i, r.Snippet)
+		}
+		// Snippet should be at most 80 chars around the match.
+		if len(r.Snippet) > 160 {
+			t.Errorf("result[%d].Snippet too long: %d chars (want <= 160)", i, len(r.Snippet))
+		}
+	}
+}
+
+// TestSearch_SnippetAroundMatch verifies the snippet is correctly windowed around the match.
+func TestSearch_SnippetAroundMatch(t *testing.T) {
+	// Long content where match is in the middle.
+	content := "start of message with lots of padding before the match keyword appears and more text after"
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "match keyword")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	if !strings.Contains(strings.ToLower(results[0].Snippet), "match keyword") {
+		t.Errorf("snippet %q does not contain the match", results[0].Snippet)
+	}
+}
+
+// TestSearch_MatchStartEndPositions verifies MatchStart and MatchEnd are set.
+func TestSearch_MatchStartEndPositions(t *testing.T) {
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: "hello world", Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "world")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	r := results[0]
+	if r.MatchStart < 0 {
+		t.Errorf("MatchStart = %d, want >= 0", r.MatchStart)
+	}
+	if r.MatchEnd <= r.MatchStart {
+		t.Errorf("MatchEnd (%d) must be > MatchStart (%d)", r.MatchEnd, r.MatchStart)
+	}
+}
+
+// ─── highlightMatch unit tests ────────────────────────────────────────────────
+
+// TestHighlightMatch_WrapsMatch verifies that highlightMatch returns a string containing
+// the original match term. In TTY environments the result will include ANSI markup;
+// in non-TTY test environments lipgloss strips ANSI codes, so we verify that
+// the match is preserved and the rest of the text is also preserved.
+func TestHighlightMatch_WrapsMatch(t *testing.T) {
+	result := tui.HighlightMatch("hello world", "world")
+	// The result must contain the matched word (either raw or with ANSI codes stripped).
+	if !strings.Contains(result, "world") {
+		t.Errorf("highlightMatch result %q must still contain 'world'", result)
+	}
+	// The un-matched prefix must be preserved.
+	if !strings.HasPrefix(result, "hello ") {
+		t.Errorf("highlightMatch result %q must have 'hello ' prefix", result)
+	}
+}
+
+// TestHighlightMatch_CaseInsensitiveWrap verifies case-insensitive matching in highlight.
+func TestHighlightMatch_CaseInsensitiveWrap(t *testing.T) {
+	result := tui.HighlightMatch("Hello World", "hello")
+	// Result must still contain the original casing of the match.
+	if !strings.Contains(result, "Hello") {
+		t.Errorf("highlightMatch result %q must preserve original casing", result)
+	}
+}
+
+// TestHighlightMatch_NoMatchReturnsOriginal verifies no-op on non-matching query.
+func TestHighlightMatch_NoMatchReturnsOriginal(t *testing.T) {
+	result := tui.HighlightMatch("hello world", "xyz")
+	if result != "hello world" {
+		t.Errorf("highlightMatch with no match: got %q, want %q", result, "hello world")
+	}
+}
+
+// ─── /search command integration tests ───────────────────────────────────────
+
+// TestSearch_BT002_EmptyQueryStatusMessage verifies that /search with no query
+// sets a status message about usage, not an overlay.
+// BT-002: When /search is issued with no query, a status message says "Usage: /search <query>".
+func TestSearch_BT002_EmptyQueryStatusMessage(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/search")
+	if m.StatusMsg() == "" {
+		t.Fatal("StatusMsg must be set when /search is issued with no query")
+	}
+	if !strings.Contains(m.StatusMsg(), "Usage") || !strings.Contains(m.StatusMsg(), "/search") {
+		t.Errorf("StatusMsg = %q, want it to contain 'Usage' and '/search'", m.StatusMsg())
+	}
+	// Overlay should NOT be open.
+	if m.OverlayActive() {
+		t.Error("OverlayActive must be false when /search has no query")
+	}
+}
+
+// TestSearch_BT003_NoMatchOverlayMessage verifies that /search with a non-matching query
+// opens an overlay showing "No matches found".
+// BT-003: When /search xyz finds no matches, overlay shows "No matches found".
+func TestSearch_BT003_NoMatchOverlayMessage(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/search xyz_no_match_xyz_abc")
+	// Overlay should be active showing "No matches found".
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive must be true after /search with no matches")
+	}
+	v := m.View()
+	if !strings.Contains(v, "No matches found") {
+		t.Errorf("View must contain 'No matches found'; got:\n%s", v)
+	}
+}
+
+// TestSearch_BT001_MatchOpensOverlayWithResult verifies /search opens the search overlay
+// when a matching transcript entry exists.
+// BT-001: When /search hello is issued and transcript contains "hello world", results include that entry.
+func TestSearch_BT001_MatchOpensOverlayWithResult(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Inject a transcript entry containing "hello world".
+	m = injectTranscriptEntry(m, "user", "hello world")
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive must be true after /search with matching results")
+	}
+	if m.ActiveOverlay() != "search" {
+		t.Errorf("ActiveOverlay = %q, want %q", m.ActiveOverlay(), "search")
+	}
+	v := m.View()
+	if !strings.Contains(v, "hello") {
+		t.Errorf("View must contain the matched text 'hello'; got:\n%s", v)
+	}
+}
+
+// TestSearch_BT007_EscapeClosesSearchOverlay verifies that Escape closes the search overlay.
+// BT-007: When the search overlay is open, Escape closes it.
+func TestSearch_BT007_EscapeClosesSearchOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "hello world")
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("precondition: search overlay must be open")
+	}
+	m, _ = sendEscape(m)
+	if m.OverlayActive() {
+		t.Error("OverlayActive must be false after Escape from search overlay")
+	}
+}
+
+// TestSearch_SearchCommandRegistered verifies that /search is registered in the command registry.
+func TestSearch_SearchCommandRegistered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("search") {
+		t.Error("'search' command must be registered in the command registry")
+	}
+}
+
+// TestSearch_HistoryCommandRegistered verifies that /history is registered in the command registry.
+func TestSearch_HistoryCommandRegistered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("history") {
+		t.Error("'history' command must be registered in the command registry")
+	}
+}
+
+// TestSearch_BT006_HistorySearchMatchesSessionLastMsg verifies that /history searches
+// session metadata's LastMsg field. This tests a no-op result since there are no
+// stored sessions in unit tests, but verifies the overlay is opened.
+// BT-006: When /history deploy matches a session's LastMsg containing "deploy", that session appears.
+func TestSearch_BT006_HistorySearchOpensOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	// Even with no sessions, the overlay should open (showing "No matches found").
+	m = sendSlashCommand(m, "/history deploy")
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive must be true after /history command")
+	}
+	v := m.View()
+	if !strings.Contains(v, "No matches found") {
+		t.Errorf("View must contain 'No matches found' when no session matches; got:\n%s", v)
+	}
+}
+
+// TestSearch_HistoryNoQueryShowsUsage verifies /history with no query shows usage hint.
+func TestSearch_HistoryNoQueryShowsUsage(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/history")
+	if m.StatusMsg() == "" {
+		t.Fatal("StatusMsg must be set when /history is issued with no query")
+	}
+	if !strings.Contains(m.StatusMsg(), "Usage") {
+		t.Errorf("StatusMsg = %q, want it to contain 'Usage'", m.StatusMsg())
+	}
+}
+
+// TestSearch_CaseInsensitiveInOverlay verifies case-insensitive matching reflected in overlay.
+// BT-004: /search HELLO matches "hello".
+func TestSearch_BT004_CaseInsensitiveInOverlay(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "assistant", "hello world from the assistant")
+	m = sendSlashCommand(m, "/search HELLO")
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive must be true for case-insensitive match")
+	}
+	v := m.View()
+	if !strings.Contains(strings.ToLower(v), "hello") {
+		t.Errorf("View must contain matched text 'hello' (case-insensitive); got:\n%s", v)
+	}
+}
+
+// TestSearch_SearchOverlayShowsRoleAndSnippet verifies the overlay contains role and snippet info.
+// BT-008: Search results include the role and a context snippet around the match.
+func TestSearch_BT008_OverlayShowsRoleAndSnippet(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "the fox ran across the field")
+	m = sendSlashCommand(m, "/search fox")
+	if !m.OverlayActive() {
+		t.Fatal("OverlayActive must be true for matching search")
+	}
+	v := m.View()
+	// The overlay should show the role.
+	if !strings.Contains(v, "user") {
+		t.Errorf("View must contain role 'user'; got:\n%s", v)
+	}
+	// The overlay should show a snippet containing the match.
+	if !strings.Contains(v, "fox") {
+		t.Errorf("View must contain matched term 'fox' in snippet; got:\n%s", v)
+	}
+}
+
+// TestSearch_RegressionClearStillWorks verifies /clear still works after adding /search.
+func TestSearch_RegressionClearStillWorks(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "some content")
+	m = sendSlashCommand(m, "/clear")
+	if m.OverlayActive() {
+		t.Error("/clear must not open any overlay")
+	}
+	if !strings.Contains(m.StatusMsg(), "cleared") {
+		t.Errorf("StatusMsg = %q, want it to contain 'cleared'", m.StatusMsg())
+	}
+}
+
+// TestSearch_RegressionSearchRegisteredAlongsideBuiltins verifies that adding /search
+// and /history does not remove existing commands from the registry.
+func TestSearch_RegressionSearchRegisteredAlongsideBuiltins(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	required := []string{"clear", "context", "export", "help", "keys", "model", "quit", "stats", "subagents", "profiles", "search", "history"}
+	for _, name := range required {
+		if !r.IsRegistered(name) {
+			t.Errorf("command %q must be registered", name)
+		}
+	}
+}
+
+// TestSearch_RegressionSessionsSessionsNotBroken verifies /sessions is not broken (it's not in the registry, fine).
+// This verifies existing commands produce expected behavior.
+func TestSearch_RegressionExistingCommandsUnaffected(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	// /help should still work.
+	m2 := sendSlashCommand(m, "/help")
+	if !m2.OverlayActive() || m2.ActiveOverlay() != "help" {
+		t.Error("/help must still open help overlay after search feature added")
+	}
+
+	// /stats should still work.
+	m3 := sendSlashCommand(m, "/stats")
+	if !m3.OverlayActive() || m3.ActiveOverlay() != "stats" {
+		t.Error("/stats must still open stats overlay after search feature added")
+	}
+}
+
+// TestSearch_SearchResultsNavigable verifies the search overlay can be navigated with Up/Down.
+func TestSearch_SearchResultsNavigable(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "hello from user")
+	m = injectTranscriptEntry(m, "assistant", "hello from assistant")
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("precondition: search overlay must be open")
+	}
+	// Press Down — should not panic.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = m2.(tui.Model)
+	// Still active after navigation.
+	if !m.OverlayActive() {
+		t.Error("OverlayActive must remain true after Down key in search overlay")
+	}
+}
+
+// injectTranscriptEntry is a test helper that adds a transcript entry to the model
+// by simulating the SSE message flow. It uses the exposed TranscriptInjector message
+// for testing purposes.
+func injectTranscriptEntry(m tui.Model, role, content string) tui.Model {
+	m2, _ := m.Update(tui.TranscriptEntryMsg{
+		Role:    role,
+		Content: content,
+	})
+	return m2.(tui.Model)
+}
+
+// ─── SessionStore unit tests (search-relevant behaviour) ─────────────────────
+
+// TestSessionStore_NewAndList verifies that NewSessionStore stores and returns sessions.
+func TestSessionStore_NewAndList(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	now := time.Now()
+	store.Add(tui.StoredSessionEntry{ID: "s1", LastMsg: "deploy to production", StartedAt: now})
+	store.Add(tui.StoredSessionEntry{ID: "s2", LastMsg: "fix the bug", StartedAt: now.Add(-time.Second)})
+	got := store.List()
+	if len(got) != 2 {
+		t.Fatalf("SessionStore.List() = %d entries, want 2", len(got))
+	}
+	// List returns entries sorted most-recent first: s1 has the later StartedAt.
+	if got[0].ID != "s1" || got[1].ID != "s2" {
+		t.Errorf("List() returned wrong sessions: %+v", got)
+	}
+}
+
+// TestSessionStore_NilListIsNoop verifies that List on a nil *SessionStore returns nil.
+func TestSessionStore_NilListIsNoop(t *testing.T) {
+	var store *tui.SessionStore
+	got := store.List()
+	if got != nil {
+		t.Errorf("nil SessionStore.List() = %v, want nil", got)
+	}
+}
+
+// TestSessionStore_MutationIsolation verifies that mutating the slice returned by
+// List() does not affect the stored sessions (caller cannot corrupt internal state).
+func TestSessionStore_MutationIsolation(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	store.Add(tui.StoredSessionEntry{ID: "original", LastMsg: "content", StartedAt: time.Now()})
+	got := store.List()
+	// Mutate the returned slice.
+	got[0].ID = "tampered"
+	// A second call must return the original data.
+	got2 := store.List()
+	if got2[0].ID != "original" {
+		t.Errorf("List() returned non-copy: internal state was mutated, got ID %q, want %q", got2[0].ID, "original")
+	}
+}
+
+// ─── SessionStore.List() defensive copy ──────────────────────────────────────
+
+// TestSessionStore_ListReturnsCopy verifies that mutating the slice returned by
+// List() does not affect the stored sessions (caller cannot corrupt internal state).
+func TestSessionStore_ListReturnsCopy(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	now := time.Now()
+	store.Add(tui.StoredSessionEntry{ID: "s1", LastMsg: "hello world", StartedAt: now})
+	store.Add(tui.StoredSessionEntry{ID: "s2", LastMsg: "goodbye world", StartedAt: now.Add(-time.Second)})
+	got := store.List()
+	// Mutate the returned slice.
+	got[0].ID = "tampered"
+	// A second call to List() must return unmodified data.
+	got2 := store.List()
+	if got2[0].ID != "s1" {
+		t.Errorf("List() returned non-copy: internal state was mutated, got ID %q, want %q", got2[0].ID, "s1")
+	}
+}
+
+// ─── Unicode-safe search ──────────────────────────────────────────────────────
+
+// TestSearch_Unicode_TurkishCapitalI verifies that SearchTranscript handles Turkish
+// capital İ correctly. strings.ToLower("İ") produces a 2-byte sequence in Turkish locale,
+// so byte offsets from the lowercased string must not be used to slice the original.
+func TestSearch_Unicode_TurkishCapitalI(t *testing.T) {
+	// "Hİllo" — İ is U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE (2 bytes in UTF-8)
+	// strings.ToLower("İ") -> "i\u0307" (2 bytes) in some locales, but Go's
+	// strings.ToLower maps İ (U+0130) to "i\u0307" (3 bytes in UTF-8: 'i' + combining dot).
+	// The key requirement: search must find the match and not panic or garble the snippet.
+	content := "Hİllo world"
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	// Query using ASCII "illo" which is definitely in the original after the İ.
+	results := tui.SearchTranscript(entries, "world")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result for Unicode content with ASCII query 'world'")
+	}
+	// Snippet must be valid UTF-8 and contain "world".
+	if !strings.Contains(results[0].Snippet, "world") {
+		t.Errorf("Snippet %q must contain 'world'", results[0].Snippet)
+	}
+	// Snippet must be valid UTF-8 (not garbled).
+	if !isValidUTF8(results[0].Snippet) {
+		t.Errorf("Snippet %q is not valid UTF-8", results[0].Snippet)
+	}
+}
+
+// TestSearch_Unicode_Emoji verifies that SearchTranscript correctly handles
+// emoji in content. An emoji like 🚀 is 4 bytes; byte-offset slicing can panic.
+func TestSearch_Unicode_Emoji(t *testing.T) {
+	content := "deploy 🚀 complete"
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "assistant", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "complete")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result for emoji content with query 'complete'")
+	}
+	if !strings.Contains(results[0].Snippet, "complete") {
+		t.Errorf("Snippet %q must contain 'complete'", results[0].Snippet)
+	}
+	if !isValidUTF8(results[0].Snippet) {
+		t.Errorf("Snippet %q is not valid UTF-8", results[0].Snippet)
+	}
+}
+
+// TestSearch_Unicode_Chinese verifies that SearchTranscript correctly handles
+// multi-byte CJK characters. Each CJK char is 3 bytes; mixed indexing panics.
+func TestSearch_Unicode_Chinese(t *testing.T) {
+	content := "搜索功能测试"
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "功能")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result for Chinese content with Chinese query")
+	}
+	if !strings.Contains(results[0].Snippet, "功能") {
+		t.Errorf("Snippet %q must contain '功能'", results[0].Snippet)
+	}
+	if !isValidUTF8(results[0].Snippet) {
+		t.Errorf("Snippet %q is not valid UTF-8", results[0].Snippet)
+	}
+}
+
+// TestSearch_Unicode_EmojiMatchStart verifies MatchStart/MatchEnd are valid rune
+// offsets in the snippet when emoji appear before the match.
+func TestSearch_Unicode_EmojiMatchStart(t *testing.T) {
+	// Emoji before the match: each emoji is 4 bytes.
+	content := "🎉🎉🎉 hello world"
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "hello")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	r := results[0]
+	snippet := []rune(r.Snippet)
+	// MatchStart and MatchEnd must be valid indices into the rune slice of Snippet.
+	if r.MatchStart < 0 || r.MatchStart >= len(snippet) {
+		t.Errorf("MatchStart=%d is out of rune bounds for snippet %q (rune len=%d)", r.MatchStart, r.Snippet, len(snippet))
+	}
+	if r.MatchEnd <= r.MatchStart || r.MatchEnd > len(snippet) {
+		t.Errorf("MatchEnd=%d is out of rune bounds for snippet %q (rune len=%d), MatchStart=%d", r.MatchEnd, r.Snippet, len(snippet), r.MatchStart)
+	}
+	// The runes from MatchStart to MatchEnd must spell "hello" (case-insensitive).
+	matchedRunes := string(snippet[r.MatchStart:r.MatchEnd])
+	if !strings.EqualFold(matchedRunes, "hello") {
+		t.Errorf("runes[MatchStart:MatchEnd] = %q, want 'hello'", matchedRunes)
+	}
+}
+
+// TestHighlightMatch_Unicode_Chinese verifies HighlightMatch handles CJK correctly.
+func TestHighlightMatch_Unicode_Chinese(t *testing.T) {
+	text := "搜索功能测试完成"
+	result := tui.HighlightMatch(text, "功能")
+	// Must still contain both surrounding characters, not garbled.
+	if !strings.Contains(result, "搜索") {
+		t.Errorf("HighlightMatch result %q lost prefix '搜索'", result)
+	}
+	if !strings.Contains(result, "测试") {
+		t.Errorf("HighlightMatch result %q lost suffix '测试'", result)
+	}
+}
+
+// TestHighlightMatch_Unicode_Emoji verifies HighlightMatch handles emoji correctly.
+func TestHighlightMatch_Unicode_Emoji(t *testing.T) {
+	text := "launch 🚀 now"
+	result := tui.HighlightMatch(text, "now")
+	if !strings.Contains(result, "launch") {
+		t.Errorf("HighlightMatch result %q lost prefix 'launch'", result)
+	}
+	if !strings.Contains(result, "now") {
+		t.Errorf("HighlightMatch result %q lost 'now'", result)
+	}
+}
+
+// TestExtractSnippet_RuneSafe verifies extractSnippet does not panic or
+// produce invalid UTF-8 when content contains multi-byte characters at boundaries.
+func TestExtractSnippet_RuneSafe(t *testing.T) {
+	// Content where byte position 40 would fall inside a multi-byte rune.
+	// "A" * 38 + "🚀" (4 bytes) + "B" * 40 — match on "BBB" starting at rune 39.
+	content := strings.Repeat("A", 38) + "🚀" + strings.Repeat("B", 40)
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "BBB")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	if !isValidUTF8(results[0].Snippet) {
+		t.Errorf("Snippet is not valid UTF-8: %q", results[0].Snippet)
+	}
+}
+
+// TestExtractSnippet_EllipsisWhenTruncated verifies that extractSnippet adds
+// ellipsis markers when the snippet is truncated (not at content boundaries).
+func TestExtractSnippet_EllipsisWhenTruncated(t *testing.T) {
+	// Match in the middle of long content — both sides should be truncated.
+	prefix := strings.Repeat("X", 60)
+	suffix := strings.Repeat("Y", 60)
+	content := prefix + "MATCH" + suffix
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "MATCH")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	snippet := results[0].Snippet
+	// Snippet must contain the ellipsis on both sides since content is truncated.
+	if !strings.Contains(snippet, "…") {
+		t.Errorf("snippet %q must contain ellipsis '…' when truncated on both sides", snippet)
+	}
+}
+
+// TestExtractSnippet_NoEllipsisAtStart verifies no leading ellipsis when match is at start.
+func TestExtractSnippet_NoEllipsisAtStart(t *testing.T) {
+	// Match at beginning — no leading truncation.
+	content := "MATCH" + strings.Repeat("Y", 60)
+	entries := []transcriptexport.TranscriptEntry{
+		{Role: "user", Content: content, Timestamp: time.Now()},
+	}
+	results := tui.SearchTranscript(entries, "MATCH")
+	if len(results) == 0 {
+		t.Fatal("expected 1 result")
+	}
+	snippet := results[0].Snippet
+	// Must NOT start with ellipsis.
+	if strings.HasPrefix(snippet, "…") {
+		t.Errorf("snippet %q must not start with ellipsis when match is at start", snippet)
+	}
+}
+
+// ─── viewSearchOverlay UX tests ───────────────────────────────────────────────
+
+// TestSearchOverlay_TitleIncludesResultCount verifies the overlay title shows
+// "Search: query (N results)" rather than just "Search: query".
+func TestSearchOverlay_TitleIncludesResultCount(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "hello world")
+	m = injectTranscriptEntry(m, "assistant", "hello from assistant")
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("precondition: overlay must be active")
+	}
+	v := m.View()
+	// Title must include "(2 results)" or similar count.
+	if !strings.Contains(v, "results") {
+		t.Errorf("overlay view must contain 'results' count in title; got:\n%s", v)
+	}
+}
+
+// TestSearchOverlay_EnterLabelSaysJumpToMatch verifies the hint line says
+// "Enter jump to match" not "Enter dismiss".
+func TestSearchOverlay_EnterLabelSaysJumpToMatch(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = injectTranscriptEntry(m, "user", "hello world")
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("precondition: overlay must be active")
+	}
+	v := m.View()
+	if strings.Contains(v, "Enter dismiss") {
+		t.Errorf("overlay must not say 'Enter dismiss'; got:\n%s", v)
+	}
+	if !strings.Contains(v, "Enter jump") {
+		t.Errorf("overlay must say 'Enter jump to match'; got:\n%s", v)
+	}
+}
+
+// TestSearchOverlay_CapsAt20Results verifies that when there are more than 20 results,
+// only 20 are shown in the overlay at a time (scroll window).
+func TestSearchOverlay_CapsAt20Results(t *testing.T) {
+	m := initModel(t, 120, 60)
+	// Inject 25 matching entries.
+	for i := 0; i < 25; i++ {
+		m = injectTranscriptEntry(m, "user", "hello world message")
+	}
+	m = sendSlashCommand(m, "/search hello")
+	if !m.OverlayActive() {
+		t.Fatal("precondition: overlay must be active")
+	}
+	v := m.View()
+	// Count occurrences of "[user]" — should be at most 20.
+	count := strings.Count(v, "[user]")
+	if count > 20 {
+		t.Errorf("overlay shows %d results, want at most 20", count)
+	}
+	// And should indicate more results exist.
+	if !strings.Contains(v, "more") {
+		t.Errorf("overlay must show 'more' indicator when results > 20; got:\n%s", v)
+	}
+}
+
+// isValidUTF8 returns true if s is valid UTF-8.
+func isValidUTF8(s string) bool {
+	for _, r := range s {
+		if r == '\uFFFD' {
+			// Check if the original truly has this replacement character or if it's garbled.
+			// Actually iterate byte-by-byte check.
+			_ = r
+		}
+	}
+	// Use standard library validation.
+	return strings.ToValidUTF8(s, "\uFFFD") == s
+}

--- a/cmd/harnesscli/tui/sessionstore.go
+++ b/cmd/harnesscli/tui/sessionstore.go
@@ -148,8 +148,11 @@ func (s *SessionStore) Update(id string, fn func(*StoredSessionEntry)) {
 }
 
 // List returns a copy of all entries sorted by StartedAt descending (most
-// recent first).
+// recent first). It is safe to call on a nil *SessionStore.
 func (s *SessionStore) List() []StoredSessionEntry {
+	if s == nil {
+		return nil
+	}
 	cp := make([]StoredSessionEntry, len(s.entries))
 	copy(cp, s.entries)
 	sort.Slice(cp, func(i, j int) bool {

--- a/cmd/harnesscli/tui/sessionstore.go
+++ b/cmd/harnesscli/tui/sessionstore.go
@@ -1,0 +1,181 @@
+package tui
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/sessionpicker"
+)
+
+const (
+	// maxStoredSessions is the maximum number of sessions kept in the store.
+	// When exceeded, the oldest session (by StartedAt) is evicted.
+	maxStoredSessions = 100
+
+	// sessionsFileName is the name of the JSON file in the config directory.
+	sessionsFileName = "sessions.json"
+)
+
+// StoredSessionEntry holds metadata for a single past session.
+// It is persisted to sessions.json.
+type StoredSessionEntry struct {
+	ID        string    `json:"id"`
+	StartedAt time.Time `json:"started_at"`
+	Model     string    `json:"model,omitempty"`
+	TurnCount int       `json:"turn_count"`
+	LastMsg   string    `json:"last_msg,omitempty"`
+}
+
+// SessionStore manages a list of StoredSessionEntry values persisted to a
+// JSON file in a config directory.  All mutating methods operate in-memory;
+// call Save() to flush to disk.
+type SessionStore struct {
+	dir     string
+	entries []StoredSessionEntry
+}
+
+// NewSessionStore creates a SessionStore that persists to <dir>/sessions.json.
+// Call Load() to populate from disk before use.
+func NewSessionStore(dir string) *SessionStore {
+	return &SessionStore{dir: dir}
+}
+
+// filePath returns the full path to the sessions JSON file.
+func (s *SessionStore) filePath() string {
+	return filepath.Join(s.dir, sessionsFileName)
+}
+
+// Load reads sessions.json from the config directory.
+// If the file does not exist, the store is initialized empty and no error is
+// returned.
+func (s *SessionStore) Load() error {
+	data, err := os.ReadFile(s.filePath())
+	if os.IsNotExist(err) {
+		s.entries = nil
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	var entries []StoredSessionEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		// Corrupt file — start fresh rather than blocking the user.
+		s.entries = nil
+		return nil
+	}
+	s.entries = entries
+	return nil
+}
+
+// Save writes the current in-memory entries to sessions.json, creating the
+// directory if necessary.  It uses a write-to-temp-then-rename pattern to
+// prevent data corruption if the process is interrupted during the write.
+func (s *SessionStore) Save() error {
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(s.entries)
+	if err != nil {
+		return err
+	}
+	tmpPath := s.filePath() + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, s.filePath())
+}
+
+// Add appends a new entry to the store.  If the store already holds
+// maxStoredSessions entries, the oldest entry (by StartedAt) is evicted first.
+// If an entry with the same ID already exists it is replaced in-place.
+func (s *SessionStore) Add(entry StoredSessionEntry) {
+	// Replace existing entry with the same ID.
+	for i, e := range s.entries {
+		if e.ID == entry.ID {
+			s.entries[i] = entry
+			return
+		}
+	}
+
+	// Evict oldest when at capacity.
+	if len(s.entries) >= maxStoredSessions {
+		oldest := 0
+		for i := 1; i < len(s.entries); i++ {
+			if s.entries[i].StartedAt.Before(s.entries[oldest].StartedAt) {
+				oldest = i
+			}
+		}
+		s.entries = append(s.entries[:oldest], s.entries[oldest+1:]...)
+	}
+
+	s.entries = append(s.entries, entry)
+}
+
+// Delete removes the entry with the given ID.  Silently ignores unknown IDs.
+func (s *SessionStore) Delete(id string) {
+	for i, e := range s.entries {
+		if e.ID == id {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return
+		}
+	}
+}
+
+// Get returns the entry with the given ID and true, or a zero value and false
+// if not found.
+func (s *SessionStore) Get(id string) (StoredSessionEntry, bool) {
+	for _, e := range s.entries {
+		if e.ID == id {
+			return e, true
+		}
+	}
+	return StoredSessionEntry{}, false
+}
+
+// Update calls fn with a pointer to the entry matching id, allowing the caller
+// to mutate it in place.  If the ID is not found, fn is not called.
+func (s *SessionStore) Update(id string, fn func(*StoredSessionEntry)) {
+	for i := range s.entries {
+		if s.entries[i].ID == id {
+			fn(&s.entries[i])
+			return
+		}
+	}
+}
+
+// List returns a copy of all entries sorted by StartedAt descending (most
+// recent first).
+func (s *SessionStore) List() []StoredSessionEntry {
+	cp := make([]StoredSessionEntry, len(s.entries))
+	copy(cp, s.entries)
+	sort.Slice(cp, func(i, j int) bool {
+		return cp[i].StartedAt.After(cp[j].StartedAt)
+	})
+	return cp
+}
+
+// SessionStoreFileInfo returns os.FileInfo for the sessions.json file in dir.
+// This is exported for use in tests that need to inspect file permissions.
+func SessionStoreFileInfo(dir string) (os.FileInfo, error) {
+	return os.Stat(filepath.Join(dir, sessionsFileName))
+}
+
+// sessionEntriesToPicker converts StoredSessionEntry values to the
+// sessionpicker.SessionEntry type expected by the picker component.
+func sessionEntriesToPicker(entries []StoredSessionEntry) []sessionpicker.SessionEntry {
+	out := make([]sessionpicker.SessionEntry, len(entries))
+	for i, e := range entries {
+		out[i] = sessionpicker.SessionEntry{
+			ID:        e.ID,
+			StartedAt: e.StartedAt,
+			Model:     e.Model,
+			TurnCount: e.TurnCount,
+			LastMsg:   e.LastMsg,
+		}
+	}
+	return out
+}

--- a/cmd/harnesscli/tui/sessionstore_test.go
+++ b/cmd/harnesscli/tui/sessionstore_test.go
@@ -1,0 +1,276 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// ─── BT-001: Session store Add + Get ─────────────────────────────────────────
+
+// TestSS001_AddAndGetByID verifies that a session added to the store can be
+// retrieved by its ID.
+func TestSS001_AddAndGetByID(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+	entry := tui.StoredSessionEntry{
+		ID:        "abc-123",
+		StartedAt: time.Now(),
+		Model:     "gpt-4o",
+		TurnCount: 2,
+		LastMsg:   "hello world",
+	}
+	store.Add(entry)
+
+	got, ok := store.Get("abc-123")
+	if !ok {
+		t.Fatal("Get returned false for entry that was just added")
+	}
+	if got.ID != "abc-123" {
+		t.Errorf("Get ID: want %q, got %q", "abc-123", got.ID)
+	}
+	if got.Model != "gpt-4o" {
+		t.Errorf("Get Model: want %q, got %q", "gpt-4o", got.Model)
+	}
+}
+
+// ─── BT-002: Max 100 sessions, oldest evicted ─────────────────────────────────
+
+// TestSS002_MaxSessionsEvictsOldest verifies that when 101 sessions are added,
+// the oldest (first-added) session is evicted, keeping the store at 100 entries.
+func TestSS002_MaxSessionsEvictsOldest(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+
+	base := time.Now()
+	// Add 100 sessions.
+	for i := 0; i < 100; i++ {
+		store.Add(tui.StoredSessionEntry{
+			ID:        string(rune('a'+i%26)) + time.Duration(i).String(),
+			StartedAt: base.Add(time.Duration(i) * time.Minute),
+			TurnCount: i,
+		})
+	}
+
+	firstID := "first-session-ever"
+	store.Add(tui.StoredSessionEntry{
+		ID:        firstID,
+		StartedAt: base.Add(-time.Hour), // oldest by time
+	})
+
+	// Add one more to trigger eviction.
+	store.Add(tui.StoredSessionEntry{
+		ID:        "newest-session",
+		StartedAt: base.Add(200 * time.Minute),
+	})
+
+	if len(store.List()) != 100 {
+		t.Errorf("List length after eviction: want 100, got %d", len(store.List()))
+	}
+
+	_, ok := store.Get(firstID)
+	if ok {
+		t.Error("oldest session should have been evicted but is still present")
+	}
+}
+
+// ─── BT-003: Delete removes session ──────────────────────────────────────────
+
+// TestSS003_DeleteRemovesSession verifies that a deleted session no longer
+// appears in List() or Get().
+func TestSS003_DeleteRemovesSession(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+	store.Add(tui.StoredSessionEntry{ID: "to-delete", StartedAt: time.Now()})
+	store.Add(tui.StoredSessionEntry{ID: "keep", StartedAt: time.Now()})
+
+	store.Delete("to-delete")
+
+	_, ok := store.Get("to-delete")
+	if ok {
+		t.Error("Get returned true for deleted session")
+	}
+
+	for _, e := range store.List() {
+		if e.ID == "to-delete" {
+			t.Error("deleted session still present in List()")
+		}
+	}
+
+	// The surviving session must still be present.
+	_, ok = store.Get("keep")
+	if !ok {
+		t.Error("non-deleted session missing from store")
+	}
+}
+
+// ─── BT-008: Missing sessions.json initializes empty ─────────────────────────
+
+// TestSS008_MissingFileInitializesEmpty verifies that when sessions.json does
+// not exist, Load returns no error and the store starts empty.
+func TestSS008_MissingFileInitializesEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+
+	// Load from a directory with no sessions.json.
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load on missing file returned error: %v", err)
+	}
+
+	if len(store.List()) != 0 {
+		t.Errorf("Expected empty store, got %d entries", len(store.List()))
+	}
+}
+
+// ─── Save + Load round-trip ───────────────────────────────────────────────────
+
+// TestSS_SaveLoadRoundtrip verifies that sessions survive a Save()/Load() cycle.
+func TestSS_SaveLoadRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+
+	now := time.Now().Truncate(time.Second)
+	store.Add(tui.StoredSessionEntry{
+		ID:        "persist-me",
+		StartedAt: now,
+		Model:     "claude-opus-4-6",
+		TurnCount: 5,
+		LastMsg:   "the last message",
+	})
+
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify the file was written.
+	_, err := os.Stat(filepath.Join(dir, "sessions.json"))
+	if err != nil {
+		t.Fatalf("sessions.json not written: %v", err)
+	}
+
+	store2 := tui.NewSessionStore(dir)
+	if err := store2.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	got, ok := store2.Get("persist-me")
+	if !ok {
+		t.Fatal("session not found after Load")
+	}
+	if got.Model != "claude-opus-4-6" {
+		t.Errorf("Model after load: want %q, got %q", "claude-opus-4-6", got.Model)
+	}
+	if got.TurnCount != 5 {
+		t.Errorf("TurnCount after load: want 5, got %d", got.TurnCount)
+	}
+	if got.LastMsg != "the last message" {
+		t.Errorf("LastMsg after load: want %q, got %q", "the last message", got.LastMsg)
+	}
+}
+
+// ─── Update modifies an existing entry ───────────────────────────────────────
+
+// TestSS_UpdateModifiesEntry verifies that Update mutates an existing entry.
+func TestSS_UpdateModifiesEntry(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+	store.Add(tui.StoredSessionEntry{ID: "upd", TurnCount: 1})
+
+	store.Update("upd", func(e *tui.StoredSessionEntry) {
+		e.TurnCount = 7
+		e.LastMsg = "updated"
+	})
+
+	got, ok := store.Get("upd")
+	if !ok {
+		t.Fatal("entry missing after Update")
+	}
+	if got.TurnCount != 7 {
+		t.Errorf("TurnCount after Update: want 7, got %d", got.TurnCount)
+	}
+	if got.LastMsg != "updated" {
+		t.Errorf("LastMsg after Update: want %q, got %q", "updated", got.LastMsg)
+	}
+}
+
+// ─── Load: corrupt JSON starts fresh ─────────────────────────────────────────
+
+// TestSS_LoadCorruptJSONStartsFresh verifies that Load returns nil (not an
+// error) when sessions.json contains invalid JSON, initializing the store empty.
+func TestSS_LoadCorruptJSONStartsFresh(t *testing.T) {
+	dir := t.TempDir()
+	// Write invalid JSON to the sessions file.
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte("not-valid-json{{{"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := tui.NewSessionStore(dir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load with corrupt JSON must not return error, got: %v", err)
+	}
+	if len(store.List()) != 0 {
+		t.Errorf("after corrupt-JSON load, want 0 entries, got %d", len(store.List()))
+	}
+}
+
+// ─── Load: non-NotExist error is returned ─────────────────────────────────────
+
+// TestSS_LoadReadError verifies that Load returns an error when the sessions
+// file exists but cannot be read (e.g. it is a directory).
+func TestSS_LoadReadError(t *testing.T) {
+	dir := t.TempDir()
+	// Create a directory at the sessions.json path so ReadFile fails with a
+	// non-IsNotExist error.
+	if err := os.Mkdir(filepath.Join(dir, "sessions.json"), 0o700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	store := tui.NewSessionStore(dir)
+	err := store.Load()
+	if err == nil {
+		t.Fatal("Load must return an error when sessions.json is a directory")
+	}
+}
+
+// ─── Save: MkdirAll error propagated ─────────────────────────────────────────
+
+// TestSS_SaveMkdirAllError verifies that Save returns an error when it cannot
+// create the config directory (e.g. the parent is a file, not a directory).
+func TestSS_SaveMkdirAllError(t *testing.T) {
+	// Create a file at the path where the directory would be created so that
+	// MkdirAll fails.
+	parent := t.TempDir()
+	dirAsFile := filepath.Join(parent, "blockingfile")
+	if err := os.WriteFile(dirAsFile, []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	// Use a path like <file>/subdir as the store dir so MkdirAll cannot succeed.
+	store := tui.NewSessionStore(filepath.Join(dirAsFile, "subdir"))
+	store.Add(tui.StoredSessionEntry{ID: "x", StartedAt: time.Now()})
+	if err := store.Save(); err == nil {
+		t.Fatal("Save must return an error when MkdirAll fails")
+	}
+}
+
+// ─── Save: WriteFile error propagated ────────────────────────────────────────
+
+// TestSS_SaveWriteFileError verifies that Save returns an error when it cannot
+// write the temporary file (e.g. the directory is read-only).
+func TestSS_SaveWriteFileError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can write to read-only directories")
+	}
+
+	dir := t.TempDir()
+	// Make the directory read-only so WriteFile fails on the .tmp path.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	store := tui.NewSessionStore(dir)
+	store.Add(tui.StoredSessionEntry{ID: "y", StartedAt: time.Now()})
+	if err := store.Save(); err == nil {
+		t.Fatal("Save must return an error when WriteFile fails on read-only dir")
+	}
+}

--- a/cmd/harnesscli/tui/tabcomplete_test.go
+++ b/cmd/harnesscli/tui/tabcomplete_test.go
@@ -15,19 +15,20 @@ func typeTab(m tui.Model) tui.Model {
 	return m2.(tui.Model)
 }
 
-// TestTabCompletion_SlashCommand verifies that typing "/h" + Tab completes to "/help ".
+// TestTabCompletion_SlashCommand verifies that typing "/he" + Tab completes to "/help ".
 // This is the core BUG-5 regression: autocomplete was wired in inputarea but
 // SetAutocompleteProvider was never called at startup so Tab was always a no-op.
+// Note: "/h" is ambiguous now that "/history" is registered; "/he" uniquely matches "/help".
 func TestTabCompletion_SlashCommand(t *testing.T) {
 	m := initModel(t, 80, 24)
-	m = typeIntoModel(m, "/h")
+	m = typeIntoModel(m, "/he")
 	m = typeTab(m)
 
-	// The only slash command starting with "/h" is "/help".
+	// The only slash command starting with "/he" is "/help".
 	// Single match → input becomes "/help " (with trailing space).
 	got := m.Input()
 	if got != "/help " {
-		t.Errorf("Tab on /h: want %q, got %q", "/help ", got)
+		t.Errorf("Tab on /he: want %q, got %q", "/help ", got)
 	}
 }
 
@@ -48,7 +49,7 @@ func TestTabCompletion_MultiMatch(t *testing.T) {
 		// The only valid extension would be a string that is a prefix of every
 		// registered command. Validate that the result is a prefix of at least
 		// one known command.
-		knownCmds := []string{"/clear", "/help", "/context", "/stats", "/quit", "/export", "/subagents", "/model"}
+		knownCmds := []string{"/clear", "/help", "/context", "/stats", "/quit", "/export", "/subagents", "/model", "/history"}
 		for _, cmd := range knownCmds {
 			if strings.HasPrefix(cmd, after) {
 				// A valid partial completion — acceptable.

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -6,7 +6,9 @@ Command Registry - 120x40
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -4,11 +4,13 @@ Command Registry - 120x40
 /context — View context window usage
 /export — Export conversation to markdown
 /help — Show help dialog
+/history — Search across stored session metadata
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/search — Search current session transcript
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -6,7 +6,9 @@ Command Registry - 200x50
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -4,11 +4,13 @@ Command Registry - 200x50
 /context — View context window usage
 /export — Export conversation to markdown
 /help — Show help dialog
+/history — Search across stored session metadata
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/search — Search current session transcript
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -4,11 +4,13 @@ Command Registry - 80x24
 /context — View context window usage
 /export — Export conversation to markdown
 /help — Show help dialog
+/history — Search across stored session metadata
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/search — Search current session transcript
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -6,7 +6,9 @@ Command Registry - 80x24
 /help — Show help dialog
 /keys — Manage provider API keys
 /model — Select AI model
+/new — Start a new session (resets conversation)
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
+/sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,21 @@ type AutoCompactConfig struct {
 	ModelContextWindow int `toml:"model_context_window"`
 }
 
+// BehavioralSpecConfig controls whether and how behavioral specifications are
+// appended to tool descriptions when building the tool catalog.
+type BehavioralSpecConfig struct {
+	// Enabled is the master toggle. When false, no specs are injected.
+	Enabled bool `toml:"enabled"`
+	// IncludeWhenNotToUse controls whether the "When NOT to Use" section is rendered.
+	IncludeWhenNotToUse bool `toml:"include_when_not_to_use"`
+	// IncludeAntiPatterns controls whether named anti-patterns are rendered.
+	IncludeAntiPatterns bool `toml:"include_anti_patterns"`
+	// IncludeCommonMistakes controls whether the Common Mistakes section is rendered.
+	IncludeCommonMistakes bool `toml:"include_common_mistakes"`
+	// MaxSpecLength is the maximum character length of a rendered spec. 0 = unlimited.
+	MaxSpecLength int `toml:"max_spec_length"`
+}
+
 // ConclusionWatcherConfig controls the conclusion-jumping detector plugin.
 type ConclusionWatcherConfig struct {
 	Enabled bool `toml:"enabled"`
@@ -178,6 +193,9 @@ type Config struct {
 	// ConclusionWatcher holds conclusion-jumping detector plugin settings.
 	ConclusionWatcher ConclusionWatcherConfig `toml:"conclusion_watcher"`
 
+	// BehavioralSpecs holds behavioral specification injection settings.
+	BehavioralSpecs BehavioralSpecConfig `toml:"behavioral_specs"`
+
 	// MCPServers is the map of named external MCP server configurations.
 	// Keys are the logical server names (used as prefixes for tool names).
 	// This field is populated from the [mcp_servers.*] sections in TOML files.
@@ -215,6 +233,13 @@ func Defaults() Config {
 			InterventionMode: "inject_validation_prompt",
 			EvaluatorEnabled: false,
 			EvaluatorModel:   "gpt-4o-mini",
+		},
+		BehavioralSpecs: BehavioralSpecConfig{
+			Enabled:               true,
+			IncludeWhenNotToUse:   true,
+			IncludeAntiPatterns:   true,
+			IncludeCommonMistakes: true,
+			MaxSpecLength:         2000,
 		},
 	}
 }
@@ -258,7 +283,16 @@ type rawLayer struct {
 	AutoCompact       *rawAutoCompact            `toml:"auto_compact"`
 	Forensics         *rawForensics              `toml:"forensics"`
 	ConclusionWatcher *rawConclusionWatcher      `toml:"conclusion_watcher"`
+	BehavioralSpecs   *rawBehavioralSpecs        `toml:"behavioral_specs"`
 	MCPServers        map[string]MCPServerConfig `toml:"mcp_servers"`
+}
+
+type rawBehavioralSpecs struct {
+	Enabled               *bool `toml:"enabled"`
+	IncludeWhenNotToUse   *bool `toml:"include_when_not_to_use"`
+	IncludeAntiPatterns   *bool `toml:"include_anti_patterns"`
+	IncludeCommonMistakes *bool `toml:"include_common_mistakes"`
+	MaxSpecLength         *int  `toml:"max_spec_length"`
 }
 
 type rawCost struct {
@@ -533,6 +567,24 @@ func applyLayer(cfg *Config, layer rawLayer) {
 		}
 		if cw.EvaluatorAPIKey != nil {
 			cfg.ConclusionWatcher.EvaluatorAPIKey = *cw.EvaluatorAPIKey
+		}
+	}
+	if layer.BehavioralSpecs != nil {
+		bs := layer.BehavioralSpecs
+		if bs.Enabled != nil {
+			cfg.BehavioralSpecs.Enabled = *bs.Enabled
+		}
+		if bs.IncludeWhenNotToUse != nil {
+			cfg.BehavioralSpecs.IncludeWhenNotToUse = *bs.IncludeWhenNotToUse
+		}
+		if bs.IncludeAntiPatterns != nil {
+			cfg.BehavioralSpecs.IncludeAntiPatterns = *bs.IncludeAntiPatterns
+		}
+		if bs.IncludeCommonMistakes != nil {
+			cfg.BehavioralSpecs.IncludeCommonMistakes = *bs.IncludeCommonMistakes
+		}
+		if bs.MaxSpecLength != nil {
+			cfg.BehavioralSpecs.MaxSpecLength = *bs.MaxSpecLength
 		}
 	}
 	if len(layer.MCPServers) > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -830,3 +830,66 @@ evaluator_api_key = "sk-test-key"
 		t.Errorf("ConclusionWatcher.EvaluatorAPIKey: got %q, want \"sk-test-key\"", cfg.ConclusionWatcher.EvaluatorAPIKey)
 	}
 }
+
+// TestBehavioralSpecConfig_Defaults verifies that the default BehavioralSpecs config
+// has enabled=true, all sections=true, max_spec_length=2000.
+func TestBehavioralSpecConfig_Defaults(t *testing.T) {
+	cfg := config.Defaults()
+
+	if !cfg.BehavioralSpecs.Enabled {
+		t.Error("BehavioralSpecs.Enabled: got false, want true")
+	}
+	if !cfg.BehavioralSpecs.IncludeWhenNotToUse {
+		t.Error("BehavioralSpecs.IncludeWhenNotToUse: got false, want true")
+	}
+	if !cfg.BehavioralSpecs.IncludeAntiPatterns {
+		t.Error("BehavioralSpecs.IncludeAntiPatterns: got false, want true")
+	}
+	if !cfg.BehavioralSpecs.IncludeCommonMistakes {
+		t.Error("BehavioralSpecs.IncludeCommonMistakes: got false, want true")
+	}
+	if cfg.BehavioralSpecs.MaxSpecLength != 2000 {
+		t.Errorf("BehavioralSpecs.MaxSpecLength: got %d, want 2000", cfg.BehavioralSpecs.MaxSpecLength)
+	}
+}
+
+// TestBehavioralSpecConfig_FromTOML verifies that [behavioral_specs] section is parsed from TOML.
+func TestBehavioralSpecConfig_FromTOML(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgFile := fmt.Sprintf("%s/config.toml", tmpDir)
+	tomlContent := `
+[behavioral_specs]
+enabled = false
+include_when_not_to_use = false
+include_anti_patterns = false
+include_common_mistakes = false
+max_spec_length = 500
+`
+	if err := os.WriteFile(cfgFile, []byte(tomlContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := config.LoadOptions{
+		UserConfigPath: cfgFile,
+		Getenv:         func(string) string { return "" },
+	}
+	cfg, err := config.Load(opts)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.BehavioralSpecs.Enabled {
+		t.Error("BehavioralSpecs.Enabled: got true, want false (from TOML)")
+	}
+	if cfg.BehavioralSpecs.IncludeWhenNotToUse {
+		t.Error("BehavioralSpecs.IncludeWhenNotToUse: got true, want false (from TOML)")
+	}
+	if cfg.BehavioralSpecs.IncludeAntiPatterns {
+		t.Error("BehavioralSpecs.IncludeAntiPatterns: got true, want false (from TOML)")
+	}
+	if cfg.BehavioralSpecs.IncludeCommonMistakes {
+		t.Error("BehavioralSpecs.IncludeCommonMistakes: got true, want false (from TOML)")
+	}
+	if cfg.BehavioralSpecs.MaxSpecLength != 500 {
+		t.Errorf("BehavioralSpecs.MaxSpecLength: got %d, want 500 (from TOML)", cfg.BehavioralSpecs.MaxSpecLength)
+	}
+}

--- a/internal/harness/tools/behavioral_specs/apply_patch.md
+++ b/internal/harness/tools/behavioral_specs/apply_patch.md
@@ -1,0 +1,27 @@
+## When to Use
+- Making changes to multiple locations across one or more files in a single operation
+- Applying a well-defined set of changes expressed as a unified diff
+- Bulk refactoring where the changes are known in advance
+
+## When NOT to Use
+- Single-location changes — use the edit tool for one targeted edit
+- Creating new files from scratch — use the write tool
+- When the patch source is unknown or untrusted
+
+## Behavioral Rules
+1. Prefer apply_patch over multiple sequential edit calls when changing more than 2 locations
+2. Verify the patch applies cleanly before relying on it — a failed patch leaves the file unchanged
+3. Use unified diff format (-u) with sufficient context lines (3+) for the patch to apply correctly
+4. After applying, verify the result with a read or build step
+
+## Common Mistakes
+- **MultipleEditsInsteadOfPatch**: Making 5 separate edit calls when a single patch would be cleaner and atomic
+- **InsufficientContext**: Writing a patch with 0 context lines — it will fail if the file has even minor whitespace differences
+- **PatchNewFile**: Using apply_patch to create a new file instead of the write tool
+
+## Examples
+### WRONG
+Use 4 separate edit tool calls to update the same import block in 4 different files.
+
+### RIGHT
+Construct a unified diff that updates all 4 files in one apply_patch call, making the change atomic.

--- a/internal/harness/tools/behavioral_specs/bash.md
+++ b/internal/harness/tools/behavioral_specs/bash.md
@@ -1,0 +1,50 @@
+## When to Use
+- Running build commands (go build, make, npm run)
+- Executing scripts and binaries
+- Installing packages or managing dependencies
+- Starting/stopping background processes
+- System operations requiring shell access
+- Chaining multiple shell commands in a single invocation
+
+## When NOT to Use
+- Reading a file — use the read tool instead of cat/head/tail
+- Writing a file — use the write tool instead of echo/tee
+- Editing a file — use the edit tool instead of sed/awk
+- Searching file contents — use the grep tool
+- Finding files by pattern — use the glob tool
+- Performing git status — use the git_status tool
+- Long-running interactive processes that need streaming output
+
+## Behavioral Rules
+1. Never use `git push --force` or `git reset --hard` without explicit user instruction
+2. Never use `git commit --amend` to rewrite history unless the user asks
+3. Never skip git hooks with `--no-verify`
+4. Never delete files or directories with `rm -rf` on the workspace root or parent paths
+5. Avoid `sleep` commands — use background jobs and polling instead
+6. Prefer parallel bash calls when commands are independent
+7. Quote file paths containing spaces to avoid shell word-splitting bugs
+8. When running go test, use -v flag to get individual test names and counts
+
+## Common Mistakes
+- **PreferDedicatedTool**: Using `cat file.go` instead of the read tool; using `grep` via bash instead of the grep tool
+- **ForcePush**: Running `git push --force` or `git push -f` without explicit instruction
+- **SleepPolling**: Using `sleep 5 && check_status` in a loop instead of background jobs with polling
+- **AmendingHistory**: Running `git commit --amend` to fix a failed commit hook instead of creating a new commit
+- **GlobViaFind**: Using `find . -name "*.go"` instead of the glob tool
+
+## Examples
+### WRONG
+```bash
+cat internal/config/config.go
+```
+
+### RIGHT
+Use the read tool with file_path parameter to read the file.
+
+### WRONG
+```bash
+sleep 10 && curl http://localhost:8080/healthz
+```
+
+### RIGHT
+Start the server as a background job with run_in_background=true, then use job_output to poll for the health endpoint becoming available.

--- a/internal/harness/tools/behavioral_specs/file_edit.md
+++ b/internal/harness/tools/behavioral_specs/file_edit.md
@@ -1,0 +1,37 @@
+## When to Use
+- Modifying an existing file when you know the exact content to change
+- Making targeted, surgical edits to specific lines or blocks
+- Renaming symbols or making the same change in multiple places (use replace_all)
+
+## When NOT to Use
+- Creating a new file — use the write tool for new files
+- Making changes without reading the file first
+- Replacing more content than necessary to uniquely identify the location
+- Rewriting the entire file — use write for complete rewrites
+
+## Behavioral Rules
+1. Always read the file with the read tool before editing — never edit blind
+2. Use the smallest unique old_string that unambiguously identifies the location (2-4 lines of context)
+3. Preserve the exact indentation (tabs/spaces) as shown in the read output — do not alter whitespace
+4. Use replace_all=true when renaming a variable or making the same change everywhere
+5. Do not include line number prefixes in old_string or new_string
+6. Verify the edit compiled or is syntactically valid after applying
+
+## Common Mistakes
+- **EditWithoutReading**: Attempting to edit a file without calling the read tool first — the edit will fail
+- **TooNarrowContext**: Using a one-word old_string that could match multiple locations, causing ambiguous edits
+- **IndentationDrift**: Changing indentation style (tabs to spaces) while making a different edit
+- **FullFileRewrite**: Providing the entire file as old_string and new_string when only a small section changed
+
+## Examples
+### WRONG
+Edit with old_string = "Enabled" — this is too short and will match the wrong location.
+
+### RIGHT
+Edit with old_string spanning 3 lines:
+```
+	Memory: MemoryConfig{
+		Enabled: true,
+		Mode:    "auto",
+```
+This uniquely identifies the exact location without ambiguity.

--- a/internal/harness/tools/behavioral_specs/file_read.md
+++ b/internal/harness/tools/behavioral_specs/file_read.md
@@ -1,0 +1,29 @@
+## When to Use
+- Reading a specific file you already know exists
+- Targeted reads of a known portion of a file (use offset and limit)
+- Reading a file before editing it (always required before edit)
+- Reading configuration files, source files, or data files
+
+## When NOT to Use
+- Searching for files by name — use the glob tool
+- Searching for content across multiple files — use the grep tool
+- Bulk exploration of a directory — use ls first, then read specific files
+- Reading an entire large file when only a section is needed — use offset/limit
+
+## Behavioral Rules
+1. Prefer offset+limit when you know which section of a large file you need
+2. Use grep to locate the relevant section first, then read with offset if the file is large
+3. Never read a file just to check if it exists — use glob or ls
+4. Reading a file that does not exist returns an error, not empty content
+
+## Common Mistakes
+- **BulkRead**: Reading all files in a directory with the read tool one by one instead of using grep to find the relevant content
+- **NoOffsetOnLargeFile**: Reading a 5000-line file from offset 0 when you only need lines 200-250
+- **ReadToCheckExistence**: Using read to check if a file exists — use glob instead
+
+## Examples
+### WRONG
+Read every file in the directory looking for a function definition.
+
+### RIGHT
+Use grep with the function name pattern to find the file and line number, then read that specific file with an appropriate offset.

--- a/internal/harness/tools/behavioral_specs/file_write.md
+++ b/internal/harness/tools/behavioral_specs/file_write.md
@@ -1,0 +1,26 @@
+## When to Use
+- Creating a brand new file that does not yet exist
+- Performing a complete, intentional rewrite of an existing file
+- Writing generated output (test fixtures, config templates, data files)
+
+## When NOT to Use
+- Modifying an existing file — use the edit tool for targeted changes
+- Adding a small section to an existing file — use edit to append or insert
+
+## Behavioral Rules
+1. If the file already exists, you MUST read it first before overwriting
+2. Prefer the edit tool for any modification to an existing file — only use write for new files or full rewrites
+3. Never write secrets, credentials, or API keys to files
+4. Use write for complete file creation; edit for surgical modifications
+
+## Common Mistakes
+- **OverwriteWithoutReading**: Writing to an existing file without reading it first — you will lose the original content
+- **WriteInsteadOfEdit**: Using write to change 3 lines in a 200-line file — the edit tool is the right choice
+- **PartialWrite**: Writing only part of the desired file content and expecting the rest to be preserved — write always replaces the entire file
+
+## Examples
+### WRONG
+Use write to add a single function to an existing Go file, losing all the other functions.
+
+### RIGHT
+Use edit to add the function by specifying old_string as the closing brace of the last function and new_string as the new function plus the closing brace.

--- a/internal/harness/tools/behavioral_specs/find_tool.md
+++ b/internal/harness/tools/behavioral_specs/find_tool.md
@@ -1,0 +1,24 @@
+## When to Use
+- Before concluding that a capability does not exist in the harness
+- When you need a tool whose name you don't know but whose behavior you can describe
+- Discovering deferred tools that are not visible in the default catalog
+
+## When NOT to Use
+- When you already know the exact tool name — call it directly
+- As a substitute for reading the tool description — use the tool, don't just find it
+
+## Behavioral Rules
+1. Search before assuming a tool doesn't exist — many tools are deferred and invisible by default
+2. Use descriptive search terms related to the capability, not the tool name
+3. After finding a tool, activate it in the same step so it becomes available
+
+## Common Mistakes
+- **AssumeAbsent**: Telling the user a capability doesn't exist without calling find_tool first
+- **NameSearch**: Searching for tool names instead of capability descriptions (search "cron" instead of "schedule recurring tasks")
+
+## Examples
+### WRONG
+Tell the user "there is no tool for scheduling tasks" without checking.
+
+### RIGHT
+Call find_tool with query "schedule recurring tasks" to discover the cron_create tool.

--- a/internal/harness/tools/behavioral_specs/glob.md
+++ b/internal/harness/tools/behavioral_specs/glob.md
@@ -1,0 +1,25 @@
+## When to Use
+- Finding files by name pattern (e.g., "**/*.go", "internal/*/config.go")
+- Discovering all files of a specific type in a directory tree
+- Checking if files matching a pattern exist before reading them
+
+## When NOT to Use
+- Searching file content — use the grep tool
+- Listing a single directory — use the ls tool for simple directory listing
+- Finding a specific known file — use the read tool directly
+
+## Behavioral Rules
+1. Use ** for recursive matching (e.g., "**/*.go" matches all Go files in any subdirectory)
+2. Prefer glob over `find` via bash for file discovery
+3. Results are sorted by modification time — most recently modified files appear first
+
+## Common Mistakes
+- **ContentSearch**: Using glob to find files, then reading each one to search for content — use grep instead
+- **FindViaBash**: Running `find . -name "*.go"` via bash instead of using the glob tool
+
+## Examples
+### WRONG
+Glob "*.go" expecting to find all Go files in subdirectories — this only matches the current level.
+
+### RIGHT
+Glob "**/*.go" to recursively match all Go files in the directory tree.

--- a/internal/harness/tools/behavioral_specs/grep.md
+++ b/internal/harness/tools/behavioral_specs/grep.md
@@ -1,0 +1,30 @@
+## When to Use
+- Searching for a string or pattern across multiple files
+- Finding where a function, variable, or symbol is defined or used
+- Locating files that contain specific content
+- Code navigation: finding all usages of an interface or type
+
+## When NOT to Use
+- Finding files by name pattern — use the glob tool
+- Reading a specific file you already know — use the read tool
+- Listing directory contents — use the ls tool
+
+## Behavioral Rules
+1. Use the glob parameter to narrow the search to relevant file types (e.g., "*.go", "**/*.ts")
+2. Use output_mode="files_with_matches" when you only need file paths
+3. Use output_mode="content" with context (-C) when you need surrounding lines
+4. Prefer grep over bash-based `grep` or `rg` commands
+
+## Common Mistakes
+- **BashGrep**: Running `grep -r pattern .` via the bash tool instead of using the grep tool directly
+- **NoGlobFilter**: Searching all files (including binaries, vendor/) when only source files are needed
+- **ReadThenSearch**: Reading entire files to search for content instead of using grep
+
+## Examples
+### WRONG
+```bash
+grep -rn "BehavioralSpec" . --include="*.go"
+```
+
+### RIGHT
+Use the grep tool with pattern="BehavioralSpec" and glob="*.go".

--- a/internal/harness/tools/behavioral_specs/loader.go
+++ b/internal/harness/tools/behavioral_specs/loader.go
@@ -1,0 +1,236 @@
+package behavioral_specs
+
+import (
+	"embed"
+	"strings"
+)
+
+//go:embed *.md
+var specsFS embed.FS
+
+// LoadSpec loads and parses the behavioral spec for the named tool.
+// Returns (nil, nil) when no spec file exists for the tool — graceful degradation.
+// Returns a non-nil error only for parse failures on existing files.
+func LoadSpec(toolName string) (*BehavioralSpec, error) {
+	data, err := specsFS.ReadFile(toolName + ".md")
+	if err != nil {
+		// File not found — graceful degradation, not an error.
+		return nil, nil
+	}
+	return ParseMarkdown(string(data))
+}
+
+// ParseMarkdown parses a behavioral spec markdown string into a BehavioralSpec.
+// Sections are identified by "## Heading" markers. Unknown sections are ignored.
+func ParseMarkdown(markdown string) (*BehavioralSpec, error) {
+	spec := &BehavioralSpec{}
+
+	lines := strings.Split(markdown, "\n")
+
+	type section struct {
+		name  string
+		lines []string
+	}
+
+	var sections []section
+	var current *section
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			heading := strings.TrimPrefix(line, "## ")
+			sections = append(sections, section{name: strings.TrimSpace(heading)})
+			current = &sections[len(sections)-1]
+			continue
+		}
+		if current != nil {
+			current.lines = append(current.lines, line)
+		}
+	}
+
+	for i := range sections {
+		s := &sections[i]
+		body := strings.TrimSpace(strings.Join(s.lines, "\n"))
+
+		switch s.name {
+		case "When to Use":
+			spec.WhenToUse = body
+		case "When NOT to Use":
+			spec.WhenNotToUse = body
+		case "Behavioral Rules":
+			spec.BehavioralRules = parseListItems(body)
+		case "Common Mistakes":
+			spec.CommonMistakes = parseListItems(body)
+		case "Examples":
+			spec.Examples = parseExamples(body)
+		}
+	}
+
+	return spec, nil
+}
+
+// parseListItems extracts list items from a markdown section body.
+// Handles both "- item" and "1. item" formats. Returns each item's text.
+func parseListItems(body string) []string {
+	var items []string
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Handle "- item" format
+		if strings.HasPrefix(line, "- ") {
+			items = append(items, strings.TrimPrefix(line, "- "))
+			continue
+		}
+		// Handle "1. item", "2. item", etc.
+		if len(line) > 2 && line[1] == '.' && line[0] >= '0' && line[0] <= '9' {
+			items = append(items, strings.TrimSpace(line[2:]))
+			continue
+		}
+		// Handle "10. item" etc (two-digit numbers)
+		if len(line) > 3 && line[2] == '.' && line[0] >= '0' && line[0] <= '9' && line[1] >= '0' && line[1] <= '9' {
+			items = append(items, strings.TrimSpace(line[3:]))
+			continue
+		}
+	}
+	return items
+}
+
+// parseExamples parses ### WRONG / ### RIGHT paired blocks from a section body.
+// Multiple example pairs can appear in a single Examples section.
+func parseExamples(body string) []SpecExample {
+	var examples []SpecExample
+	var current *SpecExample
+	var inWrong, inRight bool
+	var wrongLines, rightLines []string
+
+	flushCurrent := func() {
+		if current != nil {
+			current.Wrong = strings.TrimSpace(strings.Join(wrongLines, "\n"))
+			current.Right = strings.TrimSpace(strings.Join(rightLines, "\n"))
+			examples = append(examples, *current)
+			current = nil
+			wrongLines = nil
+			rightLines = nil
+			inWrong = false
+			inRight = false
+		}
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "### WRONG") {
+			if current != nil && inRight {
+				flushCurrent()
+			}
+			if current == nil {
+				current = &SpecExample{Label: ""}
+			}
+			inWrong = true
+			inRight = false
+			continue
+		}
+		if strings.HasPrefix(trimmed, "### RIGHT") {
+			inWrong = false
+			inRight = true
+			continue
+		}
+
+		if inWrong {
+			wrongLines = append(wrongLines, line)
+		} else if inRight {
+			rightLines = append(rightLines, line)
+		}
+	}
+
+	flushCurrent()
+	return examples
+}
+
+// FormatSpec renders a BehavioralSpec to a string according to the config toggles.
+// Returns "" when cfg.Enabled is false or spec is nil.
+func FormatSpec(spec *BehavioralSpec, cfg BehavioralSpecConfig) string {
+	if !cfg.Enabled || spec == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	if spec.WhenToUse != "" {
+		sb.WriteString("## When to Use\n")
+		sb.WriteString(spec.WhenToUse)
+		sb.WriteString("\n\n")
+	}
+
+	if cfg.IncludeWhenNotToUse && spec.WhenNotToUse != "" {
+		sb.WriteString("## When NOT to Use\n")
+		sb.WriteString(spec.WhenNotToUse)
+		sb.WriteString("\n\n")
+	}
+
+	if len(spec.BehavioralRules) > 0 {
+		sb.WriteString("## Behavioral Rules\n")
+		for i, rule := range spec.BehavioralRules {
+			sb.WriteString(strings.Join([]string{numStr(i + 1), ". ", rule, "\n"}, ""))
+		}
+		sb.WriteString("\n")
+	}
+
+	if (cfg.IncludeAntiPatterns || cfg.IncludeCommonMistakes) && len(spec.CommonMistakes) > 0 {
+		sb.WriteString("## Common Mistakes\n")
+		for _, m := range spec.CommonMistakes {
+			sb.WriteString("- ")
+			sb.WriteString(m)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(spec.Examples) > 0 {
+		sb.WriteString("## Examples\n")
+		for _, ex := range spec.Examples {
+			if ex.Label != "" {
+				sb.WriteString("### ")
+				sb.WriteString(ex.Label)
+				sb.WriteString("\n")
+			}
+			if ex.Wrong != "" {
+				sb.WriteString("### WRONG\n")
+				sb.WriteString(ex.Wrong)
+				sb.WriteString("\n\n")
+			}
+			if ex.Right != "" {
+				sb.WriteString("### RIGHT\n")
+				sb.WriteString(ex.Right)
+				sb.WriteString("\n\n")
+			}
+		}
+	}
+
+	result := strings.TrimSpace(sb.String())
+	if cfg.MaxSpecLength > 0 && len(result) > cfg.MaxSpecLength {
+		return result[:cfg.MaxSpecLength]
+	}
+	return result
+}
+
+// numStr converts an int to its string representation without importing strconv.
+func numStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	digits := make([]byte, 0, 10)
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}

--- a/internal/harness/tools/behavioral_specs/loader_test.go
+++ b/internal/harness/tools/behavioral_specs/loader_test.go
@@ -1,0 +1,260 @@
+package behavioral_specs_test
+
+import (
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness/tools/behavioral_specs"
+)
+
+// TestLoadSpec_ExistingTool verifies that loading a known spec (bash.md) populates all sections.
+func TestLoadSpec_ExistingTool(t *testing.T) {
+	spec, err := behavioral_specs.LoadSpec("bash")
+	if err != nil {
+		t.Fatalf("LoadSpec(\"bash\") unexpected error: %v", err)
+	}
+	if spec == nil {
+		t.Fatal("LoadSpec(\"bash\") returned nil spec, want non-nil")
+	}
+	if strings.TrimSpace(spec.WhenToUse) == "" {
+		t.Error("spec.WhenToUse: got empty string, want non-empty")
+	}
+	if strings.TrimSpace(spec.WhenNotToUse) == "" {
+		t.Error("spec.WhenNotToUse: got empty string, want non-empty")
+	}
+	if len(spec.BehavioralRules) == 0 {
+		t.Error("spec.BehavioralRules: got empty slice, want at least one rule")
+	}
+	if len(spec.CommonMistakes) == 0 {
+		t.Error("spec.CommonMistakes: got empty slice, want at least one mistake")
+	}
+	if len(spec.Examples) == 0 {
+		t.Error("spec.Examples: got empty slice, want at least one example")
+	}
+}
+
+// TestLoadSpec_NonExistentTool verifies graceful degradation — returns nil, no error.
+func TestLoadSpec_NonExistentTool(t *testing.T) {
+	spec, err := behavioral_specs.LoadSpec("nonexistent_tool_xyz_404")
+	if err != nil {
+		t.Fatalf("LoadSpec(nonexistent) unexpected error: %v", err)
+	}
+	if spec != nil {
+		t.Errorf("LoadSpec(nonexistent): got non-nil spec %+v, want nil", spec)
+	}
+}
+
+// TestFormatSpec_AllSectionsEnabled verifies that all sections appear when all config toggles are true.
+func TestFormatSpec_AllSectionsEnabled(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:       "use for X",
+		WhenNotToUse:    "not for Y",
+		BehavioralRules: []string{"Rule 1", "Rule 2"},
+		CommonMistakes:  []string{"**BadPattern**: description here"},
+		Examples: []behavioral_specs.SpecExample{
+			{Label: "Test", Wrong: "bad way", Right: "good way"},
+		},
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:              true,
+		IncludeWhenNotToUse:  true,
+		IncludeAntiPatterns:  true,
+		IncludeCommonMistakes: true,
+		MaxSpecLength:        0,
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+
+	if !strings.Contains(result, "When to Use") {
+		t.Error("FormatSpec: expected 'When to Use' section, not found")
+	}
+	if !strings.Contains(result, "When NOT to Use") {
+		t.Error("FormatSpec: expected 'When NOT to Use' section, not found")
+	}
+	if !strings.Contains(result, "Behavioral Rules") {
+		t.Error("FormatSpec: expected 'Behavioral Rules' section, not found")
+	}
+	if !strings.Contains(result, "Common Mistakes") {
+		t.Error("FormatSpec: expected 'Common Mistakes' section, not found")
+	}
+	if !strings.Contains(result, "Examples") {
+		t.Error("FormatSpec: expected 'Examples' section, not found")
+	}
+}
+
+// TestFormatSpec_WhenNotToUseDisabled verifies the toggle hides that section.
+func TestFormatSpec_WhenNotToUseDisabled(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:    "use for X",
+		WhenNotToUse: "not for Y",
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:             true,
+		IncludeWhenNotToUse: false,
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+
+	if strings.Contains(result, "When NOT to Use") {
+		t.Error("FormatSpec with IncludeWhenNotToUse=false: 'When NOT to Use' section should be absent, but found")
+	}
+	if !strings.Contains(result, "When to Use") {
+		t.Error("FormatSpec: 'When to Use' section should still be present")
+	}
+}
+
+// TestFormatSpec_AntiPatternsDisabled verifies the anti-patterns toggle hides Common Mistakes.
+func TestFormatSpec_AntiPatternsDisabled(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:      "use for X",
+		CommonMistakes: []string{"**BadPattern**: description"},
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:               true,
+		IncludeWhenNotToUse:   true,
+		IncludeAntiPatterns:   false,
+		IncludeCommonMistakes: false,
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+
+	if strings.Contains(result, "Common Mistakes") {
+		t.Error("FormatSpec with IncludeAntiPatterns=false: 'Common Mistakes' section should be absent, but found")
+	}
+}
+
+// TestFormatSpec_MaxLength verifies output is truncated to MaxSpecLength characters.
+func TestFormatSpec_MaxLength(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:       strings.Repeat("x", 500),
+		WhenNotToUse:    strings.Repeat("y", 500),
+		BehavioralRules: []string{strings.Repeat("z", 500)},
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:             true,
+		IncludeWhenNotToUse: true,
+		MaxSpecLength:       200,
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+
+	if len(result) > 200 {
+		t.Errorf("FormatSpec with MaxSpecLength=200: got len=%d, want <= 200", len(result))
+	}
+}
+
+// TestFormatSpec_ZeroMaxLength verifies no truncation occurs when MaxSpecLength is 0.
+func TestFormatSpec_ZeroMaxLength(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:    strings.Repeat("a", 3000),
+		WhenNotToUse: strings.Repeat("b", 3000),
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:             true,
+		IncludeWhenNotToUse: true,
+		MaxSpecLength:       0, // 0 = unlimited
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+
+	if len(result) < 5000 {
+		t.Errorf("FormatSpec with MaxSpecLength=0: got len=%d, want >= 5000 (no truncation)", len(result))
+	}
+}
+
+// TestLoadSpec_AllPriorityToolsHaveSpecs is a regression test that verifies all
+// 10 priority tool specs exist and are non-empty. If any spec file is deleted or
+// renamed, this test fails immediately.
+func TestLoadSpec_AllPriorityToolsHaveSpecs(t *testing.T) {
+	priorityTools := []string{
+		"bash",
+		"file_edit",
+		"file_read",
+		"file_write",
+		"run_agent",
+		"find_tool",
+		"web_search",
+		"grep",
+		"glob",
+		"apply_patch",
+	}
+	for _, name := range priorityTools {
+		t.Run(name, func(t *testing.T) {
+			spec, err := behavioral_specs.LoadSpec(name)
+			if err != nil {
+				t.Fatalf("LoadSpec(%q) unexpected error: %v", name, err)
+			}
+			if spec == nil {
+				t.Fatalf("LoadSpec(%q) returned nil, want non-nil spec", name)
+			}
+			if strings.TrimSpace(spec.WhenToUse) == "" {
+				t.Errorf("LoadSpec(%q).WhenToUse is empty", name)
+			}
+		})
+	}
+}
+
+// TestFormatSpec_DisabledReturnsEmpty is a regression test that if the Enabled
+// toggle is false, FormatSpec must return an empty string — not partial output.
+func TestFormatSpec_DisabledReturnsEmpty(t *testing.T) {
+	spec := &behavioral_specs.BehavioralSpec{
+		WhenToUse:    "use for X",
+		WhenNotToUse: "not for Y",
+	}
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled: false,
+	}
+	result := behavioral_specs.FormatSpec(spec, cfg)
+	if result != "" {
+		t.Errorf("FormatSpec with Enabled=false: got %q, want empty string", result)
+	}
+}
+
+// TestParseMarkdownSections verifies the markdown parser correctly populates all struct fields.
+func TestParseMarkdownSections(t *testing.T) {
+	markdown := `## When to Use
+- Positive example one
+- Positive example two
+
+## When NOT to Use
+- Negative example one
+
+## Behavioral Rules
+1. Rule number one
+2. Rule number two
+3. Rule number three
+
+## Common Mistakes
+- **FirstAntiPattern**: This is what goes wrong
+- **SecondAntiPattern**: Another common error
+
+## Examples
+### WRONG
+Do it the bad way
+### RIGHT
+Do it the good way
+`
+	spec, err := behavioral_specs.ParseMarkdown(markdown)
+	if err != nil {
+		t.Fatalf("ParseMarkdown() unexpected error: %v", err)
+	}
+	if spec == nil {
+		t.Fatal("ParseMarkdown() returned nil, want non-nil")
+	}
+	if !strings.Contains(spec.WhenToUse, "Positive example one") {
+		t.Errorf("WhenToUse: got %q, want to contain 'Positive example one'", spec.WhenToUse)
+	}
+	if !strings.Contains(spec.WhenNotToUse, "Negative example one") {
+		t.Errorf("WhenNotToUse: got %q, want to contain 'Negative example one'", spec.WhenNotToUse)
+	}
+	if len(spec.BehavioralRules) != 3 {
+		t.Errorf("BehavioralRules: got %d rules, want 3", len(spec.BehavioralRules))
+	}
+	if len(spec.CommonMistakes) != 2 {
+		t.Errorf("CommonMistakes: got %d mistakes, want 2", len(spec.CommonMistakes))
+	}
+	if len(spec.Examples) != 1 {
+		t.Errorf("Examples: got %d examples, want 1", len(spec.Examples))
+	}
+	if spec.Examples[0].Wrong == "" {
+		t.Error("Examples[0].Wrong: got empty, want non-empty")
+	}
+	if spec.Examples[0].Right == "" {
+		t.Error("Examples[0].Right: got empty, want non-empty")
+	}
+}

--- a/internal/harness/tools/behavioral_specs/run_agent.md
+++ b/internal/harness/tools/behavioral_specs/run_agent.md
@@ -1,0 +1,31 @@
+## When to Use
+- Delegating a well-scoped, self-contained sub-task that needs its own tool access
+- Tasks that require reading multiple files and producing a focused output
+- Parallel exploration tasks that can run independently
+
+## When NOT to Use
+- Tasks that require back-and-forth interaction with the parent — use inline tool calls instead
+- Simple one-step operations — call the tool directly
+- Tasks where the parent needs to inspect intermediate results before the subagent finishes
+- Creating subagents just to avoid doing work in the current context
+
+## Behavioral Rules
+1. Don't Peek: never inspect a subagent's intermediate state; wait for its terminal output
+2. Don't Race: don't start multiple subagents that write to the same file or resource
+3. Fork for isolation: use run_agent when the task needs a clean workspace context
+4. Use dedicated tools: if a dedicated tool (grep, glob, read) can accomplish the task, use it directly
+5. Scope the prompt clearly: a subagent prompt should contain all context needed; it cannot ask the parent for clarification
+6. Limit nesting: avoid spawning subagents from within subagents beyond 2 levels of depth
+
+## Common Mistakes
+- **OverDelegation**: Spawning a subagent to grep a file instead of calling grep directly
+- **RacingWriters**: Spawning two subagents that both modify the same file — the last write wins
+- **VaguePrompt**: Giving the subagent a prompt like "figure out what's wrong" without specifying files, goals, or success criteria
+- **PeekingAtState**: Reading job output mid-run expecting partial results instead of waiting for completion
+
+## Examples
+### WRONG
+Run an agent with prompt "look at the codebase and fix things" — too vague, no success criteria.
+
+### RIGHT
+Run an agent with a prompt that specifies: the exact files to examine, the specific behavior to verify or fix, the expected output format, and any relevant constraints (e.g., allowed tools).

--- a/internal/harness/tools/behavioral_specs/spec.go
+++ b/internal/harness/tools/behavioral_specs/spec.go
@@ -1,0 +1,42 @@
+// Package behavioral_specs provides types and utilities for tool behavioral specifications.
+// Specs are loaded from embedded markdown files and rendered according to config toggles.
+package behavioral_specs
+
+// BehavioralSpecConfig holds feature flags and limits for behavioral spec rendering.
+// This mirrors config.BehavioralSpecConfig to avoid import cycles; callers convert.
+type BehavioralSpecConfig struct {
+	// Enabled is the master toggle — when false, FormatSpec returns "".
+	Enabled bool
+	// IncludeWhenNotToUse controls whether the "When NOT to Use" section is rendered.
+	IncludeWhenNotToUse bool
+	// IncludeAntiPatterns controls whether named anti-patterns are rendered.
+	IncludeAntiPatterns bool
+	// IncludeCommonMistakes controls whether the Common Mistakes section is rendered.
+	IncludeCommonMistakes bool
+	// MaxSpecLength is the maximum character length of a rendered spec. 0 = unlimited.
+	MaxSpecLength int
+}
+
+// BehavioralSpec holds the structured behavioral specification for a tool.
+type BehavioralSpec struct {
+	// WhenToUse describes positive usage patterns.
+	WhenToUse string
+	// WhenNotToUse describes negative patterns and anti-patterns.
+	WhenNotToUse string
+	// BehavioralRules is an ordered list of constraints and safety rules.
+	BehavioralRules []string
+	// CommonMistakes is a list of named anti-patterns with descriptions.
+	CommonMistakes []string
+	// Examples holds WRONG/RIGHT paired examples.
+	Examples []SpecExample
+}
+
+// SpecExample is a WRONG/RIGHT usage pair.
+type SpecExample struct {
+	// Label is a short description of the example scenario.
+	Label string
+	// Wrong is the bad example.
+	Wrong string
+	// Right is the good example.
+	Right string
+}

--- a/internal/harness/tools/behavioral_specs/web_search.md
+++ b/internal/harness/tools/behavioral_specs/web_search.md
@@ -1,0 +1,27 @@
+## When to Use
+- Looking up current events, recent library versions, or live documentation
+- Finding API documentation that may have changed since training cutoff
+- Researching a topic where freshness matters
+- Verifying that a library or package exists and its current version
+
+## When NOT to Use
+- Generating code — use your training knowledge and the codebase context
+- Finding files in the local workspace — use glob or grep
+- Answering questions about the current codebase — use read/grep/glob
+- Tasks where local context is sufficient
+
+## Behavioral Rules
+1. Prefer local context (grep, read, glob) over web search for questions about the current codebase
+2. Use web search when information is time-sensitive (release notes, CVEs, current API changes)
+3. Verify fetched content with agentic_fetch for full documentation pages when snippets are insufficient
+
+## Common Mistakes
+- **SearchInsteadOfRead**: Using web search to find out what's in a local file
+- **StaleQuery**: Searching for information that is in the codebase itself (e.g., searching for function signatures that are in the local source)
+
+## Examples
+### WRONG
+Web search for the signature of a function defined in the current repository.
+
+### RIGHT
+Use grep to search the local codebase for the function name, then read the file.

--- a/internal/harness/tools/descriptions/embed.go
+++ b/internal/harness/tools/descriptions/embed.go
@@ -3,6 +3,8 @@ package descriptions
 import (
 	"embed"
 	"strings"
+
+	"go-agent-harness/internal/harness/tools/behavioral_specs"
 )
 
 //go:embed *.md
@@ -16,4 +18,22 @@ func Load(name string) string {
 		panic("missing tool description: " + name + ".md")
 	}
 	return strings.TrimSpace(string(data))
+}
+
+// LoadWithSpec reads a tool description and, if enabled, appends its behavioral spec.
+// When cfg.Enabled is false or no spec exists for the tool, returns the plain description.
+func LoadWithSpec(name string, cfg behavioral_specs.BehavioralSpecConfig) string {
+	base := Load(name)
+	if !cfg.Enabled {
+		return base
+	}
+	spec, err := behavioral_specs.LoadSpec(name)
+	if err != nil || spec == nil {
+		return base
+	}
+	formatted := behavioral_specs.FormatSpec(spec, cfg)
+	if formatted == "" {
+		return base
+	}
+	return base + "\n\n" + formatted
 }

--- a/internal/harness/tools/descriptions/embed_test.go
+++ b/internal/harness/tools/descriptions/embed_test.go
@@ -3,6 +3,8 @@ package descriptions
 import (
 	"strings"
 	"testing"
+
+	"go-agent-harness/internal/harness/tools/behavioral_specs"
 )
 
 func TestLoadReturnsContentForExistingFile(t *testing.T) {
@@ -267,6 +269,48 @@ func TestEmbeddedFSAndKnownListAreInSync(t *testing.T) {
 		if !fsNames[name] {
 			t.Errorf("known list contains %q but no corresponding .md file exists in the embedded FS", name)
 		}
+	}
+}
+
+// TestLoadWithSpec_EnabledAppendsSpec is a regression test that verifies
+// LoadWithSpec appends a behavioral spec when enabled. If LoadWithSpec loses
+// its integration with behavioral_specs, this test will fail because the
+// result will equal the base description (no spec appended).
+func TestLoadWithSpec_EnabledAppendsSpec(t *testing.T) {
+	t.Parallel()
+
+	base := Load("bash")
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled:               true,
+		IncludeWhenNotToUse:   true,
+		IncludeAntiPatterns:   true,
+		IncludeCommonMistakes: true,
+		MaxSpecLength:         0,
+	}
+	enriched := LoadWithSpec("bash", cfg)
+	if enriched == base {
+		t.Error("LoadWithSpec with Enabled=true: result equals base description — spec was not appended")
+	}
+	if len(enriched) <= len(base) {
+		t.Errorf("LoadWithSpec with Enabled=true: enriched len=%d, base len=%d — enriched should be longer", len(enriched), len(base))
+	}
+	if !strings.Contains(enriched, "When to Use") {
+		t.Error("LoadWithSpec with Enabled=true: expected 'When to Use' section in enriched description")
+	}
+}
+
+// TestLoadWithSpec_DisabledReturnsPlainDescription is a regression test that
+// LoadWithSpec must return exactly the plain description when Enabled=false.
+func TestLoadWithSpec_DisabledReturnsPlainDescription(t *testing.T) {
+	t.Parallel()
+
+	base := Load("bash")
+	cfg := behavioral_specs.BehavioralSpecConfig{
+		Enabled: false,
+	}
+	result := LoadWithSpec("bash", cfg)
+	if result != base {
+		t.Errorf("LoadWithSpec with Enabled=false: got different result from base description")
 	}
 }
 

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -143,6 +143,23 @@ type BuildOptions struct {
 	// ProfilesDir is the directory to search for user-global profile TOML files.
 	// Used by run_agent and list_profiles. Defaults to ~/.harness/profiles/.
 	ProfilesDir string
+
+	// BehavioralSpecsEnabled controls whether behavioral specs are appended to
+	// tool descriptions. When true, each tool's description is enriched with its
+	// corresponding spec (if one exists) formatted according to BehavioralSpecCfg.
+	BehavioralSpecsEnabled bool
+
+	// BehavioralSpecCfg holds the feature flags and limits for spec rendering.
+	// Ignored when BehavioralSpecsEnabled is false.
+	BehavioralSpecCfg BehavioralSpecOptions
+}
+
+// BehavioralSpecOptions mirrors config.BehavioralSpecConfig to avoid import cycles.
+type BehavioralSpecOptions struct {
+	IncludeWhenNotToUse   bool
+	IncludeAntiPatterns   bool
+	IncludeCommonMistakes bool
+	MaxSpecLength         int
 }
 
 // ConversationSummary holds lightweight metadata about a conversation.


### PR DESCRIPTION
## Summary

- Added `BehavioralSpecConfig` to TOML config with toggles for each section type (`enabled`, `include_when_not_to_use`, `include_anti_patterns`, `include_common_mistakes`, `max_spec_length`)
- Created `internal/harness/tools/behavioral_specs/` package with types (`spec.go`), loader (`loader.go`), and 10 priority tool spec files
- Tool specs cover: bash, file_edit, file_read, file_write, run_agent, find_tool, web_search, grep, glob, apply_patch
- Added `LoadWithSpec` integration point in `descriptions/embed.go` that conditionally appends spec content
- Full TDD: tests in `loader_test.go` cover loading, formatting, config toggles, and regression

## TOML Config

```toml
[behavioral_specs]
enabled = true
include_when_not_to_use = true
include_anti_patterns = true
include_common_mistakes = true
max_spec_length = 2000
```

## Testing

All targeted packages pass:

```
ok  go-agent-harness/internal/harness/tools/behavioral_specs
ok  go-agent-harness/internal/config
ok  go-agent-harness/internal/harness/tools/descriptions
```

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)