### PR TITLE
fix(harness): reject unprovisionable workspace_type synchronously at run creation

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -749,8 +749,14 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 	}
 
 	// Validate workspace_type early to fail fast before any state is created.
+	// Beyond the name check, also enforce the deterministic provisioning
+	// preconditions (registered backend, worktree repo path) so an HTTP caller
+	// gets a synchronous 400 instead of a queued run that dies in provisioning.
 	if req.WorkspaceType != "" {
 		if err := validateWorkspaceType(req.WorkspaceType); err != nil {
+			return Run{}, err
+		}
+		if err := validateWorkspaceProvisionPreconditions(req.WorkspaceType, r.config.WorkspaceBaseOptions); err != nil {
 			return Run{}, err
 		}
 	}
@@ -5172,24 +5178,8 @@ func stringSlicesEqual(a, b []string) bool {
 // Each backend ignores fields it doesn't use; the same Options struct is
 // passed to all of them.
 func provisionRunWorkspace(ctx context.Context, runID, wsType string, baseOpts WorkspaceProvisionOptions) (workspace.Workspace, error) {
-	// Surface a clearer error than the workspace package's generic ErrNotFound
-	// when the type passed validation but isn't actually registered.
-	known := false
-	for _, name := range workspace.List() {
-		if name == wsType {
-			known = true
-			break
-		}
-	}
-	if !known {
-		return nil, fmt.Errorf("unknown workspace type %q (registered: %v)", wsType, workspace.List())
-	}
-
-	// Worktree-specific precondition: it can only succeed with a real repo path.
-	// Catching this here gives a remediation-shaped message instead of a deeper
-	// "repoPath must be set" from inside the workspace package.
-	if wsType == "worktree" && baseOpts.RepoPath == "" {
-		return nil, fmt.Errorf("workspace_type=worktree requires WorkspaceBaseOptions.RepoPath to be configured in RunnerConfig")
+	if err := validateWorkspaceProvisionPreconditions(wsType, baseOpts); err != nil {
+		return nil, err
 	}
 
 	opts := workspace.Options{
@@ -5205,4 +5195,35 @@ func provisionRunWorkspace(ctx context.Context, runID, wsType string, baseOpts W
 		return nil, fmt.Errorf("provision %s workspace: %w", wsType, err)
 	}
 	return ws, nil
+}
+
+// validateWorkspaceProvisionPreconditions checks the deterministic
+// preconditions for provisioning a workspace of the given type, without
+// touching the environment: the type must be registered (a clearer error than
+// the workspace package's generic ErrNotFound), and worktree can only succeed
+// with a real repo path (a remediation-shaped message instead of a deeper
+// "repoPath must be set" from inside the workspace package).
+//
+// StartRun calls this for explicitly requested workspace types so callers get
+// a synchronous error at run creation instead of a queued run that fails in
+// provisioning; provisionRunWorkspace calls it again as the safety net for
+// profile-resolved workspace types. Environment-dependent failures (Docker
+// daemon unavailable, missing HETZNER_API_KEY) still surface at provisioning
+// time.
+func validateWorkspaceProvisionPreconditions(wsType string, baseOpts WorkspaceProvisionOptions) error {
+	known := false
+	for _, name := range workspace.List() {
+		if name == wsType {
+			known = true
+			break
+		}
+	}
+	if !known {
+		return fmt.Errorf("unknown workspace type %q (registered: %v)", wsType, workspace.List())
+	}
+
+	if wsType == "worktree" && baseOpts.RepoPath == "" {
+		return fmt.Errorf("workspace_type=worktree requires WorkspaceBaseOptions.RepoPath to be configured in RunnerConfig")
+	}
+	return nil
 }

--- a/internal/harness/runner_workspace_validation_test.go
+++ b/internal/harness/runner_workspace_validation_test.go
@@ -1,0 +1,80 @@
+package harness
+
+// runner_workspace_validation_test.go — issue #561: StartRun must reject
+// workspace types that can never provision synchronously, before any run
+// state is created, so HTTP callers get a 400 instead of a queued run that
+// dies during provisioning.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateWorkspaceProvisionPreconditions(t *testing.T) {
+	t.Parallel()
+
+	repoOpts := WorkspaceProvisionOptions{RepoPath: "/some/repo"}
+	cases := []struct {
+		name    string
+		wsType  string
+		opts    WorkspaceProvisionOptions
+		wantErr string // empty means no error
+	}{
+		{name: "local always ok", wsType: "local", opts: WorkspaceProvisionOptions{}},
+		{name: "worktree with repo ok", wsType: "worktree", opts: repoOpts},
+		{name: "worktree without repo rejected", wsType: "worktree", opts: WorkspaceProvisionOptions{}, wantErr: "RepoPath"},
+		{name: "unregistered type rejected", wsType: "does-not-exist", opts: repoOpts, wantErr: "registered"},
+		// container and vm are registered; their environment-dependent
+		// requirements (Docker, HETZNER_API_KEY) are checked at provisioning
+		// time, not here.
+		{name: "container passes preconditions", wsType: "container", opts: WorkspaceProvisionOptions{}},
+		{name: "vm passes preconditions", wsType: "vm", opts: WorkspaceProvisionOptions{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWorkspaceProvisionPreconditions(tc.wsType, tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateWorkspaceProvisionPreconditions(%q) = %v, want nil", tc.wsType, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateWorkspaceProvisionPreconditions(%q) = nil, want error containing %q", tc.wsType, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestStartRunRejectsWorktreeWithoutRepoPathSynchronously(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{DefaultModel: "test-model", MaxSteps: 1},
+	)
+
+	_, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err == nil {
+		t.Fatal("StartRun with workspace_type=worktree and no RepoPath should fail synchronously")
+	}
+	for _, want := range []string{"workspace_type=worktree", "RepoPath"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want it to contain %q", err, want)
+		}
+	}
+	runner.mu.RLock()
+	runCount := len(runner.runs)
+	runner.mu.RUnlock()
+	if runCount != 0 {
+		t.Fatalf("no run state should be created on synchronous rejection, got %d runs", runCount)
+	}
+}

--- a/internal/harness/workspace_selection_test.go
+++ b/internal/harness/workspace_selection_test.go
@@ -248,7 +248,9 @@ func TestRunRequest_WorkspaceType_Worktree(t *testing.T) {
 }
 
 // TestRunRequest_WorkspaceType_WorktreeMissingRepoPath verifies that a run
-// with workspace_type="worktree" but no repo path configured fails the run.
+// with workspace_type="worktree" but no repo path configured is rejected
+// synchronously at StartRun (issue #561) — callers get an immediate error
+// instead of a queued run that fails during provisioning.
 func TestRunRequest_WorkspaceType_WorktreeMissingRepoPath(t *testing.T) {
 	t.Parallel()
 
@@ -261,25 +263,15 @@ func TestRunRequest_WorkspaceType_WorktreeMissingRepoPath(t *testing.T) {
 		},
 	)
 
-	run, err := runner.StartRun(RunRequest{
+	_, err := runner.StartRun(RunRequest{
 		Prompt:        "hello",
 		WorkspaceType: "worktree",
 	})
-	// StartRun should succeed (validates type name only, not provisioning).
-	if err != nil {
-		t.Fatalf("StartRun unexpectedly failed: %v", err)
+	if err == nil {
+		t.Fatal("StartRun should reject workspace_type=worktree when no RepoPath is configured")
 	}
-
-	events := drainRunEventsWS(t, runner, run.ID)
-
-	var gotFailed bool
-	for _, ev := range events {
-		if ev.Type == EventRunFailed {
-			gotFailed = true
-		}
-	}
-	if !gotFailed {
-		t.Error("expected run.failed when worktree provisioning lacks a repo path")
+	if !strings.Contains(err.Error(), "RepoPath") {
+		t.Errorf("error should point at the missing RepoPath, got: %v", err)
 	}
 }
 
@@ -338,12 +330,20 @@ func TestRunRequest_WorkspaceType_ValidTypes(t *testing.T) {
 
 	// "container" and "vm" pass validation (type name is known) but
 	// provisioning will fail at execute() time for lack of orchestrator config.
-	// StartRun itself must not reject them.
+	// StartRun itself must not reject them. "worktree" additionally requires a
+	// configured RepoPath — without one StartRun rejects it synchronously
+	// (issue #561), so this runner is configured with a real repo.
 	validTypes := []string{"", "local", "worktree", "container", "vm"}
 	runner := NewRunner(
 		&staticProviderWS{result: CompletionResult{Content: "done"}},
 		NewRegistry(),
-		RunnerConfig{MaxSteps: 1},
+		RunnerConfig{
+			MaxSteps: 1,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        initGitRepoForWS(t),
+				WorktreeRootDir: t.TempDir(),
+			},
+		},
 	)
 
 	for _, wsType := range validTypes {

--- a/internal/server/http_workspace_type_test.go
+++ b/internal/server/http_workspace_type_test.go
@@ -1,0 +1,175 @@
+package server
+
+// http_workspace_type_test.go — issue #561: POST /v1/runs must reject
+// workspace_type values that can never provision with a synchronous 400,
+// instead of returning 202/queued and failing the run asynchronously during
+// provisioning. Environment-dependent types (container needs Docker, vm needs
+// HETZNER_API_KEY) are still accepted at creation and fail at provisioning
+// time, so they are deliberately not asserted on here.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+func newWorkspaceTypeTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "done"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "test-model", MaxSteps: 1},
+	)
+	t.Cleanup(func() { _ = runner.Shutdown(context.Background()) })
+
+	ts := httptest.NewServer(New(runner))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func postWorkspaceTypeRun(t *testing.T, ts *httptest.Server, body string) (int, string) {
+	t.Helper()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return res.StatusCode, string(raw)
+}
+
+func decodeWorkspaceTypeError(t *testing.T, raw string) (code, message string) {
+	t.Helper()
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("decode error body %q: %v", raw, err)
+	}
+	return body.Error.Code, body.Error.Message
+}
+
+func TestPostRunWorkspaceTypeUnknownReturns400(t *testing.T) {
+	t.Parallel()
+
+	ts := newWorkspaceTypeTestServer(t)
+	status, raw := postWorkspaceTypeRun(t, ts, `{"prompt":"hello","workspace_type":"wroktree"}`)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, raw)
+	}
+	code, message := decodeWorkspaceTypeError(t, raw)
+	if code != "invalid_request" {
+		t.Fatalf("error code = %q, want invalid_request: %s", code, raw)
+	}
+	if !strings.Contains(message, `"wroktree"`) {
+		t.Fatalf("message should name the invalid workspace_type, got %q", message)
+	}
+	if !strings.Contains(message, "local, worktree, container, vm") {
+		t.Fatalf("message should list supported values, got %q", message)
+	}
+	if strings.Contains(raw, "run_id") || strings.Contains(raw, "queued") {
+		t.Fatalf("invalid workspace request must not create a queued run: %s", raw)
+	}
+}
+
+func TestPostRunWorkspaceTypeWorktreeWithoutRepoReturns400(t *testing.T) {
+	t.Parallel()
+
+	// The test runner is configured without WorkspaceBaseOptions.RepoPath, so
+	// worktree provisioning can never succeed — the request must fail at
+	// creation, not after the run is queued.
+	ts := newWorkspaceTypeTestServer(t)
+	status, raw := postWorkspaceTypeRun(t, ts, `{"prompt":"hello","workspace_type":"worktree"}`)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, raw)
+	}
+	code, message := decodeWorkspaceTypeError(t, raw)
+	if code != "invalid_request" {
+		t.Fatalf("error code = %q, want invalid_request: %s", code, raw)
+	}
+	for _, want := range []string{"workspace_type=worktree", "RepoPath"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("message should contain %q, got %q", want, message)
+		}
+	}
+	if strings.Contains(raw, "run_id") || strings.Contains(raw, "queued") {
+		t.Fatalf("unconfigured worktree request must not create a queued run: %s", raw)
+	}
+}
+
+func TestPostRunWorkspaceTypeLocalStillProvisions(t *testing.T) {
+	t.Parallel()
+
+	ts := newWorkspaceTypeTestServer(t)
+	status, raw := postWorkspaceTypeRun(t, ts, `{"prompt":"hello","workspace_type":"local"}`)
+
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", status, raw)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &created); err != nil {
+		t.Fatalf("decode create response %q: %v", raw, err)
+	}
+	if created.RunID == "" {
+		t.Fatalf("expected run_id in create response: %s", raw)
+	}
+
+	// Poll to terminal so the events replay below is complete and non-blocking.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatalf("run %s did not reach terminal state within 10s", created.RunID)
+		}
+		res, err := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+		if err == nil {
+			var runState struct {
+				Status string `json:"status"`
+			}
+			decodeErr := json.NewDecoder(res.Body).Decode(&runState)
+			res.Body.Close()
+			if decodeErr == nil {
+				if runState.Status == "failed" || runState.Status == "cancelled" {
+					t.Fatalf("run %s status = %q, want completed", created.RunID, runState.Status)
+				}
+				if runState.Status == "completed" {
+					break
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	eventsRes, err := http.Get(ts.URL + "/v1/runs/" + created.RunID + "/events")
+	if err != nil {
+		t.Fatalf("GET events: %v", err)
+	}
+	defer eventsRes.Body.Close()
+	rawEvents, err := io.ReadAll(eventsRes.Body)
+	if err != nil {
+		t.Fatalf("read events: %v", err)
+	}
+	if !strings.Contains(string(rawEvents), "workspace.provisioned") {
+		t.Fatalf("expected workspace.provisioned event for workspace_type=local, got: %s", string(rawEvents))
+	}
+}


### PR DESCRIPTION
Fixes #561.

## Problem

`POST /v1/runs` with a `workspace_type` that can never provision (e.g. `worktree` without a configured RepoPath, or an unregistered type) returned `202 {"status":"queued"}` and the run then died asynchronously during provisioning. Callers had no synchronous signal that the request itself was unacceptable.

## Change

`StartRun` now enforces the deterministic provisioning preconditions — registered backend, worktree repo path — via a shared `validateWorkspaceProvisionPreconditions` helper that `provisionRunWorkspace` also uses as its safety net for profile-resolved workspace types. The existing StartRun error mapping in `handlePostRun` surfaces this as an HTTP 400 `invalid_request`, so no HTTP-layer wiring was needed.

Environment-dependent failures (container without Docker, vm without `HETZNER_API_KEY`) still surface at provisioning time: those types are legitimately provisionable on a configured host, so they are not rejected at creation.

## Tests

- `internal/server/http_workspace_type_test.go` — POST /v1/runs: unknown type → 400 naming the value and listing supported ones; `worktree` without repo → 400 pointing at RepoPath; neither creates a run. `local` → 202 and the run completes with `workspace.provisioned`.
- `internal/harness/runner_workspace_validation_test.go` — table test for the shared precondition helper + synchronous StartRun rejection with no run state created.
- `TestRunRequest_WorkspaceType_WorktreeMissingRepoPath` updated to the new synchronous contract; `TestRunRequest_WorkspaceType_ValidTypes` now configures a real repo so `worktree` remains a valid name.

## Scope notes (rewrite of the original draft)

This PR was rebuilt from scratch on current main. The original draft (5c1ae4a, from April) predated main's early name validation and rejected `container`/`vm` outright — that blanket rejection is now wrong because main has working Docker and Hetzner VM workspace backends, so it was dropped. The draft's unrelated drive-by test additions (`internal/checkpoints/service_test.go`, `internal/workingmemory/sqlite_test.go`) and stale plan/log documents were also dropped as out of scope for #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6