### PR TITLE
[codex] Harness retention and coveragegate tests

### DIFF
--- a/cmd/harnessd/mcp_runner_adapter_test.go
+++ b/cmd/harnessd/mcp_runner_adapter_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/mcpserver"
+	runstore "go-agent-harness/internal/store"
+)
+
+func TestMCPRunnerAdapterRunStatusListAndConversation(t *testing.T) {
+	t.Parallel()
+
+	store := runstore.NewMemoryStore()
+	runner := harness.NewRunner(&noopProvider{}, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     1,
+		Store:        store,
+	})
+	adapter := &mcpRunnerAdapter{runner: runner, store: store}
+
+	runID, err := adapter.StartRun("hello via mcp")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	status := waitForMCPRunStatus(t, adapter, runID, "completed")
+	if status.Output != "ok" {
+		t.Fatalf("status output = %q, want ok", status.Output)
+	}
+
+	runs, err := adapter.ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	found := false
+	for _, run := range runs {
+		if run.ID == runID && run.Status == "completed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("stored run %q not found in ListRuns: %+v", runID, runs)
+	}
+
+	emptyList, err := (&mcpRunnerAdapter{runner: runner}).ListRuns()
+	if err != nil {
+		t.Fatalf("ListRuns without store: %v", err)
+	}
+	if len(emptyList) != 0 {
+		t.Fatalf("ListRuns without store length = %d, want 0", len(emptyList))
+	}
+
+	conversationRun, err := runner.StartRun(harness.RunRequest{
+		Prompt:         "remember this",
+		ConversationID: "conv-mcp",
+	})
+	if err != nil {
+		t.Fatalf("direct StartRun with conversation: %v", err)
+	}
+	waitForMCPRunStatus(t, adapter, conversationRun.ID, "completed")
+	messages, ok := adapter.ConversationMessages("conv-mcp")
+	if !ok {
+		t.Fatal("ConversationMessages: expected conversation")
+	}
+	if len(messages) == 0 {
+		t.Fatal("ConversationMessages returned no messages")
+	}
+	if messages[0].Role == "" || messages[0].Content == "" {
+		t.Fatalf("unexpected conversation message: %+v", messages[0])
+	}
+
+	if _, err := adapter.GetRunStatus("missing-run"); err == nil {
+		t.Fatal("expected missing run status error")
+	}
+	if _, ok := adapter.ConversationMessages("missing-conv"); ok {
+		t.Fatal("expected missing conversation lookup to return false")
+	}
+}
+
+func TestMCPRunnerAdapterSteerRun(t *testing.T) {
+	t.Parallel()
+
+	provider := &blockingMCPProvider{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     1,
+	})
+	adapter := &mcpRunnerAdapter{runner: runner}
+
+	runID, err := adapter.StartRun("long run")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider did not start")
+	}
+	if err := adapter.SteerRun(runID, "adjust course"); err != nil {
+		t.Fatalf("SteerRun: %v", err)
+	}
+	close(provider.release)
+	waitForMCPRunStatus(t, adapter, runID, "completed")
+}
+
+func TestMCPRunnerAdapterSubmitUserInput(t *testing.T) {
+	t.Parallel()
+
+	provider := &scriptedHarnessdProvider{turns: []harness.CompletionResult{
+		{
+			ToolCalls: []harness.ToolCall{{
+				ID:        "call_ask_mcp",
+				Name:      htools.AskUserQuestionToolName,
+				Arguments: `{"questions":[{"question":"Where next?","header":"Route","options":[{"label":"Docs","description":"Read docs"},{"label":"Code","description":"Read code"}],"multiSelect":false}]}`,
+			}},
+		},
+		{Content: "resumed"},
+	}}
+	broker := harness.NewInMemoryAskUserQuestionBroker(time.Now)
+	runner := harness.NewRunner(provider, harness.NewDefaultRegistryWithOptions(t.TempDir(), harness.DefaultRegistryOptions{
+		ApprovalMode:   harness.ToolApprovalModeFullAuto,
+		AskUserBroker:  broker,
+		AskUserTimeout: 2 * time.Second,
+	}), harness.RunnerConfig{
+		DefaultModel:   "test-model",
+		MaxSteps:       4,
+		AskUserBroker:  broker,
+		AskUserTimeout: 2 * time.Second,
+	})
+	adapter := &mcpRunnerAdapter{runner: runner}
+
+	runID, err := adapter.StartRun("needs operator input")
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForMCPRunStatus(t, adapter, runID, string(harness.RunStatusWaitingForUser))
+
+	if err := adapter.SubmitUserInput(runID, "Docs"); err != nil {
+		t.Fatalf("SubmitUserInput: %v", err)
+	}
+	status := waitForMCPRunStatus(t, adapter, runID, "completed")
+	if status.Output != "resumed" {
+		t.Fatalf("output = %q, want resumed", status.Output)
+	}
+
+	if err := adapter.SubmitUserInput(runID, "Docs"); err == nil || !strings.Contains(err.Error(), "no pending input") {
+		t.Fatalf("expected no pending input error after completion, got %v", err)
+	}
+}
+
+type blockingMCPProvider struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingMCPProvider) Complete(ctx context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+	select {
+	case <-p.started:
+	default:
+		close(p.started)
+	}
+	select {
+	case <-p.release:
+		return harness.CompletionResult{Content: "released"}, nil
+	case <-ctx.Done():
+		return harness.CompletionResult{}, ctx.Err()
+	}
+}
+
+func waitForMCPRunStatus(t *testing.T, adapter *mcpRunnerAdapter, runID, want string) mcpserver.RunStatus {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	var last mcpserver.RunStatus
+	for time.Now().Before(deadline) {
+		status, err := adapter.GetRunStatus(runID)
+		if err != nil {
+			t.Fatalf("GetRunStatus(%q): %v", runID, err)
+		}
+		last = status
+		if status.Status == want {
+			return last
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for run %s status %q; last=%+v", runID, want, last)
+	return last
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,28 @@
 # Engineering Log
 
+## 2026-06-26 (Issue #649 Completed Run Retention)
+
+- Implemented reliability slice T01 from `docs/plans/2026-06-24-harness-reliability-plan.md` for issue `#649`.
+- Added bounded in-memory retention for terminal run states:
+  - `RunnerConfig.MaxCompletedRetention` defaults to 32.
+  - completed, failed, and cancelled runs are eligible for pruning only when a durable run `Store` is configured, after terminal handling, and when no subscribers remain attached.
+  - subscriber cancellation re-runs pruning so terminal runs held for streaming clients can be released after the stream detaches.
+- Added bounded in-memory conversation mirror retention:
+  - `RunnerConfig.MaxConversationRetention` defaults to 256.
+  - `r.conversations`, `r.conversationOwners`, and conversation recency metadata evict together.
+  - persistent `ConversationStore` history remains the fallback for pruned conversation mirrors.
+- Added regressions in `internal/harness/runner_prune_test.go` covering completed-run pruning, active-subscriber retention, and persistent-store fallback for evicted conversation mirrors.
+- Red phase:
+  - `go test ./internal/harness -run TestRunner_Prune -count=1` failed to build because the retention config fields did not exist.
+- Verification:
+  - `go test ./internal/harness -run TestRunner_Prune -count=1`
+  - `go test ./internal/harness -count=1`
+  - `go test ./internal/server -run TestWorkerPoolLoad -count=1`
+  - `go test ./internal/harness/... -race -count=1`
+- Regression status:
+  - `./scripts/test-regression.sh` passed the `go test ./...` and `go test ./... -race` phases.
+  - `./scripts/test-regression.sh` failed at the coverage-gate phase because existing functions outside this slice still report `0.0%` coverage; total statement coverage was `83.9%`.
+
 ## 2026-05-05 (GitHub Pages User Repositioning)
 
 - Recentered the go-code GitHub Pages copy around the developer visitor.
@@ -1115,3 +1138,29 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
   - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./cmd/harnesscli/tui/... -count=1`
   - `TMPDIR=$PWD/.tmp/tmp GOCACHE=$PWD/.tmp/go-build go test ./internal/... ./cmd/... -count=1`
   - `git diff --check`
+
+## 2026-06-26 (Issue #649 T01 Retention and Coveragegate Restoration)
+
+- Added store-gated pruning for completed harness run state and conversation mirrors.
+  - Completed runs remain available in memory when no durable run store is configured to preserve `GET /v1/runs/{id}` compatibility.
+  - Active subscribers keep terminal run state resident until they are cancelled.
+  - Conversation mirror pruning leaves persistent `ConversationStore` history untouched.
+- Restored the repo coveragegate by adding focused tests for the reported zero-coverage functions instead of weakening the gate.
+  - Covered MCP runner adapter run/list/status/steer/input/conversation paths in `cmd/harnessd`.
+  - Covered checkpoint service/store lifecycle, SQLite checkpoint round trips, goal tools, callback scheduling, approval denial, workflow/network definitions, workflow SQLite persistence, working-memory delete, replay dispatch output, path permission detection, and scheduler simulation fallback behavior.
+- Red evidence:
+  - `./scripts/test-regression.sh` previously passed `go test ./...` and `go test ./... -race`, then failed coveragegate with `45` zero-coverage functions and total statement coverage `83.9%`.
+- Green evidence:
+  - `go test ./internal/harness -run TestRunner_Prune -count=1`
+  - `go test ./internal/server -run TestWorkerPoolLoad -count=1`
+  - `go test ./internal/harness/... -race -count=1`
+  - `go test ./cmd/harnessd -run 'TestMCPRunnerAdapter' -count=1`
+  - `go test ./internal/checkpoints -count=1`
+  - `go test ./internal/harness/tools/deferred -run 'TestGoalTools' -count=1`
+  - `go test ./internal/cloudscheduler ./internal/forensics/replay ./internal/harness/tools ./internal/networks ./internal/workflow ./internal/workflows ./internal/workingmemory -count=1`
+  - `go test ./internal/harness -run 'TestRunnerNewCallbackManagerEmitsScheduledEvent|TestCheckpointApprovalBrokerDenyRejectsPendingApproval|TestRunner_Prune' -count=1`
+  - `go test ./internal/harness -count=1`
+  - `go test ./internal/harness -race -run TestRunnerNewCallbackManagerEmitsScheduledEvent -count=1 -timeout=30s`
+  - `go test ./internal/harness -race -count=1 -timeout=90s`
+  - coveragegate recheck: `coveragegate: PASS (total=84.7%, min=80.0%, zero-functions=0)`
+  - `./scripts/test-regression.sh`: `[regression] PASS`

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -995,3 +995,24 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - Whether the `spawn_agent` system prompt should continue duplicating the task text while the typed handoff block becomes the canonical parent-context contract.
 - Next verification step: add failing handoff tests in tools/subagents/harness packages, implement the shared handoff helpers and propagation fields, then rerun focused suites and broader relevant tests.
+
+## 2026-06-26 (Issue #649 Harness Retention and Coveragegate Restoration)
+
+- Command intent: Complete the current T01 reliability slice and restore the full repository regression gate, including coveragegate.
+- User intent: Keep the harness reliability work reviewable while proving the repo can pass its actual pre-merge gate without weakening coverage rules.
+- Success definition:
+  - Completed harness run state and conversation mirrors are pruned with bounded retention.
+  - Durable-store compatibility is preserved for completed run lookup.
+  - Existing T01 pruning regressions remain green.
+  - Coveragegate reports zero uncovered functions without reducing `MIN_TOTAL_COVERAGE`, removing the zero-function rule, or excluding code just to pass.
+  - `./scripts/test-regression.sh` exits 0 and prints `[regression] PASS`.
+- Non-goals:
+  - Broad reliability epic implementation outside T01.
+  - Refactoring unrelated runtime, workflow, or tool packages.
+- Guardrails/constraints:
+  - Add focused behavior tests for uncovered functions instead of superficial call-only coverage.
+  - Preserve existing local work and branch name.
+  - Update engineering evidence and local tracker state after verification.
+- Open questions:
+  - None for T01 completion.
+- Next verification step: review the scoped diff and, if accepted, promote through the repo's normal verify-and-merge flow.

--- a/internal/checkpoints/service_test.go
+++ b/internal/checkpoints/service_test.go
@@ -2,7 +2,9 @@ package checkpoints
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -127,5 +129,182 @@ func TestServiceResumeWakesWaiterAndPersistsPayload(t *testing.T) {
 	}
 	if loaded.ResumePayload == "" {
 		t.Fatal("expected persisted resume payload")
+	}
+}
+
+func TestServiceStoreDenyExpireAndWaitCancellation(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	if err := store.Close(); err != nil {
+		t.Fatalf("MemoryStore Close: %v", err)
+	}
+	svc := NewService(store, func() time.Time { return now })
+	if svc.Store() != store {
+		t.Fatal("Store did not return configured store")
+	}
+
+	denied, err := svc.Create(context.Background(), CreateRequest{
+		Kind:       KindApproval,
+		RunID:      "run-deny",
+		DeadlineAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create denied record: %v", err)
+	}
+	if err := svc.Deny(context.Background(), denied.ID); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+	result, err := svc.Wait(context.Background(), denied.ID)
+	if err != nil {
+		t.Fatalf("Wait denied: %v", err)
+	}
+	if result.Status != StatusDenied {
+		t.Fatalf("Wait denied status = %q, want %q", result.Status, StatusDenied)
+	}
+
+	expired, err := svc.Create(context.Background(), CreateRequest{
+		Kind:       KindExternalResume,
+		RunID:      "run-expire",
+		DeadlineAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create expired record: %v", err)
+	}
+	if err := svc.Expire(context.Background(), expired.ID); err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+	result, err = svc.Wait(context.Background(), expired.ID)
+	if err != nil {
+		t.Fatalf("Wait expired: %v", err)
+	}
+	if result.Status != StatusExpired {
+		t.Fatalf("Wait expired status = %q, want %q", result.Status, StatusExpired)
+	}
+
+	cancelled, err := svc.Create(context.Background(), CreateRequest{
+		Kind:       KindUserInput,
+		RunID:      "run-cancel-wait",
+		DeadlineAt: now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("Create cancellation record: %v", err)
+	}
+	waitCtx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := svc.Wait(waitCtx, cancelled.ID)
+		errCh <- err
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		svc.mu.Lock()
+		waiterCount := len(svc.waiters[cancelled.ID])
+		svc.mu.Unlock()
+		if waiterCount == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for service waiter registration")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	if err := <-errCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait cancellation error = %v, want context.Canceled", err)
+	}
+	svc.mu.Lock()
+	_, stillRegistered := svc.waiters[cancelled.ID]
+	svc.mu.Unlock()
+	if stillRegistered {
+		t.Fatal("cancelled waiter was not unregistered")
+	}
+}
+
+func TestSQLiteStoreUpdatePendingByWorkflowRunAndNotFound(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "checkpoints.db")
+	store, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 4, 5, 12, 0, 0, 123, time.UTC)
+	older := &Record{
+		ID:            "checkpoint-old",
+		Kind:          KindExternalResume,
+		Status:        StatusPending,
+		WorkflowRunID: "workflow-1",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	newer := &Record{
+		ID:            "checkpoint-new",
+		Kind:          KindExternalResume,
+		Status:        StatusPending,
+		WorkflowRunID: "workflow-1",
+		CreatedAt:     now,
+		UpdatedAt:     now.Add(time.Minute),
+	}
+	if err := store.Create(context.Background(), older); err != nil {
+		t.Fatalf("Create older: %v", err)
+	}
+	if err := store.Create(context.Background(), newer); err != nil {
+		t.Fatalf("Create newer: %v", err)
+	}
+
+	pending, err := store.PendingByWorkflowRun(context.Background(), "workflow-1")
+	if err != nil {
+		t.Fatalf("PendingByWorkflowRun: %v", err)
+	}
+	if pending == nil || pending.ID != newer.ID {
+		t.Fatalf("pending workflow checkpoint = %+v, want %s", pending, newer.ID)
+	}
+
+	newer.Status = StatusResumed
+	newer.ResumePayload = `{"approved":true}`
+	newer.UpdatedAt = now.Add(2 * time.Minute)
+	if err := store.Update(context.Background(), newer); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	loaded, err := store.Get(context.Background(), newer.ID)
+	if err != nil {
+		t.Fatalf("Get updated: %v", err)
+	}
+	if loaded.Status != StatusResumed {
+		t.Fatalf("updated status = %q, want %q", loaded.Status, StatusResumed)
+	}
+	if loaded.ResumePayload != newer.ResumePayload {
+		t.Fatalf("resume payload = %q, want %q", loaded.ResumePayload, newer.ResumePayload)
+	}
+	if !loaded.UpdatedAt.Equal(newer.UpdatedAt) {
+		t.Fatalf("updated_at = %s, want %s", loaded.UpdatedAt, newer.UpdatedAt)
+	}
+
+	pending, err = store.PendingByWorkflowRun(context.Background(), "workflow-1")
+	if err != nil {
+		t.Fatalf("PendingByWorkflowRun after update: %v", err)
+	}
+	if pending == nil || pending.ID != older.ID {
+		t.Fatalf("pending workflow checkpoint after update = %+v, want %s", pending, older.ID)
+	}
+
+	_, err = store.Get(context.Background(), "missing")
+	if !IsNotFound(err) {
+		t.Fatalf("Get missing error = %v, want NotFoundError", err)
+	}
+	if !strings.Contains(err.Error(), "checkpoint not found: missing") {
+		t.Fatalf("NotFoundError text = %q", err.Error())
+	}
+	if IsNotFound(context.Canceled) {
+		t.Fatal("IsNotFound returned true for unrelated error")
 	}
 }

--- a/internal/cloudscheduler/docker_executor_test.go
+++ b/internal/cloudscheduler/docker_executor_test.go
@@ -1,0 +1,33 @@
+package cloudscheduler
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDockerExecutorSimulatedExecuteIncludesJobAndBackend(t *testing.T) {
+	t.Parallel()
+
+	executor := &DockerExecutor{}
+	out := executor.simulatedExecute(Job{
+		ID:           "job-123",
+		WorkflowName: "nightly-regression",
+	})
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("simulated output is not JSON: %v; output=%q", err, out)
+	}
+	if payload["status"] != "completed" {
+		t.Fatalf("status = %q, want completed", payload["status"])
+	}
+	if payload["workflow"] != "nightly-regression" {
+		t.Fatalf("workflow = %q, want nightly-regression", payload["workflow"])
+	}
+	if payload["result"] != "simulated-job-123" {
+		t.Fatalf("result = %q, want simulated-job-123", payload["result"])
+	}
+	if payload["backend"] != "docker-simulated" {
+		t.Fatalf("backend = %q, want docker-simulated", payload["backend"])
+	}
+}

--- a/internal/forensics/replay/recordedprovider_test.go
+++ b/internal/forensics/replay/recordedprovider_test.go
@@ -243,6 +243,17 @@ func TestRecordedProvider_NoUsageLeavesCostStatusUnset(t *testing.T) {
 func TestReplayToolDispatch_ReturnsRecordedOutput(t *testing.T) {
 	events := multiStepRollout()
 
+	dispatch, err := NewReplayToolDispatch(events)
+	if err != nil {
+		t.Fatalf("NewReplayToolDispatch: %v", err)
+	}
+	if out, ok := dispatch.Output("call_1"); !ok || out != "file contents here" {
+		t.Fatalf("Output(call_1) = %q, %v; want recorded output", out, ok)
+	}
+	if out, ok := dispatch.Output("missing"); ok || out != "" {
+		t.Fatalf("Output(missing) = %q, %v; want empty false", out, ok)
+	}
+
 	handler, err := NewReplayToolHandler(events)
 	if err != nil {
 		t.Fatalf("NewReplayToolHandler: %v", err)

--- a/internal/harness/callback_bridge_test.go
+++ b/internal/harness/callback_bridge_test.go
@@ -1,0 +1,112 @@
+package harness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+func TestRunnerNewCallbackManagerEmitsScheduledEvent(t *testing.T) {
+	t.Parallel()
+
+	provider := &blockingCallbackProvider{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     1,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:         "keep callback stream open",
+		ConversationID: "conv-callback",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	select {
+	case <-provider.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider did not start")
+	}
+
+	history, stream, cancelSub, err := runner.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cancelSub()
+
+	manager := runner.NewCallbackManager(callbackStarterStub{})
+	defer manager.Shutdown()
+
+	info, err := manager.Set(htools.SetRequest{
+		ConversationID: "conv-callback",
+		Delay:          htools.MinCallbackDelay,
+		Prompt:         "check status later",
+	})
+	if err != nil {
+		t.Fatalf("Set callback: %v", err)
+	}
+
+	event := waitForCallbackEvent(t, history, stream, EventCallbackScheduled)
+	if event.RunID != run.ID {
+		t.Fatalf("callback event run id = %q, want %q", event.RunID, run.ID)
+	}
+	if event.Payload["callback_id"] != info.ID {
+		t.Fatalf("callback_id = %v, want %s", event.Payload["callback_id"], info.ID)
+	}
+	if event.Payload["conversation_id"] != "conv-callback" {
+		t.Fatalf("conversation_id = %v, want conv-callback", event.Payload["conversation_id"])
+	}
+
+	close(provider.release)
+}
+
+type blockingCallbackProvider struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *blockingCallbackProvider) Complete(ctx context.Context, _ CompletionRequest) (CompletionResult, error) {
+	select {
+	case <-p.started:
+	default:
+		close(p.started)
+	}
+	select {
+	case <-p.release:
+		return CompletionResult{Content: "done"}, nil
+	case <-ctx.Done():
+		return CompletionResult{}, ctx.Err()
+	}
+}
+
+type callbackStarterStub struct{}
+
+func (callbackStarterStub) StartRun(string, string, string, string) error { return nil }
+
+func waitForCallbackEvent(t *testing.T, history []Event, stream <-chan Event, want EventType) Event {
+	t.Helper()
+	for _, event := range history {
+		if event.Type == want {
+			return event
+		}
+	}
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case event, ok := <-stream:
+			if !ok {
+				t.Fatalf("stream closed before %s", want)
+			}
+			if event.Type == want {
+				return event
+			}
+		case <-timeout:
+			t.Fatalf("timed out waiting for %s", want)
+		}
+	}
+}

--- a/internal/harness/checkpoint_broker_test.go
+++ b/internal/harness/checkpoint_broker_test.go
@@ -73,6 +73,59 @@ func TestCheckpointApprovalBrokerPersistsPendingApproval(t *testing.T) {
 	}
 }
 
+func TestCheckpointApprovalBrokerDenyRejectsPendingApproval(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	checkpointSvc := checkpoints.NewService(checkpoints.NewMemoryStore(), func() time.Time { return now })
+	broker := NewCheckpointApprovalBroker(checkpointSvc)
+
+	resultCh := make(chan bool, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		approved, err := broker.Ask(context.Background(), ApprovalRequest{
+			RunID:   "run-denied",
+			CallID:  "call-denied",
+			Tool:    "write",
+			Args:    `{"path":"blocked.txt"}`,
+			Timeout: time.Minute,
+		})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		resultCh <- approved
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, ok := broker.Pending("run-denied"); ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for pending approval")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if err := broker.Deny("run-denied"); err != nil {
+		t.Fatalf("Deny: %v", err)
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("Ask returned error: %v", err)
+	case approved := <-resultCh:
+		if approved {
+			t.Fatal("denied approval returned approved=true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for denied approval result")
+	}
+	if err := broker.Deny("run-denied"); err != ErrNoPendingApproval {
+		t.Fatalf("Deny after resolution = %v, want ErrNoPendingApproval", err)
+	}
+}
+
 func TestCheckpointAskUserBrokerPersistsQuestionsAndAnswers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -9,6 +9,7 @@ import (
 	osuser "os/user"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -215,6 +216,11 @@ const recorderDrainTimeout = 30 * time.Second
 // the model returns 0 completion_tokens with empty content.
 const maxEmptyRetries = 3
 
+const (
+	defaultMaxCompletedRetention    = 32
+	defaultMaxConversationRetention = 256
+)
+
 // conversationOwner records the tenant and agent that own a conversation.
 // This is used to enforce conversation scoping: a caller-supplied ConversationID
 // must match the requesting tenant + agent before its history is loaded.
@@ -241,6 +247,10 @@ type Runner struct {
 	mu            sync.RWMutex
 	runs          map[string]*runState
 	conversations map[string][]Message
+	// conversationTouched tracks recency for the in-memory conversation mirror.
+	// It deliberately mirrors r.conversations only; durable retention is owned
+	// by ConversationStore implementations.
+	conversationTouched map[string]time.Time
 	// conversationOwners maps conversation_id -> owner (tenantID + agentID).
 	// It is populated when a run completes and its conversation is saved to the
 	// in-memory conversations map. Used to validate caller-supplied conversation IDs.
@@ -299,6 +309,12 @@ func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner 
 	if config.ModelContextWindow == 0 {
 		config.ModelContextWindow = 128000
 	}
+	if config.MaxCompletedRetention <= 0 {
+		config.MaxCompletedRetention = defaultMaxCompletedRetention
+	}
+	if config.MaxConversationRetention <= 0 {
+		config.MaxConversationRetention = defaultMaxConversationRetention
+	}
 	if tools == nil {
 		tools = NewRegistry()
 	}
@@ -327,17 +343,18 @@ func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner 
 	}
 
 	r := &Runner{
-		provider:           provider,
-		tools:              tools,
-		config:             config,
-		providerRegistry:   config.ProviderRegistry,
-		activations:        activations,
-		skillConstraints:   skillConstraints,
-		envInfo:            envInfo,
-		runs:               make(map[string]*runState),
-		conversations:      make(map[string][]Message),
-		conversationOwners: make(map[string]conversationOwner),
-		done:               make(chan struct{}),
+		provider:            provider,
+		tools:               tools,
+		config:              config,
+		providerRegistry:    config.ProviderRegistry,
+		activations:         activations,
+		skillConstraints:    skillConstraints,
+		envInfo:             envInfo,
+		runs:                make(map[string]*runState),
+		conversations:       make(map[string][]Message),
+		conversationTouched: make(map[string]time.Time),
+		conversationOwners:  make(map[string]conversationOwner),
+		done:                make(chan struct{}),
 	}
 	if config.WorkerPoolSize > 0 {
 		// Bounded pool: workerSem acts as a counting semaphore.
@@ -349,6 +366,109 @@ func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner 
 		go r.poolDispatcher()
 	}
 	return r
+}
+
+type retainedRunCandidate struct {
+	id        string
+	updatedAt time.Time
+}
+
+func (r *Runner) pruneCompletedRuns() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneCompletedRunsLocked()
+}
+
+func (r *Runner) pruneCompletedRunsLocked() {
+	if r.config.Store == nil {
+		return
+	}
+
+	limit := r.config.MaxCompletedRetention
+	if limit <= 0 {
+		limit = defaultMaxCompletedRetention
+	}
+
+	terminalCount := 0
+	candidates := make([]retainedRunCandidate, 0)
+	for runID, state := range r.runs {
+		if state == nil || !isTerminalRunStatus(state.run.Status) {
+			continue
+		}
+		terminalCount++
+		if len(state.subscribers) == 0 {
+			candidates = append(candidates, retainedRunCandidate{
+				id:        runID,
+				updatedAt: state.run.UpdatedAt,
+			})
+		}
+	}
+	if terminalCount <= limit || len(candidates) == 0 {
+		return
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].updatedAt.Equal(candidates[j].updatedAt) {
+			return candidates[i].id < candidates[j].id
+		}
+		return candidates[i].updatedAt.Before(candidates[j].updatedAt)
+	})
+
+	toDelete := terminalCount - limit
+	if toDelete > len(candidates) {
+		toDelete = len(candidates)
+	}
+	for i := 0; i < toDelete; i++ {
+		delete(r.runs, candidates[i].id)
+	}
+}
+
+type retainedConversationCandidate struct {
+	id        string
+	touchedAt time.Time
+}
+
+func (r *Runner) pruneConversationMirror() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pruneConversationMirrorLocked()
+}
+
+func (r *Runner) pruneConversationMirrorLocked() {
+	limit := r.config.MaxConversationRetention
+	if limit <= 0 {
+		limit = defaultMaxConversationRetention
+	}
+	if len(r.conversations) <= limit {
+		return
+	}
+
+	candidates := make([]retainedConversationCandidate, 0, len(r.conversations))
+	for convID := range r.conversations {
+		touchedAt := r.conversationTouched[convID]
+		candidates = append(candidates, retainedConversationCandidate{
+			id:        convID,
+			touchedAt: touchedAt,
+		})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].touchedAt.Equal(candidates[j].touchedAt) {
+			return candidates[i].id < candidates[j].id
+		}
+		return candidates[i].touchedAt.Before(candidates[j].touchedAt)
+	})
+
+	toDelete := len(r.conversations) - limit
+	for i := 0; i < toDelete; i++ {
+		convID := candidates[i].id
+		delete(r.conversations, convID)
+		delete(r.conversationOwners, convID)
+		delete(r.conversationTouched, convID)
+	}
+}
+
+func isTerminalRunStatus(status RunStatus) bool {
+	return status == RunStatusCompleted || status == RunStatusFailed || status == RunStatusCancelled
 }
 
 // GetProviderRegistry returns the provider registry, if configured.
@@ -1536,16 +1656,18 @@ func (r *Runner) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 
 	cancel := func() {
 		r.mu.Lock()
-		defer r.mu.Unlock()
 
 		state, ok := r.runs[runID]
 		if !ok {
+			r.mu.Unlock()
 			return
 		}
 		if _, exists := state.subscribers[ch]; exists {
 			delete(state.subscribers, ch)
 			close(ch)
 		}
+		r.pruneCompletedRunsLocked()
+		r.mu.Unlock()
 	}
 	return history, ch, cancel, nil
 }
@@ -2459,7 +2581,9 @@ func (r *Runner) completeRun(runID, output string) {
 		r.mu.RUnlock()
 
 		r.mu.Lock()
+		touchedAt := time.Now().UTC()
 		r.conversations[convID] = msgs
+		r.conversationTouched[convID] = touchedAt
 		// Record ownership so that future StartRun callers with the same
 		// ConversationID can be validated against the originating tenant+agent
 		// (cross-tenant/cross-agent disclosure prevention, issue #221).
@@ -2496,6 +2620,7 @@ func (r *Runner) completeRun(runID, output string) {
 				}
 			}
 		}
+		r.pruneConversationMirror()
 	} else {
 		r.mu.RUnlock()
 	}
@@ -2531,6 +2656,7 @@ func (r *Runner) completeRun(runID, output string) {
 	// S3 backup: upload JSONL after the terminal event is emitted and the
 	// store has been updated. Runs in a goroutine; errors are non-fatal.
 	r.backupRunToS3(runID)
+	r.pruneCompletedRuns()
 }
 
 // maybeEmitProfileEfficiencySuggestion emits a profile.efficiency_suggestion
@@ -2878,6 +3004,7 @@ func (r *Runner) failRun(runID string, err error) {
 	// S3 backup: upload JSONL after the terminal event is emitted.
 	// Runs in a goroutine; errors are non-fatal.
 	r.backupRunToS3(runID)
+	r.pruneCompletedRuns()
 }
 
 // failRunMaxSteps is a specialisation of failRun used when the step loop
@@ -2930,6 +3057,7 @@ func (r *Runner) failRunMaxSteps(runID string, maxSteps int) {
 	// S3 backup: upload JSONL after the terminal event is emitted.
 	// Runs in a goroutine; errors are non-fatal.
 	r.backupRunToS3(runID)
+	r.pruneCompletedRuns()
 }
 
 // failRunMaxTurns is a specialisation of failRun used when the step loop
@@ -2982,6 +3110,7 @@ func (r *Runner) failRunMaxTurns(runID string, maxTurns int) {
 	// S3 backup: upload JSONL after the terminal event is emitted.
 	// Runs in a goroutine; errors are non-fatal.
 	r.backupRunToS3(runID)
+	r.pruneCompletedRuns()
 }
 
 // cancelledRun emits the run.cancelled terminal event and sets the run's status
@@ -3017,6 +3146,7 @@ func (r *Runner) cancelledRun(runID string) {
 		"usage_totals": usageTotals,
 		"cost_totals":  costTotals,
 	})
+	r.pruneCompletedRuns()
 }
 
 // CancelRun requests cooperative cancellation of the run identified by runID.

--- a/internal/harness/runner_prune_test.go
+++ b/internal/harness/runner_prune_test.go
@@ -1,0 +1,273 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	runstore "go-agent-harness/internal/store"
+)
+
+func TestRunner_PruneCompletedRunsFromMemory(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(staticContentProvider{content: "done"}, NewRegistry(), RunnerConfig{
+		DefaultModel:          "test-model",
+		MaxSteps:              1,
+		MaxCompletedRetention: 3,
+		Store:                 runstore.NewMemoryStore(),
+	})
+
+	for i := 0; i < 8; i++ {
+		run, err := runner.StartRun(RunRequest{Prompt: fmt.Sprintf("run %d", i)})
+		if err != nil {
+			t.Fatalf("start run %d: %v", i, err)
+		}
+		if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+			t.Fatalf("collect run %d events: %v", i, err)
+		}
+	}
+
+	waitForRunnerPrune(t, runner, func() bool {
+		runner.mu.RLock()
+		defer runner.mu.RUnlock()
+		return len(runner.runs) <= 3
+	})
+}
+
+func TestRunner_PruneKeepsCompletedRunWithActiveSubscriber(t *testing.T) {
+	t.Parallel()
+
+	runner := NewRunner(staticContentProvider{content: "done"}, NewRegistry(), RunnerConfig{
+		DefaultModel:          "test-model",
+		MaxSteps:              1,
+		MaxCompletedRetention: 1,
+		Store:                 runstore.NewMemoryStore(),
+	})
+
+	pinned, err := runner.StartRun(RunRequest{Prompt: "keep subscriber"})
+	if err != nil {
+		t.Fatalf("start pinned run: %v", err)
+	}
+	history, stream, cancelPinned, err := runner.Subscribe(pinned.ID)
+	if err != nil {
+		t.Fatalf("subscribe pinned run: %v", err)
+	}
+	if !hasTerminalEvent(history) {
+		for ev := range stream {
+			if IsTerminalEvent(ev.Type) {
+				break
+			}
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		run, err := runner.StartRun(RunRequest{Prompt: fmt.Sprintf("extra %d", i)})
+		if err != nil {
+			t.Fatalf("start extra run %d: %v", i, err)
+		}
+		if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+			t.Fatalf("collect extra run %d events: %v", i, err)
+		}
+	}
+
+	runner.mu.RLock()
+	_, ok := runner.runs[pinned.ID]
+	runner.mu.RUnlock()
+	if !ok {
+		t.Fatal("completed run with an active subscriber was pruned")
+	}
+
+	cancelPinned()
+
+	replacement, err := runner.StartRun(RunRequest{Prompt: "replacement"})
+	if err != nil {
+		t.Fatalf("start replacement run: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, replacement.ID); err != nil {
+		t.Fatalf("collect replacement events: %v", err)
+	}
+
+	waitForRunnerPrune(t, runner, func() bool {
+		runner.mu.RLock()
+		defer runner.mu.RUnlock()
+		_, stillPresent := runner.runs[pinned.ID]
+		return !stillPresent && len(runner.runs) <= 1
+	})
+}
+
+func TestRunner_PruneConversationMirrorFallsBackToPersistentStore(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryConversationStore()
+	runner := NewRunner(staticContentProvider{content: "done"}, NewRegistry(), RunnerConfig{
+		DefaultModel:             "test-model",
+		MaxSteps:                 1,
+		MaxCompletedRetention:    8,
+		MaxConversationRetention: 2,
+		ConversationStore:        store,
+		Store:                    runstore.NewMemoryStore(),
+	})
+
+	const oldConvID = "conv-0"
+	for i := 0; i < 5; i++ {
+		run, err := runner.StartRun(RunRequest{
+			Prompt:         fmt.Sprintf("conversation %d", i),
+			ConversationID: fmt.Sprintf("conv-%d", i),
+		})
+		if err != nil {
+			t.Fatalf("start run %d: %v", i, err)
+		}
+		if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+			t.Fatalf("collect run %d events: %v", i, err)
+		}
+	}
+
+	waitForRunnerPrune(t, runner, func() bool {
+		runner.mu.RLock()
+		defer runner.mu.RUnlock()
+		return len(runner.conversations) <= 2
+	})
+
+	runner.mu.RLock()
+	_, inMemory := runner.conversations[oldConvID]
+	runner.mu.RUnlock()
+	if inMemory {
+		t.Fatalf("%s still present in in-memory conversation mirror", oldConvID)
+	}
+
+	msgs, ok := runner.ConversationMessages(oldConvID)
+	if !ok {
+		t.Fatalf("%s should still load from the persistent conversation store", oldConvID)
+	}
+	if len(msgs) == 0 {
+		t.Fatalf("%s loaded from store with no messages", oldConvID)
+	}
+}
+
+func waitForRunnerPrune(t *testing.T, runner *Runner, done func() bool) {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if done() {
+			return
+		}
+		select {
+		case <-deadline:
+			runner.mu.RLock()
+			runCount := len(runner.runs)
+			conversationCount := len(runner.conversations)
+			runner.mu.RUnlock()
+			t.Fatalf("timed out waiting for prune; runs=%d conversations=%d", runCount, conversationCount)
+		case <-ticker.C:
+		}
+	}
+}
+
+type staticContentProvider struct {
+	content string
+}
+
+func (p staticContentProvider) Complete(context.Context, CompletionRequest) (CompletionResult, error) {
+	return CompletionResult{Content: p.content}, nil
+}
+
+type memoryConversationStore struct {
+	mu       sync.Mutex
+	messages map[string][]Message
+	owners   map[string]*Conversation
+}
+
+func newMemoryConversationStore() *memoryConversationStore {
+	return &memoryConversationStore{
+		messages: make(map[string][]Message),
+		owners:   make(map[string]*Conversation),
+	}
+}
+
+func (s *memoryConversationStore) Migrate(context.Context) error { return nil }
+
+func (s *memoryConversationStore) Close() error { return nil }
+
+func (s *memoryConversationStore) SaveConversation(ctx context.Context, convID string, msgs []Message) error {
+	return s.SaveConversationWithCost(ctx, convID, msgs, ConversationTokenCost{})
+}
+
+func (s *memoryConversationStore) SaveConversationWithCost(_ context.Context, convID string, msgs []Message, _ ConversationTokenCost) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.messages[convID] = copyMessages(msgs)
+	now := time.Now().UTC()
+	conv := s.owners[convID]
+	if conv == nil {
+		conv = &Conversation{ID: convID, CreatedAt: now}
+		s.owners[convID] = conv
+	}
+	conv.UpdatedAt = now
+	conv.MsgCount = len(msgs)
+	return nil
+}
+
+func (s *memoryConversationStore) LoadMessages(_ context.Context, convID string) ([]Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return copyMessages(s.messages[convID]), nil
+}
+
+func (s *memoryConversationStore) ListConversations(context.Context, ConversationFilter, int, int) ([]Conversation, error) {
+	return nil, nil
+}
+
+func (s *memoryConversationStore) DeleteConversation(_ context.Context, convID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.messages, convID)
+	delete(s.owners, convID)
+	return nil
+}
+
+func (s *memoryConversationStore) UpdateConversationMeta(_ context.Context, convID, workspace, tenantID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	conv := s.owners[convID]
+	if conv == nil {
+		conv = &Conversation{ID: convID, CreatedAt: time.Now().UTC()}
+		s.owners[convID] = conv
+	}
+	conv.Workspace = workspace
+	conv.TenantID = tenantID
+	return nil
+}
+
+func (s *memoryConversationStore) GetConversationOwner(_ context.Context, convID string) (*Conversation, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	conv := s.owners[convID]
+	if conv == nil {
+		return nil, nil
+	}
+	out := *conv
+	return &out, nil
+}
+
+func (s *memoryConversationStore) SearchMessages(context.Context, string, string, int) ([]MessageSearchResult, error) {
+	return nil, nil
+}
+
+func (s *memoryConversationStore) DeleteOldConversations(context.Context, time.Time) (int, error) {
+	return 0, nil
+}
+
+func (s *memoryConversationStore) PinConversation(context.Context, string, bool) error {
+	return nil
+}
+
+func (s *memoryConversationStore) CompactConversation(context.Context, string, int, Message) error {
+	return nil
+}

--- a/internal/harness/tools/common_paths_test.go
+++ b/internal/harness/tools/common_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -147,4 +148,18 @@ func TestEnsureWorkspaceRootUsable(t *testing.T) {
 			t.Fatalf("expected no error for usable workspace root, got: %v", err)
 		}
 	})
+}
+
+func TestIsEACCESRecognizesPathPermissionError(t *testing.T) {
+	t.Parallel()
+
+	if !isEACCES(&os.PathError{Op: "open", Path: "secret", Err: syscall.EACCES}) {
+		t.Fatal("expected EACCES path error to be recognized")
+	}
+	if isEACCES(&os.PathError{Op: "open", Path: "missing", Err: syscall.ENOENT}) {
+		t.Fatal("did not expect ENOENT to be recognized as EACCES")
+	}
+	if isEACCES(syscall.EACCES) {
+		t.Fatal("bare syscall error should not match PathError-specific helper")
+	}
 }

--- a/internal/harness/tools/deferred/goals_tool_test.go
+++ b/internal/harness/tools/deferred/goals_tool_test.go
@@ -1,0 +1,150 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/goals"
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+func TestGoalToolsNilManager(t *testing.T) {
+	t.Parallel()
+
+	if NewGoalTools(nil) != nil {
+		t.Fatal("NewGoalTools(nil) should return nil")
+	}
+}
+
+func TestGoalToolsCRUDListAndReady(t *testing.T) {
+	t.Parallel()
+
+	manager := goals.NewManager(nil)
+	factory := NewGoalTools(manager)
+	if factory == nil {
+		t.Fatal("NewGoalTools returned nil factory")
+	}
+	tool := factory()
+	if tool.Definition.Name != "goals" {
+		t.Fatalf("tool name = %q, want goals", tool.Definition.Name)
+	}
+	if tool.Definition.Tier != tools.TierDeferred {
+		t.Fatalf("tool tier = %q, want %q", tool.Definition.Tier, tools.TierDeferred)
+	}
+	if tool.Handler == nil {
+		t.Fatal("tool handler is nil")
+	}
+
+	created := callGoalTool(t, tool, map[string]any{
+		"action":             "create",
+		"id":                 "goal-parent",
+		"name":               "Parent",
+		"description":        "Parent goal",
+		"verify_criteria":    "tests pass",
+		"progress_total":     4,
+		"progress_completed": 1,
+		"metadata":           map[string]string{"ticket": "649"},
+	})
+	if created["action"] != "created" {
+		t.Fatalf("create action = %v", created["action"])
+	}
+	if created["goal_id"] != "goal-parent" {
+		t.Fatalf("goal_id = %v", created["goal_id"])
+	}
+
+	callGoalTool(t, tool, map[string]any{
+		"action":     "create",
+		"id":         "goal-child",
+		"name":       "Child",
+		"depends_on": []string{"goal-parent"},
+	})
+
+	got := callGoalTool(t, tool, map[string]any{"action": "get", "id": "goal-parent"})
+	goal := got["goal"].(map[string]any)
+	if goal["name"] != "Parent" {
+		t.Fatalf("get goal name = %v", goal["name"])
+	}
+
+	updated := callGoalTool(t, tool, map[string]any{
+		"action":             "update",
+		"id":                 "goal-parent",
+		"status":             "completed",
+		"progress_total":     4,
+		"progress_completed": 4,
+		"metadata":           map[string]string{"gate": "green"},
+		"result":             "done",
+	})
+	updatedGoal := updated["goal"].(map[string]any)
+	if updatedGoal["status"] != "completed" {
+		t.Fatalf("updated status = %v", updatedGoal["status"])
+	}
+	metadata := updatedGoal["metadata"].(map[string]any)
+	if metadata["ticket"] != "649" || metadata["gate"] != "green" {
+		t.Fatalf("merged metadata = %#v", metadata)
+	}
+
+	listed := callGoalTool(t, tool, map[string]any{
+		"action":        "list",
+		"filter_status": "pending",
+		"limit":         5,
+	})
+	if listed["action"] != "list" || listed["count"].(float64) != 1 {
+		t.Fatalf("list response = %#v", listed)
+	}
+
+	ready := callGoalTool(t, tool, map[string]any{"action": "ready"})
+	if ready["action"] != "ready" || ready["count"].(float64) != 1 {
+		t.Fatalf("ready response = %#v", ready)
+	}
+	readyGoals := ready["goals"].([]any)
+	readyGoal := readyGoals[0].(map[string]any)
+	if readyGoal["id"] != "goal-child" {
+		t.Fatalf("ready goal id = %v, want goal-child", readyGoal["id"])
+	}
+}
+
+func TestGoalToolsValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tool := NewGoalTools(goals.NewManager(nil))()
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "invalid json", raw: `{`, wantErr: "invalid goals request"},
+		{name: "unknown action", raw: `{"action":"delete"}`, wantErr: `unknown action "delete"`},
+		{name: "create missing name", raw: `{"action":"create"}`, wantErr: "name is required"},
+		{name: "get missing id", raw: `{"action":"get"}`, wantErr: "id is required"},
+		{name: "update missing id", raw: `{"action":"update"}`, wantErr: "id is required"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tool.Handler(context.Background(), json.RawMessage(tc.raw))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func callGoalTool(t *testing.T, tool tools.Tool, payload map[string]any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	out, err := tool.Handler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("goal tool %v: %v", payload["action"], err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("unmarshal response %q: %v", out, err)
+	}
+	return decoded
+}

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -468,8 +468,16 @@ type RunnerConfig struct {
 	// slots free up. When 0 (the default), there is no cap — all runs start
 	// immediately (the legacy unbounded behaviour).
 	WorkerPoolSize int
-	AskUserTimeout time.Duration
-	AskUserBroker  htools.AskUserQuestionBroker
+	// MaxCompletedRetention caps completed/failed/cancelled run states retained
+	// in memory after terminal events are persisted and subscribers drain.
+	// 0 uses the default retention window.
+	MaxCompletedRetention int
+	// MaxConversationRetention caps the in-memory conversation transcript mirror.
+	// Persistent ConversationStore history, when configured, is left untouched.
+	// 0 uses the default retention window.
+	MaxConversationRetention int
+	AskUserTimeout           time.Duration
+	AskUserBroker            htools.AskUserQuestionBroker
 	// ApprovalBroker is the broker used to pause/resume tool calls that require
 	// operator approval. When nil, no approval pausing occurs even if
 	// PermissionConfig.Approval is set to ApprovalPolicyDestructive or

--- a/internal/networks/engine_test.go
+++ b/internal/networks/engine_test.go
@@ -122,3 +122,32 @@ func TestCompileDefinitionIncludesStructuredResultInstructions(t *testing.T) {
 		t.Fatal("expected compiled run step")
 	}
 }
+
+func TestEngineGetDefinition(t *testing.T) {
+	t.Parallel()
+
+	engine := NewEngine(Options{Definitions: []Definition{{
+		Name:        "planner",
+		Description: "plan work",
+		Roles: []RoleDefinition{{
+			ID:     "lead",
+			Prompt: "Plan",
+			Model:  "gpt-test",
+		}},
+	}}})
+
+	def, ok := engine.GetDefinition("planner")
+	if !ok {
+		t.Fatal("expected planner definition")
+	}
+	if def.Description != "plan work" {
+		t.Fatalf("description = %q, want plan work", def.Description)
+	}
+	if len(def.Roles) != 1 || def.Roles[0].ID != "lead" {
+		t.Fatalf("roles = %+v, want lead role", def.Roles)
+	}
+
+	if _, ok := engine.GetDefinition("missing"); ok {
+		t.Fatal("missing definition returned ok=true")
+	}
+}

--- a/internal/workflow/context_internal_test.go
+++ b/internal/workflow/context_internal_test.go
@@ -1,0 +1,69 @@
+package workflow
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestMaxConcurrencyMatchesDefaultBounds(t *testing.T) {
+	t.Parallel()
+
+	got := maxConcurrency()
+	want := runtime.NumCPU() - 2
+	if want < 1 {
+		want = 1
+	}
+	if want > 16 {
+		want = 16
+	}
+	if got != want {
+		t.Fatalf("maxConcurrency = %d, want %d", got, want)
+	}
+}
+
+func TestMemoryStoreGetRunReturnsCopyAndNilForMissing(t *testing.T) {
+	t.Parallel()
+
+	store := newMemoryStore()
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	run := &Run{
+		ID:           "workflow-run-1",
+		WorkflowName: "demo",
+		Status:       RunStatusRunning,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	if err := store.CreateRun(context.Background(), run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	loaded, err := store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected run")
+	}
+	if loaded.ID != run.ID || loaded.Status != RunStatusRunning {
+		t.Fatalf("loaded run = %+v", loaded)
+	}
+
+	loaded.Status = RunStatusCompleted
+	loadedAgain, err := store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetRun again: %v", err)
+	}
+	if loadedAgain.Status != RunStatusRunning {
+		t.Fatalf("stored run was mutated through returned pointer: %+v", loadedAgain)
+	}
+
+	missing, err := store.GetRun(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("GetRun missing: %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("missing run = %+v, want nil", missing)
+	}
+}

--- a/internal/workflows/engine_test.go
+++ b/internal/workflows/engine_test.go
@@ -3,6 +3,7 @@ package workflows
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -162,6 +163,67 @@ func TestEngineExecutesRunStep(t *testing.T) {
 	}
 }
 
+func TestEngineDefinitionSubscribeAndFailureEvents(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	engine := NewEngine(Options{
+		Definitions: []Definition{{
+			Name: "failing-flow",
+			Steps: []StepDefinition{{
+				ID:   "needs-tool",
+				Type: StepTypeTool,
+				Tool: "missing_executor",
+			}},
+		}},
+		Store: NewMemoryStore(),
+		Now:   func() time.Time { return now },
+	})
+
+	def, ok := engine.GetDefinition("failing-flow")
+	if !ok {
+		t.Fatal("expected failing-flow definition")
+	}
+	if len(def.Steps) != 1 || def.Steps[0].ID != "needs-tool" {
+		t.Fatalf("definition steps = %+v", def.Steps)
+	}
+	if _, ok := engine.GetDefinition("missing"); ok {
+		t.Fatal("missing definition returned ok=true")
+	}
+
+	run, err := engine.Start("failing-flow", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	history, live, cancel, err := engine.Subscribe(run.ID)
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cancel()
+
+	finalRun, _, err := waitForWorkflowRun(engine, run.ID)
+	if err != nil {
+		t.Fatalf("waitForWorkflowRun: %v", err)
+	}
+	if finalRun.Status != RunStatusFailed {
+		t.Fatalf("status = %q, want %q", finalRun.Status, RunStatusFailed)
+	}
+	if !strings.Contains(finalRun.Error, "tool executor is not configured") {
+		t.Fatalf("error = %q", finalRun.Error)
+	}
+
+	events := append([]Event(nil), history...)
+	deadline := time.After(2 * time.Second)
+	for !hasWorkflowEvent(events, "workflow.failed") {
+		select {
+		case event := <-live:
+			events = append(events, event)
+		case <-deadline:
+			t.Fatalf("timed out waiting for workflow.failed event; events=%+v", events)
+		}
+	}
+}
+
 type toolExecutorFunc func(ctx context.Context, name string, args json.RawMessage) (string, error)
 
 func (f toolExecutorFunc) Execute(ctx context.Context, name string, args json.RawMessage) (string, error) {
@@ -204,4 +266,13 @@ func waitForWorkflowRun(engine *Engine, runID string) (Run, []StepState, error) 
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func hasWorkflowEvent(events []Event, eventType string) bool {
+	for _, event := range events {
+		if event.Type == eventType {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/workflows/sqlite_test.go
+++ b/internal/workflows/sqlite_test.go
@@ -1,0 +1,137 @@
+package workflows
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSQLiteStoreRunStepAndEventRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "workflows.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 4, 5, 12, 0, 0, 123, time.UTC)
+	run := &Run{
+		ID:                  "workflow-run-1",
+		WorkflowName:        "review",
+		Status:              RunStatusRunning,
+		CurrentStepID:       "step-1",
+		CurrentCheckpointID: "checkpoint-1",
+		InputJSON:           `{"ticket":"649"}`,
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if err := store.CreateRun(context.Background(), run); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	run.Status = RunStatusCompleted
+	run.CurrentStepID = ""
+	run.OutputJSON = `{"ok":true}`
+	run.UpdatedAt = now.Add(time.Minute)
+	if err := store.UpdateRun(context.Background(), run); err != nil {
+		t.Fatalf("UpdateRun: %v", err)
+	}
+	loadedRun, err := store.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if loadedRun.Status != RunStatusCompleted {
+		t.Fatalf("loaded status = %q, want %q", loadedRun.Status, RunStatusCompleted)
+	}
+	if loadedRun.OutputJSON != run.OutputJSON {
+		t.Fatalf("loaded output = %q, want %q", loadedRun.OutputJSON, run.OutputJSON)
+	}
+	if !loadedRun.UpdatedAt.Equal(run.UpdatedAt) {
+		t.Fatalf("loaded updated_at = %s, want %s", loadedRun.UpdatedAt, run.UpdatedAt)
+	}
+
+	state1 := &StepState{
+		WorkflowRunID: run.ID,
+		StepID:        "step-1",
+		Status:        StepStatusRunning,
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}
+	state2 := &StepState{
+		WorkflowRunID: run.ID,
+		StepID:        "step-2",
+		Status:        StepStatusCompleted,
+		OutputJSON:    `{"done":true}`,
+		StartedAt:     now.Add(time.Second),
+		UpdatedAt:     now.Add(time.Second),
+	}
+	if err := store.UpsertStepState(context.Background(), state2); err != nil {
+		t.Fatalf("UpsertStepState step2: %v", err)
+	}
+	if err := store.UpsertStepState(context.Background(), state1); err != nil {
+		t.Fatalf("UpsertStepState step1: %v", err)
+	}
+	state1.Status = StepStatusCompleted
+	state1.OutputJSON = `{"result":"first"}`
+	state1.UpdatedAt = now.Add(2 * time.Second)
+	if err := store.UpsertStepState(context.Background(), state1); err != nil {
+		t.Fatalf("UpsertStepState update step1: %v", err)
+	}
+
+	states, err := store.ListStepStates(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("ListStepStates: %v", err)
+	}
+	if len(states) != 2 {
+		t.Fatalf("state count = %d, want 2", len(states))
+	}
+	if states[0].StepID != "step-1" || states[0].Status != StepStatusCompleted {
+		t.Fatalf("states[0] = %+v", states[0])
+	}
+	if states[1].StepID != "step-2" {
+		t.Fatalf("states[1] = %+v", states[1])
+	}
+
+	event1 := &Event{
+		WorkflowRunID: run.ID,
+		Seq:           1,
+		Type:          "workflow.started",
+		Payload:       map[string]any{"workflow": "review"},
+		Timestamp:     now,
+	}
+	event2 := &Event{
+		WorkflowRunID: run.ID,
+		Seq:           2,
+		Type:          "workflow.completed",
+		Payload:       map[string]any{"ok": true},
+		Timestamp:     now.Add(3 * time.Second),
+	}
+	if err := store.AppendEvent(context.Background(), event1); err != nil {
+		t.Fatalf("AppendEvent event1: %v", err)
+	}
+	if err := store.AppendEvent(context.Background(), event2); err != nil {
+		t.Fatalf("AppendEvent event2: %v", err)
+	}
+	events, err := store.GetEvents(context.Background(), run.ID, 1)
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Seq != 2 || events[0].Type != "workflow.completed" {
+		t.Fatalf("events after seq 1 = %+v", events)
+	}
+	if events[0].Payload["ok"] != true {
+		t.Fatalf("event payload = %#v", events[0].Payload)
+	}
+
+	if got := formatTime(now); got == "" {
+		t.Fatal("formatTime returned empty string")
+	}
+	if parsed := parseTime(formatTime(now)); !parsed.Equal(now) {
+		t.Fatalf("parseTime(formatTime(now)) = %s, want %s", parsed, now)
+	}
+}

--- a/internal/workingmemory/store_test.go
+++ b/internal/workingmemory/store_test.go
@@ -2,6 +2,7 @@ package workingmemory
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	om "go-agent-harness/internal/observationalmemory"
@@ -55,5 +56,44 @@ func TestMemoryStoreCRUDAndScopeIsolation(t *testing.T) {
 	}
 	if len(entries) != 1 {
 		t.Fatalf("entry count = %d, want 1", len(entries))
+	}
+}
+
+func TestSQLiteStoreDeleteRemovesScopedEntry(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "working-memory.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	defer store.Close()
+
+	scope := om.ScopeKey{TenantID: "tenant", ConversationID: "conv", AgentID: "agent"}
+	if err := store.Set(context.Background(), scope, "plan", map[string]any{"step": "collect"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if _, ok, err := store.Get(context.Background(), scope, "plan"); err != nil {
+		t.Fatalf("Get before delete: %v", err)
+	} else if !ok {
+		t.Fatal("expected entry before delete")
+	}
+
+	if err := store.Delete(context.Background(), scope, "plan"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok, err := store.Get(context.Background(), scope, "plan"); err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	} else if ok {
+		t.Fatal("entry still exists after delete")
+	}
+	entries, err := store.List(context.Background(), scope)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("entries after delete = %#v", entries)
 	}
 }


### PR DESCRIPTION
Adds bounded in-memory retention for terminal harness run states and conversation mirrors while preserving durable-store fallback and active subscriber compatibility.
Restores the coveragegate by adding focused behavior tests for every reported zero-coverage path across MCP adapter, checkpoints, goals, workflows, replay, networks, scheduler, and working memory.
Records red/green evidence in the engineering and long-term thinking logs.
Validated with the focused T01/package suites, coveragegate `PASS (total=84.7%, min=80.0%, zero-functions=0)`, `./scripts/test-regression.sh` `[regression] PASS`, and `git diff --check`.
