### PR TITLE
docs: add git & merge discipline to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This repository is a Go coding harness with a streamed run API, a CLI smoke-test client, and a growing catalog of local and optional remote tools.
 
+## Git & Merge Discipline
+
+- **Merge at the end of a unit of work — do not leave branches sitting.** This repo's `main` moves fast (many concurrent squash-merged PRs) and subsystems get reimplemented in parallel, so a branch left unmerged drifts behind quickly and turns into a conflict-heavy, duplicated-work mess to reconcile. It gets messy if you don't.
+- When a unit of work is reviewable: open the PR, get CI green (re-run known-flaky checks rather than merging red), and squash-merge to `main` promptly. Then delete the branch.
+- Prefer small, scoped PRs that merge quickly over long-lived branches that accumulate multiple units of work. Always branch from the latest `origin/main`, not an older base.
+
 ## Current Source Of Truth
 
 - The canonical implementation details are in `internal/server`, `internal/harness`, `internal/config`, `cmd/harnessd`, and `cmd/harnesscli`.


### PR DESCRIPTION
Codifies the workflow lesson from this session: `main` moves fast with many concurrent squash-merged PRs, and subsystems get reimplemented in parallel, so an unmerged branch drifts and becomes a conflict-heavy, duplicated-work mess (exactly what happened with the stale relay branch). Adds a short **Git & Merge Discipline** section to `CLAUDE.md`: merge each unit of work promptly, keep PRs small and scoped, branch from the latest `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)