### PR TITLE
prompts: add interactive intent so local go-code is conversational

### DIFF
--- a/prompts/catalog.yaml
+++ b/prompts/catalog.yaml
@@ -4,6 +4,7 @@ defaults:
   model_profile: default
 intents:
   general: intents/general.md
+  interactive: intents/interactive.md
   code_review: intents/code_review.md
   frontend_design: intents/frontend_design.md
 model_profiles:

--- a/prompts/intents/interactive.md
+++ b/prompts/intents/interactive.md
@@ -1,0 +1,27 @@
+Interactive operating mode:
+
+You are working alongside a human in a live terminal session, inside the
+project directory where they launched you. There IS a user present — talk to
+them.
+
+- Answer conversational messages conversationally. A greeting like "hello", a
+  question, or "thanks" gets a direct, friendly reply — do NOT run tools,
+  explore the filesystem, or treat it as a task to complete.
+- Only use tools (read, edit, bash, etc.) when the user actually asks you to do
+  or find something. Match the effort to the request: don't run reconnaissance
+  commands "just in case."
+- When there IS real work, do it directly with your tools rather than only
+  describing it — but keep the user in the loop and prefer the smallest change
+  that satisfies the request.
+- You MAY ask the user a brief clarifying question when a request is genuinely
+  ambiguous and the answer changes what you do. Don't ask for permission to do
+  the obvious thing.
+- Do not report "task status" or "NOT DONE" for casual conversation. Reserve
+  step-by-step task framing for actual multi-step work the user requested.
+
+Environment:
+- You are running on the user's own machine, in their current working
+  directory — not a sandboxed container. Do not assume paths like `/app`, do
+  not assume you are root, and do not use `sudo` unless the user asks.
+- Use relative paths from the current directory, or absolute paths the user
+  gives you. Discover the working directory only when a task actually needs it.

--- a/scripts/go-code.sh
+++ b/scripts/go-code.sh
@@ -184,8 +184,15 @@ start_server() {
   local harnessd_bin
   harnessd_bin="$(command -v harnessd)"
 
+  # go-code is the local, interactive entry point: default the agent to the
+  # conversational "interactive" intent rather than the container/benchmark
+  # "general" intent (which assumes /app, Docker root, and task-completion
+  # framing). The benchmark harness invokes harnessd directly and is unaffected.
+  # An explicit HARNESS_DEFAULT_AGENT_INTENT always wins.
+  local intent="${HARNESS_DEFAULT_AGENT_INTENT:-interactive}"
+
   # Start in background, capturing the PID.
-  HARNESS_ADDR=":${port}" "$harnessd_bin" &
+  HARNESS_ADDR=":${port}" HARNESS_DEFAULT_AGENT_INTENT="${intent}" "$harnessd_bin" &
   local pid=$!
   PID_FILE="${TMPDIR:-/tmp}/harnessd.${$}.pid"
   echo "$pid" > "$PID_FILE"


### PR DESCRIPTION
## Problem

A plain "Hello!" in the interactive TUI made the agent run `/app` filesystem recon (`find /app …`, `pwd`, `ls /`, repo `find`) and then reply **"Task status: NOT DONE (no actionable task provided)"** instead of greeting the user.

**Root cause:** the default agent intent is `general` (`prompts/catalog.yaml`), and `prompts/intents/general.md` is written entirely for the **containerized benchmark harness** — it states "there is NO user to respond to questions", "YOU ARE ROOT… Docker container", tells the model to `find /app -maxdepth 3 -type f` for "task files", and imposes a task-completion protocol on every turn. Local interactive runs inherited all of it.

## Fix

- **`prompts/intents/interactive.md`** (new): a conversational, environment-neutral intent — there *is* a user, greet/answer directly, use tools only when there's real work, no `/app`/Docker-root assumptions, operate in the user's own cwd, don't emit "task status" for chit-chat.
- **`prompts/catalog.yaml`**: register `interactive`. `general` stays the default so the benchmark harness is unchanged.
- **`scripts/go-code.sh`**: the local entry point now defaults `HARNESS_DEFAULT_AGENT_INTENT=interactive` when starting `harnessd` (an explicit env value still wins). The benchmark invokes `harnessd` directly and keeps `general`.

## Verified

- `internal/systemprompt` catalog validation passes with the new intent.
- Direct compose check: the `interactive` prompt is conversational with no container framing; `general` still carries the `/app`/Docker framing (benchmark unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)