### PR TITLE
feat: wire four registered/registrable tools to real backends

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -13,6 +13,7 @@ import (
 	githubadapter "go-agent-harness/internal/github"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/deferred"
 	linearadapter "go-agent-harness/internal/linear"
 	"go-agent-harness/internal/networks"
 	"go-agent-harness/internal/provider/anthropic"
@@ -373,6 +374,7 @@ type serverBootstrapOptions struct {
 	providerRegistry *catalog.ProviderRegistry
 	runStore         istore.Store
 	relayWorkerStore relay.WorkerStore
+	todos            deferred.TodoManager
 	triggers         triggerRuntime
 	rolloutDir       string
 }
@@ -393,6 +395,7 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		ProviderRegistry: opts.providerRegistry,
 		Store:            opts.runStore,
 		RelayWorkerStore: opts.relayWorkerStore,
+		Todos:            opts.todos,
 		Validators:       opts.triggers.validators,
 		GitHubAdapter:    opts.triggers.github,
 		SlackAdapter:     opts.triggers.slack,

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -25,6 +25,7 @@ import (
 	"go-agent-harness/internal/fakeprovider"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/deferred"
 	"go-agent-harness/internal/mcp"
 	"go-agent-harness/internal/networks"
 	om "go-agent-harness/internal/observationalmemory"
@@ -34,6 +35,7 @@ import (
 	"go-agent-harness/internal/provider/pricing"
 	"go-agent-harness/internal/server"
 	"go-agent-harness/internal/skills"
+	"go-agent-harness/internal/skills/packs"
 	istore "go-agent-harness/internal/store"
 	"go-agent-harness/internal/store/s3backup"
 	"go-agent-harness/internal/systemprompt"
@@ -672,6 +674,32 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	if goWorkflowCacheDir == "" {
 		goWorkflowCacheDir = filepath.Join(workspace, ".harness", "workflow-cache")
 	}
+	// Shared todo store: one instance backs both the todos tool and the
+	// /v1/runs/{id}/todos HTTP route. The store is keyed by run ID internally,
+	// so a single process-wide instance keeps runs isolated.
+	todoManager, todosToolBuilder := deferred.NewTodoStore()
+
+	// Profile run store: powers get_efficiency_report (read) and per-run history
+	// persistence (write). Optional — on open failure the feature degrades to a
+	// no-history report rather than failing startup.
+	var profileReadStore deferred.ProfileRunStoreIface
+	var profileWriteStore istore.ProfileRunStoreIface
+	if ps, perr := istore.NewSQLiteProfileRunStore(filepath.Join(globalDir, "profile-runs.db")); perr != nil {
+		log.Printf("profile run store disabled: %v", perr)
+	} else {
+		profileWriteStore = ps
+		profileReadStore = profiles.NewEfficiencyReadAdapter(ps)
+		defer ps.Close()
+	}
+
+	// Skill pack registry: powers manage_skill_packs. Returns an empty (but
+	// usable) registry when the directory is absent.
+	packRegistry, perr := packs.NewPackRegistry(filepath.Join(globalDir, "skill-packs"))
+	if perr != nil {
+		log.Printf("skill pack registry disabled: %v", perr)
+		packRegistry = nil
+	}
+
 	baseRegistryOptions := harness.DefaultRegistryOptions{
 		ApprovalMode:       approvalMode,
 		Policy:             nil,
@@ -699,6 +727,9 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		ConversationStore: convStore,
 		MessageSummarizer: msgSummarizer,
 		MCPRegistry:       mcpRegistry,
+		ProfileRunStore:   profileReadStore,
+		PackRegistry:      packRegistry,
+		TodosTool:         todosToolBuilder,
 	}
 	tools := harness.NewDefaultRegistryWithOptions(workspace, baseRegistryOptions)
 	if rolloutDir != "" {
@@ -730,6 +761,10 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		WorktreeRootDir:     subagentWorktreeRoot,
 		BaseRegistryOptions: baseRegistryOptions,
 	})
+
+	// Persist per-run profile history so get_efficiency_report has data to
+	// aggregate. Nil when the store failed to open (feature degrades gracefully).
+	runnerCfg.ProfileRunStore = profileWriteStore
 
 	// S3 backup: wire uploader when all required env vars are present.
 	if s3cfg, ok := s3backup.ConfigFromEnv(getenv); ok {
@@ -839,6 +874,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		providerRegistry:     providerRegistry,
 		runStore:             runStore,
 		relayWorkerStore:     relayWorkerStore,
+		todos:                todoManager,
 		triggers:             triggerRuntime,
 		callbackStarter:      callbackStarter,
 		callbackBridge:       callbackBridge,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -10,6 +10,7 @@ import (
 	"go-agent-harness/internal/checkpoints"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/deferred"
 	"go-agent-harness/internal/mcpserver"
 	"go-agent-harness/internal/networks"
 	"go-agent-harness/internal/provider/catalog"
@@ -75,6 +76,7 @@ type httpRuntimeOptions struct {
 	providerRegistry     *catalog.ProviderRegistry
 	runStore             istore.Store
 	relayWorkerStore     relay.WorkerStore
+	todos                deferred.TodoManager
 	triggers             triggerRuntime
 	callbackStarter      *callbackRunStarter
 	callbackBridge       *harness.CallbackEventBridge
@@ -180,6 +182,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		providerRegistry: opts.providerRegistry,
 		runStore:         opts.runStore,
 		relayWorkerStore: opts.relayWorkerStore,
+		todos:            opts.todos,
 		triggers:         opts.triggers,
 		rolloutDir:       opts.runnerCfg.RolloutDir,
 	}))

--- a/internal/harness/tools/deferred/deploy.go
+++ b/internal/harness/tools/deferred/deploy.go
@@ -31,7 +31,7 @@ func DeployTool(registry DeployPlatformRegistry, workspaceRoot string) tools.Too
 		Mutating:     true,
 		ParallelSafe: false,
 		Tier:         tools.TierDeferred,
-		Tags:         []string{"deploy", "cloud", "infrastructure", "railway", "fly", "vercel", "cloudflare"},
+		Tags:         []string{"deploy", "cloud", "infrastructure", "railway", "fly"},
 		Parameters: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
@@ -94,9 +94,20 @@ func DeployTool(registry DeployPlatformRegistry, workspaceRoot string) tools.Too
 				return "", fmt.Errorf("detect platform: %w", err)
 			}
 			all := deploy.DetectAll(wsDir)
+			// Distinguish what we can DETECT from what we can actually DEPLOY:
+			// detection recognises more project types (e.g. vercel, cloudflare)
+			// than there are deploy adapters for. Report the deployable subset so
+			// the caller does not assume a detected platform can be deployed here.
+			deployable := make([]string, 0, len(all))
+			for _, p := range all {
+				if _, ok := registry[p]; ok {
+					deployable = append(deployable, p)
+				}
+			}
 			return tools.MarshalToolResult(map[string]any{
-				"platform": name,
-				"all":      all,
+				"platform":   name,
+				"all":        all,
+				"deployable": deployable,
 			})
 		}
 

--- a/internal/harness/tools/deferred/deploy_test.go
+++ b/internal/harness/tools/deferred/deploy_test.go
@@ -393,3 +393,54 @@ func TestDeployTool_ForceFlag(t *testing.T) {
 		t.Fatal("expected non-empty result")
 	}
 }
+
+// TestDeployTool_DoesNotAdvertiseUnbackedPlatforms guards the honesty fix: the
+// tool must not tag itself with platforms it has no deploy adapter for.
+func TestDeployTool_DoesNotAdvertiseUnbackedPlatforms(t *testing.T) {
+	tool := DeployTool(DefaultDeployPlatformRegistry(), t.TempDir())
+	for _, tag := range tool.Definition.Tags {
+		if tag == "vercel" || tag == "cloudflare" {
+			t.Errorf("deploy tool advertises %q but has no adapter for it; tags=%v", tag, tool.Definition.Tags)
+		}
+	}
+}
+
+// TestDeployTool_DetectReportsDeployableSubset verifies the detect action
+// separates what it can DETECT from what it can DEPLOY: a vercel project is
+// detected (in "all") but excluded from "deployable" since there is no adapter.
+func TestDeployTool_DetectReportsDeployableSubset(t *testing.T) {
+	dir := t.TempDir()
+	writeDeployFile(t, dir, "fly.toml")    // deployable
+	writeDeployFile(t, dir, "vercel.json") // detected only
+	tool := DeployTool(DefaultDeployPlatformRegistry(), dir)
+	args, _ := json.Marshal(map[string]string{"action": "detect"})
+	result, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	var parsed struct {
+		All        []string `json:"all"`
+		Deployable []string `json:"deployable"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("parse result %q: %v", result, err)
+	}
+	if !containsStr(parsed.All, "vercel") {
+		t.Errorf("expected vercel in detected 'all', got %v", parsed.All)
+	}
+	if containsStr(parsed.Deployable, "vercel") {
+		t.Errorf("vercel must not appear in 'deployable' (no adapter), got %v", parsed.Deployable)
+	}
+	if !containsStr(parsed.Deployable, "flyio") {
+		t.Errorf("expected flyio in 'deployable', got %v", parsed.Deployable)
+	}
+}
+
+func containsStr(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/harness/tools/deferred/todos_test.go
+++ b/internal/harness/tools/deferred/todos_test.go
@@ -1,8 +1,53 @@
 package deferred
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
+
+	tools "go-agent-harness/internal/harness/tools"
 )
+
+// TestNewTodoStore_ToolAndManagerShareStore is the regression test for the wiring
+// fix: a write performed through the LLM-facing tool handler (run ID taken from
+// context) must be visible through the TodoManager handed to the HTTP layer, and
+// vice-versa. Before the fix, TodosTool() built an isolated store so the
+// /v1/runs/{id}/todos route never saw tool writes.
+func TestNewTodoStore_ToolAndManagerShareStore(t *testing.T) {
+	t.Parallel()
+
+	mgr, toolFn := NewTodoStore()
+	tool := toolFn()
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunID, "run-shared")
+
+	// Write via the tool handler; read via the manager (HTTP path).
+	_, err := tool.Handler(ctx, json.RawMessage(`{"action":"set","todos":[{"id":"1","text":"from tool","status":"pending"}]}`))
+	if err != nil {
+		t.Fatalf("tool set: %v", err)
+	}
+	got := mgr.GetTodos("run-shared")
+	if len(got) != 1 || got[0].Text != "from tool" {
+		t.Fatalf("manager did not see tool write; got %+v", got)
+	}
+
+	// Write via the manager (HTTP path); read via the tool handler (get action).
+	if err := mgr.SetTodos("run-shared", []TodoItem{{ID: "2", Text: "from http", Status: "completed"}}); err != nil {
+		t.Fatalf("manager set: %v", err)
+	}
+	out, err := tool.Handler(ctx, json.RawMessage(`{"action":"get"}`))
+	if err != nil {
+		t.Fatalf("tool get: %v", err)
+	}
+	if want := "from http"; !strings.Contains(out, want) {
+		t.Fatalf("tool did not see manager write; got %s", out)
+	}
+
+	// Runs are isolated by run ID.
+	if other := mgr.GetTodos("run-other"); len(other) != 0 {
+		t.Fatalf("expected run isolation, got %+v", other)
+	}
+}
 
 func TestNewTodoStore_ReturnsManagerAndToolFactory(t *testing.T) {
 	t.Parallel()

--- a/internal/harness/tools_contract_test.go
+++ b/internal/harness/tools_contract_test.go
@@ -30,6 +30,7 @@ func TestDefaultRegistryToolContract(t *testing.T) {
 		"compact_history",
 		"context_status",
 		"create_prompt_extension",
+		"deploy",
 		"download",
 		"edit",
 		"file_inspect",

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -53,6 +53,10 @@ type DefaultRegistryOptions struct {
 	// ProfileRunStore is the optional store for profile run history.
 	// When non-nil, enables the get_efficiency_report tool.
 	ProfileRunStore deferred.ProfileRunStoreIface
+	// TodosTool, when non-nil, builds the todos tool bound to a store shared
+	// with the HTTP layer (see deferred.NewTodoStore). When nil, an isolated
+	// per-registry store is used and the /v1/runs/{id}/todos route sees nothing.
+	TodosTool func() htools.Tool
 }
 
 // conversationStoreAdapter adapts ConversationStore (harness package) to htools.ConversationReader.
@@ -229,7 +233,11 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 	deferredTools = append(deferredTools, deferred.CreatePromptExtensionTool(buildOpts.PromptExtensionDirs))
 
 	if buildOpts.EnableTodos {
-		coreTools = append(coreTools, deferred.TodosTool())
+		if opts.TodosTool != nil {
+			coreTools = append(coreTools, opts.TodosTool())
+		} else {
+			coreTools = append(coreTools, deferred.TodosTool())
+		}
 	}
 	// LSP tools (lsp_diagnostics, lsp_references, lsp_restart) are intentionally
 	// absent from the default registry. See BuildOptions comment above.
@@ -390,6 +398,10 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 
 	// get_efficiency_report: always registered; returns no-history report when store is nil.
 	deferredTools = append(deferredTools, deferred.GetEfficiencyReportTool(opts.ProfileRunStore))
+
+	// deploy: always registered. The built-in registry supports the railway and
+	// flyio adapters; the tool reports its deployable platforms honestly.
+	deferredTools = append(deferredTools, deferred.DeployTool(deferred.DefaultDeployPlatformRegistry(), workspaceRoot))
 
 	// Deep git history tools: always registered since git is already required by the
 	// existing git_status and git_diff core tools.

--- a/internal/profiles/read_adapter.go
+++ b/internal/profiles/read_adapter.go
@@ -1,0 +1,60 @@
+package profiles
+
+import (
+	"context"
+
+	"go-agent-harness/internal/store"
+)
+
+// EfficiencyReadAdapter adapts a store.ProfileRunStoreIface (the persistence
+// interface implemented by store.SQLiteProfileRunStore) to the read-only
+// interface expected by the get_efficiency_report tool
+// (deferred.ProfileRunStoreIface).
+//
+// It bridges two concerns the tool and the store keep deliberately separate:
+//   - the tool speaks in profiles.ProfileStats and needs an explicit
+//     found bool ("does any history exist for this profile?");
+//   - the store speaks in store.ProfileStats and signals "no history" with
+//     RunCount == 0 rather than a bool.
+//
+// The adapter satisfies deferred.ProfileRunStoreIface structurally, so it can
+// be assigned to DefaultRegistryOptions.ProfileRunStore without profiles
+// importing the deferred package (which would create an import cycle, since
+// deferred already imports profiles).
+type EfficiencyReadAdapter struct {
+	store store.ProfileRunStoreIface
+}
+
+// NewEfficiencyReadAdapter wraps a profile run store for read access by the
+// efficiency report tool. Passing a nil store yields a nil adapter so callers
+// can treat "no store configured" uniformly.
+func NewEfficiencyReadAdapter(s store.ProfileRunStoreIface) *EfficiencyReadAdapter {
+	if s == nil {
+		return nil
+	}
+	return &EfficiencyReadAdapter{store: s}
+}
+
+// AggregateProfileStats returns aggregate statistics for the named profile as a
+// profiles.ProfileStats, plus a found bool that is false when no run history
+// exists for the profile (store RunCount == 0).
+//
+// TopTools and MaxSteps are left zero-valued: the store's aggregate query does
+// not compute cross-run tool frequency or the profile's configured max_steps,
+// and the efficiency report treats both as optional.
+func (a *EfficiencyReadAdapter) AggregateProfileStats(ctx context.Context, profileName string) (ProfileStats, bool, error) {
+	st, err := a.store.AggregateProfileStats(ctx, profileName)
+	if err != nil {
+		return ProfileStats{}, false, err
+	}
+	if st.RunCount == 0 {
+		return ProfileStats{}, false, nil
+	}
+	return ProfileStats{
+		ProfileName: st.ProfileName,
+		RunCount:    st.RunCount,
+		AvgSteps:    st.AvgSteps,
+		AvgCostUSD:  st.AvgCostUSD,
+		SuccessRate: st.SuccessRate,
+	}, true, nil
+}

--- a/internal/profiles/read_adapter_test.go
+++ b/internal/profiles/read_adapter_test.go
@@ -1,0 +1,73 @@
+package profiles
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go-agent-harness/internal/store"
+)
+
+// fakeAggStore implements store.ProfileRunStoreIface for adapter tests.
+type fakeAggStore struct {
+	stats store.ProfileStats
+	err   error
+}
+
+func (f *fakeAggStore) RecordProfileRun(context.Context, store.ProfileRunRecord) error {
+	return nil
+}
+func (f *fakeAggStore) QueryRecentProfileRuns(context.Context, string, int) ([]store.ProfileRunRecord, error) {
+	return nil, nil
+}
+func (f *fakeAggStore) AggregateProfileStats(context.Context, string) (store.ProfileStats, error) {
+	return f.stats, f.err
+}
+
+func TestEfficiencyReadAdapter_FoundWhenHistoryExists(t *testing.T) {
+	adapter := NewEfficiencyReadAdapter(&fakeAggStore{stats: store.ProfileStats{
+		ProfileName: "researcher",
+		RunCount:    4,
+		AvgSteps:    12.5,
+		AvgCostUSD:  0.42,
+		SuccessRate: 0.75,
+	}})
+	got, found, err := adapter.AggregateProfileStats(context.Background(), "researcher")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found=true when RunCount>0")
+	}
+	if got.RunCount != 4 || got.AvgSteps != 12.5 || got.AvgCostUSD != 0.42 || got.SuccessRate != 0.75 {
+		t.Errorf("field mismatch: %+v", got)
+	}
+	if got.ProfileName != "researcher" {
+		t.Errorf("profile name mismatch: %q", got.ProfileName)
+	}
+}
+
+func TestEfficiencyReadAdapter_NotFoundWhenNoHistory(t *testing.T) {
+	adapter := NewEfficiencyReadAdapter(&fakeAggStore{stats: store.ProfileStats{ProfileName: "x", RunCount: 0}})
+	_, found, err := adapter.AggregateProfileStats(context.Background(), "x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false when RunCount==0")
+	}
+}
+
+func TestEfficiencyReadAdapter_PropagatesError(t *testing.T) {
+	adapter := NewEfficiencyReadAdapter(&fakeAggStore{err: errors.New("db down")})
+	_, _, err := adapter.AggregateProfileStats(context.Background(), "x")
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestNewEfficiencyReadAdapter_NilStoreYieldsNil(t *testing.T) {
+	if NewEfficiencyReadAdapter(nil) != nil {
+		t.Fatal("expected nil adapter for nil store")
+	}
+}


### PR DESCRIPTION
## What

Four tools whose handlers already worked but whose **production wiring was missing** — so they returned empty data, stayed unregistered, or advertised capabilities they lacked. This connects each to a real backend. (Wave 1 of the "wire the orphaned/fake features" effort.)

| Tool | Before | After |
|------|--------|-------|
| `deploy` | defined but **never registered**; tags advertised `vercel`/`cloudflare` with no adapters | registered in the default catalog; false tags removed; `detect` reports a `deployable` subset vs `all` |
| `manage_skill_packs` | gated on a `PackRegistry` nothing ever built → always inert | registry constructed from `<globalDir>/skill-packs` |
| `todos` | tool used an **isolated** store; HTTP `Todos` never set → GET empty / PUT 501 | one run-keyed store shared between the tool and `/v1/runs/{id}/todos` |
| `get_efficiency_report` | store fields never assigned → always "no history" | SQLite profile store wired on both write (per-run persistence) and read (via new adapter) |

## Notable details

- **todos**: the `todoStore` is internally keyed by run ID, so a single process-wide instance shared via `deferred.NewTodoStore()` keeps runs isolated while making tool writes visible to the HTTP route and vice-versa.
- **get_efficiency_report**: the SQLite store satisfies the *write* interface directly but not the *read* interface (`store.ProfileStats` + no bool vs `profiles.ProfileStats` + `found` bool). A new `profiles.EfficiencyReadAdapter` bridges them without an import cycle (it lives in `profiles`, which already imports `store`, and satisfies the `deferred` interface structurally). Every field degrades to nil gracefully if the DB can't open — no startup failure.
- **deploy honesty**: detection of a `vercel.json`/`wrangler.toml` is still reported (it's a true statement), but clearly separated from what the tool can deploy.

## Tests
- Cross-path todos sharing (tool write ↔ HTTP manager read) + run isolation
- Deploy tag honesty (no vercel/cloudflare tags) + `deployable`-subset filtering
- Efficiency adapter found/not-found/error semantics + nil-store handling
- Tool-contract golden count updated 28→29 for the newly-registered `deploy`

`go vet ./...` clean; full `./internal/... ./cmd/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)