### PR TITLE
feat: wire the goals subsystem for real (persistent + registered)

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -23,6 +23,7 @@ import (
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/cron"
 	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/goals"
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/harness/tools/deferred"
@@ -700,6 +701,18 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		packRegistry = nil
 	}
 
+	// Goals: persistent, cross-session goal tracking (the goals tool). Backed by
+	// SQLite; on open failure NewManager falls back to an in-memory store so the
+	// tool still works within the process (non-persistent) rather than vanishing.
+	var goalStore goals.Store
+	if gs, gerr := goals.NewSQLiteStore(filepath.Join(globalDir, "goals.db")); gerr != nil {
+		log.Printf("goals persistence disabled (using in-memory): %v", gerr)
+	} else {
+		goalStore = gs
+		defer gs.Close()
+	}
+	goalManager := goals.NewManager(goalStore)
+
 	baseRegistryOptions := harness.DefaultRegistryOptions{
 		ApprovalMode:       approvalMode,
 		Policy:             nil,
@@ -730,6 +743,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		ProfileRunStore:   profileReadStore,
 		PackRegistry:      packRegistry,
 		TodosTool:         todosToolBuilder,
+		GoalManager:       goalManager,
 	}
 	tools := harness.NewDefaultRegistryWithOptions(workspace, baseRegistryOptions)
 	if rolloutDir != "" {

--- a/internal/goals/store_sqlite.go
+++ b/internal/goals/store_sqlite.go
@@ -1,0 +1,393 @@
+package goals
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// goalsSchema defines the goals table. Slice/map fields are stored as JSON TEXT
+// and timestamps as RFC3339Nano strings. completed_at is nullable (NULL when the
+// goal has no completion time).
+const goalsSchema = `
+CREATE TABLE IF NOT EXISTS goals (
+	id                 TEXT PRIMARY KEY,
+	name               TEXT NOT NULL DEFAULT '',
+	description        TEXT NOT NULL DEFAULT '',
+	status             TEXT NOT NULL DEFAULT '',
+	progress_total     INTEGER NOT NULL DEFAULT 0,
+	progress_completed INTEGER NOT NULL DEFAULT 0,
+	progress_percent   INTEGER NOT NULL DEFAULT 0,
+	depends_on         TEXT NOT NULL DEFAULT '[]',
+	blocks             TEXT NOT NULL DEFAULT '[]',
+	verify_criteria    TEXT NOT NULL DEFAULT '',
+	metadata           TEXT NOT NULL DEFAULT '{}',
+	result             TEXT NOT NULL DEFAULT '',
+	error              TEXT NOT NULL DEFAULT '',
+	created_at         TEXT NOT NULL,
+	updated_at         TEXT NOT NULL,
+	completed_at       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_goals_status  ON goals(status);
+CREATE INDEX IF NOT EXISTS idx_goals_created ON goals(created_at);
+`
+
+// SQLiteStore is a durable, SQLite-backed implementation of the Store interface.
+// It is safe for concurrent use.
+type SQLiteStore struct {
+	mu sync.Mutex
+	db *sql.DB
+}
+
+// compile-time assertion that *SQLiteStore satisfies the Store interface.
+var _ Store = (*SQLiteStore)(nil)
+
+// NewSQLiteStore opens (or creates) a SQLite database at path and applies the
+// goals schema. The returned store is ready to use immediately.
+func NewSQLiteStore(path string) (*SQLiteStore, error) {
+	if path == "" {
+		return nil, fmt.Errorf("goals store: path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("goals store: create directory: %w", err)
+	}
+	dsn := path + "?_txlock=immediate"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("goals store: open: %w", err)
+	}
+	// Single writer to avoid SQLITE_BUSY.
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(`PRAGMA journal_mode=WAL;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("goals store: set WAL: %w", err)
+	}
+	if _, err := db.Exec(`PRAGMA busy_timeout=5000;`); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("goals store: busy timeout: %w", err)
+	}
+	if _, err := db.Exec(goalsSchema); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("goals store: migrate: %w", err)
+	}
+	return &SQLiteStore{db: db}, nil
+}
+
+// Close releases the database connection. It is safe to call on a nil store.
+func (s *SQLiteStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Create inserts a new goal. The caller is expected to have set the ID and
+// timestamps (the Manager does this before calling the store).
+func (s *SQLiteStore) Create(ctx context.Context, goal *Goal) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dependsOn, err := json.Marshal(goal.DependsOn)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal depends_on: %w", err)
+	}
+	blocks, err := json.Marshal(goal.Blocks)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal blocks: %w", err)
+	}
+	metadata, err := json.Marshal(goal.Metadata)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal metadata: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO goals
+	(id, name, description, status,
+	 progress_total, progress_completed, progress_percent,
+	 depends_on, blocks, verify_criteria, metadata,
+	 result, error, created_at, updated_at, completed_at)
+VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`,
+		goal.ID,
+		goal.Name,
+		goal.Description,
+		string(goal.Status),
+		goal.Progress.Total,
+		goal.Progress.Completed,
+		goal.Progress.Percent,
+		string(dependsOn),
+		string(blocks),
+		goal.VerifyCriteria,
+		string(metadata),
+		goal.Result,
+		goal.Error,
+		timeString(goal.CreatedAt),
+		timeString(goal.UpdatedAt),
+		nullableTime(goal.CompletedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("goals store: create goal: %w", err)
+	}
+	return nil
+}
+
+// Get returns the goal with the given id, or a "not found" error.
+func (s *SQLiteStore) Get(ctx context.Context, id string) (*Goal, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	row := s.db.QueryRowContext(ctx, selectColumns+` WHERE id = ?`, id)
+	goal, err := scanGoal(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("goal %q not found", id)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("goals store: get goal: %w", err)
+	}
+	return goal, nil
+}
+
+// Update replaces an existing goal. It returns a "not found" error if no goal
+// with the given ID exists.
+func (s *SQLiteStore) Update(ctx context.Context, goal *Goal) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dependsOn, err := json.Marshal(goal.DependsOn)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal depends_on: %w", err)
+	}
+	blocks, err := json.Marshal(goal.Blocks)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal blocks: %w", err)
+	}
+	metadata, err := json.Marshal(goal.Metadata)
+	if err != nil {
+		return fmt.Errorf("goals store: marshal metadata: %w", err)
+	}
+
+	res, err := s.db.ExecContext(ctx, `
+UPDATE goals SET
+	name = ?, description = ?, status = ?,
+	progress_total = ?, progress_completed = ?, progress_percent = ?,
+	depends_on = ?, blocks = ?, verify_criteria = ?, metadata = ?,
+	result = ?, error = ?, created_at = ?, updated_at = ?, completed_at = ?
+WHERE id = ?
+`,
+		goal.Name,
+		goal.Description,
+		string(goal.Status),
+		goal.Progress.Total,
+		goal.Progress.Completed,
+		goal.Progress.Percent,
+		string(dependsOn),
+		string(blocks),
+		goal.VerifyCriteria,
+		string(metadata),
+		goal.Result,
+		goal.Error,
+		timeString(goal.CreatedAt),
+		timeString(goal.UpdatedAt),
+		nullableTime(goal.CompletedAt),
+		goal.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("goals store: update goal: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("goals store: update goal rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("goal %q not found", goal.ID)
+	}
+	return nil
+}
+
+// Delete removes the goal with the given id, or returns a "not found" error.
+func (s *SQLiteStore) Delete(ctx context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	res, err := s.db.ExecContext(ctx, `DELETE FROM goals WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("goals store: delete goal: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("goals store: delete goal rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("goal %q not found", id)
+	}
+	return nil
+}
+
+// List returns goals matching the filter. It filters by Status (empty = all),
+// sorts by SortBy ("created_at" default, "updated_at", "name"), reverses when
+// SortDesc is set, then applies Offset and Limit (Limit==0 = unlimited).
+// Sorting and pagination are performed in Go so that variable-width
+// RFC3339Nano timestamps compare chronologically rather than lexically.
+func (s *SQLiteStore) List(ctx context.Context, filter GoalFilter) ([]Goal, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	query := selectColumns
+	var args []any
+	if filter.Status != "" {
+		query += ` WHERE status = ?`
+		args = append(args, string(filter.Status))
+	}
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("goals store: list goals: %w", err)
+	}
+	defer rows.Close()
+
+	var goals []Goal
+	for rows.Next() {
+		g, err := scanGoal(rows)
+		if err != nil {
+			return nil, fmt.Errorf("goals store: scan goal: %w", err)
+		}
+		goals = append(goals, *g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("goals store: list goals rows: %w", err)
+	}
+
+	sortGoals(goals, filter.SortBy, filter.SortDesc)
+
+	// Apply offset then limit.
+	if filter.Offset > 0 {
+		if filter.Offset < len(goals) {
+			goals = goals[filter.Offset:]
+		} else {
+			goals = nil
+		}
+	}
+	if filter.Limit > 0 && filter.Limit < len(goals) {
+		goals = goals[:filter.Limit]
+	}
+	return goals, nil
+}
+
+// selectColumns is the shared SELECT prefix for Get and List.
+const selectColumns = `
+SELECT id, name, description, status,
+       progress_total, progress_completed, progress_percent,
+       depends_on, blocks, verify_criteria, metadata,
+       result, error, created_at, updated_at, completed_at
+FROM goals`
+
+// rowScanner abstracts *sql.Row and *sql.Rows so scanGoal works with both.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanGoal reads one goal row into a *Goal.
+func scanGoal(sc rowScanner) (*Goal, error) {
+	var g Goal
+	var status string
+	var dependsOnJSON, blocksJSON, metadataJSON string
+	var createdText, updatedText string
+	var completedText sql.NullString
+
+	if err := sc.Scan(
+		&g.ID,
+		&g.Name,
+		&g.Description,
+		&status,
+		&g.Progress.Total,
+		&g.Progress.Completed,
+		&g.Progress.Percent,
+		&dependsOnJSON,
+		&blocksJSON,
+		&g.VerifyCriteria,
+		&metadataJSON,
+		&g.Result,
+		&g.Error,
+		&createdText,
+		&updatedText,
+		&completedText,
+	); err != nil {
+		return nil, err
+	}
+
+	g.Status = Status(status)
+
+	if dependsOnJSON != "" && dependsOnJSON != "null" {
+		if err := json.Unmarshal([]byte(dependsOnJSON), &g.DependsOn); err != nil {
+			return nil, fmt.Errorf("unmarshal depends_on: %w", err)
+		}
+	}
+	if blocksJSON != "" && blocksJSON != "null" {
+		if err := json.Unmarshal([]byte(blocksJSON), &g.Blocks); err != nil {
+			return nil, fmt.Errorf("unmarshal blocks: %w", err)
+		}
+	}
+	if metadataJSON != "" && metadataJSON != "null" {
+		if err := json.Unmarshal([]byte(metadataJSON), &g.Metadata); err != nil {
+			return nil, fmt.Errorf("unmarshal metadata: %w", err)
+		}
+	}
+
+	if t, err := time.Parse(time.RFC3339Nano, createdText); err == nil {
+		g.CreatedAt = t
+	}
+	if t, err := time.Parse(time.RFC3339Nano, updatedText); err == nil {
+		g.UpdatedAt = t
+	}
+	if completedText.Valid && completedText.String != "" {
+		if t, err := time.Parse(time.RFC3339Nano, completedText.String); err == nil {
+			g.CompletedAt = &t
+		}
+	}
+
+	return &g, nil
+}
+
+// sortGoals sorts goals in place per the given field and direction.
+func sortGoals(goals []Goal, sortBy string, desc bool) {
+	less := func(i, j int) bool {
+		switch sortBy {
+		case "name":
+			return goals[i].Name < goals[j].Name
+		case "updated_at":
+			return goals[i].UpdatedAt.Before(goals[j].UpdatedAt)
+		default: // "created_at" and empty
+			return goals[i].CreatedAt.Before(goals[j].CreatedAt)
+		}
+	}
+	sort.SliceStable(goals, func(i, j int) bool {
+		if desc {
+			return less(j, i)
+		}
+		return less(i, j)
+	})
+}
+
+// timeString formats a time as an RFC3339Nano UTC string for storage.
+func timeString(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// nullableTime returns a sql-storable value for a *time.Time: NULL when nil,
+// otherwise an RFC3339Nano string.
+func nullableTime(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return timeString(*t)
+}

--- a/internal/goals/store_sqlite_test.go
+++ b/internal/goals/store_sqlite_test.go
@@ -1,0 +1,285 @@
+package goals
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "goals.db")
+	st, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestSQLiteStore_CreateGetRoundTrip(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	completed := time.Date(2026, 7, 12, 10, 30, 0, 123456789, time.UTC)
+	full := &Goal{
+		ID:          "g-full",
+		Name:        "Full goal",
+		Description: "a description",
+		Status:      StatusCompleted,
+		Progress:    Progress{Total: 10, Completed: 4, Percent: 40},
+		DependsOn:   []string{"a", "b"},
+		Blocks:      []string{"c"},
+		VerifyCriteria: "all tests pass",
+		Metadata:    map[string]string{"key1": "val1", "key2": "val2"},
+		Result:      "done",
+		Error:       "",
+		CreatedAt:   time.Date(2026, 7, 12, 9, 0, 0, 111, time.UTC),
+		UpdatedAt:   time.Date(2026, 7, 12, 9, 30, 0, 222, time.UTC),
+		CompletedAt: &completed,
+	}
+	if err := st.Create(ctx, full); err != nil {
+		t.Fatalf("Create full: %v", err)
+	}
+
+	got, err := st.Get(ctx, "g-full")
+	if err != nil {
+		t.Fatalf("Get full: %v", err)
+	}
+	if got.ID != full.ID || got.Name != full.Name || got.Description != full.Description {
+		t.Errorf("scalar fields mismatch: got %+v", got)
+	}
+	if got.Status != StatusCompleted {
+		t.Errorf("Status = %q, want %q", got.Status, StatusCompleted)
+	}
+	if got.Progress != full.Progress {
+		t.Errorf("Progress = %+v, want %+v", got.Progress, full.Progress)
+	}
+	if len(got.DependsOn) != 2 || got.DependsOn[0] != "a" || got.DependsOn[1] != "b" {
+		t.Errorf("DependsOn = %v, want [a b]", got.DependsOn)
+	}
+	if len(got.Blocks) != 1 || got.Blocks[0] != "c" {
+		t.Errorf("Blocks = %v, want [c]", got.Blocks)
+	}
+	if got.VerifyCriteria != full.VerifyCriteria {
+		t.Errorf("VerifyCriteria = %q, want %q", got.VerifyCriteria, full.VerifyCriteria)
+	}
+	if len(got.Metadata) != 2 || got.Metadata["key1"] != "val1" || got.Metadata["key2"] != "val2" {
+		t.Errorf("Metadata = %v, want map[key1:val1 key2:val2]", got.Metadata)
+	}
+	if got.Result != "done" {
+		t.Errorf("Result = %q, want done", got.Result)
+	}
+	if !got.CreatedAt.Equal(full.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, full.CreatedAt)
+	}
+	if !got.UpdatedAt.Equal(full.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", got.UpdatedAt, full.UpdatedAt)
+	}
+	if got.CompletedAt == nil {
+		t.Fatalf("CompletedAt = nil, want %v", completed)
+	}
+	if !got.CompletedAt.Equal(completed) {
+		t.Errorf("CompletedAt = %v, want %v", got.CompletedAt, completed)
+	}
+
+	// Second goal with nil CompletedAt must round-trip as nil.
+	nilCompleted := &Goal{
+		ID:        "g-nil",
+		Name:      "No completion",
+		Status:    StatusPending,
+		CreatedAt: time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 7, 12, 8, 0, 0, 0, time.UTC),
+	}
+	if err := st.Create(ctx, nilCompleted); err != nil {
+		t.Fatalf("Create nil-completed: %v", err)
+	}
+	got2, err := st.Get(ctx, "g-nil")
+	if err != nil {
+		t.Fatalf("Get nil-completed: %v", err)
+	}
+	if got2.CompletedAt != nil {
+		t.Errorf("CompletedAt = %v, want nil", got2.CompletedAt)
+	}
+}
+
+func TestSQLiteStore_NotFound(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := st.Get(ctx, "missing"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Get missing err = %v, want contains 'not found'", err)
+	}
+	if err := st.Update(ctx, &Goal{ID: "missing"}); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Update missing err = %v, want contains 'not found'", err)
+	}
+	if err := st.Delete(ctx, "missing"); err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Delete missing err = %v, want contains 'not found'", err)
+	}
+}
+
+func TestSQLiteStore_UpdatePersists(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	g := &Goal{
+		ID:        "g1",
+		Name:      "original",
+		Status:    StatusPending,
+		CreatedAt: time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC),
+	}
+	if err := st.Create(ctx, g); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	g.Name = "changed"
+	g.Status = StatusRunning
+	g.Result = "partial"
+	g.Progress = Progress{Total: 4, Completed: 2, Percent: 50}
+	if err := st.Update(ctx, g); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	got, err := st.Get(ctx, "g1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != "changed" || got.Status != StatusRunning || got.Result != "partial" {
+		t.Errorf("update not persisted: got %+v", got)
+	}
+	if got.Progress != (Progress{Total: 4, Completed: 2, Percent: 50}) {
+		t.Errorf("Progress = %+v, want {4 2 50}", got.Progress)
+	}
+}
+
+func TestSQLiteStore_List(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	base := time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC)
+	goals := []*Goal{
+		{ID: "1", Name: "charlie", Status: StatusPending, CreatedAt: base, UpdatedAt: base},
+		{ID: "2", Name: "alpha", Status: StatusRunning, CreatedAt: base.Add(time.Minute), UpdatedAt: base.Add(time.Minute)},
+		{ID: "3", Name: "bravo", Status: StatusPending, CreatedAt: base.Add(2 * time.Minute), UpdatedAt: base.Add(2 * time.Minute)},
+	}
+	for _, g := range goals {
+		if err := st.Create(ctx, g); err != nil {
+			t.Fatalf("Create %s: %v", g.ID, err)
+		}
+	}
+
+	// Status filter returns only matching.
+	pending, err := st.List(ctx, GoalFilter{Status: StatusPending})
+	if err != nil {
+		t.Fatalf("List pending: %v", err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("pending count = %d, want 2", len(pending))
+	}
+	for _, g := range pending {
+		if g.Status != StatusPending {
+			t.Errorf("got status %q in pending filter", g.Status)
+		}
+	}
+
+	// Empty filter returns all.
+	all, err := st.List(ctx, GoalFilter{})
+	if err != nil {
+		t.Fatalf("List all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("all count = %d, want 3", len(all))
+	}
+
+	// No match returns empty (not error).
+	failed, err := st.List(ctx, GoalFilter{Status: StatusFailed})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(failed) != 0 {
+		t.Errorf("failed count = %d, want 0", len(failed))
+	}
+
+	// Sort by name descending: charlie, bravo, alpha.
+	byNameDesc, err := st.List(ctx, GoalFilter{SortBy: "name", SortDesc: true})
+	if err != nil {
+		t.Fatalf("List name desc: %v", err)
+	}
+	wantNames := []string{"charlie", "bravo", "alpha"}
+	if len(byNameDesc) != 3 {
+		t.Fatalf("byNameDesc count = %d, want 3", len(byNameDesc))
+	}
+	for i, want := range wantNames {
+		if byNameDesc[i].Name != want {
+			t.Errorf("byNameDesc[%d].Name = %q, want %q", i, byNameDesc[i].Name, want)
+		}
+	}
+
+	// Sort by name ascending with Limit=1, Offset=1: skip alpha, take bravo.
+	page, err := st.List(ctx, GoalFilter{SortBy: "name", Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("List page: %v", err)
+	}
+	if len(page) != 1 {
+		t.Fatalf("page count = %d, want 1", len(page))
+	}
+	if page[0].Name != "bravo" {
+		t.Errorf("page[0].Name = %q, want bravo", page[0].Name)
+	}
+
+	// Default sort is created_at ascending: charlie, alpha, bravo.
+	byCreated, err := st.List(ctx, GoalFilter{})
+	if err != nil {
+		t.Fatalf("List default: %v", err)
+	}
+	wantOrder := []string{"charlie", "alpha", "bravo"}
+	for i, want := range wantOrder {
+		if byCreated[i].Name != want {
+			t.Errorf("byCreated[%d].Name = %q, want %q", i, byCreated[i].Name, want)
+		}
+	}
+}
+
+func TestSQLiteStore_PersistAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "goals.db")
+
+	st, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	g := &Goal{
+		ID:        "persist",
+		Name:      "survives restart",
+		Status:    StatusRunning,
+		Metadata:  map[string]string{"a": "1"},
+		CreatedAt: time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 7, 12, 9, 0, 0, 0, time.UTC),
+	}
+	if err := st.Create(ctx, g); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := NewSQLiteStore(path)
+	if err != nil {
+		t.Fatalf("reopen NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	got, err := reopened.Get(ctx, "persist")
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	if got.Name != "survives restart" || got.Status != StatusRunning {
+		t.Errorf("reopened goal mismatch: %+v", got)
+	}
+	if got.Metadata["a"] != "1" {
+		t.Errorf("Metadata not persisted: %v", got.Metadata)
+	}
+}

--- a/internal/harness/tools_contract_test.go
+++ b/internal/harness/tools_contract_test.go
@@ -6,8 +6,35 @@ import (
 	"testing"
 	"time"
 
+	"go-agent-harness/internal/goals"
 	htools "go-agent-harness/internal/harness/tools"
 )
+
+// TestGoalsToolRegistersWithManager verifies the goals tool is present exactly
+// when a GoalManager is wired: absent by default, registered when provided.
+func TestGoalsToolRegistersWithManager(t *testing.T) {
+	t.Parallel()
+
+	has := func(reg *Registry) bool {
+		for _, def := range reg.Definitions() {
+			if def.Name == "goals" {
+				return true
+			}
+		}
+		return false
+	}
+
+	if has(NewDefaultRegistry(t.TempDir())) {
+		t.Error("goals tool should not be registered without a GoalManager")
+	}
+
+	withMgr := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		GoalManager: goals.NewManager(nil),
+	})
+	if !has(withMgr) {
+		t.Error("goals tool should be registered when a GoalManager is provided")
+	}
+}
 
 func TestDefaultRegistryToolContract(t *testing.T) {
 	t.Parallel()

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -57,6 +57,9 @@ type DefaultRegistryOptions struct {
 	// with the HTTP layer (see deferred.NewTodoStore). When nil, an isolated
 	// per-registry store is used and the /v1/runs/{id}/todos route sees nothing.
 	TodosTool func() htools.Tool
+	// GoalManager, when non-nil, enables the goals tool for persistent,
+	// cross-session goal tracking. Backed by a persistent store in production.
+	GoalManager deferred.GoalCreator
 }
 
 // conversationStoreAdapter adapts ConversationStore (harness package) to htools.ConversationReader.
@@ -402,6 +405,14 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 	// deploy: always registered. The built-in registry supports the railway and
 	// flyio adapters; the tool reports its deployable platforms honestly.
 	deferredTools = append(deferredTools, deferred.DeployTool(deferred.DefaultDeployPlatformRegistry(), workspaceRoot))
+
+	// goals: registered when a goal manager is wired. Enables persistent,
+	// cross-session goal tracking with dependency chains.
+	if opts.GoalManager != nil {
+		if goalTool := deferred.NewGoalTools(opts.GoalManager); goalTool != nil {
+			deferredTools = append(deferredTools, goalTool())
+		}
+	}
 
 	// Deep git history tools: always registered since git is already required by the
 	// existing git_status and git_diff core tools.


### PR DESCRIPTION
## What

The goals subsystem (`internal/goals` + the goals tool) existed and was tested but was **fully orphaned**: the tool was never registered in any catalog, no manager or store was ever constructed, and the only `Store` implementation was in-memory. Agents never saw a goals tool, and nothing persisted across restarts. This makes it real.

## Changes

- **`internal/goals/store_sqlite.go`** — new `SQLiteStore`, a durable implementation of the existing `goals.Store` interface, modelled on the sibling `store.SQLiteProfileRunStore` (`modernc.org/sqlite`, WAL, single writer, `busy_timeout`). Slice/map fields (`depends_on`, `blocks`, `metadata`) are JSON columns; timestamps are RFC3339Nano; `completed_at` is nullable. `List` filters by status in SQL and sorts/paginates in Go so variable-width RFC3339Nano timestamps compare **chronologically rather than lexically**. Compile-time `Store` assertion + a full round-trip / reopen test suite.
- **`cmd/harnessd/main.go`** — construct a `goals.Manager` backed by `<globalDir>/goals.db`. If the DB can't open, `NewManager` falls back to the in-memory store so the tool still works within the process rather than disappearing.
- **`internal/harness/tools_default.go`** — register the goals tool when `DefaultRegistryOptions.GoalManager` is set. Absent by default (tool contract unchanged), present once a manager is provided.

## Tests
- New `TestGoalsToolRegistersWithManager` (present iff a manager is wired)
- SQLite store: field round-trip incl. nil/non-nil `CompletedAt`, not-found semantics, status filter, limit/offset/sort, persistence across reopen
- Full `./internal/... ./cmd/...` suite green

## Follow-up (not in this PR)
An HTTP route (e.g. `/v1/goals`) to expose goals to external operators, mirroring the todos route. The agent-facing tool + persistence is the core of making the subsystem real and lands here; the operator API is a clean, separable addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)