### PR TITLE
feat(server): add GET /v1/tools to enumerate the registered tool catalog

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -385,6 +385,7 @@ type serverBootstrapOptions struct {
 	runStore         istore.Store
 	relayWorkerStore relay.WorkerStore
 	relayControl     *relay.ControlPlane
+	tools            *harness.Registry
 	todos            deferred.TodoManager
 	triggers         triggerRuntime
 	rolloutDir       string
@@ -407,6 +408,7 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		Store:            opts.runStore,
 		RelayWorkerStore: opts.relayWorkerStore,
 		RelayControl:     opts.relayControl,
+		Tools:            opts.tools,
 		Todos:            opts.todos,
 		Validators:       opts.triggers.validators,
 		GitHubAdapter:    opts.triggers.github,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -184,6 +184,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		runStore:         opts.runStore,
 		relayWorkerStore: opts.relayWorkerStore,
 		relayControl:     opts.relayControl,
+		tools:            opts.tools,
 		todos:            opts.todos,
 		triggers:         opts.triggers,
 		rolloutDir:       opts.runnerCfg.RolloutDir,

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -128,6 +128,9 @@ type ServerOptions struct {
 	// event stores). When provided, the /v1/relay control-plane endpoints are
 	// enabled.
 	RelayControl *relay.ControlPlane
+	// Tools is the optional registered tool catalog. When provided, GET /v1/tools
+	// enumerates the tools available to agent runs.
+	Tools toolCatalog
 	// RolloutDir is the configured root directory for JSONL rollout files. When
 	// set (and auth is enabled), POST /v1/runs/replay enforces two-part safety:
 	//  1. Read-safety containment: the caller-supplied rollout_path must resolve
@@ -185,6 +188,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		linearAdapter:     opts.LinearAdapter,
 		relayWorkerStore:  opts.RelayWorkerStore,
 		relayControl:      opts.RelayControl,
+		toolCatalog:       opts.Tools,
 		rolloutDir:        opts.RolloutDir,
 		maxBodyBytes:      opts.MaxRequestBodyBytes,
 		replayBodyBytes:   opts.ReplayMaxRequestBodyBytes,
@@ -311,6 +315,9 @@ func (s *Server) buildMux() http.Handler {
 	mux.Handle("/v1/relay/operator/workers", auth(http.HandlerFunc(s.handleRelayOperatorWorkers)))
 	mux.Handle("/v1/relay/capabilities/", auth(http.HandlerFunc(s.handleRelayCapabilitiesByWorker)))
 
+	// /v1/tools — enumerate the registered tool catalog (runs:read).
+	mux.Handle("/v1/tools", auth(http.HandlerFunc(s.handleTools)))
+
 	return s.hardenHandler(mux)
 }
 
@@ -385,6 +392,8 @@ type Server struct {
 	// relayControl is the optional self-contained relay control plane enabling
 	// the /v1/relay placement, contract, policy, capability, and operator routes.
 	relayControl *relay.ControlPlane
+	// toolCatalog is the optional registered tool catalog for GET /v1/tools.
+	toolCatalog toolCatalog
 	// rolloutDir is the configured root directory for JSONL rollout files. When
 	// set (and auth is enabled), POST /v1/runs/replay enforces read-safety
 	// containment (rollout_path must resolve under this dir after symlink

--- a/internal/server/http_tools.go
+++ b/internal/server/http_tools.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"net/http"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/store"
+)
+
+// toolCatalog is the read-only view the server needs to enumerate the registered
+// LLM tool catalog. *harness.Registry satisfies it.
+type toolCatalog interface {
+	DefinitionsWithMetadata() []harness.ToolMetadata
+}
+
+// toolCatalogEntry is the flattened, cleanly-tagged JSON shape for one tool.
+// It decouples the HTTP contract from harness.ToolMetadata (whose fields carry
+// no JSON tags).
+type toolCatalogEntry struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Tier        string         `json:"tier"`
+	Tags        []string       `json:"tags,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+// handleTools handles GET /v1/tools: enumerate the registered tool catalog
+// (core and deferred), so operators and clients can see exactly which tools an
+// agent run has available without starting a run.
+func (s *Server) handleTools(w http.ResponseWriter, r *http.Request) {
+	if s.toolCatalog == nil {
+		writeError(w, http.StatusNotImplemented, "not_configured", "tool catalog not configured")
+		return
+	}
+	if !hasScope(r.Context(), store.ScopeRunsRead) {
+		writeScopeError(w, store.ScopeRunsRead)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	metas := s.toolCatalog.DefinitionsWithMetadata()
+	entries := make([]toolCatalogEntry, 0, len(metas))
+	for _, m := range metas {
+		entries = append(entries, toolCatalogEntry{
+			Name:        m.Definition.Name,
+			Description: m.Definition.Description,
+			Tier:        string(m.Tier),
+			Tags:        m.Tags,
+			Parameters:  m.Definition.Parameters,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"tools": entries,
+		"count": len(entries),
+	})
+}

--- a/internal/server/http_tools_test.go
+++ b/internal/server/http_tools_test.go
@@ -1,0 +1,78 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-agent-harness/internal/goals"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+)
+
+func TestToolsEndpoint_EnumeratesCatalog(t *testing.T) {
+	// A default registry with a goals manager wired: exercises both an
+	// always-registered tool (deploy) and a conditionally-registered one (goals).
+	reg := harness.NewDefaultRegistryWithOptions(t.TempDir(), harness.DefaultRegistryOptions{
+		GoalManager: goals.NewManager(nil),
+	})
+	h := server.NewWithOptions(server.ServerOptions{
+		AuthDisabled: true,
+		Tools:        reg,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/tools", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		Count int `json:"count"`
+		Tools []struct {
+			Name        string   `json:"name"`
+			Description string   `json:"description"`
+			Tier        string   `json:"tier"`
+			Tags        []string `json:"tags"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Count == 0 || resp.Count != len(resp.Tools) {
+		t.Fatalf("count %d does not match tools len %d", resp.Count, len(resp.Tools))
+	}
+
+	byName := make(map[string]bool, len(resp.Tools))
+	for _, tool := range resp.Tools {
+		byName[tool.Name] = true
+		if tool.Name == "" || tool.Tier == "" {
+			t.Errorf("tool has empty name or tier: %+v", tool)
+		}
+	}
+	for _, want := range []string{"deploy", "goals", "todos", "read", "bash"} {
+		if !byName[want] {
+			t.Errorf("expected tool %q in catalog; got %v", want, keysOf(byName))
+		}
+	}
+}
+
+func TestToolsEndpoint_NotConfigured501(t *testing.T) {
+	h := server.NewWithOptions(server.ServerOptions{AuthDisabled: true})
+	req := httptest.NewRequest(http.MethodGet, "/v1/tools", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotImplemented {
+		t.Errorf("status = %d, want 501", rec.Code)
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Why

There was no way to see which LLM tools an agent run has available **without starting a run** — the per-run tool registry was only visible to the model. That made the tool wiring from recent PRs (`deploy`, `goals`, `todos`, `get_efficiency_report`, `manage_skill_packs`) awkward to observe or verify from outside (as called out during testing).

## What

A read-only catalog endpoint mirroring the existing `/v1/networks` and `/v1/workflows` pattern.

- **`GET /v1/tools`** returns every registered tool (core + deferred) with `name`, `description`, `tier`, `tags`, and `parameters` schema, sourced from the process registry's `DefinitionsWithMetadata()`. Scope `runs:read`; `501` when no catalog is wired.
- The registry (already built in harnessd bootstrap and passed to the runner) is threaded to the server as `ServerOptions.Tools` via a small `toolCatalog` interface that `*harness.Registry` satisfies structurally — no new coupling, response DTO flattened so the HTTP contract is clean snake_case.

## Verified live
Against the built binary, `GET /v1/tools` reports all **44** registered tools, including the five recently wired ones with honest metadata (e.g. `deploy` → `tier: deferred`, `tags: [deploy, cloud, infrastructure, railway, fly]` — no phantom vercel/cloudflare).

## Tests
Unit: catalog contains `deploy`/`goals`/`todos`/`read`/`bash`, `count` matches `len(tools)`, `501` when unconfigured. Full `./internal/server/... ./cmd/harnessd/...` green.

## Note on the other item raised
Profile-run recording turned out **not** to need a change — it already records for any run with a `"profile"` field (not just subagents); my earlier summary was wrong. Verified live: a `researcher`-profiled run persisted `profile=researcher status=completed steps=2 tool_calls=1`. No code change, just a corrected claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)