### PR TITLE
fix(security): don't force-grant find_tool/skill to runs that restrict allowed_tools (#527)

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -2579,7 +2579,16 @@ func (r *Runner) filteredToolsForRun(runID string) []ToolDefinition {
 		allowed[name] = true
 	}
 	for name := range AlwaysAvailableTools {
-		allowed[name] = true
+		// When a run explicitly restricts its tools via allowed_tools, only
+		// AskUserQuestion is truly unconditional infrastructure. find_tool and
+		// skill must NOT be silently force-granted: find_tool can surface
+		// deferred tools and skill can activate a skill constraint whose own
+		// allowlist replaces this base filter — both would let a restricted run
+		// reach tools outside its allowed_tools boundary (issue #527). They are
+		// available only when the caller lists them explicitly.
+		if name == "AskUserQuestion" || allowed[name] {
+			allowed[name] = true
+		}
 	}
 	filtered := make([]ToolDefinition, 0, len(allowed))
 	for _, def := range defs {

--- a/internal/harness/runner_tool_filter_test.go
+++ b/internal/harness/runner_tool_filter_test.go
@@ -901,3 +901,73 @@ type funcProvider struct {
 func (p *funcProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResult, error) {
 	return p.fn(ctx, req)
 }
+
+// TestFindToolSkill_NotForceGrantedInRestrictedRun is the regression test for
+// the issue #527 security fix: when a run explicitly sets allowed_tools,
+// find_tool and skill must NOT be silently force-granted (they can reach tools
+// outside the allowlist — skill by activating a broader skill constraint), while
+// AskUserQuestion (pure infrastructure) stays available. When the caller lists
+// find_tool explicitly, it is available.
+func TestFindToolSkill_NotForceGrantedInRestrictedRun(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	reg := func(name string) {
+		_ = registry.Register(ToolDefinition{
+			Name: name, Description: name,
+			Parameters: map[string]any{"type": "object"},
+		}, func(_ context.Context, _ json.RawMessage) (string, error) { return `{}`, nil })
+	}
+	// Register the always-available infra tools plus a normal restricted tool.
+	for _, n := range []string{"AskUserQuestion", "find_tool", "skill", "read_thing", "bash"} {
+		reg(n)
+	}
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "gpt-4.1-mini", MaxSteps: 1})
+
+	// Restricted run: allowed_tools = [read_thing] only.
+	run, err := runner.StartRun(RunRequest{Prompt: "x", AllowedTools: []string{"read_thing"}})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collect events: %v", err)
+	}
+
+	names := make(map[string]bool)
+	for _, d := range runner.filteredToolsForRun(run.ID) {
+		names[d.Name] = true
+	}
+	if !names["read_thing"] {
+		t.Error("expected the explicitly-allowed tool read_thing to be available")
+	}
+	if !names["AskUserQuestion"] {
+		t.Error("expected AskUserQuestion to remain available (unconditional infrastructure)")
+	}
+	if names["find_tool"] {
+		t.Error("SECURITY: find_tool must NOT be force-granted to a run that restricted allowed_tools (issue #527)")
+	}
+	if names["skill"] {
+		t.Error("SECURITY: skill must NOT be force-granted to a run that restricted allowed_tools (issue #527)")
+	}
+	if names["bash"] {
+		t.Error("bash was not in allowed_tools and must be filtered out")
+	}
+
+	// When find_tool is explicitly allowed, it is available.
+	run2, err := runner.StartRun(RunRequest{Prompt: "y", AllowedTools: []string{"read_thing", "find_tool"}})
+	if err != nil {
+		t.Fatalf("start run2: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run2.ID); err != nil {
+		t.Fatalf("collect events2: %v", err)
+	}
+	names2 := make(map[string]bool)
+	for _, d := range runner.filteredToolsForRun(run2.ID) {
+		names2[d.Name] = true
+	}
+	if !names2["find_tool"] {
+		t.Error("find_tool should be available when explicitly listed in allowed_tools")
+	}
+}


### PR DESCRIPTION
## The bug (issue #527)

`AlwaysAvailableTools = {AskUserQuestion, find_tool, skill}`. In `filteredToolsForRun`, when a run **explicitly** sets `allowed_tools`, the base-allowed path added **all three** to the permitted set unconditionally — so a run restricted to, say, `[read]` still got `skill` and `find_tool`. That's a real escape hatch:

- **`skill`** force-available → the agent can activate a skill constraint whose `AllowedTools` **replaces** the base filter, escalating to a broader toolset than the run's `allowed_tools` allowed.
- **`find_tool`** force-available → surfaces deferred tools the run was meant to be restricted from.

## The fix

Keep only **`AskUserQuestion`** (pure infrastructure, can't escalate) unconditional in the base-allowed path. `find_tool`/`skill` are now granted only when the caller lists them explicitly.

- **Unrestricted runs are unaffected** — empty `allowed_tools` early-returns the full tool set before this loop.
- The **skill-constraint path** (already inside an activated skill) and the **advisory profile manifest** are intentionally unchanged.

## Why applied directly, not cherry-picked

The origin branch (`deep-claude/issue-527`) is 27 days diverged (a whole-file diff reverts ~50 KB of newer main work) and bundles two unrelated commits — including a stale-tool-defs filter that **doesn't compile** (a literal `or` instead of `||`). So this applies the one-block fix directly to current `main` instead.

## Tests

`TestFindToolSkill_NotForceGrantedInRestrictedRun`: a run with `allowed_tools=[read_thing]` must exclude `find_tool`/`skill`, keep `AskUserQuestion` + the allowed tool, and include `find_tool` when explicitly listed. **Mutation-checked** — it fails on the pre-fix code. Full `./internal/harness/...` suite green; no existing test regressed.

## Note
This is a deliberate policy tightening: in explicitly-restricted runs, `find_tool`/`skill` are no longer "always-available infrastructure." The docs describing `AlwaysAvailableTools` may warrant a follow-up note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)