### PR TITLE
fix: retry runCommand on external signal kills to deflake tests (#530)

### DIFF
--- a/internal/harness/tools/common_exec.go
+++ b/internal/harness/tools/common_exec.go
@@ -9,7 +9,9 @@ import (
 	"time"
 )
 
-func runCommand(ctx context.Context, timeout time.Duration, command string, args ...string) (string, int, bool, error) {
+// runCommandOnce executes a single attempt.  exitCode == -1 signals the
+// process was killed (signal) rather than exiting normally.
+func runCommandOnce(ctx context.Context, timeout time.Duration, command string, args ...string) (string, int, bool, error) {
 	ctxTimeout, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -32,16 +34,49 @@ func runCommand(ctx context.Context, timeout time.Duration, command string, args
 	timedOut := errors.Is(ctxTimeout.Err(), context.DeadlineExceeded)
 
 	output := mergeCommandStreams(strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()))
-	if err != nil && exitCode == -1 {
-		if timedOut {
-			// Process was killed by the function's own context timeout.
-			// The timeout is already communicated via the timedOut boolean,
-			// so return nil error here. Callers inspect timedOut to detect
-			// the timeout condition, matching the bash_manager.go pattern.
-			return output, exitCode, timedOut, nil
+	return output, exitCode, timedOut, err
+}
+
+func runCommand(ctx context.Context, timeout time.Duration, command string, args ...string) (string, int, bool, error) {
+	// When a subprocess is killed by an external OS signal (not our own
+	// timeout), it may be a transient condition such as CI OOM pressure.
+	// Retry up to 2 extra times with a brief backoff to deflake tests and
+	// production usage. Timeouts and normal exits are never retried.
+	const maxAttempts = 3
+
+	var lastOutput string
+	var lastExitCode int
+	var lastTimedOut bool
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		output, exitCode, timedOut, err := runCommandOnce(ctx, timeout, command, args...)
+
+		if err != nil && exitCode == -1 {
+			if timedOut {
+				// Killed by our own context timeout. Preserve the existing
+				// contract: the timeout is communicated via the timedOut
+				// boolean, so callers see a nil error (matching bash_manager).
+				return output, exitCode, timedOut, nil
+			}
+
+			// External signal kill: retry if we have attempts remaining.
+			lastOutput, lastExitCode, lastTimedOut, lastErr = output, exitCode, timedOut, err
+			if attempt < maxAttempts-1 {
+				select {
+				case <-ctx.Done():
+					return output, exitCode, timedOut, fmt.Errorf("run command: %w", err)
+				case <-time.After(time.Duration(attempt+1) * 100 * time.Millisecond):
+				}
+				continue
+			}
+			return output, exitCode, timedOut, fmt.Errorf("run command: %w", err)
 		}
-		// Process was killed by an external signal (e.g. OOM killer).
-		return output, exitCode, timedOut, fmt.Errorf("run command: %w", err)
+
+		// Normal exit (including non-zero) or success: preserve the existing
+		// nil-error contract.
+		return output, exitCode, timedOut, nil
 	}
-	return output, exitCode, timedOut, nil
+
+	return lastOutput, lastExitCode, lastTimedOut, fmt.Errorf("run command: %w", lastErr)
 }

--- a/internal/harness/tools/common_exec_test.go
+++ b/internal/harness/tools/common_exec_test.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestRunCommand_TimeoutReturnsNilError guards the merge-critical contract: a
+// command killed by our own context timeout reports timedOut=true with a NIL
+// error (the timeout is signalled via the boolean, matching bash_manager). The
+// #530 retry logic must not turn this into an error or retry it.
+func TestRunCommand_TimeoutReturnsNilError(t *testing.T) {
+	t.Parallel()
+	start := time.Now()
+	_, exitCode, timedOut, err := runCommand(context.Background(), 100*time.Millisecond, "sleep", "5")
+	if !timedOut {
+		t.Errorf("expected timedOut=true for a command that exceeds the timeout")
+	}
+	if err != nil {
+		t.Errorf("expected nil error on timeout (contract), got %v", err)
+	}
+	if exitCode != -1 {
+		t.Errorf("expected exitCode -1 (killed), got %d", exitCode)
+	}
+	// Must NOT have retried the timeout (single ~100ms attempt, no 300ms backoff).
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("timeout was retried (took %s); it must not be", elapsed)
+	}
+}
+
+// TestRunCommand_NormalNonZeroExitNilError verifies a normal non-zero exit is
+// not treated as a signal kill: nil error, real exit code, no retry.
+func TestRunCommand_NormalNonZeroExitNilError(t *testing.T) {
+	t.Parallel()
+	_, exitCode, timedOut, err := runCommand(context.Background(), 5*time.Second, "bash", "-c", "exit 3")
+	if err != nil {
+		t.Errorf("normal non-zero exit should return nil error, got %v", err)
+	}
+	if timedOut {
+		t.Error("normal exit should not be timedOut")
+	}
+	if exitCode != 3 {
+		t.Errorf("expected exit code 3, got %d", exitCode)
+	}
+}
+
+// TestRunCommand_ExternalSignalKillRetriesThenErrors verifies the #530 fix: a
+// command killed by an external signal (not our timeout) is retried and, when
+// it keeps failing, returns an error with exitCode -1 and timedOut=false. The
+// retries introduce a small backoff (100ms + 200ms), so the call takes >=300ms.
+func TestRunCommand_ExternalSignalKillRetriesThenErrors(t *testing.T) {
+	t.Parallel()
+	start := time.Now()
+	_, exitCode, timedOut, err := runCommand(context.Background(), 5*time.Second, "bash", "-c", "kill -9 $$")
+	if err == nil {
+		t.Error("expected an error for a command persistently killed by an external signal")
+	}
+	if timedOut {
+		t.Error("external signal kill must not be reported as timedOut")
+	}
+	if exitCode != -1 {
+		t.Errorf("expected exitCode -1 for a signal kill, got %d", exitCode)
+	}
+	if elapsed := time.Since(start); elapsed < 300*time.Millisecond {
+		t.Errorf("expected retry backoff (>=300ms) for signal kills, took only %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Bug (#530)

`runCommand` returned immediately with a wrapped error whenever a subprocess exited with code `-1` — which covers **both** our own timeout **and** an external signal kill (e.g. CI OOM pressure), with zero retry. That external-signal case is the flaky failure in #530 (`run command: signal: killed`).

## Fix

Forward-ported from the unmerged `deep-claude/issue-530` branch (commit `8d29c43`). Splits the executor into `runCommandOnce` (single attempt) wrapped by a retrying `runCommand`: on an `exitCode == -1` **non-timeout** kill, retry up to 2 more times with a 100ms/200ms backoff (bailing on `ctx.Done()`); timeouts and normal exits are never retried. Worst-case added latency for a persistently-signalled command is ~300ms.

## Conflict resolution (important)

`main` had independently evolved `runCommand` to return a **nil** error on its own timeout (signalling via the `timedOut` boolean, matching `bash_manager.go`). The original branch commit returned an *error* on timeout. I reconciled these: the ported retry wrapper **preserves main's nil-on-timeout contract** and only retries genuine external-signal kills. Resolved by hand, not a blind cherry-pick.

## Tests

The branch shipped no test for this, so I added `common_exec_test.go` covering exactly the contract that the conflict resolution turns on:
- **timeout → `timedOut=true`, nil error, single attempt** (no retry)
- **normal non-zero exit → nil error, real exit code**
- **external signal kill (`kill -9 $$`) → error, `exitCode -1`, not timedOut, ≥300ms** (retry backoff observed)

`go build ./...` clean; full `./internal/harness/tools/...` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)