### PR TITLE
fix(security): make the sandbox apply by DEFAULT + guard WebFetcher tools + wire allowlist

### DIFF
--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -1160,3 +1160,23 @@ Decision rule: when uncertain, default to `command intent` and `user intent` bel
 - Open questions:
   - None for T01 completion.
 - Next verification step: review the scoped diff and, if accepted, promote through the repo's normal verify-and-merge flow.
+
+## 2026-07-14 (Sandbox Default Flip + WebFetcher SSRF Guard + Operator Allowlist)
+
+- Command intent: Close three gaps left by the `fix/tool-sandbox-ssrf` branch on `fix/sandbox-defaults-webfetch`: (1) the workspace-confinement fix was inert because `DefaultPermissionConfig()` still defaulted to `SandboxScopeUnrestricted`; (2) the WebFetcher-backed tools (`web_fetch`, `web_search`, `agentic_fetch`) had no SSRF guard; (3) `tools_default.go` never threaded an operator `NetworkAllowlist` into `BuildOptions`.
+- User intent: Err on the side of safety — flip the sandbox default only after measuring blast radius, and give operators an explicit, auditable opt-out/opt-in rather than leaving either an inert protection or an unconditionally locked-down default.
+- Success definition:
+  - `DefaultPermissionConfig()` and the empty-Sandbox fallback in `normalizePermissionConfig` default to `SandboxScopeWorkspace`; a fresh acceptance test proves a default-configured run cannot read an absolute path outside the workspace (e.g. a stand-in for `~/.ssh/id_rsa`).
+  - Blast radius measured before deciding: full suite went from 2 failures (one stale assertion, one genuine macOS seatbelt symlink bug — `/var` vs `/private/var` — now fixed) to 0 after the flip; decision was to keep the flip per the task's own stated threshold.
+  - `GuardedWebFetcher` (new, `internal/harness/tools/web_fetcher_guard.go`) reuses `ssrf_guard.go`'s dial-time guard for `Fetch`, is wired at both `BuildCatalog` and `NewDefaultRegistryWithOptions`, and preserves a wrapped base implementation's actual `Fetch`/`Search` content (proven by the pre-existing mock-based `TestMCPDynamicAndAgentTools`, which stayed green through the change).
+  - `DefaultRegistryOptions` gained `NetworkAllowlist` and `WebFetcher` fields (neither existed before) so an operator can legitimately allow specific hosts; default stays empty/deny.
+  - Full suite (`go test ./...`), `go test ./internal/harness/... -race`, and `go vet ./internal/harness/...` all clean.
+- Non-goals:
+  - Building or wiring a real production `WebFetcher` implementation (none exists in this repo; the investigation found `web_fetch`/`web_search`/`agentic_fetch` were previously dead/unregistered tools in every production entry point).
+  - Wiring `NetworkAllowlist` through a CLI flag/env var in `cmd/harnessd/main.go` (out of scope; mirrors `SandboxScope`, which also has no CLI flag today).
+- Guardrails/constraints:
+  - Strict TDD: red-then-green per gap, plus a final cross-gap regression commit; never weaken an existing security assertion to make a test pass (the one pre-existing test edited, `TestPermissionConfigDefaults`, only updates the asserted default value).
+  - Measure the default-flip blast radius on the real suite before deciding to keep or revert it, per the task's explicit two-step directive.
+- Open questions:
+  - None outstanding for this branch; see the worker's final report for the full acceptance-question answer and file list.
+- Next verification step: review the diff against `fix/tool-sandbox-ssrf`, then promote through the repo's normal PR/CI/squash-merge flow.

--- a/internal/harness/default_registry_network_allowlist_test.go
+++ b/internal/harness/default_registry_network_allowlist_test.go
@@ -1,0 +1,82 @@
+package harness
+
+// GAP-3: internal/harness/tools_default.go builds the production tool
+// registry but, before this change, never threaded an operator-configured
+// NetworkAllowlist through to BuildOptions.NetworkAllowlist at all — so an
+// operator had no way to legitimately allow a specific internal/localhost
+// host for the `download` tool (and, per the GAP-2 fix, the WebFetcher-backed
+// tools) even when they explicitly needed to. This test proves the allowlist
+// now actually reaches the `download` tool built by
+// NewDefaultRegistryWithOptions: an allowlisted host is reachable, and a
+// non-allowlisted loopback host is not.
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewDefaultRegistryWithOptions_DownloadTool_AllowlistReachesTool(t *testing.T) {
+	t.Parallel()
+
+	allowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("allowed content"))
+	}))
+	defer allowed.Close()
+
+	blocked := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("blocked content"))
+	}))
+	defer blocked.Close()
+
+	allowedHost, _, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(allowed.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse allowed server host: %v", err)
+	}
+
+	workspace := t.TempDir()
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+		ApprovalMode:     ToolApprovalModeFullAuto,
+		NetworkAllowlist: []string{allowedHost},
+	})
+
+	// The allowlisted host must be reachable via the `download` tool.
+	allowedArgs, _ := json.Marshal(map[string]any{"url": allowed.URL, "file_path": "allowed.txt"})
+	out, err := registry.Execute(context.Background(), "download", allowedArgs)
+	if err != nil {
+		t.Fatalf("expected allowlisted host to be reachable via download tool, got error: %v", err)
+	}
+	if !strings.Contains(out, "\"bytes_written\"") {
+		t.Fatalf("expected a successful download result, got: %s", out)
+	}
+	written, readErr := os.ReadFile(filepath.Join(workspace, "allowed.txt"))
+	if readErr != nil {
+		t.Fatalf("read downloaded file: %v", readErr)
+	}
+	if string(written) != "allowed content" {
+		t.Fatalf("unexpected downloaded content %q", written)
+	}
+
+	// A DIFFERENT loopback server, NOT covered by the allowlist entry (the
+	// allowlist only names allowed.URL's host:port pairing via the bare
+	// host match, and blocked.URL listens on a different port on the same
+	// loopback address — but the guard's default-deny still applies to any
+	// destination not explicitly allowlisted; to make the negative case
+	// unambiguous we assert against a private RFC1918 destination that is
+	// categorically outside both the allowlist and the public-address
+	// default-allow).
+	blockedArgs, _ := json.Marshal(map[string]any{"url": "http://10.255.255.1:1/", "file_path": "blocked.txt"})
+	_, err = registry.Execute(context.Background(), "download", blockedArgs)
+	if err == nil {
+		t.Fatal("expected a non-allowlisted private destination to be refused via download tool")
+	}
+	if !strings.Contains(err.Error(), "ssrf-guard") {
+		t.Fatalf("expected the ssrf guard to be what rejected the request, got: %v", err)
+	}
+}

--- a/internal/harness/default_registry_webfetcher_test.go
+++ b/internal/harness/default_registry_webfetcher_test.go
@@ -1,0 +1,117 @@
+package harness
+
+// GAP-2/GAP-3 wiring proof at the production registry layer
+// (NewDefaultRegistryWithOptions, tools_default.go).
+//
+// Before this change, DefaultRegistryOptions had no WebFetcher field at all,
+// so web_fetch/web_search/agentic_fetch could never be registered by the
+// production HTTP runtime (cmd/harnessd) regardless of any guard — the
+// WebFetcher-gated branch in tools_default.go was permanently dead code
+// there. This test proves the newly-added field both (a) actually reaches
+// the registered web_fetch tool, and (b) is guarded by construction: an
+// unguarded, real-HTTP WebFetcher test double supplied via
+// DefaultRegistryOptions.WebFetcher still cannot reach a loopback
+// destination through web_fetch.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeAgentRunnerForWebTest struct{}
+
+func (fakeAgentRunnerForWebTest) RunPrompt(_ context.Context, prompt string) (string, error) {
+	return "ran: " + prompt, nil
+}
+
+// realHTTPWebFetcherForRegistryTest performs a real, unguarded HTTP fetch —
+// the shape any actual production WebFetcher implementation would take.
+type realHTTPWebFetcherForRegistryTest struct {
+	client *http.Client
+}
+
+func (f *realHTTPWebFetcherForRegistryTest) Fetch(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := f.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (f *realHTTPWebFetcherForRegistryTest) Search(_ context.Context, query string, maxResults int) ([]map[string]any, error) {
+	return []map[string]any{{"query": query, "max": maxResults}}, nil
+}
+
+func TestNewDefaultRegistryWithOptions_WebFetchTool_RefusesLoopbackByDefault(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("internal secret"))
+	}))
+	defer srv.Close()
+
+	workspace := t.TempDir()
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+		AgentRunner:  fakeAgentRunnerForWebTest{},
+		WebFetcher:   &realHTTPWebFetcherForRegistryTest{client: &http.Client{Timeout: 5 * time.Second}},
+	})
+
+	args, _ := json.Marshal(map[string]any{"url": srv.URL})
+	out, err := registry.Execute(context.Background(), "web_fetch", args)
+	if err == nil && !strings.Contains(out, "\"error\"") {
+		t.Fatalf("expected web_fetch (built by NewDefaultRegistryWithOptions) to refuse a loopback destination, but it succeeded: err=%v out=%s", err, out)
+	}
+}
+
+// TestNewDefaultRegistryWithOptions_WebFetchTool_AllowlistPermitsExplicitHost
+// proves the operator-configured NetworkAllowlist (GAP-3) actually reaches
+// the WebFetcher-backed tools built by NewDefaultRegistryWithOptions, not
+// just the download tool.
+func TestNewDefaultRegistryWithOptions_WebFetchTool_AllowlistPermitsExplicitHost(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://")
+	if idx := strings.LastIndex(host, ":"); idx != -1 {
+		// keep host:port as-is; the allowlist below uses the bare host, so
+		// strip the port for the hostname-match branch of the guard.
+		host = host[:idx]
+	}
+
+	workspace := t.TempDir()
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+		ApprovalMode:     ToolApprovalModeFullAuto,
+		AgentRunner:      fakeAgentRunnerForWebTest{},
+		WebFetcher:       &realHTTPWebFetcherForRegistryTest{client: &http.Client{Timeout: 5 * time.Second}},
+		NetworkAllowlist: []string{host},
+	})
+
+	args, _ := json.Marshal(map[string]any{"url": srv.URL})
+	out, err := registry.Execute(context.Background(), "web_fetch", args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Fatalf("expected allowlisted host to be reachable and return its content, got: %s", out)
+	}
+}

--- a/internal/harness/default_sandbox_acceptance_test.go
+++ b/internal/harness/default_sandbox_acceptance_test.go
@@ -1,0 +1,86 @@
+package harness
+
+// This is the single acceptance test for the GAP-1 security effort: a
+// completely DEFAULT-configured run (no explicit Permissions/Sandbox set on
+// the RunRequest, exactly as an existing caller that never learned about the
+// new Sandbox field would submit) must NOT be able to read an absolute path
+// outside the workspace via the `read` tool.
+//
+// Before the fix, harness.DefaultPermissionConfig() returned
+// Sandbox: SandboxScopeUnrestricted, so the workspace confinement added by
+// ConfineWorkspacePath/ResolveWorkspacePathConfined (common_paths.go) never
+// engaged unless a caller explicitly opted in to SandboxScopeWorkspace. This
+// test proves that gap is closed: it reads a file standing in for
+// ~/.ssh/id_rsa (an absolute path well outside the run's workspace) via a
+// real Runner + real default tool registry + real step engine, with NO
+// Permissions field set on the RunRequest at all.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultConfiguredRun_CannotReadAbsolutePathOutsideWorkspace(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+
+	// Stand-in for a sensitive file outside the workspace, e.g. ~/.ssh/id_rsa.
+	outsideDir := t.TempDir()
+	secretPath := filepath.Join(outsideDir, "id_rsa")
+	if err := os.WriteFile(secretPath, []byte("-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"), 0o600); err != nil {
+		t.Fatalf("write fixture secret file: %v", err)
+	}
+
+	// The production default tool registry, built with zero-value options —
+	// exactly what an operator gets who does not pass a SandboxScope.
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{})
+
+	provider := &continuationProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_read_secret",
+					Name:      "read",
+					Arguments: fmt.Sprintf(`{"path":%q}`, secretPath),
+				}},
+			},
+			{Content: "done"},
+		},
+	}
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	// The crux of the test: NO Permissions field is set on the request. This
+	// is what "default-configured run" means for the acceptance question.
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "please read my ssh private key at an absolute path",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	payload := toolMessagePayload(t, runner, run.ID, "read")
+
+	if content, ok := payload["content"].(string); ok && strings.Contains(content, "BEGIN PRIVATE KEY") {
+		t.Fatalf("SECURITY REGRESSION: default-configured run read the absolute-path secret file outside the workspace: %+v", payload)
+	}
+
+	errMsg, _ := payload["error"].(string)
+	if errMsg == "" {
+		t.Fatalf("expected the default-configured run to be denied reading an absolute path outside the workspace, but got no error. payload=%+v", payload)
+	}
+	if !strings.Contains(errMsg, "sandbox") && !strings.Contains(errMsg, "escapes") {
+		t.Fatalf("expected a sandbox/escape violation error, got: %q", errMsg)
+	}
+}

--- a/internal/harness/permission_config_test.go
+++ b/internal/harness/permission_config_test.go
@@ -9,13 +9,21 @@ import (
 )
 
 // TestPermissionConfigDefaults verifies that DefaultPermissionConfig returns
-// the expected unrestricted/none combination.
+// the expected workspace/none combination.
+//
+// SAFETY DEFAULT (GAP-1): Sandbox defaults to SandboxScopeWorkspace, not
+// SandboxScopeUnrestricted. A caller that submits a run with no Permissions
+// field at all must be workspace-confined by default; callers that
+// legitimately need broader filesystem access must explicitly opt in via
+// PermissionConfig.Sandbox: SandboxScopeLocal or SandboxScopeUnrestricted.
+// See TestDefaultConfiguredRun_CannotReadAbsolutePathOutsideWorkspace for the
+// end-to-end acceptance test of this default.
 func TestPermissionConfigDefaults(t *testing.T) {
 	t.Parallel()
 
 	cfg := DefaultPermissionConfig()
-	if cfg.Sandbox != SandboxScopeUnrestricted {
-		t.Errorf("expected default sandbox %q, got %q", SandboxScopeUnrestricted, cfg.Sandbox)
+	if cfg.Sandbox != SandboxScopeWorkspace {
+		t.Errorf("expected default sandbox %q, got %q", SandboxScopeWorkspace, cfg.Sandbox)
 	}
 	if cfg.Approval != ApprovalPolicyNone {
 		t.Errorf("expected default approval %q, got %q", ApprovalPolicyNone, cfg.Approval)

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -5116,7 +5116,8 @@ func copyStringSlice(src []string) []string {
 
 func normalizePermissionConfig(p PermissionConfig) PermissionConfig {
 	if p.Sandbox == "" {
-		p.Sandbox = SandboxScopeUnrestricted
+		// Safety-biased default: see DefaultPermissionConfig in types.go.
+		p.Sandbox = SandboxScopeWorkspace
 	}
 	if p.Approval == "" {
 		p.Approval = ApprovalPolicyNone

--- a/internal/harness/sandbox_webfetch_regression_test.go
+++ b/internal/harness/sandbox_webfetch_regression_test.go
@@ -1,0 +1,137 @@
+package harness
+
+// End-to-end regression coverage for the sandbox-defaults-webfetch security
+// pass (GAP-1, GAP-2, GAP-3). Each test here targets an angle NOT already
+// covered by the gap-specific behavioral tests, so a future change that
+// silently reverts or narrows any of the three fixes gets caught here even
+// if it doesn't touch the original acceptance tests directly.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRegression_DefaultConfiguredRun_WriteTool_CannotEscapeWorkspace proves
+// GAP-1's fix generalizes beyond the `read` tool: `write` (a different
+// code path, core/write.go) is also confined by default. If a future change
+// re-narrows the DefaultPermissionConfig fix to only cover reads, this
+// catches it.
+func TestRegression_DefaultConfiguredRun_WriteTool_CannotEscapeWorkspace(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	targetPath := filepath.Join(outsideDir, "authorized_keys")
+
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{})
+	provider := &continuationProvider{
+		turns: []CompletionResult{
+			{ToolCalls: []ToolCall{{
+				ID:        "call_write_outside",
+				Name:      "write",
+				Arguments: fmt.Sprintf(`{"path":%q,"content":"attacker-controlled-key"}`, targetPath),
+			}}},
+			{Content: "done"},
+		},
+	}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test-model", MaxSteps: 4})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "write outside the workspace"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	if _, statErr := os.Stat(targetPath); statErr == nil {
+		t.Fatalf("SECURITY REGRESSION: default-configured run wrote outside the workspace at %s", targetPath)
+	}
+
+	payload := toolMessagePayload(t, runner, run.ID, "write")
+	errMsg, _ := payload["error"].(string)
+	if errMsg == "" {
+		t.Fatalf("expected the default-configured run's write to be denied, got payload=%+v", payload)
+	}
+}
+
+// TestRegression_ExplicitUnrestrictedOptOut_StillWorks proves the GAP-1 fix
+// left the documented escape hatch intact: a run that EXPLICITLY requests
+// SandboxScope: unrestricted can still read outside the workspace. Without
+// this, an operator with a legitimate need (e.g. a purely local, trusted,
+// single-tenant CLI session) would have no way to opt out, which was
+// explicitly required by the task ("a user/operator can still opt out
+// cleanly").
+func TestRegression_ExplicitUnrestrictedOptOut_StillWorks(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	referencePath := filepath.Join(outsideDir, "reference.txt")
+	if err := os.WriteFile(referencePath, []byte("shared reference data"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{})
+	provider := &continuationProvider{
+		turns: []CompletionResult{
+			{ToolCalls: []ToolCall{{
+				ID:        "call_read_ref",
+				Name:      "read",
+				Arguments: fmt.Sprintf(`{"path":%q}`, referencePath),
+			}}},
+			{Content: "done"},
+		},
+	}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test-model", MaxSteps: 4})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "read the shared reference file",
+		Permissions: &PermissionConfig{
+			Sandbox:  SandboxScopeUnrestricted,
+			Approval: ApprovalPolicyNone,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+
+	payload := toolMessagePayload(t, runner, run.ID, "read")
+	content, _ := payload["content"].(string)
+	if content != "shared reference data" {
+		t.Fatalf("expected the explicit unrestricted opt-out to still permit reading outside the workspace, payload=%+v", payload)
+	}
+}
+
+// TestRegression_NewDefaultRegistryWithOptions_ZeroValueAllowlist_StaysDenyByDefault
+// proves GAP-3's default (an operator who does not set NetworkAllowlist at
+// all — the zero value) remains deny-by-default: a private destination is
+// still refused via the download tool. This guards against a future change
+// that accidentally makes the zero value permissive (e.g. treating a nil
+// slice as "allow everything" instead of "allow nothing").
+func TestRegression_NewDefaultRegistryWithOptions_ZeroValueAllowlist_StaysDenyByDefault(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+		// NetworkAllowlist intentionally left as the zero value (nil).
+	})
+
+	args, _ := json.Marshal(map[string]any{"url": "http://10.255.255.2:1/", "file_path": "out.bin"})
+	_, err := registry.Execute(context.Background(), "download", args)
+	if err == nil {
+		t.Fatal("expected a private destination to be refused when NetworkAllowlist is left at its zero value")
+	}
+	if !strings.Contains(err.Error(), "ssrf-guard") {
+		t.Fatalf("expected the ssrf guard to be what rejected the request, got: %v", err)
+	}
+}

--- a/internal/harness/tools/apply_patch.go
+++ b/internal/harness/tools/apply_patch.go
@@ -57,7 +57,7 @@ type unifiedPatchHunk struct {
 	NewText string
 }
 
-func applyPatchTool(workspaceRoot string) Tool {
+func applyPatchTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "apply_patch",
 		Description:  descriptions.Load("apply_patch"),
@@ -96,7 +96,7 @@ func applyPatchTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Path            string      `json:"path"`
 			FilePath        string      `json:"file_path"`
@@ -122,7 +122,7 @@ func applyPatchTool(workspaceRoot string) Tool {
 			args.Patch = args.UnifiedDiff
 		}
 		if strings.TrimSpace(args.Patch) != "" {
-			return applyUnifiedPatch(workspaceRoot, args.Patch)
+			return applyUnifiedPatch(ctx, workspaceRoot, sandboxScope, args.Patch)
 		}
 		if args.Path == "" {
 			args.Path = args.FilePath
@@ -131,7 +131,7 @@ func applyPatchTool(workspaceRoot string) Tool {
 			return "", fmt.Errorf("path is required")
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}
@@ -294,7 +294,7 @@ func isStandardUnifiedDiff(patch string) bool {
 	return strings.HasPrefix(trimmed, "--- ")
 }
 
-func applyUnifiedPatch(workspaceRoot, patch string) (string, error) {
+func applyUnifiedPatch(ctx context.Context, workspaceRoot string, sandboxScope SandboxScope, patch string) (string, error) {
 	var files []unifiedPatchFile
 	var err error
 	if isStandardUnifiedDiff(patch) {
@@ -308,7 +308,7 @@ func applyUnifiedPatch(workspaceRoot, patch string) (string, error) {
 
 	results := make([]map[string]any, 0, len(files))
 	for _, filePatch := range files {
-		absPath, err := ResolveWorkspacePath(workspaceRoot, filePatch.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, filePatch.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/catalog.go
+++ b/internal/harness/tools/catalog.go
@@ -32,21 +32,21 @@ func BuildCatalog(opts BuildOptions) ([]Tool, error) {
 
 	tools := []Tool{
 		askUserQuestionTool(opts.AskUserBroker, opts.AskUserTimeout),
-		observationalMemoryTool(opts.WorkspaceRoot, opts.MemoryManager, opts.AgentRunner),
-		readTool(opts.WorkspaceRoot),
-		writeTool(opts.WorkspaceRoot),
-		editTool(opts.WorkspaceRoot),
+		observationalMemoryTool(opts.WorkspaceRoot, opts.MemoryManager, opts.AgentRunner, opts.SandboxScope),
+		readTool(opts.WorkspaceRoot, opts.SandboxScope),
+		writeTool(opts.WorkspaceRoot, opts.SandboxScope),
+		editTool(opts.WorkspaceRoot, opts.SandboxScope),
 		bashTool(jobManager),
 		jobOutputTool(jobManager),
 		jobKillTool(jobManager),
-		lsTool(opts.WorkspaceRoot),
-		globTool(opts.WorkspaceRoot),
-		grepTool(opts.WorkspaceRoot),
-		applyPatchTool(opts.WorkspaceRoot),
+		lsTool(opts.WorkspaceRoot, opts.SandboxScope),
+		globTool(opts.WorkspaceRoot, opts.SandboxScope),
+		grepTool(opts.WorkspaceRoot, opts.SandboxScope),
+		applyPatchTool(opts.WorkspaceRoot, opts.SandboxScope),
 		gitStatusTool(opts.WorkspaceRoot),
-		gitDiffTool(opts.WorkspaceRoot),
+		gitDiffTool(opts.WorkspaceRoot, opts.SandboxScope),
 		fetchTool(opts.HTTPClient),
-		downloadTool(opts.WorkspaceRoot, opts.HTTPClient),
+		downloadTool(opts.WorkspaceRoot, opts.HTTPClient, opts.SandboxScope),
 		contextStatusTool(),
 		compactHistoryTool(opts.MessageSummarizer),
 	}
@@ -55,7 +55,7 @@ func BuildCatalog(opts BuildOptions) ([]Tool, error) {
 		tools = append(tools, todosTool(todos))
 	}
 	if opts.EnableLSP {
-		tools = append(tools, lspDiagnosticsTool(opts.WorkspaceRoot), lspReferencesTool(opts.WorkspaceRoot), lspRestartTool(opts.WorkspaceRoot))
+		tools = append(tools, lspDiagnosticsTool(opts.WorkspaceRoot, opts.SandboxScope), lspReferencesTool(opts.WorkspaceRoot, opts.SandboxScope), lspRestartTool(opts.WorkspaceRoot))
 	}
 	if opts.Sourcegraph.Endpoint != "" {
 		tools = append(tools, sourcegraphTool(opts.HTTPClient, opts.Sourcegraph))

--- a/internal/harness/tools/catalog.go
+++ b/internal/harness/tools/catalog.go
@@ -80,7 +80,14 @@ func BuildCatalog(opts BuildOptions) ([]Tool, error) {
 	if opts.EnableAgent && opts.AgentRunner != nil {
 		tools = append(tools, agentTool(opts.AgentRunner))
 		if opts.EnableWebOps && opts.WebFetcher != nil {
-			tools = append(tools, agenticFetchTool(opts.WebFetcher, opts.AgentRunner), webSearchTool(opts.WebFetcher), webFetchTool(opts.WebFetcher))
+			// GAP-2: web_fetch/web_search/agentic_fetch are all backed by
+			// WebFetcher, whose Fetch(url) argument is chosen by the LLM.
+			// Wrap with the same dial-time SSRF guard used by the
+			// fetch/download tools (ssrf_guard.go) rather than trusting
+			// whatever transport the supplied WebFetcher implementation uses
+			// internally. See web_fetcher_guard.go.
+			guardedFetcher := NewGuardedWebFetcher(opts.WebFetcher, opts.NetworkAllowlist)
+			tools = append(tools, agenticFetchTool(guardedFetcher, opts.AgentRunner), webSearchTool(guardedFetcher), webFetchTool(guardedFetcher))
 		}
 	}
 	if opts.EnableCron && opts.CronClient != nil {

--- a/internal/harness/tools/catalog.go
+++ b/internal/harness/tools/catalog.go
@@ -45,8 +45,8 @@ func BuildCatalog(opts BuildOptions) ([]Tool, error) {
 		applyPatchTool(opts.WorkspaceRoot, opts.SandboxScope),
 		gitStatusTool(opts.WorkspaceRoot),
 		gitDiffTool(opts.WorkspaceRoot, opts.SandboxScope),
-		fetchTool(opts.HTTPClient),
-		downloadTool(opts.WorkspaceRoot, opts.HTTPClient, opts.SandboxScope),
+		fetchTool(opts.HTTPClient, opts.NetworkAllowlist),
+		downloadTool(opts.WorkspaceRoot, opts.HTTPClient, opts.SandboxScope, opts.NetworkAllowlist),
 		contextStatusTool(),
 		compactHistoryTool(opts.MessageSummarizer),
 	}

--- a/internal/harness/tools/catalog_test.go
+++ b/internal/harness/tools/catalog_test.go
@@ -390,6 +390,41 @@ func TestFetchAndDownloadTools(t *testing.T) {
 	}
 }
 
+// TestFetchAndDownloadTools_BlockLoopbackWithoutAllowlist is a regression
+// test proving the fetch/download tools built via BuildCatalog (the MCP
+// stdio catalog path) are wired through the SSRF guard by default: without
+// an explicit NetworkAllowlist entry, requests to a loopback test server
+// must fail rather than silently succeeding as they did before BUG-2 was
+// fixed. If NewGuardedHTTPClient is ever dropped from downloadTool/fetchTool
+// (e.g. during a future refactor of catalog.go), this test starts failing.
+func TestFetchAndDownloadTools_BlockLoopbackWithoutAllowlist(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "should never reach the agent")
+	}))
+	defer server.Close()
+
+	workspace := t.TempDir()
+	list, err := BuildCatalog(BuildOptions{WorkspaceRoot: workspace, HTTPClient: server.Client()})
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+
+	fetchTool := findToolByName(t, list, "fetch")
+	if _, err := fetchTool.Handler(context.Background(), json.RawMessage(`{"url":"`+server.URL+`"}`)); err == nil {
+		t.Fatal("expected fetch of an unallowlisted loopback URL to be blocked by default")
+	}
+
+	downloadTool := findToolByName(t, list, "download")
+	if _, err := downloadTool.Handler(context.Background(), json.RawMessage(`{"url":"`+server.URL+`","file_path":"blocked.bin"}`)); err == nil {
+		t.Fatal("expected download from an unallowlisted loopback URL to be blocked by default")
+	}
+	if _, statErr := os.Stat(filepath.Join(workspace, "blocked.bin")); statErr == nil {
+		t.Fatal("expected no file to be written when the download destination is blocked")
+	}
+}
+
 func TestPermissionsModePolicy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/harness/tools/catalog_test.go
+++ b/internal/harness/tools/catalog_test.go
@@ -367,7 +367,11 @@ func TestFetchAndDownloadTools(t *testing.T) {
 
 	workspace := t.TempDir()
 	client := server.Client()
-	list, err := BuildCatalog(BuildOptions{WorkspaceRoot: workspace, HTTPClient: client})
+	// server listens on loopback, which the SSRF guard (BUG-2) blocks by
+	// default — this test exercises the explicit opt-in NetworkAllowlist to
+	// reach it, proving the guard doesn't break legitimate, explicitly
+	// permitted local fetches.
+	list, err := BuildCatalog(BuildOptions{WorkspaceRoot: workspace, HTTPClient: client, NetworkAllowlist: []string{"127.0.0.1"}})
 	if err != nil {
 		t.Fatalf("BuildCatalog: %v", err)
 	}

--- a/internal/harness/tools/common_paths.go
+++ b/internal/harness/tools/common_paths.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -123,4 +124,22 @@ func isEACCES(err error) bool {
 		}
 	}
 	return false
+}
+
+// TODO(BUG-1 red phase): stub only — does not yet confine anything.
+// EffectiveSandboxScope will resolve the per-call sandbox scope override.
+func EffectiveSandboxScope(ctx context.Context, defaultScope SandboxScope) SandboxScope {
+	return defaultScope
+}
+
+// TODO(BUG-1 red phase): stub only — passes every path through unchanged,
+// which is exactly today's vulnerable behavior. The real implementation
+// canonicalizes absPath (symlink-resolved) and verifies containment.
+func ConfineWorkspacePath(scope SandboxScope, workspaceRoot string, extraAllowedRoots []string, absPath string) (string, error) {
+	return absPath, nil
+}
+
+// TODO(BUG-1 red phase): stub only — delegates to the unconfined resolver.
+func ResolveWorkspacePathConfined(ctx context.Context, workspaceRoot, relativePath string, defaultScope SandboxScope) (string, error) {
+	return ResolveWorkspacePath(workspaceRoot, relativePath)
 }

--- a/internal/harness/tools/common_paths.go
+++ b/internal/harness/tools/common_paths.go
@@ -126,20 +126,148 @@ func isEACCES(err error) bool {
 	return false
 }
 
-// TODO(BUG-1 red phase): stub only — does not yet confine anything.
-// EffectiveSandboxScope will resolve the per-call sandbox scope override.
+// EffectiveSandboxScope resolves the sandbox scope to enforce for a single
+// tool invocation: the per-call context override set by the step engine
+// (tools.WithSandboxScope, see runner_step_engine.go) takes precedence over
+// the scope the tool catalog was built with (defaultScope). This mirrors the
+// pattern already used by JobManager.sandboxScopeForContext for the bash
+// tool, so file tools and bash tools honor the same override semantics.
 func EffectiveSandboxScope(ctx context.Context, defaultScope SandboxScope) SandboxScope {
+	if scope, ok := SandboxScopeFromContext(ctx); ok && scope != "" {
+		return scope
+	}
 	return defaultScope
 }
 
-// TODO(BUG-1 red phase): stub only — passes every path through unchanged,
-// which is exactly today's vulnerable behavior. The real implementation
-// canonicalizes absPath (symlink-resolved) and verifies containment.
+// ConfineWorkspacePath enforces that absPath lies inside workspaceRoot (or one
+// of the explicitly allowlisted extraAllowedRoots) once symlinks are
+// resolved, and returns the (unresolved) absPath for I/O when the check
+// passes.
+//
+// This is the enforcement point for SandboxScopeWorkspace. It is a no-op
+// (existing pass-through behavior) for any other scope: SandboxScopeLocal and
+// SandboxScopeUnrestricted are the existing, explicit opt-in mechanism a
+// caller uses when it legitimately needs to reach outside the workspace, and
+// this function does not second-guess that choice.
+//
+// The check is performed on the canonicalized FINAL path, not on the input
+// string:
+//   - Absolute-path escapes and "../" traversal are caught because the
+//     canonical candidate is compared against the canonical root by path
+//     COMPONENT (filepath.Rel), never by string-prefix matching — so a
+//     sibling directory that merely shares a name prefix with the root
+//     (e.g. "/tmp/ws-evil" vs root "/tmp/ws") cannot pass.
+//   - Symlink escapes (a symlink inside the workspace whose target lives
+//     outside it) are caught because filepath.EvalSymlinks is applied to the
+//     path — or to its nearest existing ancestor, for a file that does not
+//     exist yet (e.g. a `write` call creating a new file) — before the
+//     containment check runs.
 func ConfineWorkspacePath(scope SandboxScope, workspaceRoot string, extraAllowedRoots []string, absPath string) (string, error) {
-	return absPath, nil
+	if scope != SandboxScopeWorkspace {
+		return absPath, nil
+	}
+
+	canonicalRoot, err := canonicalizeExistingRoot(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve workspace root: %w", err)
+	}
+
+	canonicalPath, err := canonicalizePathAllowingMissing(absPath)
+	if err != nil {
+		return "", fmt.Errorf("sandbox: resolve path %q: %w", absPath, err)
+	}
+
+	if pathWithinRoot(canonicalPath, canonicalRoot) {
+		return absPath, nil
+	}
+
+	for _, extraRoot := range extraAllowedRoots {
+		canonicalExtra, err := canonicalizeExistingRoot(extraRoot)
+		if err != nil {
+			// A misconfigured or missing allowlist entry should not itself grant
+			// access; skip it rather than fail the whole check.
+			continue
+		}
+		if pathWithinRoot(canonicalPath, canonicalExtra) {
+			return absPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("sandbox violation: path %q escapes the allowed workspace root %q", absPath, workspaceRoot)
 }
 
-// TODO(BUG-1 red phase): stub only — delegates to the unconfined resolver.
+// pathWithinRoot reports whether candidate lies inside root, comparing by
+// path component (filepath.Rel) rather than string prefix so that a sibling
+// directory sharing a name prefix with root (e.g. root "/tmp/ws" and
+// candidate "/tmp/ws-evil/secret") is correctly rejected.
+func pathWithinRoot(candidate, root string) bool {
+	if candidate == root {
+		return true
+	}
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// canonicalizeExistingRoot resolves symlinks for a path that is expected to
+// already exist (a workspace root or an allowlisted extra root).
+func canonicalizeExistingRoot(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}
+
+// canonicalizePathAllowingMissing resolves symlinks for absPath. If absPath
+// (or an ancestor of it) does not exist yet — as with a `write` or
+// `apply_patch` call creating a brand-new file — it walks up to the nearest
+// existing ancestor, resolves THAT ancestor's symlinks, and rejoins the
+// non-existent trailing components literally. This defeats a symlink placed
+// inside the workspace whose target directory lies outside it, even when the
+// final path component has not been created yet.
+func canonicalizePathAllowingMissing(absPath string) (string, error) {
+	clean := filepath.Clean(absPath)
+	resolved, err := filepath.EvalSymlinks(clean)
+	if err == nil {
+		return resolved, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	parent := filepath.Dir(clean)
+	base := filepath.Base(clean)
+	if parent == clean {
+		// Reached the filesystem root without finding an existing ancestor.
+		return clean, nil
+	}
+	resolvedParent, err := canonicalizePathAllowingMissing(parent)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedParent, base), nil
+}
+
+// ResolveWorkspacePathConfined resolves relativePath against workspaceRoot
+// exactly like ResolveWorkspacePath, then additionally enforces
+// ConfineWorkspacePath using the effective sandbox scope (context override,
+// falling back to defaultScope). This is the single call every path-resolving
+// tool handler should use going forward.
 func ResolveWorkspacePathConfined(ctx context.Context, workspaceRoot, relativePath string, defaultScope SandboxScope) (string, error) {
-	return ResolveWorkspacePath(workspaceRoot, relativePath)
+	absPath, err := ResolveWorkspacePath(workspaceRoot, relativePath)
+	if err != nil {
+		return "", err
+	}
+	scope := EffectiveSandboxScope(ctx, defaultScope)
+	return ConfineWorkspacePath(scope, workspaceRoot, nil, absPath)
 }

--- a/internal/harness/tools/core/apply_patch.go
+++ b/internal/harness/tools/core/apply_patch.go
@@ -68,7 +68,7 @@ func ApplyPatchTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path            string      `json:"path"`
 			FilePath        string      `json:"file_path"`
@@ -83,7 +83,7 @@ func ApplyPatchTool(opts tools.BuildOptions) tools.Tool {
 			return "", fmt.Errorf("parse apply_patch args: %w", err)
 		}
 		if strings.TrimSpace(args.Patch) != "" {
-			return applyUnifiedPatch(workspaceRoot, args.Patch)
+			return applyUnifiedPatch(ctx, workspaceRoot, opts.SandboxScope, args.Patch)
 		}
 		if args.Path == "" {
 			args.Path = args.FilePath
@@ -92,7 +92,7 @@ func ApplyPatchTool(opts tools.BuildOptions) tools.Tool {
 			return "", fmt.Errorf("path is required")
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}
@@ -212,7 +212,7 @@ func isStandardUnifiedDiff(patch string) bool {
 	return strings.HasPrefix(trimmed, "--- ")
 }
 
-func applyUnifiedPatch(workspaceRoot, patch string) (string, error) {
+func applyUnifiedPatch(ctx context.Context, workspaceRoot string, sandboxScope tools.SandboxScope, patch string) (string, error) {
 	var files []unifiedPatchFile
 	var err error
 	if isStandardUnifiedDiff(patch) {
@@ -226,7 +226,7 @@ func applyUnifiedPatch(workspaceRoot, patch string) (string, error) {
 
 	results := make([]map[string]any, 0, len(files))
 	for _, filePatch := range files {
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, filePatch.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, filePatch.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/core_test.go
+++ b/internal/harness/tools/core/core_test.go
@@ -45,6 +45,38 @@ func TestReadTool_Handler_Success(t *testing.T) {
 	}
 }
 
+// TestReadTool_Handler_WorkspaceScope_BlocksAbsoluteEscape is a regression
+// test for BUG-1 exercised through the PRODUCTION tool (core.ReadTool, as
+// wired by harness.NewDefaultRegistryWithOptions), not just the shared
+// ConfineWorkspacePath helper: if the SandboxScope wiring in core/read.go is
+// ever dropped, this test starts passing again and catches it.
+func TestReadTool_Handler_WorkspaceScope_BlocksAbsoluteEscape(t *testing.T) {
+	dir := t.TempDir()
+	secret := t.TempDir()
+	secretFile := filepath.Join(secret, "id_rsa")
+	if err := os.WriteFile(secretFile, []byte("private key material"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := ReadTool(tools.BuildOptions{WorkspaceRoot: dir, SandboxScope: tools.SandboxScopeWorkspace})
+	args, _ := json.Marshal(map[string]string{"path": secretFile})
+	if _, err := tool.Handler(context.Background(), args); err == nil {
+		t.Fatal("expected read of an absolute path outside the workspace to be rejected under workspace sandbox scope")
+	}
+
+	// Legitimate in-workspace reads must still work under the same scope.
+	if err := os.WriteFile(filepath.Join(dir, "ok.txt"), []byte("fine"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	result, err := tool.Handler(context.Background(), json.RawMessage(`{"path":"ok.txt"}`))
+	if err != nil {
+		t.Fatalf("expected legitimate in-workspace read to still succeed under workspace scope: %v", err)
+	}
+	if result == "" {
+		t.Fatal("expected non-empty result for in-workspace read")
+	}
+}
+
 // TestWriteTool_Definition verifies the write tool constructor.
 func TestWriteTool_Definition(t *testing.T) {
 	tool := WriteTool(tools.BuildOptions{WorkspaceRoot: t.TempDir()})
@@ -86,6 +118,36 @@ func TestWriteTool_Handler_Success(t *testing.T) {
 	}
 	if string(data) != "hello" {
 		t.Errorf("expected 'hello', got %q", string(data))
+	}
+}
+
+// TestWriteTool_Handler_WorkspaceScope_BlocksAbsoluteEscape is a regression
+// test for BUG-1's write-side coverage through the PRODUCTION tool
+// (core.WriteTool): an absolute path outside the workspace must be rejected
+// under workspace sandbox scope, so an attacker cannot overwrite arbitrary
+// host files (e.g. ~/.ssh/authorized_keys) via the write tool. Uses the same
+// scope wiring as core.ReadTool but exercises the WRITE code path
+// specifically, since read and write resolve paths independently.
+func TestWriteTool_Handler_WorkspaceScope_BlocksAbsoluteEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	targetFile := filepath.Join(outside, "authorized_keys")
+	if err := os.WriteFile(targetFile, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tool := WriteTool(tools.BuildOptions{WorkspaceRoot: dir, SandboxScope: tools.SandboxScopeWorkspace})
+	args, _ := json.Marshal(map[string]string{"path": targetFile, "content": "attacker-controlled-key"})
+	if _, err := tool.Handler(context.Background(), args); err == nil {
+		t.Fatal("expected write to an absolute path outside the workspace to be rejected under workspace sandbox scope")
+	}
+
+	data, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("target file should be untouched: %v", err)
+	}
+	if string(data) != "original" {
+		t.Fatalf("expected target file to remain unmodified, got %q", string(data))
 	}
 }
 

--- a/internal/harness/tools/core/edit.go
+++ b/internal/harness/tools/core/edit.go
@@ -36,7 +36,7 @@ func EditTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path            string `json:"path"`
 			FilePath        string `json:"file_path"`
@@ -58,7 +58,7 @@ func EditTool(opts tools.BuildOptions) tools.Tool {
 			return "", fmt.Errorf("old_text is required")
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/file_inspect.go
+++ b/internal/harness/tools/core/file_inspect.go
@@ -40,7 +40,7 @@ func FileInspectTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path         string `json:"path"`
 			PreviewLines int    `json:"preview_lines"`
@@ -67,7 +67,7 @@ func FileInspectTool(opts tools.BuildOptions) tools.Tool {
 			args.HexBytes = 1024
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/git.go
+++ b/internal/harness/tools/core/git.go
@@ -122,7 +122,7 @@ func GitDiffTool(opts tools.BuildOptions) tools.Tool {
 			cmdArgs = append(cmdArgs, args.Target)
 		}
 		if strings.TrimSpace(args.Path) != "" {
-			absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+			absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}

--- a/internal/harness/tools/core/grep.go
+++ b/internal/harness/tools/core/grep.go
@@ -41,7 +41,7 @@ func GrepTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Query         string `json:"query"`
 			Path          string `json:"path"`
@@ -68,7 +68,7 @@ func GrepTool(opts tools.BuildOptions) tools.Tool {
 			args.Regex = false
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/ls.go
+++ b/internal/harness/tools/core/ls.go
@@ -38,7 +38,7 @@ func LsTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path          string `json:"path"`
 			Recursive     bool   `json:"recursive"`
@@ -63,7 +63,7 @@ func LsTool(opts tools.BuildOptions) tools.Tool {
 			args.Depth = 0
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/observational_memory.go
+++ b/internal/harness/tools/core/observational_memory.go
@@ -150,7 +150,7 @@ func ObservationalMemoryTool(opts tools.BuildOptions) tools.Tool {
 					fmt.Sprintf("memory-%s.%s", time.Now().UTC().Format("20060102-150405"), ext),
 				))
 			}
-			absPath, pathErr := tools.ResolveWorkspacePath(workspaceRoot, exportPath)
+			absPath, pathErr := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, exportPath, opts.SandboxScope)
 			if pathErr != nil {
 				return "", pathErr
 			}

--- a/internal/harness/tools/core/read.go
+++ b/internal/harness/tools/core/read.go
@@ -35,7 +35,7 @@ func ReadTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path     string `json:"path"`
 			FilePath string `json:"file_path"`
@@ -66,7 +66,7 @@ func ReadTool(opts tools.BuildOptions) tools.Tool {
 			args.Limit = 0
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/core/write.go
+++ b/internal/harness/tools/core/write.go
@@ -40,7 +40,7 @@ func WriteTool(opts tools.BuildOptions) tools.Tool {
 
 	workspaceRoot := opts.WorkspaceRoot
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		var args struct {
 			Path            string  `json:"path"`
 			FilePath        string  `json:"file_path"`
@@ -80,7 +80,7 @@ func WriteTool(opts tools.BuildOptions) tools.Tool {
 			return "", err
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/coverage_boost_test.go
+++ b/internal/harness/tools/coverage_boost_test.go
@@ -353,7 +353,7 @@ func TestApplyUnifiedPatchAddFile(t *testing.T) {
 	workspace := t.TempDir()
 	patch := "*** Begin Patch\n*** Add File: newfile.txt\n+hello world\n*** End Patch"
 
-	result, err := applyUnifiedPatch(workspace, patch)
+	result, err := applyUnifiedPatch(context.Background(), workspace, SandboxScopeUnrestricted, patch)
 	if err != nil {
 		t.Fatalf("applyUnifiedPatch: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestApplyUnifiedPatchDeleteFile(t *testing.T) {
 	}
 
 	patch := "*** Begin Patch\n*** Delete File: todelete.txt\n*** End Patch"
-	result, err := applyUnifiedPatch(workspace, patch)
+	result, err := applyUnifiedPatch(context.Background(), workspace, SandboxScopeUnrestricted, patch)
 	if err != nil {
 		t.Fatalf("applyUnifiedPatch: %v", err)
 	}
@@ -404,7 +404,7 @@ func TestApplyUnifiedPatchUpdateFile(t *testing.T) {
 	}
 
 	patch := "*** Begin Patch\n*** Update File: src.txt\n@@ section\n-old line\n+new line\n*** End Patch"
-	result, err := applyUnifiedPatch(workspace, patch)
+	result, err := applyUnifiedPatch(context.Background(), workspace, SandboxScopeUnrestricted, patch)
 	if err != nil {
 		t.Fatalf("applyUnifiedPatch: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestApplyUnifiedPatchUpdateMissingOldText(t *testing.T) {
 	}
 
 	patch := "*** Begin Patch\n*** Update File: src.txt\n@@ section\n+only new\n*** End Patch"
-	_, err := applyUnifiedPatch(workspace, patch)
+	_, err := applyUnifiedPatch(context.Background(), workspace, SandboxScopeUnrestricted, patch)
 	if err == nil || !strings.Contains(err.Error(), "missing old text") {
 		t.Fatalf("expected missing old text error, got: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestApplyUnifiedPatchUpdateHunkNotPresent(t *testing.T) {
 	}
 
 	patch := "*** Begin Patch\n*** Update File: src.txt\n@@ section\n-nonexistent content\n+replacement\n*** End Patch"
-	_, err := applyUnifiedPatch(workspace, patch)
+	_, err := applyUnifiedPatch(context.Background(), workspace, SandboxScopeUnrestricted, patch)
 	if err == nil || !strings.Contains(err.Error(), "not present") {
 		t.Fatalf("expected hunk not present error, got: %v", err)
 	}

--- a/internal/harness/tools/deferred/deferred_test.go
+++ b/internal/harness/tools/deferred/deferred_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -93,18 +94,34 @@ func withRunMetadata(ctx context.Context, md tools.RunMetadata) context.Context 
 	return context.WithValue(ctx, tools.ContextKeyRunMetadata, md)
 }
 
+// testServerHost extracts the host (without port) from an httptest.Server URL,
+// for use as an SSRF-guard NetworkAllowlist entry in tests that legitimately
+// need to reach a local test server.
+func testServerHost(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse test server URL %q: %v", rawURL, err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		t.Fatalf("test server URL %q has no host", rawURL)
+	}
+	return host
+}
+
 // ---------- tests ----------
 
 // TestFetchTool_Definition verifies the fetch tool constructor.
 func TestFetchTool_Definition(t *testing.T) {
-	tool := FetchTool(http.DefaultClient)
+	tool := FetchTool(http.DefaultClient, nil)
 	assertToolDef(t, tool, "fetch", tools.TierDeferred)
 	assertHasTags(t, tool, "http", "web")
 }
 
 // TestFetchTool_Handler_MissingURL verifies fetch returns an error when url is empty.
 func TestFetchTool_Handler_MissingURL(t *testing.T) {
-	tool := FetchTool(http.DefaultClient)
+	tool := FetchTool(http.DefaultClient, nil)
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("expected error for missing url")
@@ -113,7 +130,7 @@ func TestFetchTool_Handler_MissingURL(t *testing.T) {
 
 // TestFetchTool_Handler_BadScheme verifies fetch rejects non-http schemes.
 func TestFetchTool_Handler_BadScheme(t *testing.T) {
-	tool := FetchTool(http.DefaultClient)
+	tool := FetchTool(http.DefaultClient, nil)
 	_, err := tool.Handler(context.Background(), json.RawMessage(`{"url":"ftp://example.com"}`))
 	if err == nil {
 		t.Fatal("expected error for ftp scheme")
@@ -121,13 +138,17 @@ func TestFetchTool_Handler_BadScheme(t *testing.T) {
 }
 
 // TestFetchTool_Handler_Success verifies fetch returns content from a test server.
+// The test server listens on loopback, which the SSRF guard blocks by
+// default (see ssrf_guard_test.go in the parent package) — so this test
+// exercises the explicit opt-in allowlist to reach it, proving the guard
+// doesn't break legitimate, explicitly-permitted local fetches.
 func TestFetchTool_Handler_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "hello from server")
 	}))
 	defer ts.Close()
 
-	tool := FetchTool(ts.Client())
+	tool := FetchTool(ts.Client(), []string{testServerHost(t, ts.URL)})
 	args, _ := json.Marshal(map[string]string{"url": ts.URL})
 	result, err := tool.Handler(context.Background(), json.RawMessage(args))
 	if err != nil {
@@ -163,7 +184,34 @@ func TestDownloadTool_Handler_MissingFilePath(t *testing.T) {
 	}
 }
 
+// TestDownloadTool_Handler_BlocksLoopbackByDefault is a regression test for
+// the SSRF guard wiring specifically on the production download tool
+// (BUG-2): without an explicit NetworkAllowlist entry, a request to a
+// loopback test server must be refused, proving DownloadTool actually routes
+// through the guarded client rather than the raw one.
+func TestDownloadTool_Handler_BlocksLoopbackByDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("should never reach the agent"))
+	}))
+	defer ts.Close()
+
+	dir := t.TempDir()
+	tool := DownloadTool(tools.BuildOptions{WorkspaceRoot: dir, HTTPClient: ts.Client()})
+	args, _ := json.Marshal(map[string]string{"url": ts.URL, "file_path": "dl.txt"})
+	_, err := tool.Handler(context.Background(), json.RawMessage(args))
+	if err == nil {
+		t.Fatal("expected download from an unallowlisted loopback destination to be blocked by default")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "dl.txt")); statErr == nil {
+		t.Fatal("expected no file to be written when the destination is blocked")
+	}
+}
+
 // TestDownloadTool_Handler_Success verifies download saves content from a test server.
+// The test server listens on loopback, which the SSRF guard blocks by
+// default — so this test exercises the explicit opt-in NetworkAllowlist to
+// reach it, proving the guard doesn't break legitimate, explicitly-permitted
+// local fetches.
 func TestDownloadTool_Handler_Success(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("downloaded content"))
@@ -171,7 +219,7 @@ func TestDownloadTool_Handler_Success(t *testing.T) {
 	defer ts.Close()
 
 	dir := t.TempDir()
-	tool := DownloadTool(tools.BuildOptions{WorkspaceRoot: dir, HTTPClient: ts.Client()})
+	tool := DownloadTool(tools.BuildOptions{WorkspaceRoot: dir, HTTPClient: ts.Client(), NetworkAllowlist: []string{testServerHost(t, ts.URL)}})
 	args, _ := json.Marshal(map[string]string{"url": ts.URL, "file_path": "dl.txt"})
 	result, err := tool.Handler(context.Background(), json.RawMessage(args))
 	if err != nil {

--- a/internal/harness/tools/deferred/download.go
+++ b/internal/harness/tools/deferred/download.go
@@ -42,6 +42,7 @@ func DownloadTool(opts tools.BuildOptions) tools.Tool {
 	if client == nil {
 		client = http.DefaultClient
 	}
+	client = tools.NewGuardedHTTPClient(client, opts.NetworkAllowlist)
 	workspaceRoot := opts.WorkspaceRoot
 
 	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {

--- a/internal/harness/tools/deferred/download.go
+++ b/internal/harness/tools/deferred/download.go
@@ -80,7 +80,7 @@ func DownloadTool(opts tools.BuildOptions) tools.Tool {
 			args.MaxBytes = 100 * 1024 * 1024
 		}
 
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.FilePath)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.FilePath, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/deferred/fetch.go
+++ b/internal/harness/tools/deferred/fetch.go
@@ -15,7 +15,8 @@ import (
 )
 
 // FetchTool returns a deferred tool for fetching URL content with bounded timeout and size.
-func FetchTool(client *http.Client) tools.Tool {
+func FetchTool(client *http.Client, networkAllowlist []string) tools.Tool {
+	client = tools.NewGuardedHTTPClient(client, networkAllowlist)
 	def := tools.Definition{
 		Name:         "fetch",
 		Description:  descriptions.Load("fetch"),

--- a/internal/harness/tools/deferred/git_deep.go
+++ b/internal/harness/tools/deferred/git_deep.go
@@ -131,7 +131,7 @@ func GitLogSearchTool(opts tools.BuildOptions) tools.Tool {
 		// Build optional path suffix
 		var pathSuffix []string
 		if strings.TrimSpace(args.Path) != "" {
-			absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+			absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}
@@ -263,7 +263,7 @@ func GitFileHistoryTool(opts tools.BuildOptions) tools.Tool {
 		if err != nil {
 			return "", fmt.Errorf("resolve workspace root: %w", err)
 		}
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}
@@ -433,7 +433,7 @@ func GitBlameContextTool(opts tools.BuildOptions) tools.Tool {
 		if err != nil {
 			return "", fmt.Errorf("resolve workspace root: %w", err)
 		}
-		absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 		if err != nil {
 			return "", err
 		}
@@ -657,7 +657,7 @@ func GitDiffRangeTool(opts tools.BuildOptions) tools.Tool {
 		// Build optional path suffix
 		var pathSuffix []string
 		if strings.TrimSpace(args.Path) != "" {
-			absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+			absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}
@@ -795,7 +795,7 @@ func GitContributorContextTool(opts tools.BuildOptions) tools.Tool {
 			cmdArgs = append(cmdArgs, "--since="+args.Since)
 		}
 		if strings.TrimSpace(args.Path) != "" {
-			absPath, err := tools.ResolveWorkspacePath(workspaceRoot, args.Path)
+			absPath, err := tools.ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}

--- a/internal/harness/tools/deferred/lsp.go
+++ b/internal/harness/tools/deferred/lsp.go
@@ -43,7 +43,7 @@ func LspDiagnosticsTool(opts tools.BuildOptions) tools.Tool {
 		}
 		target := "./..."
 		if strings.TrimSpace(args.FilePath) != "" {
-			absPath, err := tools.ResolveWorkspacePath(opts.WorkspaceRoot, args.FilePath)
+			absPath, err := tools.ResolveWorkspacePathConfined(ctx, opts.WorkspaceRoot, args.FilePath, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}
@@ -95,7 +95,7 @@ func LspReferencesTool(opts tools.BuildOptions) tools.Tool {
 			return "", fmt.Errorf("resolve workspace root: %w", err)
 		}
 		if strings.TrimSpace(args.Path) != "" {
-			resolved, err := tools.ResolveWorkspacePath(opts.WorkspaceRoot, args.Path)
+			resolved, err := tools.ResolveWorkspacePathConfined(ctx, opts.WorkspaceRoot, args.Path, opts.SandboxScope)
 			if err != nil {
 				return "", err
 			}

--- a/internal/harness/tools/download.go
+++ b/internal/harness/tools/download.go
@@ -15,7 +15,8 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func downloadTool(workspaceRoot string, client *http.Client, sandboxScope SandboxScope) Tool {
+func downloadTool(workspaceRoot string, client *http.Client, sandboxScope SandboxScope, networkAllowlist []string) Tool {
+	client = NewGuardedHTTPClient(client, networkAllowlist)
 	def := Definition{
 		Name:         "download",
 		Description:  descriptions.Load("download"),

--- a/internal/harness/tools/download.go
+++ b/internal/harness/tools/download.go
@@ -15,7 +15,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func downloadTool(workspaceRoot string, client *http.Client) Tool {
+func downloadTool(workspaceRoot string, client *http.Client, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "download",
 		Description:  descriptions.Load("download"),
@@ -71,7 +71,7 @@ func downloadTool(workspaceRoot string, client *http.Client) Tool {
 			args.MaxBytes = 100 * 1024 * 1024
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.FilePath)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.FilePath, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/edit.go
+++ b/internal/harness/tools/edit.go
@@ -10,7 +10,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func editTool(workspaceRoot string) Tool {
+func editTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "edit",
 		Description:  descriptions.Load("edit"),
@@ -34,7 +34,7 @@ func editTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Path            string `json:"path"`
 			FilePath        string `json:"file_path"`
@@ -58,7 +58,7 @@ func editTool(workspaceRoot string) Tool {
 			return "", fmt.Errorf("old_text is required")
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/fetch.go
+++ b/internal/harness/tools/fetch.go
@@ -13,7 +13,8 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func fetchTool(client *http.Client) Tool {
+func fetchTool(client *http.Client, networkAllowlist []string) Tool {
+	client = NewGuardedHTTPClient(client, networkAllowlist)
 	def := Definition{
 		Name:         "fetch",
 		Description:  descriptions.Load("fetch"),

--- a/internal/harness/tools/git_diff.go
+++ b/internal/harness/tools/git_diff.go
@@ -11,7 +11,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func gitDiffTool(workspaceRoot string) Tool {
+func gitDiffTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "git_diff",
 		Description:  descriptions.Load("git_diff"),
@@ -61,7 +61,7 @@ func gitDiffTool(workspaceRoot string) Tool {
 			cmdArgs = append(cmdArgs, args.Target)
 		}
 		if strings.TrimSpace(args.Path) != "" {
-			absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+			absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 			if err != nil {
 				return "", err
 			}

--- a/internal/harness/tools/glob.go
+++ b/internal/harness/tools/glob.go
@@ -11,7 +11,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func globTool(workspaceRoot string) Tool {
+func globTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "glob",
 		Description:  descriptions.Load("glob"),
@@ -28,7 +28,7 @@ func globTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Pattern    string `json:"pattern"`
 			MaxMatches int    `json:"max_matches"`
@@ -59,6 +59,7 @@ func globTool(workspaceRoot string) Tool {
 			return "", fmt.Errorf("glob pattern: %w", err)
 		}
 
+		scope := EffectiveSandboxScope(ctx, sandboxScope)
 		filtered := make([]string, 0, len(matches))
 		for _, match := range matches {
 			rel, err := filepath.Rel(absRoot, match)
@@ -66,6 +67,13 @@ func globTool(workspaceRoot string) Tool {
 				continue
 			}
 			if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				continue
+			}
+			// Under workspace scope, also drop matches that only appear inside the
+			// workspace because a symlink component in the pattern resolves outside
+			// it (e.g. a `workspace/escape-link -> /etc` symlink followed by the
+			// glob library when matching `escape-link/*`).
+			if _, err := ConfineWorkspacePath(scope, workspaceRoot, nil, match); err != nil {
 				continue
 			}
 			filtered = append(filtered, filepath.ToSlash(rel))

--- a/internal/harness/tools/grep.go
+++ b/internal/harness/tools/grep.go
@@ -17,7 +17,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func grepTool(workspaceRoot string) Tool {
+func grepTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "grep",
 		Description:  descriptions.Load("grep"),
@@ -38,7 +38,7 @@ func grepTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Query         string `json:"query"`
 			Path          string `json:"path"`
@@ -63,7 +63,7 @@ func grepTool(workspaceRoot string) Tool {
 			args.Regex = false
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/ls.go
+++ b/internal/harness/tools/ls.go
@@ -15,7 +15,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func lsTool(workspaceRoot string) Tool {
+func lsTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "ls",
 		Description:  descriptions.Load("ls"),
@@ -34,7 +34,7 @@ func lsTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Path          string `json:"path"`
 			Recursive     bool   `json:"recursive"`
@@ -57,7 +57,7 @@ func lsTool(workspaceRoot string) Tool {
 			args.Depth = 0
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/lsp.go
+++ b/internal/harness/tools/lsp.go
@@ -12,7 +12,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func lspDiagnosticsTool(workspaceRoot string) Tool {
+func lspDiagnosticsTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "lsp_diagnostics",
 		Description:  descriptions.Load("lsp_diagnostics"),
@@ -40,7 +40,7 @@ func lspDiagnosticsTool(workspaceRoot string) Tool {
 		}
 		target := "./..."
 		if strings.TrimSpace(args.FilePath) != "" {
-			absPath, err := ResolveWorkspacePath(workspaceRoot, args.FilePath)
+			absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.FilePath, sandboxScope)
 			if err != nil {
 				return "", err
 			}
@@ -55,7 +55,7 @@ func lspDiagnosticsTool(workspaceRoot string) Tool {
 	return Tool{Definition: def, Handler: handler}
 }
 
-func lspReferencesTool(workspaceRoot string) Tool {
+func lspReferencesTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "lsp_references",
 		Description:  descriptions.Load("lsp_references"),
@@ -89,7 +89,7 @@ func lspReferencesTool(workspaceRoot string) Tool {
 			return "", fmt.Errorf("resolve workspace root: %w", err)
 		}
 		if strings.TrimSpace(args.Path) != "" {
-			resolved, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+			resolved, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 			if err != nil {
 				return "", err
 			}

--- a/internal/harness/tools/observational_memory.go
+++ b/internal/harness/tools/observational_memory.go
@@ -29,7 +29,7 @@ type observationalMemoryArgs struct {
 	} `json:"review,omitempty"`
 }
 
-func observationalMemoryTool(workspaceRoot string, manager om.Manager, runner AgentRunner) Tool {
+func observationalMemoryTool(workspaceRoot string, manager om.Manager, runner AgentRunner, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "observational_memory",
 		Description:  descriptions.Load("observational_memory"),
@@ -142,7 +142,7 @@ func observationalMemoryTool(workspaceRoot string, manager om.Manager, runner Ag
 					fmt.Sprintf("memory-%s.%s", time.Now().UTC().Format("20060102-150405"), ext),
 				))
 			}
-			absPath, pathErr := ResolveWorkspacePath(workspaceRoot, exportPath)
+			absPath, pathErr := ResolveWorkspacePathConfined(ctx, workspaceRoot, exportPath, sandboxScope)
 			if pathErr != nil {
 				return "", pathErr
 			}

--- a/internal/harness/tools/observational_memory_test.go
+++ b/internal/harness/tools/observational_memory_test.go
@@ -70,7 +70,7 @@ func (r *reviewRunnerStub) RunPrompt(_ context.Context, prompt string) (string, 
 }
 
 func TestObservationalMemoryToolStatusWithoutManager(t *testing.T) {
-	tool := observationalMemoryTool(t.TempDir(), nil, nil)
+	tool := observationalMemoryTool(t.TempDir(), nil, nil, SandboxScopeUnrestricted)
 	out, err := tool.Handler(context.WithValue(context.Background(), ContextKeyRunID, "run_1"), json.RawMessage(`{"action":"status"}`))
 	if err != nil {
 		t.Fatalf("handler error: %v", err)
@@ -88,7 +88,7 @@ func TestObservationalMemoryToolStatusWithoutManager(t *testing.T) {
 func TestObservationalMemoryToolExportWritesFile(t *testing.T) {
 	workspace := t.TempDir()
 	stub := &memoryStub{status: om.Status{Mode: om.ModeLocalCoordinator, MemoryID: "default|conv|agent", Scope: om.ScopeKey{TenantID: "default", ConversationID: "conv", AgentID: "agent"}, Enabled: true, UpdatedAt: time.Now().UTC()}}
-	tool := observationalMemoryTool(workspace, stub, nil)
+	tool := observationalMemoryTool(workspace, stub, nil, SandboxScopeUnrestricted)
 	ctx := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run_1", TenantID: "default", ConversationID: "conv", AgentID: "agent"})
 	ctx = context.WithValue(ctx, ContextKeyRunID, "run_1")
 	out, err := tool.Handler(ctx, json.RawMessage(`{"action":"export","export":{"format":"json","path":"exports/memory.json"}}`))
@@ -119,7 +119,7 @@ func TestObservationalMemoryToolExportWritesFile(t *testing.T) {
 func TestObservationalMemoryToolEnableUsesConfig(t *testing.T) {
 	workspace := t.TempDir()
 	stub := &memoryStub{status: om.Status{Mode: om.ModeLocalCoordinator, MemoryID: "default|conv|agent", Scope: om.ScopeKey{TenantID: "default", ConversationID: "conv", AgentID: "agent"}, Enabled: false, UpdatedAt: time.Now().UTC()}}
-	tool := observationalMemoryTool(workspace, stub, nil)
+	tool := observationalMemoryTool(workspace, stub, nil, SandboxScopeUnrestricted)
 	ctx := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run_1", TenantID: "default", ConversationID: "conv", AgentID: "agent"})
 	ctx = context.WithValue(ctx, ContextKeyRunID, "run_1")
 	out, err := tool.Handler(ctx, json.RawMessage(`{"action":"enable","config":{"observe_min_tokens":11,"snippet_max_tokens":22,"reflect_threshold_tokens":33}}`))
@@ -144,7 +144,7 @@ func TestObservationalMemoryToolReviewCallsRunner(t *testing.T) {
 		exported: om.ExportResult{Format: "markdown", Content: "# memory\n- note", Bytes: 14},
 	}
 	runner := &reviewRunnerStub{out: "analysis output"}
-	tool := observationalMemoryTool(workspace, stub, runner)
+	tool := observationalMemoryTool(workspace, stub, runner, SandboxScopeUnrestricted)
 	ctx := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run_1", TenantID: "default", ConversationID: "conv", AgentID: "agent"})
 	ctx = context.WithValue(ctx, ContextKeyRunID, "run_1")
 
@@ -164,7 +164,7 @@ func TestObservationalMemoryToolReviewCallsRunner(t *testing.T) {
 }
 
 func TestObservationalMemoryToolRejectsUnsupportedAction(t *testing.T) {
-	tool := observationalMemoryTool(t.TempDir(), &memoryStub{}, nil)
+	tool := observationalMemoryTool(t.TempDir(), &memoryStub{}, nil, SandboxScopeUnrestricted)
 	ctx := context.WithValue(context.Background(), ContextKeyRunID, "run_1")
 	ctx = context.WithValue(ctx, ContextKeyRunMetadata, RunMetadata{RunID: "run_1", ConversationID: "conv"})
 	if _, err := tool.Handler(ctx, json.RawMessage(`{"action":"unknown"}`)); err == nil {
@@ -173,7 +173,7 @@ func TestObservationalMemoryToolRejectsUnsupportedAction(t *testing.T) {
 }
 
 func TestObservationalMemoryToolRequiresRunContext(t *testing.T) {
-	tool := observationalMemoryTool(t.TempDir(), &memoryStub{}, nil)
+	tool := observationalMemoryTool(t.TempDir(), &memoryStub{}, nil, SandboxScopeUnrestricted)
 	if _, err := tool.Handler(context.Background(), json.RawMessage(`{"action":"status"}`)); err == nil {
 		t.Fatalf("expected run context error")
 	}

--- a/internal/harness/tools/read.go
+++ b/internal/harness/tools/read.go
@@ -11,7 +11,7 @@ import (
 	"go-agent-harness/internal/harness/tools/descriptions"
 )
 
-func readTool(workspaceRoot string) Tool {
+func readTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "read",
 		Description:  descriptions.Load("read"),
@@ -32,7 +32,7 @@ func readTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Path      string `json:"path"`
 			FilePath  string `json:"file_path"`
@@ -63,7 +63,7 @@ func readTool(workspaceRoot string) Tool {
 			args.Limit = 0
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools/sandbox_darwin.go
+++ b/internal/harness/tools/sandbox_darwin.go
@@ -38,6 +38,19 @@ func buildSandboxedCommand(ctx context.Context, scope SandboxScope, workspaceRoo
 		if absErr != nil {
 			absRoot = workspaceRoot
 		}
+		// Canonicalize through symlinks before embedding the root in the
+		// seatbelt profile's (subpath ...) predicate. macOS resolves /tmp,
+		// /var, and TMPDIR-based paths (as returned by t.TempDir() and most
+		// container/worktree provisioning) through a /var -> /private/var
+		// symlink; sandbox-exec's subpath match is against the kernel's
+		// resolved path, not the symlinked one the caller passed in. Without
+		// this, every legitimate in-workspace write under a symlinked root
+		// is denied with "Operation not permitted" — the same class of
+		// symlink pitfall ConfineWorkspacePath (common_paths.go) already
+		// guards against for the Go-side path checks.
+		if resolvedRoot, err := filepath.EvalSymlinks(absRoot); err == nil {
+			absRoot = resolvedRoot
+		}
 
 		profile := seatbeltProfile(scope, absRoot)
 		f, err := os.CreateTemp("", "harness-sandbox-*.sb")

--- a/internal/harness/tools/ssrf_guard.go
+++ b/internal/harness/tools/ssrf_guard.go
@@ -1,0 +1,29 @@
+package tools
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// TODO(BUG-2 red phase): stub only — allows every destination. The real
+// implementation blocks non-public IPs at dial time unless allowlisted.
+func sandboxedDialerControl(allowlist []string) func(network, address string, c syscall.RawConn) error {
+	return func(network, address string, c syscall.RawConn) error {
+		return nil
+	}
+}
+
+// TODO(BUG-2 red phase): stub only — returns base unmodified (today's
+// vulnerable behavior: no SSRF protection at all).
+func NewGuardedHTTPClient(base *http.Client, allowlist []string) *http.Client {
+	if base == nil {
+		return &http.Client{Timeout: 30 * time.Second}
+	}
+	return base
+}
+
+var _ = context.Background
+var _ = net.SplitHostPort

--- a/internal/harness/tools/ssrf_guard.go
+++ b/internal/harness/tools/ssrf_guard.go
@@ -2,28 +2,161 @@ package tools
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"syscall"
 	"time"
 )
 
-// TODO(BUG-2 red phase): stub only — allows every destination. The real
-// implementation blocks non-public IPs at dial time unless allowlisted.
+// sandboxedDialerControl returns a net.Dialer.Control hook that inspects the
+// ACTUAL destination address being dialed (after DNS resolution) and refuses
+// to connect unless the address is a public IP or explicitly allowlisted by
+// IP/CIDR.
+//
+// This is the DNS-rebinding-safe enforcement point: Control fires once per
+// real connection attempt, for the concrete resolved address, not for the
+// original hostname string. A hostname that resolves to a public IP when
+// checked ahead of time but to a private IP at the moment of connection is
+// still caught here, because there is no "ahead of time" check to bypass —
+// the check IS the connection attempt.
 func sandboxedDialerControl(allowlist []string) func(network, address string, c syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
-		return nil
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return fmt.Errorf("ssrf-guard: could not parse destination IP %q for dial", host)
+		}
+		if isIPAllowlisted(ip, allowlist) {
+			return nil
+		}
+		if isPublicIP(ip) {
+			return nil
+		}
+		return fmt.Errorf("ssrf-guard: destination %s is not a public address and is not in the network allowlist (blocked by default; see BuildOptions.NetworkAllowlist)", ip)
 	}
 }
 
-// TODO(BUG-2 red phase): stub only — returns base unmodified (today's
-// vulnerable behavior: no SSRF protection at all).
+// isPublicIP reports whether ip is safe to dial by default: not loopback,
+// not link-local (covers 169.254.0.0/16 cloud-metadata range and IPv6
+// fe80::/10), not private (RFC1918 10/8, 172.16/12, 192.168/16, and IPv6
+// unique-local fc00::/7 via net.IP.IsPrivate), and not unspecified/multicast.
+func isPublicIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified() ||
+		ip.IsMulticast() {
+		return false
+	}
+	return true
+}
+
+// isIPAllowlisted reports whether ip matches any allowlist entry that is an
+// IP literal or CIDR. Bare-hostname entries are ignored here (they are
+// matched against the pre-resolution request host by isHostAllowlisted).
+func isIPAllowlisted(ip net.IP, allowlist []string) bool {
+	for _, entry := range allowlist {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if strings.Contains(entry, "/") {
+			if _, ipnet, err := net.ParseCIDR(entry); err == nil && ipnet.Contains(ip) {
+				return true
+			}
+			continue
+		}
+		if allowedIP := net.ParseIP(entry); allowedIP != nil && allowedIP.Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// isHostAllowlisted reports whether host (the ORIGINAL, pre-resolution
+// request host, e.g. "localhost" or "internal-api.corp.example") matches a
+// bare-hostname allowlist entry, case-insensitively. IP/CIDR entries are
+// deliberately skipped here — those are matched against the resolved
+// destination address by isIPAllowlisted / sandboxedDialerControl instead,
+// so a plain IP entry cannot be used to bypass by claiming an unrelated host
+// string.
+func isHostAllowlisted(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	for _, entry := range allowlist {
+		entry = strings.ToLower(strings.TrimSpace(entry))
+		if entry == "" || strings.Contains(entry, "/") || net.ParseIP(entry) != nil {
+			continue
+		}
+		if entry == host {
+			return true
+		}
+	}
+	return false
+}
+
+// NewGuardedHTTPClient returns an *http.Client based on base (or a sane
+// default if base is nil) whose Transport routes every dial through the SSRF
+// guard: by default only public destination addresses can be connected to.
+// This is the sole enforcement point for the download/fetch tools' SSRF
+// protection (BUG-2) and is applied by every outbound-fetch tool constructor
+// in this package that owns an *http.Client (fetch, download, and their
+// deferred-tier equivalents) — regardless of what Transport the caller
+// originally configured on base.
+//
+// allowlist entries are the explicit, safety-biased-default opt-in: a bare
+// hostname (matched against the pre-resolution request host, e.g.
+// "localhost") or an IP/CIDR literal (matched against the actual resolved
+// destination address at dial time, e.g. "10.0.0.0/8" or "127.0.0.1"). An
+// empty allowlist means no exceptions: only public addresses are reachable.
+//
+// The guard is both DNS-rebinding safe and redirect safe: the same
+// Transport (and therefore the same guarded DialContext) is reused for every
+// connection a request needs, including connections made while following
+// HTTP redirects, so the dial-time check runs again for each new
+// destination — a public URL that 302s to a blocked address still fails.
 func NewGuardedHTTPClient(base *http.Client, allowlist []string) *http.Client {
 	if base == nil {
-		return &http.Client{Timeout: 30 * time.Second}
+		base = &http.Client{Timeout: 30 * time.Second}
 	}
-	return base
-}
+	clone := *base
 
-var _ = context.Background
-var _ = net.SplitHostPort
+	var transport *http.Transport
+	if t, ok := base.Transport.(*http.Transport); ok && t != nil {
+		transport = t.Clone()
+	} else {
+		transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+
+	control := sandboxedDialerControl(allowlist)
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		dialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}
+		if !isHostAllowlisted(host, allowlist) {
+			// Not explicitly allowlisted by hostname: every candidate address this
+			// dial resolves to must individually pass the public-address check.
+			dialer.Control = control
+		}
+		return dialer.DialContext(ctx, network, address)
+	}
+	clone.Transport = transport
+	return &clone
+}

--- a/internal/harness/tools/ssrf_guard_test.go
+++ b/internal/harness/tools/ssrf_guard_test.go
@@ -1,0 +1,181 @@
+package tools
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These tests are written as ATTACKS against the outbound fetch/download
+// tools' network guard (BUG 2, P2): by default, dialing loopback,
+// link-local (incl. 169.254.169.254 cloud metadata), and RFC1918/ULA private
+// destinations must be refused — including when a hostname only resolves to
+// such an address AT DIAL TIME (DNS-rebinding safety), and including via
+// HTTP redirects. The explicit opt-in allowlist is the only way through.
+
+func TestSSRFGuard_DialControl_RejectsLoopback(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	if err := control("tcp", "127.0.0.1:80", nil); err == nil {
+		t.Fatal("expected loopback destination to be rejected by default")
+	}
+}
+
+func TestSSRFGuard_DialControl_RejectsCloudMetadataLinkLocal(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	if err := control("tcp", "169.254.169.254:80", nil); err == nil {
+		t.Fatal("expected link-local cloud metadata address to be rejected by default")
+	}
+}
+
+func TestSSRFGuard_DialControl_RejectsRFC1918Private(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	if err := control("tcp", "10.1.2.3:443", nil); err == nil {
+		t.Fatal("expected RFC1918 private destination to be rejected by default")
+	}
+}
+
+func TestSSRFGuard_DialControl_RejectsIPv6LinkLocal(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	if err := control("tcp", "[fe80::1]:80", nil); err == nil {
+		t.Fatal("expected IPv6 link-local destination to be rejected by default")
+	}
+}
+
+func TestSSRFGuard_DialControl_RejectsIPv6UniqueLocal(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	if err := control("tcp", "[fd00::1]:80", nil); err == nil {
+		t.Fatal("expected IPv6 unique-local (fc00::/7) destination to be rejected by default")
+	}
+}
+
+func TestSSRFGuard_DialControl_AllowsPublicAddress(t *testing.T) {
+	control := sandboxedDialerControl(nil)
+	// 93.184.216.34 (example.com) is a public IP literal — no real network
+	// access happens in this test since Control only inspects the address
+	// string; it never dials.
+	if err := control("tcp", "93.184.216.34:443", nil); err != nil {
+		t.Fatalf("expected public destination to be allowed by default, got: %v", err)
+	}
+}
+
+func TestSSRFGuard_DialControl_CIDRAllowlistPermitsOtherwiseBlockedIP(t *testing.T) {
+	control := sandboxedDialerControl([]string{"10.0.0.0/8"})
+	if err := control("tcp", "10.5.5.5:80", nil); err != nil {
+		t.Fatalf("expected 10.5.5.5 to be permitted by the 10.0.0.0/8 allowlist entry, got: %v", err)
+	}
+	// A private address NOT covered by the allowlist entry must still be blocked.
+	if err := control("tcp", "192.168.1.1:80", nil); err == nil {
+		t.Fatal("expected 192.168.1.1 (not covered by allowlist) to still be rejected")
+	}
+}
+
+// TestSSRFGuard_GuardedClient_BlocksLoopbackByDefault proves the guard is
+// wired into the actual http.Client used by the fetch/download tools: an
+// httptest server is, by construction, listening on loopback — dialing it
+// through the guarded client must fail unless explicitly allowlisted.
+func TestSSRFGuard_GuardedClient_BlocksLoopbackByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("secret"))
+	}))
+	defer srv.Close()
+
+	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, nil)
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected request to loopback httptest server to be blocked by default")
+	}
+}
+
+// TestSSRFGuard_GuardedClient_AllowlistPermitsExplicitHost proves the opt-in
+// escape hatch: adding the httptest server's host to the allowlist permits
+// the exact same request that was blocked above.
+func TestSSRFGuard_GuardedClient_AllowlistPermitsExplicitHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	host, _, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse httptest server host: %v", err)
+	}
+
+	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, []string{host})
+	res, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("expected explicitly allowlisted host to be permitted, got: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if string(body) != "hello" {
+		t.Fatalf("unexpected body %q", body)
+	}
+}
+
+// TestSSRFGuard_GuardedClient_DNSNameResolvingToLoopback_RefusedAtDialTime
+// proves the check runs at actual dial time (post-resolution), not just on
+// the literal hostname string: "localhost" is a real DNS/hosts name that
+// resolves via the normal system resolver, and must still be blocked because
+// the resolved address is loopback.
+func TestSSRFGuard_GuardedClient_DNSNameResolvingToLoopback_RefusedAtDialTime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse httptest server port: %v", err)
+	}
+
+	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, nil)
+	_, err = client.Get("http://localhost:" + port)
+	if err == nil {
+		t.Fatal("expected a hostname resolving to loopback to be refused at dial time")
+	}
+}
+
+// TestSSRFGuard_GuardedClient_RedirectToBlockedDestination_Refused proves
+// that a request to an allowlisted ("public-standing-in") host that then
+// redirects to a non-allowlisted ("private-standing-in") host is blocked —
+// because both hops go through the same guarded Transport, and the dial-time
+// Control check runs again for the redirect target.
+func TestSSRFGuard_GuardedClient_RedirectToBlockedDestination_Refused(t *testing.T) {
+	blocked := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("should never be reached"))
+	}))
+	defer blocked.Close()
+
+	allowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, blocked.URL, http.StatusFound)
+	}))
+	defer allowed.Close()
+
+	allowedHost, _, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(allowed.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse allowed host: %v", err)
+	}
+
+	// Only the entry (redirect origin) host is allowlisted — the redirect target is not.
+	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, []string{allowedHost})
+	_, err = client.Get(allowed.URL)
+	if err == nil {
+		t.Fatal("expected redirect to a non-allowlisted blocked destination to fail")
+	}
+}
+
+func TestSSRFGuard_ContextCancellation_DoesNotHang(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	client := NewGuardedHTTPClient(&http.Client{}, nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:1/", nil)
+	_, err := client.Do(req)
+	if err == nil {
+		t.Fatal("expected blocked loopback request to fail")
+	}
+}

--- a/internal/harness/tools/ssrf_guard_test.go
+++ b/internal/harness/tools/ssrf_guard_test.go
@@ -140,30 +140,48 @@ func TestSSRFGuard_GuardedClient_DNSNameResolvingToLoopback_RefusedAtDialTime(t 
 	}
 }
 
+// newLoopbackServerOn starts an httptest server bound to a specific loopback
+// address (rather than httptest's default, always-127.0.0.1 listener) so two
+// servers in the same test can be distinguished by IP for allowlist purposes.
+// Both "127.0.0.1" and "::1" are loopback addresses active by default on
+// every supported platform, so this needs no special host configuration.
+func newLoopbackServerOn(t *testing.T, ip string, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(handler)
+	_ = srv.Listener.Close()
+	srv.Listener = l
+	srv.Start()
+	return srv
+}
+
 // TestSSRFGuard_GuardedClient_RedirectToBlockedDestination_Refused proves
 // that a request to an allowlisted ("public-standing-in") host that then
 // redirects to a non-allowlisted ("private-standing-in") host is blocked —
 // because both hops go through the same guarded Transport, and the dial-time
-// Control check runs again for the redirect target.
+// Control check runs again for the redirect target. The two servers are
+// bound to distinct loopback addresses (::1 vs 127.0.0.1) so the allowlist,
+// which matches by address, can actually distinguish "allowed origin" from
+// "blocked redirect target" — using httptest's default listener for both
+// would put them on the identical IP and make the test meaningless.
 func TestSSRFGuard_GuardedClient_RedirectToBlockedDestination_Refused(t *testing.T) {
-	blocked := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	blocked := newLoopbackServerOn(t, "127.0.0.1", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("should never be reached"))
-	}))
+	})
 	defer blocked.Close()
 
-	allowed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	allowed := newLoopbackServerOn(t, "::1", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, blocked.URL, http.StatusFound)
-	}))
+	})
 	defer allowed.Close()
 
-	allowedHost, _, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(allowed.URL, "http://"), "https://"))
-	if err != nil {
-		t.Fatalf("parse allowed host: %v", err)
-	}
-
-	// Only the entry (redirect origin) host is allowlisted — the redirect target is not.
-	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, []string{allowedHost})
-	_, err = client.Get(allowed.URL)
+	// Only the redirect ORIGIN address (::1) is allowlisted — the redirect
+	// target (127.0.0.1) is not.
+	client := NewGuardedHTTPClient(&http.Client{Timeout: 5 * time.Second}, []string{"::1"})
+	_, err := client.Get(allowed.URL)
 	if err == nil {
 		t.Fatal("expected redirect to a non-allowlisted blocked destination to fail")
 	}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -101,10 +101,23 @@ type PromptExtensionDirs struct {
 }
 
 type BuildOptions struct {
-	WorkspaceRoot      string
-	ApprovalMode       ApprovalMode
-	Policy             Policy
-	SandboxScope       SandboxScope // controls filesystem/network restrictions
+	WorkspaceRoot string
+	ApprovalMode  ApprovalMode
+	Policy        Policy
+	SandboxScope  SandboxScope // controls filesystem/network restrictions
+	// NetworkAllowlist is the explicit opt-in escape hatch for the outbound
+	// fetch/download tools' SSRF guard (see ssrf_guard.go): by default those
+	// tools refuse to dial loopback, link-local, RFC1918/ULA-private, or
+	// otherwise non-public destination IPs, even if a URL's hostname first
+	// resolves to a public address (the check runs at actual dial time, so it
+	// is DNS-rebinding safe). Each entry may be a bare hostname (matched
+	// against the request's original, pre-resolution host — e.g. "localhost")
+	// or a CIDR (e.g. "10.0.0.0/8", "127.0.0.1/32") matched against the
+	// resolved destination IP. Empty means no exceptions: only public
+	// addresses are reachable. This extends the same BuildOptions mechanism
+	// already used to configure SandboxScope, rather than introducing a
+	// separate configuration system.
+	NetworkAllowlist   []string
 	HTTPClient         *http.Client
 	Now                func() time.Time
 	AskUserBroker      AskUserQuestionBroker

--- a/internal/harness/tools/web_fetcher_guard.go
+++ b/internal/harness/tools/web_fetcher_guard.go
@@ -1,0 +1,164 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// guardedWebFetchMaxBytes bounds how much of a fetched page GuardedWebFetcher
+// will read into memory when it serves Fetch directly (no base configured),
+// mirroring the existing `fetch` tool's default cap (fetch.go).
+const guardedWebFetchMaxBytes = 512 * 1024
+
+// GuardedWebFetcher is the enforcement point for GAP-2: web_fetch,
+// web_search, and agentic_fetch (deferred/web.go, deferred/agent.go,
+// agent.go) are all backed by the WebFetcher interface (types.go), whose
+// concrete implementation lives outside this package — and, as of this
+// change, there is no production implementation of WebFetcher anywhere in
+// this repository at all, so there was no existing *http.Client construction
+// site to wrap. Rather than leave every future implementation to remember to
+// guard itself, GuardedWebFetcher closes the hole at the one choke point
+// that already exists for every caller: the BuildOptions.WebFetcher /
+// DefaultRegistryOptions.WebFetcher wiring in catalog.go and
+// tools_default.go, which now wrap whatever WebFetcher is supplied with this
+// type before handing it to the tool constructors.
+//
+// Fetch(url) is the surface with an agent/attacker-controlled destination —
+// the LLM chooses the URL directly:
+//   - When no base WebFetcher is configured, Fetch is served entirely by
+//     GuardedWebFetcher itself, through NewGuardedHTTPClient — the same
+//     dial-time, DNS-rebinding-safe, redirect-safe guard used by the
+//     fetch/download tools.
+//   - When a base WebFetcher IS configured, GuardedWebFetcher does not own
+//     its transport (and must not silently discard whatever that
+//     implementation actually does — content rendering, auth headers,
+//     caching, etc. — by replacing it with a bare GET; doing so would be
+//     surprising and would break legitimate implementations and tests that
+//     inject a fake/mock WebFetcher). Instead it performs a best-effort
+//     PRE-FLIGHT check: it resolves the destination host and rejects the
+//     call before ever invoking base.Fetch if any resolved address is not
+//     public or allowlisted. This is NOT dial-time safe against an
+//     adversarial DNS server that changes its answer between this check and
+//     base's own (separate, unowned) dial moments later — that stronger
+//     guarantee is only available in the no-base branch above and in
+//     ssrf_guard.go's NewGuardedHTTPClient, which own the transport. It DOES
+//     catch the threat cases this gap is scoped to: a literal
+//     private/loopback/link-local/cloud-metadata IP, and a hostname that
+//     resolves (statically, i.e. absent an active rebinding attacker) to
+//     one.
+//
+// Search(query) has no agent-supplied destination host — the search
+// backend's endpoint is chosen by whichever concrete WebFetcher
+// implementation the operator wires in, not by the LLM — so it is not a
+// dial-time-guardable SSRF surface in the same sense as Fetch, and is passed
+// through to base unchanged.
+type GuardedWebFetcher struct {
+	base      WebFetcher
+	allowlist []string
+	client    *http.Client // used only when base == nil
+}
+
+// NewGuardedWebFetcher wraps base (which may be nil) so that Fetch is always
+// subject to the SSRF guard. allowlist is the same bare-hostname/CIDR opt-in
+// used by NewGuardedHTTPClient and BuildOptions.NetworkAllowlist.
+func NewGuardedWebFetcher(base WebFetcher, allowlist []string) *GuardedWebFetcher {
+	return &GuardedWebFetcher{
+		base:      base,
+		allowlist: allowlist,
+		client:    NewGuardedHTTPClient(&http.Client{Timeout: 30 * time.Second}, allowlist),
+	}
+}
+
+// Fetch retrieves rawURL, refusing loopback, link-local (including
+// 169.254.169.254 cloud metadata), and RFC1918/ULA-private destinations by
+// default — unless the destination is covered by the allowlist this fetcher
+// was constructed with. See the type doc comment for the dial-time guarantee
+// difference between the base == nil and base != nil cases.
+func (g *GuardedWebFetcher) Fetch(ctx context.Context, rawURL string) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid url: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported url scheme %q", parsed.Scheme)
+	}
+
+	if g.base == nil {
+		return g.fetchDirect(ctx, rawURL)
+	}
+
+	if err := checkFetchDestinationAllowed(ctx, parsed, g.allowlist); err != nil {
+		return "", err
+	}
+	return g.base.Fetch(ctx, rawURL)
+}
+
+// fetchDirect serves Fetch entirely through the dial-time-guarded HTTP
+// client, with no base implementation to delegate to.
+func (g *GuardedWebFetcher) fetchDirect(ctx context.Context, rawURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build fetch request: %w", err)
+	}
+	res, err := g.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, guardedWebFetchMaxBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read fetch body: %w", err)
+	}
+	if len(body) > guardedWebFetchMaxBytes {
+		body = body[:guardedWebFetchMaxBytes]
+	}
+	return string(body), nil
+}
+
+// checkFetchDestinationAllowed resolves parsed's host and rejects unless
+// every resolved address is public or explicitly allowlisted (fail closed:
+// if a hostname resolves to a mix of public and private addresses, the
+// private one is what an attacker would actually want reached, so any
+// non-allowed address in the result set is enough to reject the whole
+// request). A bare-hostname allowlist match short-circuits without a DNS
+// lookup, exactly like isHostAllowlisted's use in ssrf_guard.go.
+func checkFetchDestinationAllowed(ctx context.Context, parsed *url.URL, allowlist []string) error {
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("ssrf-guard: url %q has no host", parsed.String())
+	}
+	if isHostAllowlisted(host, allowlist) {
+		return nil
+	}
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return fmt.Errorf("ssrf-guard: could not resolve host %q: %w", host, err)
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("ssrf-guard: host %q did not resolve to any address", host)
+	}
+	for _, addr := range addrs {
+		if isIPAllowlisted(addr.IP, allowlist) || isPublicIP(addr.IP) {
+			continue
+		}
+		return fmt.Errorf("ssrf-guard: destination %s (resolved from %q) is not a public address and is not in the network allowlist (blocked by default; see BuildOptions.NetworkAllowlist)", addr.IP, host)
+	}
+	return nil
+}
+
+// Search delegates to the wrapped base WebFetcher unchanged: the search
+// backend's destination is operator-configured, not agent-supplied, so it is
+// outside the SSRF threat model Fetch's guard addresses. Returns an error if
+// no base WebFetcher was supplied.
+func (g *GuardedWebFetcher) Search(ctx context.Context, query string, maxResults int) ([]map[string]any, error) {
+	if g.base == nil {
+		return nil, fmt.Errorf("web search is not configured")
+	}
+	return g.base.Search(ctx, query, maxResults)
+}

--- a/internal/harness/tools/web_fetcher_guard_test.go
+++ b/internal/harness/tools/web_fetcher_guard_test.go
@@ -1,0 +1,120 @@
+package tools
+
+// These tests are written as ATTACKS against the WebFetcher-backed tools
+// (GAP-2 / BUG-2 follow-up): web_fetch, web_search, and agentic_fetch are all
+// backed by a WebFetcher whose Fetch(url) argument is chosen directly by the
+// LLM. Before this fix, BuildCatalog (catalog.go) and
+// NewDefaultRegistryWithOptions (tools_default.go) handed whatever WebFetcher
+// implementation the caller supplied straight to the tool constructors with
+// no guard at all, so a prompt-injected agent could reach loopback,
+// link-local (169.254.169.254 cloud metadata), and RFC1918/ULA-private
+// destinations through web_fetch/agentic_fetch even though the exact same
+// class of destination is already refused by the `fetch`/`download` tools'
+// guard (ssrf_guard.go).
+//
+// realHTTPWebFetcher below stands in for what an actual (currently
+// nonexistent in this repo) production WebFetcher implementation would look
+// like: it performs a real, UNGUARDED http.Get. It is deliberately NOT
+// guarded itself — proving the guard must be applied at the wiring point
+// (BuildCatalog / NewDefaultRegistryWithOptions), not by every future
+// implementation remembering to guard itself.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// realHTTPWebFetcher is a WebFetcher that performs actual, unguarded HTTP
+// requests — the shape any real (currently absent) production
+// implementation would take.
+type realHTTPWebFetcher struct {
+	client *http.Client
+}
+
+func newRealHTTPWebFetcher() *realHTTPWebFetcher {
+	return &realHTTPWebFetcher{client: &http.Client{Timeout: 5 * time.Second}}
+}
+
+func (f *realHTTPWebFetcher) Fetch(ctx context.Context, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := f.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (f *realHTTPWebFetcher) Search(_ context.Context, query string, maxResults int) ([]map[string]any, error) {
+	return []map[string]any{{"query": query, "max": maxResults}}, nil
+}
+
+// TestBuildCatalog_WebFetchTool_RefusesLoopbackDestination proves web_fetch
+// (built by BuildCatalog) refuses a loopback destination by default, even
+// though the underlying WebFetcher implementation would happily perform the
+// request itself (realHTTPWebFetcher has no guard of its own).
+func TestBuildCatalog_WebFetchTool_RefusesLoopbackDestination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("internal secret"))
+	}))
+	defer srv.Close()
+
+	list, err := BuildCatalog(BuildOptions{
+		WorkspaceRoot: t.TempDir(),
+		EnableAgent:   true,
+		AgentRunner:   &fakeRunner{},
+		EnableWebOps:  true,
+		WebFetcher:    newRealHTTPWebFetcher(),
+	})
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	webFetch := findToolByName(t, list, "web_fetch")
+
+	args, _ := json.Marshal(map[string]any{"url": srv.URL})
+	out, err := webFetch.Handler(context.Background(), args)
+	if err == nil && !strings.Contains(out, "\"error\"") {
+		t.Fatalf("expected web_fetch to refuse a loopback destination, but it succeeded: err=%v out=%s", err, out)
+	}
+}
+
+// TestBuildCatalog_AgenticFetchTool_RefusesLoopbackDestination proves
+// agentic_fetch (which also calls WebFetcher.Fetch with an agent-supplied
+// URL) is guarded the same way as web_fetch.
+func TestBuildCatalog_AgenticFetchTool_RefusesLoopbackDestination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("internal secret"))
+	}))
+	defer srv.Close()
+
+	list, err := BuildCatalog(BuildOptions{
+		WorkspaceRoot: t.TempDir(),
+		EnableAgent:   true,
+		AgentRunner:   &fakeRunner{},
+		EnableWebOps:  true,
+		WebFetcher:    newRealHTTPWebFetcher(),
+	})
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	agenticFetch := findToolByName(t, list, "agentic_fetch")
+
+	args, _ := json.Marshal(map[string]any{"url": srv.URL, "prompt": "summarize"})
+	out, err := agenticFetch.Handler(context.Background(), args)
+	if err == nil && !strings.Contains(out, "\"error\"") {
+		t.Fatalf("expected agentic_fetch to refuse a loopback destination, but it succeeded: err=%v out=%s", err, out)
+	}
+}

--- a/internal/harness/tools/web_fetcher_guard_unit_test.go
+++ b/internal/harness/tools/web_fetcher_guard_unit_test.go
@@ -1,0 +1,140 @@
+package tools
+
+// Direct unit tests of GuardedWebFetcher (GAP-2 implementation). These mirror
+// the required proving-test scenarios: 169.254.169.254 and 127.0.0.1 are
+// refused, a DNS name resolving to a private IP is refused AT DIAL TIME, a
+// permitted (allowlisted) destination still works, and Search is passed
+// through unchanged (it has no agent-supplied destination).
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGuardedWebFetcher_Fetch_RejectsLoopbackLiteral proves Fetch refuses a
+// literal 127.0.0.1 destination by default, and does so via the guard (not
+// via network unreachability) — the rejection is near-instant because
+// sandboxedDialerControl's Control hook fires before any connect() syscall.
+func TestGuardedWebFetcher_Fetch_RejectsLoopbackLiteral(t *testing.T) {
+	fetcher := NewGuardedWebFetcher(nil, nil)
+
+	start := time.Now()
+	_, err := fetcher.Fetch(context.Background(), "http://127.0.0.1:1/")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected loopback literal destination to be rejected by default")
+	}
+	if !strings.Contains(err.Error(), "ssrf-guard") {
+		t.Fatalf("expected the ssrf guard to be what rejected the request, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected the guard to reject before any real dial attempt (near-instant), took %s: %v", elapsed, err)
+	}
+}
+
+// TestGuardedWebFetcher_Fetch_RejectsCloudMetadataLiteral proves Fetch
+// refuses the AWS/GCP/Azure link-local metadata address 169.254.169.254, the
+// highest-value SSRF target (credential theft), and that the guard (not
+// network unreachability) is what blocks it.
+func TestGuardedWebFetcher_Fetch_RejectsCloudMetadataLiteral(t *testing.T) {
+	fetcher := NewGuardedWebFetcher(nil, nil)
+
+	start := time.Now()
+	_, err := fetcher.Fetch(context.Background(), "http://169.254.169.254/latest/meta-data/")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the cloud metadata destination to be rejected by default")
+	}
+	if !strings.Contains(err.Error(), "ssrf-guard") {
+		t.Fatalf("expected the ssrf guard to be what rejected the request, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("expected the guard to reject before any real dial attempt (near-instant), took %s: %v", elapsed, err)
+	}
+}
+
+// TestGuardedWebFetcher_Fetch_RejectsDNSNameResolvingToPrivateIP_AtDialTime
+// proves the check runs at actual dial time (post-resolution), not just on
+// the literal hostname string: "localhost" resolves via the normal system
+// resolver, and must still be blocked because the resolved address is
+// loopback.
+func TestGuardedWebFetcher_Fetch_RejectsDNSNameResolvingToPrivateIP_AtDialTime(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse httptest server port: %v", err)
+	}
+
+	fetcher := NewGuardedWebFetcher(nil, nil)
+	_, err = fetcher.Fetch(context.Background(), "http://localhost:"+port)
+	if err == nil {
+		t.Fatal("expected a hostname resolving to loopback to be refused at dial time")
+	}
+}
+
+// TestGuardedWebFetcher_Fetch_AllowlistPermitsExplicitHost proves the opt-in
+// escape hatch: adding the httptest server's host to the allowlist permits
+// the exact same request that would otherwise be blocked, and the actual
+// content is returned — proving Fetch performs a real request when allowed
+// (this stands in for "a public destination still works", since a real
+// public IP is not reachable in this offline test environment; public-IP
+// literal permission is unit-tested directly against the underlying dial
+// Control in ssrf_guard_test.go, which GuardedWebFetcher reuses unchanged).
+func TestGuardedWebFetcher_Fetch_AllowlistPermitsExplicitHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hello from allowlisted host"))
+	}))
+	defer srv.Close()
+
+	host, _, err := net.SplitHostPort(strings.TrimPrefix(strings.TrimPrefix(srv.URL, "http://"), "https://"))
+	if err != nil {
+		t.Fatalf("parse httptest server host: %v", err)
+	}
+
+	fetcher := NewGuardedWebFetcher(nil, []string{host})
+	content, err := fetcher.Fetch(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("expected explicitly allowlisted host to be permitted, got: %v", err)
+	}
+	if content != "hello from allowlisted host" {
+		t.Fatalf("unexpected content %q", content)
+	}
+}
+
+// TestGuardedWebFetcher_Search_DelegatesToBaseUnchanged proves Search is
+// passed through to the wrapped base implementation unchanged — it has no
+// agent-supplied destination host, so it is outside Fetch's SSRF threat
+// model.
+func TestGuardedWebFetcher_Search_DelegatesToBaseUnchanged(t *testing.T) {
+	base := &fakeWeb{}
+	fetcher := NewGuardedWebFetcher(base, nil)
+
+	results, err := fetcher.Search(context.Background(), "golang", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || results[0]["query"] != "golang" {
+		t.Fatalf("expected Search to delegate to base unchanged, got: %+v", results)
+	}
+}
+
+// TestGuardedWebFetcher_Search_NoBaseConfigured_ReturnsError proves Search
+// fails clearly (rather than silently returning nothing) when no base
+// WebFetcher was supplied.
+func TestGuardedWebFetcher_Search_NoBaseConfigured_ReturnsError(t *testing.T) {
+	fetcher := NewGuardedWebFetcher(nil, nil)
+	if _, err := fetcher.Search(context.Background(), "golang", 3); err == nil {
+		t.Fatal("expected an error when no base WebFetcher is configured for Search")
+	}
+}

--- a/internal/harness/tools/web_fetcher_guard_unit_test.go
+++ b/internal/harness/tools/web_fetcher_guard_unit_test.go
@@ -138,3 +138,34 @@ func TestGuardedWebFetcher_Search_NoBaseConfigured_ReturnsError(t *testing.T) {
 		t.Fatal("expected an error when no base WebFetcher is configured for Search")
 	}
 }
+
+// TestRegression_GuardedWebFetcher_NoBase_RedirectToBlockedDestination_Refused
+// proves the no-base Fetch path (fetchDirect) retains the fetch/download
+// tools' redirect safety: a request to an allowlisted origin that redirects
+// to a non-allowlisted destination must still fail, because both hops share
+// the same guarded Transport (NewGuardedHTTPClient), and the dial-time
+// Control check runs again for the redirect target. If a future change
+// swapped fetchDirect's client for a plain (unguarded) one, or built a fresh
+// http.Client per-request instead of reusing the guarded one, this is what
+// would catch it — mirroring
+// TestSSRFGuard_GuardedClient_RedirectToBlockedDestination_Refused for the
+// underlying NewGuardedHTTPClient in ssrf_guard_test.go.
+func TestRegression_GuardedWebFetcher_NoBase_RedirectToBlockedDestination_Refused(t *testing.T) {
+	blocked := newLoopbackServerOn(t, "127.0.0.1", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("should never be reached"))
+	})
+	defer blocked.Close()
+
+	allowed := newLoopbackServerOn(t, "::1", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, blocked.URL, http.StatusFound)
+	})
+	defer allowed.Close()
+
+	// Only the redirect ORIGIN address (::1) is allowlisted — the redirect
+	// target (127.0.0.1) is not.
+	fetcher := NewGuardedWebFetcher(nil, []string{"::1"})
+	_, err := fetcher.Fetch(context.Background(), allowed.URL)
+	if err == nil {
+		t.Fatal("expected redirect to a non-allowlisted blocked destination to fail")
+	}
+}

--- a/internal/harness/tools/workspace_confinement_test.go
+++ b/internal/harness/tools/workspace_confinement_test.go
@@ -1,0 +1,241 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests are written as ATTACKS against the workspace sandbox, per the
+// task contract for BUG 1 (P1): the SandboxScopeWorkspace scope must actually
+// confine file-tool I/O to the workspace root (and any explicit allowlisted
+// roots), defeating absolute-path escape, traversal, symlink escape, and the
+// sibling-directory-name-prefix trap. SandboxScopeLocal/Unrestricted remain
+// the existing, explicit opt-out and must keep passing through unchanged.
+
+func TestConfineWorkspacePath_AbsolutePathEscape_RejectedUnderWorkspaceScope(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, "/etc/passwd")
+	if err == nil {
+		t.Fatal("expected absolute path outside workspace to be rejected under workspace scope")
+	}
+	if !strings.Contains(err.Error(), "escapes") && !strings.Contains(err.Error(), "sandbox") {
+		t.Fatalf("error should describe a sandbox/escape violation, got: %v", err)
+	}
+}
+
+func TestConfineWorkspacePath_TraversalEscape_RejectedUnderWorkspaceScope(t *testing.T) {
+	root := t.TempDir()
+	// Simulate what ResolveWorkspacePath would compute for a relative "../../etc/passwd"
+	// input joined against a directory *inside* the workspace, then Cleaned — the
+	// classic traversal shape that must still be caught on the final canonical path.
+	escaped := filepath.Clean(filepath.Join(root, "..", "..", "etc", "passwd"))
+
+	_, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, escaped)
+	if err == nil {
+		t.Fatal("expected traversal path to be rejected under workspace scope")
+	}
+}
+
+func TestConfineWorkspacePath_SymlinkEscape_RejectedUnderWorkspaceScope(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	secretOutside := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secretOutside, []byte("top secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A symlink *inside* the workspace whose target lives *outside* it — the
+	// classic bypass this check must defeat.
+	link := filepath.Join(root, "escape-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	candidate := filepath.Join(link, "secret.txt")
+	_, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, candidate)
+	if err == nil {
+		t.Fatal("expected symlink escape to be rejected under workspace scope")
+	}
+}
+
+func TestConfineWorkspacePath_SiblingPrefixDirectory_RejectedUnderWorkspaceScope(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "ws")
+	evil := filepath.Join(parent, "ws-evil")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(evil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	evilFile := filepath.Join(evil, "secret.txt")
+	if err := os.WriteFile(evilFile, []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A naive string-prefix check ("does the path start with root?") would
+	// wrongly allow this, because "/tmp/xyz/ws-evil/..." starts with the
+	// STRING "/tmp/xyz/ws". The check must be component-wise.
+	_, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, evilFile)
+	if err == nil {
+		t.Fatalf("expected sibling directory %q (prefix of %q) to be rejected", evil, root)
+	}
+}
+
+func TestConfineWorkspacePath_LegitimateInWorkspaceAccess_Allowed(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "src", "pkg")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(nested, "file.go")
+	if err := os.WriteFile(target, []byte("package pkg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, target)
+	if err != nil {
+		t.Fatalf("expected legitimate in-workspace path to be allowed, got error: %v", err)
+	}
+	if resolved == "" {
+		t.Fatal("expected a non-empty resolved path")
+	}
+}
+
+func TestConfineWorkspacePath_InWorkspaceSymlinkStayingInside_Allowed(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(realDir, "file.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "alias")
+	if err := os.Symlink(realDir, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+
+	candidate := filepath.Join(link, "file.txt")
+	if _, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, candidate); err != nil {
+		t.Fatalf("expected in-workspace symlink that stays inside the workspace to be allowed, got: %v", err)
+	}
+}
+
+func TestConfineWorkspacePath_NotYetExistingFile_ConfinedByParent(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// A symlinked directory inside the workspace pointing outside; the file
+	// itself does not exist yet (as with a `write` tool call creating a new
+	// file). The not-yet-existing-file case must canonicalize the parent.
+	link := filepath.Join(root, "escape-link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink not supported in this environment: %v", err)
+	}
+	newFile := filepath.Join(link, "new-file.txt")
+
+	if _, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, newFile); err == nil {
+		t.Fatal("expected new file under an escaping symlinked parent to be rejected")
+	}
+
+	// And the legitimate case: a new file directly under the workspace root
+	// (no symlink involved) must be allowed even though it doesn't exist yet.
+	legitNewFile := filepath.Join(root, "brand-new.txt")
+	if _, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, nil, legitNewFile); err != nil {
+		t.Fatalf("expected legitimate not-yet-existing in-workspace file to be allowed, got: %v", err)
+	}
+}
+
+func TestConfineWorkspacePath_NonWorkspaceScopes_PassThroughUnchanged(t *testing.T) {
+	root := t.TempDir()
+	outsidePath := "/etc/passwd"
+
+	for _, scope := range []SandboxScope{SandboxScopeLocal, SandboxScopeUnrestricted, ""} {
+		resolved, err := ConfineWorkspacePath(scope, root, nil, outsidePath)
+		if err != nil {
+			t.Fatalf("scope %q: expected pass-through (existing opt-in behavior) for absolute path, got error: %v", scope, err)
+		}
+		if resolved != outsidePath {
+			t.Fatalf("scope %q: expected unchanged path %q, got %q", scope, outsidePath, resolved)
+		}
+	}
+}
+
+func TestConfineWorkspacePath_ExtraAllowedRoots_Permitted(t *testing.T) {
+	root := t.TempDir()
+	extra := t.TempDir()
+	allowedFile := filepath.Join(extra, "catalog.yaml")
+	if err := os.WriteFile(allowedFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, []string{extra}, allowedFile); err != nil {
+		t.Fatalf("expected explicitly allowlisted extra root to be permitted, got: %v", err)
+	}
+
+	// Something outside both the workspace and the allowlisted root is still rejected.
+	other := t.TempDir()
+	otherFile := filepath.Join(other, "nope.txt")
+	if err := os.WriteFile(otherFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ConfineWorkspacePath(SandboxScopeWorkspace, root, []string{extra}, otherFile); err == nil {
+		t.Fatal("expected path outside both workspace root and allowlisted roots to be rejected")
+	}
+}
+
+func TestEffectiveSandboxScope_ContextOverrideTakesPrecedence(t *testing.T) {
+	ctx := WithSandboxScope(context.Background(), SandboxScopeWorkspace)
+	if got := EffectiveSandboxScope(ctx, SandboxScopeUnrestricted); got != SandboxScopeWorkspace {
+		t.Fatalf("expected context override %q, got %q", SandboxScopeWorkspace, got)
+	}
+}
+
+func TestEffectiveSandboxScope_FallsBackToDefaultWhenNoContextOverride(t *testing.T) {
+	if got := EffectiveSandboxScope(context.Background(), SandboxScopeWorkspace); got != SandboxScopeWorkspace {
+		t.Fatalf("expected default %q, got %q", SandboxScopeWorkspace, got)
+	}
+}
+
+func TestResolveWorkspacePathConfined_AbsoluteEscape_RejectedUnderWorkspaceScope(t *testing.T) {
+	root := t.TempDir()
+	ctx := context.Background()
+
+	if _, err := ResolveWorkspacePathConfined(ctx, root, "/etc/passwd", SandboxScopeWorkspace); err == nil {
+		t.Fatal("expected absolute-path escape via ResolveWorkspacePathConfined to be rejected")
+	}
+}
+
+func TestResolveWorkspacePathConfined_RelativeInWorkspace_AllowedUnderWorkspaceScope(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "ok.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	resolved, err := ResolveWorkspacePathConfined(ctx, root, "ok.txt", SandboxScopeWorkspace)
+	if err != nil {
+		t.Fatalf("expected legitimate relative in-workspace write to succeed, got: %v", err)
+	}
+	if filepath.Base(resolved) != "ok.txt" {
+		t.Fatalf("unexpected resolved path %q", resolved)
+	}
+}
+
+func TestResolveWorkspacePathConfined_ContextScopeOverridesDefault(t *testing.T) {
+	root := t.TempDir()
+	ctx := WithSandboxScope(context.Background(), SandboxScopeWorkspace)
+
+	// defaultScope passed at construction is unrestricted, but the per-run
+	// context override (workspace) must still confine — proving the step
+	// engine's per-call scope override is honored, not just the build-time default.
+	if _, err := ResolveWorkspacePathConfined(ctx, root, "/etc/passwd", SandboxScopeUnrestricted); err == nil {
+		t.Fatal("expected context-level workspace scope override to confine the path even though the default scope is unrestricted")
+	}
+}

--- a/internal/harness/tools/write.go
+++ b/internal/harness/tools/write.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func writeTool(workspaceRoot string) Tool {
+func writeTool(workspaceRoot string, sandboxScope SandboxScope) Tool {
 	def := Definition{
 		Name:         "write",
 		Description:  descriptions.Load("write"),
@@ -36,7 +36,7 @@ func writeTool(workspaceRoot string) Tool {
 		},
 	}
 
-	handler := func(_ context.Context, raw json.RawMessage) (string, error) {
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
 		args := struct {
 			Path            string  `json:"path"`
 			FilePath        string  `json:"file_path"`
@@ -76,7 +76,7 @@ func writeTool(workspaceRoot string) Tool {
 			return "", err
 		}
 
-		absPath, err := ResolveWorkspacePath(workspaceRoot, args.Path)
+		absPath, err := ResolveWorkspacePathConfined(ctx, workspaceRoot, args.Path, sandboxScope)
 		if err != nil {
 			return "", err
 		}

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -23,7 +23,28 @@ type DefaultRegistryOptions struct {
 	ApprovalMode        ToolApprovalMode
 	Policy              ToolPolicy
 	SandboxScope        SandboxScope // controls filesystem/network restrictions
-	AskUserBroker       htools.AskUserQuestionBroker
+	// NetworkAllowlist is the operator-configured, explicit opt-in escape
+	// hatch for the outbound network guard (GAP-3): by default the
+	// fetch/download tools and the WebFetcher-backed tools (web_fetch,
+	// web_search, agentic_fetch) refuse to dial loopback, link-local,
+	// RFC1918/ULA-private, or otherwise non-public destinations, even when a
+	// URL's hostname first resolves to a public address. Each entry may be a
+	// bare hostname (matched against the request's original,
+	// pre-resolution host — e.g. "localhost") or a CIDR (e.g. "10.0.0.0/8",
+	// "127.0.0.1/32") matched against the resolved destination IP. Empty
+	// (the default) means no exceptions: only public addresses are
+	// reachable. See htools.BuildOptions.NetworkAllowlist and
+	// htools.NewGuardedHTTPClient (ssrf_guard.go).
+	NetworkAllowlist []string
+	// WebFetcher backs the web_fetch, web_search, and agentic_fetch tools.
+	// When nil (the default), those tools are not registered. When set, it
+	// is automatically wrapped with htools.GuardedWebFetcher (GAP-2) before
+	// being handed to the tool constructors, so Fetch(url) — the
+	// agent-supplied-destination surface — is always subject to the same
+	// dial-time SSRF guard as the fetch/download tools, regardless of what
+	// this implementation would otherwise have done for Fetch itself.
+	WebFetcher    htools.WebFetcher
+	AskUserBroker htools.AskUserQuestionBroker
 	AskUserTimeout      time.Duration
 	MemoryManager       om.Manager
 	WorkingMemoryStore  workingmemory.Store
@@ -157,6 +178,8 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 		ApprovalMode:       approvalMode,
 		Policy:             policyAdapter,
 		SandboxScope:       htools.SandboxScope(opts.SandboxScope),
+		NetworkAllowlist:   opts.NetworkAllowlist,
+		WebFetcher:         opts.WebFetcher,
 		HTTPClient:         httpClient,
 		Now:                time.Now,
 		AskUserBroker:      opts.AskUserBroker,
@@ -274,10 +297,14 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 			deferred.TaskCompleteTool(opts.AgentRunner),
 		)
 		if buildOpts.EnableWebOps && buildOpts.WebFetcher != nil {
+			// GAP-2: see the identical comment in tools/catalog.go. Wrap
+			// before wiring into the tool constructors so Fetch(url) is
+			// always subject to the dial-time SSRF guard.
+			guardedFetcher := htools.NewGuardedWebFetcher(buildOpts.WebFetcher, buildOpts.NetworkAllowlist)
 			deferredTools = append(deferredTools,
-				deferred.AgenticFetchTool(buildOpts.WebFetcher, opts.AgentRunner),
-				deferred.WebSearchTool(buildOpts.WebFetcher),
-				deferred.WebFetchTool(buildOpts.WebFetcher),
+				deferred.AgenticFetchTool(guardedFetcher, opts.AgentRunner),
+				deferred.WebSearchTool(guardedFetcher),
+				deferred.WebFetchTool(guardedFetcher),
 			)
 		}
 	}

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -702,10 +702,20 @@ type PermissionConfig struct {
 	Rules *PermissionRuleSet `json:"rules,omitempty"`
 }
 
-// DefaultPermissionConfig returns the default (unrestricted, no approval required).
+// DefaultPermissionConfig returns the default (workspace-confined, no
+// approval required) permission configuration.
+//
+// SAFETY DEFAULT: Sandbox defaults to SandboxScopeWorkspace, not
+// SandboxScopeUnrestricted. The harness is used both as a local coding tool
+// and to run multi-agent/multi-tenant workloads; a caller that does not
+// explicitly opt out must not be able to read/write arbitrary absolute host
+// paths (e.g. ~/.ssh/id_rsa) via the file tools. Callers that legitimately
+// need broader filesystem access must explicitly request
+// SandboxScopeLocal or SandboxScopeUnrestricted via PermissionConfig.Sandbox
+// on the run request.
 func DefaultPermissionConfig() PermissionConfig {
 	return PermissionConfig{
-		Sandbox:  SandboxScopeUnrestricted,
+		Sandbox:  SandboxScopeWorkspace,
 		Approval: ApprovalPolicyNone,
 	}
 }
@@ -731,7 +741,9 @@ func ValidatePermissionConfig(p PermissionConfig) error {
 	case SandboxScopeWorkspace, SandboxScopeLocal, SandboxScopeUnrestricted:
 		// valid
 	case "":
-		// empty defaults to unrestricted — also valid at validation time
+		// empty defaults to workspace (the safety-biased default; see
+		// DefaultPermissionConfig and normalizePermissionConfig) — also valid
+		// at validation time
 	default:
 		return fmt.Errorf("invalid sandbox scope %q: must be one of workspace, local, unrestricted", p.Sandbox)
 	}


### PR DESCRIPTION
**Stacked on #711.** Without this, #711 is inert.

## The sandbox was installed but not switched on (CRITICAL)
`DefaultPermissionConfig()` returned `SandboxScopeUnrestricted`, and an empty value also fell back to unrestricted — so #711's confinement only engaged if a caller *explicitly* asked for `workspace` scope. **A default-configured run could still read `~/.ssh/id_rsa` via an absolute path.**

Rather than guess at the blast radius, we flipped the default and **measured**: `go test ./...` → **2 failures out of ~107 packages**.
1. A test asserting the old default literally (updated).
2. A **genuine pre-existing bug**: `sandbox_darwin.go` embedded the workspace root into the seatbelt profile **un-canonicalized**, so any workspace reached through the macOS `/var` → `/private/var` symlink (i.e. every `t.TempDir()` and every provisioned worktree) was denied writes *by its own sandbox*. Masked until now precisely because the sandbox was never on. Fixed with `EvalSymlinks` before embedding.

Small, clean blast radius → **kept the flip**.

**Acceptance: with this branch, a default run CANNOT read `~/.ssh/id_rsa`.** Proven by `TestDefaultConfiguredRun_CannotReadAbsolutePathOutsideWorkspace`. The explicit opt-out (`Permissions.Sandbox: local`/`unrestricted`) still works, proven by its own regression test.

## WebFetcher SSRF gap (HIGH)
`web_fetch`/`web_search`/`agentic_fetch` had no guard — the most-used fetch paths. `GuardedWebFetcher` reuses `ssrf_guard.go` (no duplicated logic) and is wired at both construction choke points, so any future implementation is protected **by construction**.

Investigation finding worth flagging: there is currently **no concrete non-test `WebFetcher` implementation** in the repo, and the production registry had no field to inject one — these tools were unregistered/dead in every production entry point, independent of any guard.

## Operator allowlist
`NetworkAllowlist` now threads through `tools_default.go` (mirroring the existing `SandboxScope` plumbing). Default stays empty/deny.

## Verification
`go build ./...` clean; **full `go test ./...` → 107 packages, 0 failures**; `go test ./internal/harness/... -race` clean; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6