### PR TITLE
fix(cron): fatal map race, stale-snapshot writeback resurrecting paused jobs, 5-min shutdown stall

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -1732,7 +1732,12 @@ func (a *embeddedCronAdapter) UpdateJob(ctx context.Context, id string, req htoo
 		}
 	}
 
-	if req.Schedule != nil && (req.Status == nil || *req.Status == cron.StatusActive) {
+	// Gate on job.Status (the EFFECTIVE post-update status), not on
+	// req.Status (the raw request field) — mirrors the fix in
+	// internal/cron/server.go's handleUpdateJob. A schedule-only update
+	// (req.Status == nil) must not re-arm a job whose stored status is
+	// paused: job.Status already reflects that live status in that case.
+	if req.Schedule != nil && job.Status == cron.StatusActive {
 		if err := a.scheduler.UpdateJobSchedule(job); err != nil {
 			return htools.CronJob{}, fmt.Errorf("scheduler: %w", err)
 		}

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -2467,6 +2467,63 @@ func TestEmbeddedCronAdapterUpdateJob(t *testing.T) {
 	}
 }
 
+// TestEmbeddedCronAdapterUpdateJob_PausedJobScheduleOnlyPatch_NotReArmed
+// (BUG 4, BT-006, P2) reproduces the parallel copy of the BUG-4 re-arm
+// condition in embeddedCronAdapter.UpdateJob (main.go ~1735):
+// `req.Schedule != nil && (req.Status == nil || *req.Status == cron.StatusActive)`.
+// A schedule-only update (req.Status == nil) on an already-paused job must
+// not re-add it to the live scheduler.
+//
+// This fails before the fix (scheduler.HasEntry reports true after a
+// schedule-only update on a paused job) and passes after (gating on the
+// job's effective post-update status).
+func TestEmbeddedCronAdapterUpdateJob_PausedJobScheduleOnlyPatch_NotReArmed(t *testing.T) {
+	t.Parallel()
+
+	store := newTestCronStore(t)
+	clock := testClock{t: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
+	scheduler := cron.NewScheduler(store, &cron.ShellExecutor{}, clock, cron.SchedulerConfig{MaxConcurrent: 1})
+	if err := scheduler.Start(context.Background()); err != nil {
+		t.Fatalf("start scheduler: %v", err)
+	}
+	defer scheduler.Stop()
+
+	adapter := &embeddedCronAdapter{store: store, scheduler: scheduler, clock: clock}
+
+	created, err := adapter.CreateJob(context.Background(), htools.CronCreateJobRequest{
+		Name: "pause-then-schedule-only", Schedule: "*/5 * * * *", ExecType: "shell",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	// Pause it first — this removes it from the live scheduler.
+	paused := "paused"
+	if _, err := adapter.UpdateJob(context.Background(), created.ID, htools.CronUpdateJobRequest{
+		Status: &paused,
+	}); err != nil {
+		t.Fatalf("UpdateJob pause: %v", err)
+	}
+	if scheduler.HasEntry(created.ID) {
+		t.Fatalf("expected job to be removed from the live scheduler after pausing")
+	}
+
+	// PATCH only the schedule — no Status field.
+	newSched := "0 * * * *"
+	updated, err := adapter.UpdateJob(context.Background(), created.ID, htools.CronUpdateJobRequest{
+		Schedule: &newSched,
+	})
+	if err != nil {
+		t.Fatalf("UpdateJob schedule-only: %v", err)
+	}
+	if updated.Status != "paused" {
+		t.Fatalf("expected status to remain paused, got %q", updated.Status)
+	}
+	if scheduler.HasEntry(created.ID) {
+		t.Fatal("expected a schedule-only update on a paused job to NOT re-arm it in the live scheduler")
+	}
+}
+
 func TestEmbeddedCronAdapterDeleteJob(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -2524,6 +2524,57 @@ func TestEmbeddedCronAdapterUpdateJob_PausedJobScheduleOnlyPatch_NotReArmed(t *t
 	}
 }
 
+// TestEmbeddedCronAdapterUpdateJob_ResumeAndScheduleReArms (regression for
+// BUG 4) is the positive counterpart of the test above: an update that
+// resumes AND reschedules a paused job in the same call must still re-arm
+// it. This guards against overcorrecting the fix into never re-arming.
+func TestEmbeddedCronAdapterUpdateJob_ResumeAndScheduleReArms(t *testing.T) {
+	t.Parallel()
+
+	store := newTestCronStore(t)
+	clock := testClock{t: time.Date(2026, 3, 8, 12, 0, 0, 0, time.UTC)}
+	scheduler := cron.NewScheduler(store, &cron.ShellExecutor{}, clock, cron.SchedulerConfig{MaxConcurrent: 1})
+	if err := scheduler.Start(context.Background()); err != nil {
+		t.Fatalf("start scheduler: %v", err)
+	}
+	defer scheduler.Stop()
+
+	adapter := &embeddedCronAdapter{store: store, scheduler: scheduler, clock: clock}
+
+	created, err := adapter.CreateJob(context.Background(), htools.CronCreateJobRequest{
+		Name: "resume-and-schedule", Schedule: "*/5 * * * *", ExecType: "shell",
+	})
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	paused := "paused"
+	if _, err := adapter.UpdateJob(context.Background(), created.ID, htools.CronUpdateJobRequest{
+		Status: &paused,
+	}); err != nil {
+		t.Fatalf("UpdateJob pause: %v", err)
+	}
+	if scheduler.HasEntry(created.ID) {
+		t.Fatalf("expected job to be removed from the live scheduler after pausing")
+	}
+
+	active := "active"
+	newSched := "0 * * * *"
+	updated, err := adapter.UpdateJob(context.Background(), created.ID, htools.CronUpdateJobRequest{
+		Status:   &active,
+		Schedule: &newSched,
+	})
+	if err != nil {
+		t.Fatalf("UpdateJob resume+schedule: %v", err)
+	}
+	if updated.Status != "active" {
+		t.Fatalf("expected status active, got %q", updated.Status)
+	}
+	if !scheduler.HasEntry(created.ID) {
+		t.Fatal("expected a resume+schedule update to re-arm the job in the live scheduler")
+	}
+}
+
 func TestEmbeddedCronAdapterDeleteJob(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cron/executor.go
+++ b/internal/cron/executor.go
@@ -5,8 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"syscall"
 	"time"
 )
+
+// shellCommandWaitDelay bounds how long ShellExecutor.Execute waits for
+// cmd.Wait() to return after the job's timeout fires. Without it, Wait
+// blocks until the process's stdout/stderr pipes reach EOF, which can
+// never happen if a background grandchild process inherited those pipes
+// and is still running — even after the direct child has been killed.
+const shellCommandWaitDelay = 5 * time.Second
 
 const maxOutputBytes = 4096
 
@@ -41,6 +49,28 @@ func (e *ShellExecutor) Execute(ctx context.Context, job Job) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", cfg.Command)
+
+	// Bound how long Wait can block after the timeout kills the command:
+	// force-close the I/O pipes after shellCommandWaitDelay even if a
+	// grandchild process is still holding them open. Without this, a
+	// worker can leak forever (never releasing its scheduler semaphore
+	// slot / WaitGroup count), which also prevents Scheduler.Stop() from
+	// ever completing.
+	cmd.WaitDelay = shellCommandWaitDelay
+
+	// Run the command in its own process group and kill the WHOLE group
+	// on cancellation, so background/orphaned children spawned by the
+	// shell (e.g. `cmd &`) are actually terminated on timeout rather than
+	// left running to hold the output pipes open. Mirrors the pattern in
+	// internal/harness/tools/script/loader.go and internal/workflow/source.go.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
 	out, err := cmd.CombinedOutput()
 
 	// Truncate output to maxOutputBytes.

--- a/internal/cron/executor_test.go
+++ b/internal/cron/executor_test.go
@@ -2,6 +2,9 @@ package cron
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -219,4 +222,60 @@ func TestShellExecutor_TimeoutWithOrphanedChildHoldingPipes(t *testing.T) {
 	case <-time.After(12 * time.Second):
 		t.Fatal("Execute did not return within 12s of a 1s timeout: a background child holding the output pipes open is blocking Wait() indefinitely")
 	}
+}
+
+// TestShellExecutor_TimeoutKillsOrphanedChild_DoesNotLeaveItRunning
+// (regression for BUG 5) covers a different angle than the red test: it
+// doesn't just check that Execute returns promptly, it checks that the
+// background grandchild is actually TERMINATED, not merely abandoned to
+// keep running detached from the (now-exited) parent shell.
+//
+// The backgrounded child appends a line to a marker file every 200ms.
+// If the process-group kill in Execute actually reaps it, writes stop
+// shortly after Execute returns. If the child were only orphaned (the
+// pre-fix behavior, modulo WaitDelay), it would keep writing for its
+// full ~10s run, and this test would catch that by observing the marker
+// file still growing well after Execute has returned.
+func TestShellExecutor_TimeoutKillsOrphanedChild_DoesNotLeaveItRunning(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell backgrounding construct")
+	}
+
+	executor := &ShellExecutor{}
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+
+	shCmd := fmt.Sprintf(`(i=0; while [ $i -lt 50 ]; do echo x >> %q; sleep 0.2; i=$((i+1)); done &) ; sleep 60`, marker)
+	job := Job{
+		ExecConfig: fmt.Sprintf(`{"command":%q}`, shCmd),
+		TimeoutSec: 1,
+	}
+
+	if _, err := executor.Execute(context.Background(), job); err == nil {
+		t.Fatal("expected an error for a command killed by its timeout")
+	}
+
+	sizeAfterExecute := markerSize(t, marker)
+
+	// Give a killed-but-still-writing process ample time to prove it's
+	// still alive, while staying well under its ~10s natural run length.
+	time.Sleep(3 * time.Second)
+
+	sizeLater := markerSize(t, marker)
+	if sizeLater > sizeAfterExecute {
+		t.Fatalf("background child kept writing to the marker file after Execute returned (size %d -> %d after a 3s settle wait): it was orphaned rather than actually killed",
+			sizeAfterExecute, sizeLater)
+	}
+}
+
+func markerSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("stat marker file: %v", err)
+	}
+	return info.Size()
 }

--- a/internal/cron/executor_test.go
+++ b/internal/cron/executor_test.go
@@ -2,8 +2,10 @@ package cron
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestShellExecutor_Success(t *testing.T) {
@@ -162,5 +164,59 @@ func TestShellExecutor_DefaultTimeout(t *testing.T) {
 	}
 	if strings.TrimSpace(output) != "fast" {
 		t.Fatalf("expected 'fast', got %q", output)
+	}
+}
+
+// TestShellExecutor_TimeoutWithOrphanedChildHoldingPipes (BT-007, P2)
+// reproduces BUG 5: ShellExecutor.Execute calls cmd.CombinedOutput() with
+// no WaitDelay set. When the context deadline kills the direct child (the
+// "sh" process) but a background grandchild it spawned still holds the
+// inherited stdout/stderr pipes open, Wait() blocks until that grandchild
+// exits and closes the pipes on its own — potentially forever (or, here,
+// bounded only by the grandchild's own sleep), even though the job's
+// configured timeout was 1 second.
+//
+// The shell command backgrounds a 30s sleep (`(sleep 30 &)`) that
+// inherits the parent's stdout/stderr, then the parent itself sleeps far
+// longer than the 1s job timeout. Before the fix, Execute does not return
+// until the orphaned "sleep 30" exits and releases the pipe — this test
+// bounds its wait at 10s (well under 30s) so a regression fails fast
+// instead of hanging the test suite for 30+ seconds.
+func TestShellExecutor_TimeoutWithOrphanedChildHoldingPipes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell backgrounding construct")
+	}
+
+	executor := &ShellExecutor{}
+	job := Job{
+		ExecConfig: `{"command":"(sleep 30 &) ; sleep 60"}`,
+		TimeoutSec: 1,
+	}
+
+	type result struct {
+		elapsed time.Duration
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		_, execErr := executor.Execute(context.Background(), job)
+		done <- result{elapsed: time.Since(start), err: execErr}
+	}()
+
+	select {
+	case r := <-done:
+		// cmd.WaitDelay (5s, once set) starts counting from the 1s
+		// context deadline, so total elapsed should land around 6s; allow
+		// generous headroom for CI/test-machine scheduling jitter while
+		// staying far below the orphaned child's 30s sleep.
+		if r.elapsed > 10*time.Second {
+			t.Fatalf("Execute took %v after a 1s job timeout; expected it to return in roughly job-timeout+WaitDelay, not block on an orphaned child holding the output pipes", r.elapsed)
+		}
+		if r.err == nil {
+			t.Fatal("expected an error for a command killed by its timeout")
+		}
+	case <-time.After(12 * time.Second):
+		t.Fatal("Execute did not return within 12s of a 1s timeout: a background child holding the output pipes open is blocking Wait() indefinitely")
 	}
 }

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -159,6 +159,23 @@ func (s *Scheduler) fireJob(job Job, jitter time.Duration) {
 		s.sleepFn(jitterOffset)
 	}
 
+	// Re-read the job's current state from the store before firing. The
+	// job value captured in AddJob's closure can be arbitrarily stale by
+	// the time the timer/jitter wait elapses: the schedule, execution
+	// config, timeout, tags, or status may have changed (e.g. the job may
+	// have been paused or deleted). Firing based on the stale snapshot
+	// would ignore those edits and could resurrect a paused job.
+	current, err := s.store.GetJob(ctx, job.ID)
+	if err != nil {
+		log.Printf("cron: skipping fire for job %s: failed to reload current state: %v", job.ID, err)
+		return
+	}
+	if current.Status != StatusActive {
+		log.Printf("cron: skipping fire for job %s: no longer active (status=%s)", job.ID, current.Status)
+		return
+	}
+	job = current
+
 	exec := Execution{
 		ID:        uuid.New().String(),
 		JobID:     job.ID,
@@ -166,7 +183,7 @@ func (s *Scheduler) fireJob(job Job, jitter time.Duration) {
 		Status:    ExecStatusPending,
 	}
 
-	exec, err := s.store.CreateExecution(ctx, exec)
+	exec, err = s.store.CreateExecution(ctx, exec)
 	if err != nil {
 		log.Printf("cron: failed to create execution for job %s: %v", job.ID, err)
 		return
@@ -211,15 +228,19 @@ func (s *Scheduler) fireJob(job Job, jitter time.Duration) {
 			log.Printf("cron: failed to update execution %s: %v", exec.ID, updateErr)
 		}
 
-		// Update job's last_run_at and recompute NextRunAt.
-		job.LastRunAt = endTime
-		job.UpdatedAt = endTime
+		// Record last_run_at and recompute next_run_at using a targeted
+		// update that only touches run-tracking columns. This must NOT be
+		// a full-object UpdateJob write: job is still the state read at
+		// the top of fireJob, and by the time execution finishes it may
+		// again be stale relative to concurrent edits. TouchJobRun never
+		// clobbers schedule, execution config, status, timeout, or tags.
+		nextRun := job.NextRunAt
 		if next, parseErr := NextRunTime(job.Schedule, endTime); parseErr == nil {
-			job.NextRunAt = next
+			nextRun = next
 		}
 		// On schedule parse error, NextRunAt is left unchanged.
-		if updateErr := s.store.UpdateJob(ctx, job); updateErr != nil {
-			log.Printf("cron: failed to update job %s last_run_at: %v", job.ID, updateErr)
+		if touchErr := s.store.TouchJobRun(ctx, job.ID, endTime, nextRun, endTime); touchErr != nil {
+			log.Printf("cron: failed to touch job %s last_run_at: %v", job.ID, touchErr)
 		}
 	}()
 }

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -89,15 +89,20 @@ func (s *Scheduler) AddJob(job Job) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Compute and cache a deterministic jitter offset for this job.
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = computeJitter(
-		s.jitterCfg, job.ID, job.Schedule,
-	)
+	// Compute a deterministic jitter offset for this job. jitterCache is
+	// retained (and still populated here, under s.mu) so tests and any
+	// future callers can introspect the cached value, but fireJob itself
+	// no longer reads this map — the computed jitter is captured directly
+	// in the closure below and passed to fireJob as a parameter. This
+	// avoids the unsynchronized read that previously raced with this write
+	// (fireJob ran on the robfig/cron goroutine with no lock held).
+	jitter := computeJitter(s.jitterCfg, job.ID, job.Schedule)
+	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = jitter
 
-	// Capture job for the closure.
+	// Capture job and its jitter offset for the closure.
 	j := job
 	entryID, err := s.cron.AddFunc(job.Schedule, func() {
-		s.fireJob(j)
+		s.fireJob(j, jitter)
 	})
 	if err != nil {
 		return fmt.Errorf("add cron entry: %w", err)
@@ -131,15 +136,20 @@ func (s *Scheduler) UpdateJobSchedule(job Job) error {
 
 // fireJob executes a job: creates an execution record, runs the executor,
 // and updates the execution and job records.
-func (s *Scheduler) fireJob(job Job) {
+//
+// jitter is the base jitter offset computed once by AddJob at registration
+// time. fireJob deliberately does NOT read s.jitterCache itself: fireJob
+// runs on the robfig/cron dispatch goroutine outside of s.mu, and reading
+// the cache concurrently with AddJob's locked write previously caused a
+// fatal, unrecoverable "concurrent map read and map write" runtime error.
+func (s *Scheduler) fireJob(job Job, jitter time.Duration) {
 	ctx := context.Background()
 	now := s.clock.Now()
 
 	// Apply jitter delay before execution work.
 	// The base jitter offset is computed deterministically at registration time.
 	// Minute-mark avoidance is applied now using the actual fire time.
-	jitterKey := jitterCacheKey(job.ID, job.Schedule)
-	baseJitter := s.jitterCache[jitterKey]
+	baseJitter := jitter
 	if baseJitter > 0 {
 		jitterOffset := avoidMinuteMarks(baseJitter, now, s.jitterCfg.AvoidMarks)
 		if s.jitterCfg.LogJitteredTimes {

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -24,6 +24,8 @@ type Scheduler struct {
 	jitterCfg   JitterConfig
 	jitterCache map[string]time.Duration // jobID|schedule -> jitter offset
 	sleepFn     func(time.Duration)      // injectable sleep for testing; defaults to time.Sleep
+	done        chan struct{}           // closed by Stop to interrupt in-flight jitter waits
+	stopOnce    sync.Once               // guards closing done so a double Stop cannot panic
 }
 
 // SchedulerConfig holds scheduler configuration.
@@ -56,6 +58,7 @@ func NewScheduler(store Store, executor Executor, clock Clock, cfg SchedulerConf
 		jitterCfg:   cfg.Jitter,
 		jitterCache: make(map[string]time.Duration),
 		sleepFn:     time.Sleep,
+		done:        make(chan struct{}),
 	}
 }
 
@@ -78,8 +81,20 @@ func (s *Scheduler) Start(ctx context.Context) error {
 }
 
 // Stop stops the cron scheduler and waits for in-flight executions.
+//
+// Stop first tells robfig/cron to stop dispatching new ticks (s.cron.Stop
+// returns a context that becomes Done once any invocation already in
+// progress returns). It then closes s.done — BEFORE waiting on that
+// context — so that any fireJob call currently blocked in its jitter wait
+// is interrupted immediately and returns without executing the job. Only
+// after that does Stop wait for cron's context and then for s.wg, which
+// tracks the async goroutines doing the actual execution work (those are
+// allowed to run to completion; only the pre-execution jitter wait is
+// abandoned on shutdown). Closing done is idempotent (sync.Once) so a
+// double Stop call cannot panic.
 func (s *Scheduler) Stop() {
 	ctx := s.cron.Stop()
+	s.stopOnce.Do(func() { close(s.done) })
 	<-ctx.Done()
 	s.wg.Wait()
 }
@@ -156,7 +171,26 @@ func (s *Scheduler) fireJob(job Job, jitter time.Duration) {
 			log.Printf("cron: job %s jittered by %v (original schedule: %s, base jitter: %v)",
 				job.ID, jitterOffset, job.Schedule, baseJitter)
 		}
-		s.sleepFn(jitterOffset)
+
+		// The jitter wait must be interruptible by Stop(), otherwise
+		// shutdown blocks for up to the full jitter window (which can be
+		// minutes with the default jitter config) before the HTTP server
+		// even begins draining. s.sleepFn is run in a background
+		// goroutine so tests can keep injecting a fast/no-op sleep, while
+		// production (sleepFn == time.Sleep) still returns from fireJob
+		// promptly on shutdown: if s.done closes first, fireJob abandons
+		// this fire entirely rather than executing the job mid-shutdown.
+		sleepDone := make(chan struct{})
+		go func() {
+			s.sleepFn(jitterOffset)
+			close(sleepDone)
+		}()
+		select {
+		case <-sleepDone:
+		case <-s.done:
+			log.Printf("cron: shutdown in progress, skipping fire for job %s", job.ID)
+			return
+		}
 	}
 
 	// Re-read the job's current state from the store before firing. The

--- a/internal/cron/scheduler.go
+++ b/internal/cron/scheduler.go
@@ -126,6 +126,18 @@ func (s *Scheduler) AddJob(job Job) error {
 	return nil
 }
 
+// HasEntry reports whether jobID is currently registered with the live
+// cron dispatcher — i.e. it will fire on its schedule. A paused or
+// removed job is not registered. Exposed primarily so callers (including
+// tests outside this package) can observe live scheduler state without
+// reaching into unexported fields.
+func (s *Scheduler) HasEntry(jobID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.entries[jobID]
+	return ok
+}
+
 // RemoveJob removes a job from the cron scheduler.
 func (s *Scheduler) RemoveJob(jobID string) {
 	s.mu.Lock()

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -819,3 +819,78 @@ func TestScheduler_ConcurrentAddJobAndFireJob_NoDataRace(t *testing.T) {
 	wg.Wait()
 	s.wg.Wait()
 }
+
+// TestScheduler_ConcurrentUpdateJobScheduleAndFireJob_NoDataRace (regression
+// for BUG 1) exercises UpdateJobSchedule concurrently with fireJob under
+// -race. UpdateJobSchedule takes a different path than plain AddJob (it
+// removes the old entry, recomputes and re-writes s.jitterCache, then calls
+// AddJob again), so it is a distinct angle from the original red test: it
+// would fail (fatal "concurrent map read and map write", or be flagged by
+// -race) if fireJob ever went back to reading s.jitterCache directly instead
+// of using the jitter value captured in AddJob's/UpdateJobSchedule's closure.
+func TestScheduler_ConcurrentUpdateJobScheduleAndFireJob_NoDataRace(t *testing.T) {
+	store := &mockStore{
+		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
+			return nil
+		},
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{}, ErrJobNotFound
+		},
+		UpdateJobFunc: func(ctx context.Context, job Job) error {
+			return nil
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 10})
+	s.sleepFn = func(time.Duration) {} // no-op so fireJob returns quickly
+
+	fireTarget := testJob("update-schedule-race-target")
+	if err := s.AddJob(fireTarget); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const iterations = 200
+
+	// Goroutines that repeatedly UpdateJobSchedule for an unrelated job,
+	// exercising RemoveJob + jitterCache re-write + AddJob.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			job := testJob(fmt.Sprintf("update-schedule-race-%d", gid))
+			if err := s.AddJob(job); err != nil {
+				return
+			}
+			for i := 0; i < iterations; i++ {
+				job.Schedule = "*/5 * * * *"
+				_ = s.UpdateJobSchedule(job)
+				job.Schedule = "0 * * * *"
+				_ = s.UpdateJobSchedule(job)
+			}
+		}(g)
+	}
+
+	// Goroutines that repeatedly call fireJob for a stable, already
+	// registered job.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				s.fireJob(fireTarget, 0)
+			}
+		}()
+	}
+
+	wg.Wait()
+	s.wg.Wait()
+}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -1141,3 +1141,76 @@ func TestScheduler_Stop_InterruptsLongJitterWait(t *testing.T) {
 		t.Fatal("expected fireJob to skip execution when Stop() interrupts the jitter wait, but the executor ran")
 	}
 }
+
+// TestScheduler_Stop_IsIdempotent (regression for BUG 3) verifies that
+// calling Stop() twice does not panic. The fix closes s.done via
+// sync.Once specifically so a double Stop is safe; a regression here
+// would surface as a "close of closed channel" panic.
+func TestScheduler_Stop_IsIdempotent(t *testing.T) {
+	s := NewScheduler(&mockStore{}, &mockExecutor{}, RealClock{}, SchedulerConfig{})
+	s.Stop()
+	s.Stop() // must not panic
+}
+
+// TestScheduler_Stop_InterruptsMultipleConcurrentJitterWaits (regression
+// for BUG 3) covers a different angle than the red test: several fireJob
+// calls blocked in a long jitter wait AT ONCE (rather than one job
+// dispatched through the real robfig cron mechanism). It would fail if
+// Stop() only interrupted the first waiter, or if the done-channel signal
+// were somehow consumed by one goroutine and unavailable to the others
+// (e.g. a regression from `<-s.done` being changed to a receive from a
+// non-broadcasting channel).
+func TestScheduler_Stop_InterruptsMultipleConcurrentJitterWaits(t *testing.T) {
+	var executedCount int32
+
+	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{}, ErrJobNotFound
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			atomic.AddInt32(&executedCount, 1)
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Now())
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 5})
+
+	const n = 5
+	const longJitter = 5 * time.Second
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			job := testJob(fmt.Sprintf("multi-stop-%d", i))
+			s.fireJob(job, longJitter)
+		}(i)
+	}
+
+	// Give the goroutines a moment to enter their jitter waits.
+	time.Sleep(100 * time.Millisecond)
+
+	stopStart := time.Now()
+	s.Stop()
+	stopDuration := time.Since(stopStart)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fireJob goroutines did not return promptly after Stop()")
+	}
+
+	if stopDuration > 1500*time.Millisecond {
+		t.Fatalf("Stop() took %v, expected all %d jitter waits to be interrupted promptly", stopDuration, n)
+	}
+	if c := atomic.LoadInt32(&executedCount); c != 0 {
+		t.Fatalf("expected 0 executions (all interrupted by Stop()), got %d", c)
+	}
+}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -104,10 +104,15 @@ func TestUpdateJobSchedule(t *testing.T) {
 func TestFireJob_CreatesExecution(t *testing.T) {
 	var createdExec Execution
 	var updatedExecs []Execution
-	var updatedJob Job
+	var touchedJobID string
 	var mu sync.Mutex
 
+	job := testJob("fire-test")
+
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			mu.Lock()
 			createdExec = exec
@@ -120,9 +125,9 @@ func TestFireJob_CreatesExecution(t *testing.T) {
 			mu.Unlock()
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			mu.Lock()
-			updatedJob = job
+			touchedJobID = jobID
 			mu.Unlock()
 			return nil
 		},
@@ -136,7 +141,6 @@ func TestFireJob_CreatesExecution(t *testing.T) {
 
 	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
-	job := testJob("fire-test")
 
 	s.fireJob(job, 0)
 	s.wg.Wait()
@@ -165,8 +169,8 @@ func TestFireJob_CreatesExecution(t *testing.T) {
 		t.Fatalf("expected output 'test output', got %q", updatedExecs[1].OutputSummary)
 	}
 
-	if updatedJob.ID != job.ID {
-		t.Fatalf("expected job update for %s, got %s", job.ID, updatedJob.ID)
+	if touchedJobID != job.ID {
+		t.Fatalf("expected TouchJobRun for %s, got %s", job.ID, touchedJobID)
 	}
 }
 
@@ -174,7 +178,12 @@ func TestFireJob_ExecutorError(t *testing.T) {
 	var updatedExecs []Execution
 	var mu sync.Mutex
 
+	job := testJob("error-test")
+
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
@@ -184,7 +193,7 @@ func TestFireJob_ExecutorError(t *testing.T) {
 			mu.Unlock()
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -197,7 +206,6 @@ func TestFireJob_ExecutorError(t *testing.T) {
 
 	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
-	job := testJob("error-test")
 
 	s.fireJob(job, 0)
 	s.wg.Wait()
@@ -221,7 +229,12 @@ func TestFireJob_TimeoutError(t *testing.T) {
 	var updatedExecs []Execution
 	var mu sync.Mutex
 
+	job := testJob("timeout-test")
+
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
@@ -231,7 +244,7 @@ func TestFireJob_TimeoutError(t *testing.T) {
 			mu.Unlock()
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -244,7 +257,6 @@ func TestFireJob_TimeoutError(t *testing.T) {
 
 	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
-	job := testJob("timeout-test")
 
 	s.fireJob(job, 0)
 	s.wg.Wait()
@@ -264,13 +276,16 @@ func TestConcurrencySemaphore(t *testing.T) {
 	var mu sync.Mutex
 
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{ID: id, Status: StatusActive, Schedule: "*/5 * * * *"}, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
 		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -355,13 +370,16 @@ func TestStop_WaitsForInFlight(t *testing.T) {
 	var completed int32
 
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{ID: id, Status: StatusActive, Schedule: "*/5 * * * *"}, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
 		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -426,6 +444,9 @@ func TestScheduler_StopWithInflightExecutions(t *testing.T) {
 	var storedExecs []Execution
 
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{ID: id, Status: StatusActive, Schedule: "*/5 * * * *"}, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
@@ -437,7 +458,7 @@ func TestScheduler_StopWithInflightExecutions(t *testing.T) {
 			}
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -474,7 +495,11 @@ func TestScheduler_StopWithInflightExecutions(t *testing.T) {
 }
 
 func TestFireJob_CreateExecutionError(t *testing.T) {
+	job := testJob("create-exec-error")
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return Execution{}, fmt.Errorf("db error")
 		},
@@ -482,7 +507,6 @@ func TestFireJob_CreateExecutionError(t *testing.T) {
 
 	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 	s := NewScheduler(store, &mockExecutor{}, clock, SchedulerConfig{MaxConcurrent: 1})
-	job := testJob("create-exec-error")
 
 	// Should not panic; just logs the error.
 	s.fireJob(job, 0)
@@ -612,7 +636,12 @@ func TestFireJob_JitterAppliedToExecutionTiming(t *testing.T) {
 	var createdExec Execution
 	var sleptDuration time.Duration
 
+	job := testJob("jitter-fire")
+
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			createdExec = exec
 			return exec, nil
@@ -620,7 +649,7 @@ func TestFireJob_JitterAppliedToExecutionTiming(t *testing.T) {
 		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			return nil
 		},
 	}
@@ -643,7 +672,6 @@ func TestFireJob_JitterAppliedToExecutionTiming(t *testing.T) {
 
 	// The jitter offset is passed directly to fireJob, as AddJob would do
 	// (fireJob no longer reads s.jitterCache itself).
-	job := testJob("jitter-fire")
 	knownJitter := 1234 * time.Millisecond
 
 	// fireJob should call sleepFn with the jitter duration, then proceed.
@@ -675,19 +703,30 @@ func TestJitter_SameJobSameSchedule_SameJitter(t *testing.T) {
 // TestFireJobAdvancesNextRunAt (T1) — fireJob must recompute NextRunAt after execution.
 // Before P1, fireJob never sets NextRunAt, so the stored job keeps the stale original value.
 func TestFireJobAdvancesNextRunAt(t *testing.T) {
-	var updatedJob Job
+	var touchedLastRun, touchedNextRun time.Time
+	var touchCalled bool
 	var mu sync.Mutex
 
+	job := testJob("advance-next-run-at")
+	job.Schedule = "*/5 * * * *"
+	// Set an obviously stale NextRunAt so we can detect if it is unchanged.
+	job.NextRunAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
 	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
 		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
 			return nil
 		},
-		UpdateJobFunc: func(ctx context.Context, job Job) error {
+		TouchJobRunFunc: func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			mu.Lock()
-			updatedJob = job
+			touchCalled = true
+			touchedLastRun = lastRun
+			touchedNextRun = nextRun
 			mu.Unlock()
 			return nil
 		},
@@ -711,17 +750,18 @@ func TestFireJobAdvancesNextRunAt(t *testing.T) {
 	s := NewScheduler(store, executor, clock, cfg)
 	s.sleepFn = func(d time.Duration) {} // no-op
 
-	job := testJob("advance-next-run-at")
-	job.Schedule = "*/5 * * * *"
-	// Set an obviously stale NextRunAt so we can detect if it is unchanged.
-	job.NextRunAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-
 	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
-	got := updatedJob
-	mu.Unlock()
+	defer mu.Unlock()
+
+	if !touchCalled {
+		t.Fatal("expected TouchJobRun to be called")
+	}
+	if !touchedLastRun.Equal(fireTime) {
+		t.Fatalf("expected TouchJobRun lastRun %v, got %v", fireTime, touchedLastRun)
+	}
 
 	// Compute the expected NextRunAt: first occurrence of "*/5 * * * *" after fireTime.
 	want, err := NextRunTime(job.Schedule, fireTime)
@@ -729,12 +769,12 @@ func TestFireJobAdvancesNextRunAt(t *testing.T) {
 		t.Fatalf("NextRunTime: %v", err)
 	}
 
-	if got.NextRunAt.IsZero() {
-		t.Fatal("NextRunAt was not set on updated job")
+	if touchedNextRun.IsZero() {
+		t.Fatal("NextRunAt was not set via TouchJobRun")
 	}
-	if !got.NextRunAt.Equal(want) {
+	if !touchedNextRun.Equal(want) {
 		t.Fatalf("NextRunAt = %v, want %v (schedule %q, fire time %v)",
-			got.NextRunAt, want, job.Schedule, fireTime)
+			touchedNextRun, want, job.Schedule, fireTime)
 	}
 }
 

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	robfigcron "github.com/robfig/cron/v3"
 )
 
 func TestNewScheduler_DefaultMaxConcurrent(t *testing.T) {
@@ -1063,5 +1064,80 @@ func TestFireJob_DoesNotWriteBackStaleFullSnapshot(t *testing.T) {
 	}
 	if executedTags != "edited-tag" {
 		t.Fatalf("expected fireJob to execute with the current (edited) job state %q, got %q", "edited-tag", executedTags)
+	}
+}
+
+// --- BUG 3: shutdown blocks up to the full jitter window ---
+
+// TestScheduler_Stop_InterruptsLongJitterWait (BT-004, P1) reproduces the
+// shutdown stall: cronScheduler.Stop() blocks until in-flight fireJob
+// invocations dispatched by robfig/cron finish, and fireJob's jitter wait
+// was an UNINTERRUPTIBLE sleep that can be minutes long. So Stop() (and
+// therefore the whole harnessd shutdown sequence, which calls Stop()
+// before draining the HTTP server) stalls for as long as the jitter.
+//
+// This test registers a job directly with the underlying robfig/cron
+// dispatcher (bypassing the 5-field, minute-resolution schedule parser
+// Scheduler.AddJob uses) so that fireJob is invoked the same way
+// production code invokes it: synchronously, from cron's own dispatch
+// goroutine, tracked by cron.Stop()'s returned context. The job's jitter
+// is deliberately long (a few seconds — long enough to prove the point
+// without making the test suite slow, since production jitter can be up
+// to 5 minutes by default).
+//
+// Before the fix: Stop() blocks for close to the full jitter duration
+// (uninterruptible time.Sleep) and the job still fires afterward. After
+// the fix: Stop() returns promptly (closing s.done interrupts the wait)
+// and the job is skipped entirely rather than firing mid-shutdown.
+func TestScheduler_Stop_InterruptsLongJitterWait(t *testing.T) {
+	var executed bool
+	var mu sync.Mutex
+
+	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{}, ErrJobNotFound
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			mu.Lock()
+			executed = true
+			mu.Unlock()
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Now())
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
+	// sleepFn is left at its default (time.Sleep) deliberately: this test
+	// must exercise a REAL blocking sleep to prove Stop() interrupts it,
+	// not just that a test double happens to return quickly.
+
+	job := testJob("stop-interrupt-test")
+	const longJitter = 3 * time.Second
+
+	// Register directly with the underlying robfig cron dispatcher so
+	// fireJob is invoked synchronously from cron's own goroutine — the
+	// same mechanism Scheduler.Stop()'s `s.cron.Stop()` context waits on.
+	s.cron.Schedule(robfigcron.Every(time.Second), robfigcron.FuncJob(func() {
+		s.fireJob(job, longJitter)
+	}))
+	s.cron.Start()
+
+	// Give the first tick (fires ~1s after Start, per robfig's Every()
+	// minimum resolution) a chance to enter the jitter wait.
+	time.Sleep(1500 * time.Millisecond)
+
+	stopStart := time.Now()
+	s.Stop()
+	stopDuration := time.Since(stopStart)
+
+	if stopDuration > 1500*time.Millisecond {
+		t.Fatalf("Stop() took %v, expected it to return promptly (well under the %v jitter wait)", stopDuration, longJitter)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if executed {
+		t.Fatal("expected fireJob to skip execution when Stop() interrupts the jitter wait, but the executor ran")
 	}
 }

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -894,3 +894,134 @@ func TestScheduler_ConcurrentUpdateJobScheduleAndFireJob_NoDataRace(t *testing.T
 	wg.Wait()
 	s.wg.Wait()
 }
+
+// --- BUG 2: fireJob writes back a stale Job snapshot ---
+
+// TestFireJob_SkipsExecutionWhenJobPausedInStore (BT-002, P1) reproduces the
+// "resurrects paused jobs" half of BUG 2: fireJob captures a full Job at
+// AddJob/schedule time and, before the fix, never re-checks the job's
+// current status before firing. If a job is paused via the store after it
+// was scheduled but before the timer fires, fireJob must NOT execute it.
+//
+// Before the fix, fireJob has no way to observe the pause (it never calls
+// store.GetJob), so it fires anyway. This test fails before the fix
+// (executor.Execute is called) and passes after the fix (fireJob re-reads
+// the job from the store and skips firing when the live status isn't
+// active).
+func TestFireJob_SkipsExecutionWhenJobPausedInStore(t *testing.T) {
+	var executed bool
+	var mu sync.Mutex
+
+	// job is the STALE snapshot fireJob receives — captured as active at
+	// schedule time via AddJob's closure.
+	job := testJob("pause-skip-test")
+	job.Status = StatusActive
+
+	// pausedJob is what the store now reports: the user paused the job
+	// after it was scheduled but before this fire.
+	pausedJob := job
+	pausedJob.Status = StatusPaused
+
+	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return pausedJob, nil
+		},
+		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error { return nil },
+		UpdateJobFunc: func(ctx context.Context, job Job) error { return nil },
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			mu.Lock()
+			executed = true
+			mu.Unlock()
+			return "ok", nil
+		},
+	}
+
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}})
+	s.sleepFn = func(time.Duration) {}
+
+	s.fireJob(job, 0)
+	s.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if executed {
+		t.Fatal("expected fireJob to skip execution for a job that is now paused in the store, but the executor ran (paused job was resurrected)")
+	}
+}
+
+// TestFireJob_DoesNotWriteBackStaleFullSnapshot (BT-003, P1) reproduces the
+// "silently reverts user edits" half of BUG 2: fireJob previously called
+// store.UpdateJob with the full Job struct it captured at schedule time,
+// clobbering any edits (schedule, execution config, timeout, tags) made to
+// the job in the store since it was scheduled.
+//
+// The fix must stop calling store.UpdateJob for run-tracking bookkeeping —
+// it should use a narrower method (TouchJobRun, added in the next commit)
+// that only touches last_run_at/next_run_at/updated_at. This test asserts
+// that fireJob never calls store.UpdateJob at all as part of a normal fire,
+// and that execution uses the CURRENT (re-read) job state rather than the
+// stale snapshot. Before the fix, UpdateJobFunc IS invoked (with the stale
+// snapshot) and the stale ExecConfig/Tags are used, so this test fails.
+// After the fix, UpdateJob is never called and the live state is used.
+func TestFireJob_DoesNotWriteBackStaleFullSnapshot(t *testing.T) {
+	var updateJobCalled bool
+	var mu sync.Mutex
+
+	// job is the STALE snapshot captured at schedule time.
+	job := testJob("stale-snapshot-test")
+	job.Tags = "stale-tag"
+	job.TimeoutSec = 30
+
+	// current is what the store now reports: the user edited tags and
+	// timeout after the job was scheduled.
+	current := job
+	current.Tags = "edited-tag"
+	current.TimeoutSec = 999
+
+	var executedTags string
+	store := &mockStore{
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return current, nil
+		},
+		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error { return nil },
+		UpdateJobFunc: func(ctx context.Context, job Job) error {
+			mu.Lock()
+			updateJobCalled = true
+			mu.Unlock()
+			return nil
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, execJob Job) (string, error) {
+			mu.Lock()
+			executedTags = execJob.Tags
+			mu.Unlock()
+			return "ok", nil
+		},
+	}
+
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}})
+	s.sleepFn = func(time.Duration) {}
+
+	s.fireJob(job, 0)
+	s.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if updateJobCalled {
+		t.Fatal("fireJob must not call store.UpdateJob with a full job snapshot (it can silently revert concurrent edits); it should only touch run-tracking columns via TouchJobRun")
+	}
+	if executedTags != "edited-tag" {
+		t.Fatalf("expected fireJob to execute with the current (edited) job state %q, got %q", "edited-tag", executedTags)
+	}
+}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -138,7 +138,7 @@ func TestFireJob_CreatesExecution(t *testing.T) {
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
 	job := testJob("fire-test")
 
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
@@ -199,7 +199,7 @@ func TestFireJob_ExecutorError(t *testing.T) {
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
 	job := testJob("error-test")
 
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
@@ -246,7 +246,7 @@ func TestFireJob_TimeoutError(t *testing.T) {
 	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
 	job := testJob("timeout-test")
 
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
@@ -295,7 +295,7 @@ func TestConcurrencySemaphore(t *testing.T) {
 	// Fire 5 jobs concurrently.
 	for i := 0; i < 5; i++ {
 		job := testJob(fmt.Sprintf("concurrent-%d", i))
-		s.fireJob(job)
+		s.fireJob(job, 0)
 	}
 	s.wg.Wait()
 
@@ -379,7 +379,7 @@ func TestStop_WaitsForInFlight(t *testing.T) {
 
 	// Fire a job.
 	job := testJob("inflight")
-	s.fireJob(job)
+	s.fireJob(job, 0)
 
 	// Stop should wait for the in-flight execution.
 	s.Stop()
@@ -456,7 +456,7 @@ func TestScheduler_StopWithInflightExecutions(t *testing.T) {
 	// Fire 3 jobs.
 	for i := 0; i < 3; i++ {
 		job := testJob(fmt.Sprintf("inflight-%d", i))
-		s.fireJob(job)
+		s.fireJob(job, 0)
 	}
 
 	// Immediately call Stop() — should block until all 3 finish.
@@ -485,7 +485,7 @@ func TestFireJob_CreateExecutionError(t *testing.T) {
 	job := testJob("create-exec-error")
 
 	// Should not panic; just logs the error.
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 }
 
@@ -641,15 +641,13 @@ func TestFireJob_JitterAppliedToExecutionTiming(t *testing.T) {
 		sleptDuration = d
 	}
 
-	// Pre-populate the jitter cache with a known value (as AddJob would).
+	// The jitter offset is passed directly to fireJob, as AddJob would do
+	// (fireJob no longer reads s.jitterCache itself).
 	job := testJob("jitter-fire")
 	knownJitter := 1234 * time.Millisecond
-	s.mu.Lock()
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = knownJitter
-	s.mu.Unlock()
 
 	// fireJob should call sleepFn with the jitter duration, then proceed.
-	s.fireJob(job)
+	s.fireJob(job, knownJitter)
 	s.wg.Wait()
 
 	if createdExec.JobID != job.ID {
@@ -718,12 +716,7 @@ func TestFireJobAdvancesNextRunAt(t *testing.T) {
 	// Set an obviously stale NextRunAt so we can detect if it is unchanged.
 	job.NextRunAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Pre-populate the jitter cache so fireJob does not panic on a missing key.
-	s.mu.Lock()
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
-	s.mu.Unlock()
-
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
@@ -818,7 +811,7 @@ func TestScheduler_ConcurrentAddJobAndFireJob_NoDataRace(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				s.fireJob(fireTarget)
+				s.fireJob(fireTarget, 0)
 			}
 		}()
 	}

--- a/internal/cron/scheduler_test.go
+++ b/internal/cron/scheduler_test.go
@@ -744,3 +744,85 @@ func TestFireJobAdvancesNextRunAt(t *testing.T) {
 			got.NextRunAt, want, job.Schedule, fireTime)
 	}
 }
+
+// --- BUG 1: jitterCache concurrent access ---
+
+// TestScheduler_ConcurrentAddJobAndFireJob_NoDataRace (BT-001, P1) reproduces
+// the fatal, unrecoverable Go runtime error that crashes the daemon when
+// fireJob reads s.jitterCache without holding s.mu while AddJob concurrently
+// writes to the same map under s.mu.
+//
+// fireJob currently reads `s.jitterCache[jitterKey]` with no lock at all
+// (scheduler.go ~141-142), while AddJob writes that map under s.mu
+// (scheduler.go ~93). A concurrent unsynchronized map read + write is a
+// fatal Go runtime error ("concurrent map read and map write") that cannot
+// be recovered with panic/recover — it kills the whole process.
+//
+// This test must be run with `-race` to reliably surface the problem
+// (`go test ./internal/cron/... -race -run TestScheduler_ConcurrentAddJobAndFireJob_NoDataRace`).
+// Before the fix, this crashes the test binary with a fatal runtime error
+// (or is flagged by the race detector) because fireJob's map read at
+// scheduler.go:142 races with AddJob's map write at scheduler.go:93.
+// After the fix, fireJob never touches s.jitterCache (the jitter offset is
+// passed in directly by AddJob's closure), so there is nothing to race on.
+func TestScheduler_ConcurrentAddJobAndFireJob_NoDataRace(t *testing.T) {
+	store := &mockStore{
+		CreateExecutionFunc: func(ctx context.Context, exec Execution) (Execution, error) {
+			return exec, nil
+		},
+		UpdateExecutionFunc: func(ctx context.Context, exec Execution) error {
+			return nil
+		},
+		GetJobFunc: func(ctx context.Context, id string) (Job, error) {
+			return Job{}, ErrJobNotFound
+		},
+		UpdateJobFunc: func(ctx context.Context, job Job) error {
+			return nil
+		},
+	}
+	executor := &mockExecutor{
+		ExecuteFunc: func(ctx context.Context, job Job) (string, error) {
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 10})
+	s.sleepFn = func(time.Duration) {} // no-op so fireJob returns quickly
+
+	// One job that's already registered, so fireJob has a real jitterCache
+	// entry to read while other goroutines mutate the map.
+	fireTarget := testJob("race-fire-target")
+	if err := s.AddJob(fireTarget); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const iterations = 200
+
+	// Goroutines that repeatedly AddJob (writes s.jitterCache under s.mu).
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				job := testJob(fmt.Sprintf("race-writer-%d-%d", gid, i))
+				_ = s.AddJob(job)
+			}
+		}(g)
+	}
+
+	// Goroutines that repeatedly call fireJob for the pre-registered job,
+	// exercising the unsynchronized jitterCache read on the old code path.
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				s.fireJob(fireTarget)
+			}
+		}()
+	}
+
+	wg.Wait()
+	s.wg.Wait()
+}

--- a/internal/cron/server.go
+++ b/internal/cron/server.go
@@ -236,7 +236,14 @@ func (s *Server) handleUpdateJob(w http.ResponseWriter, r *http.Request, id stri
 		}
 	}
 
-	if req.Schedule != nil && (req.Status == nil || *req.Status == StatusActive) {
+	// Gate on job.Status (the EFFECTIVE post-update status), not on
+	// req.Status (the raw request field). A schedule-only PATCH
+	// (req.Status == nil) must not re-arm a job whose stored status is
+	// paused: job.Status already reflects that live status in that case.
+	// For a resume+schedule PATCH, the status block above already set
+	// job.Status = StatusActive, so this still correctly re-arms
+	// genuinely-active jobs.
+	if req.Schedule != nil && job.Status == StatusActive {
 		if err := s.scheduler.UpdateJobSchedule(job); err != nil {
 			writeError(w, http.StatusInternalServerError, "scheduler_error", err.Error())
 			return

--- a/internal/cron/server_test.go
+++ b/internal/cron/server_test.go
@@ -251,6 +251,55 @@ func TestServerUpdateJobSchedule(t *testing.T) {
 	}
 }
 
+// TestServerUpdateJobSchedule_PausedJobNotReArmed (BT-005, P2) reproduces
+// BUG 4: PATCHing only the schedule of a PAUSED job re-arms it in the live
+// scheduler. The re-arm condition in handleUpdateJob (~line 239) is
+// `req.Schedule != nil && (req.Status == nil || *req.Status == StatusActive)`.
+// A schedule-only PATCH leaves req.Status nil, so a paused job is added
+// back to the live scheduler even though its stored status remains
+// "paused" — a paused job starts firing (or, after the BUG-2 fix, at least
+// sits incorrectly registered in the scheduler's live entry set).
+//
+// This test fails before the fix (the job ends up in scheduler.entries)
+// and passes after the fix (gating on the job's effective post-update
+// status rather than the request's status field).
+func TestServerUpdateJobSchedule_PausedJobNotReArmed(t *testing.T) {
+	store := &mockStore{}
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	executor := &mockExecutor{}
+	scheduler := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
+	handler := NewServer(store, scheduler, clock)
+
+	// j is already paused and, per the real job lifecycle, was removed
+	// from the live scheduler when it was paused — it is NOT in
+	// scheduler.entries at the start of this test.
+	j := testJob("patch-paused-schedule")
+	j.Status = StatusPaused
+
+	store.GetJobFunc = func(_ context.Context, id string) (Job, error) {
+		return j, nil
+	}
+	store.UpdateJobFunc = func(_ context.Context, job Job) error { return nil }
+
+	// PATCH only the schedule — no "status" field in the request body.
+	newSchedule := "0 * * * *"
+	payload := fmt.Sprintf(`{"schedule":"%s"}`, newSchedule)
+	req := httptest.NewRequest(http.MethodPatch, "/v1/jobs/"+j.ID, strings.NewReader(payload))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	scheduler.mu.Lock()
+	_, scheduled := scheduler.entries[j.ID]
+	scheduler.mu.Unlock()
+	if scheduled {
+		t.Fatal("expected a schedule-only PATCH on a paused job to NOT re-arm it in the live scheduler, but it was added to scheduler.entries")
+	}
+}
+
 func TestServerUpdateJobPause(t *testing.T) {
 	handler, store := newTestServer(t)
 	j := testJob("pause-test")

--- a/internal/cron/server_test.go
+++ b/internal/cron/server_test.go
@@ -346,6 +346,45 @@ func TestServerUpdateJobResume(t *testing.T) {
 	}
 }
 
+// TestServerUpdateJobResumeAndSchedule_ReArms (regression for BUG 4) is the
+// positive counterpart of TestServerUpdateJobSchedule_PausedJobNotReArmed:
+// a PATCH that resumes AND reschedules a paused job in the same request
+// must still re-arm it in the live scheduler. This guards against
+// overcorrecting the BUG-4 fix into never re-arming (e.g. accidentally
+// checking req.Status instead of the freshly-set job.Status, or checking
+// the OLD status instead of the effective one).
+func TestServerUpdateJobResumeAndSchedule_ReArms(t *testing.T) {
+	store := &mockStore{}
+	clock := newMockClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	executor := &mockExecutor{}
+	scheduler := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1})
+	handler := NewServer(store, scheduler, clock)
+
+	j := testJob("resume-and-schedule")
+	j.Status = StatusPaused
+
+	store.GetJobFunc = func(_ context.Context, id string) (Job, error) {
+		return j, nil
+	}
+	store.UpdateJobFunc = func(_ context.Context, job Job) error { return nil }
+
+	payload := `{"status":"active","schedule":"0 * * * *"}`
+	req := httptest.NewRequest(http.MethodPatch, "/v1/jobs/"+j.ID, strings.NewReader(payload))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	scheduler.mu.Lock()
+	_, scheduled := scheduler.entries[j.ID]
+	scheduler.mu.Unlock()
+	if !scheduled {
+		t.Fatal("expected a resume+schedule PATCH to re-arm the job in the live scheduler")
+	}
+}
+
 func TestServerUpdateJobNotFound(t *testing.T) {
 	handler, store := newTestServer(t)
 	store.GetJobFunc = func(_ context.Context, id string) (Job, error) {

--- a/internal/cron/store.go
+++ b/internal/cron/store.go
@@ -1,6 +1,9 @@
 package cron
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // Store is the persistence interface for cron jobs and executions.
 type Store interface {
@@ -11,6 +14,12 @@ type Store interface {
 	GetJobByName(ctx context.Context, name string) (Job, error)
 	ListJobs(ctx context.Context) ([]Job, error)
 	UpdateJob(ctx context.Context, job Job) error
+	// TouchJobRun updates only the run-tracking columns (last_run_at,
+	// next_run_at, updated_at) for a job. Unlike UpdateJob, it never
+	// touches schedule, execution config, status, timeout, or tags, so it
+	// is safe to call from the scheduler after a fire without risking a
+	// silent revert of concurrent user edits or resurrecting a paused job.
+	TouchJobRun(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error
 	DeleteJob(ctx context.Context, id string) error // soft delete
 
 	CreateExecution(ctx context.Context, exec Execution) (Execution, error)

--- a/internal/cron/store_sqlite.go
+++ b/internal/cron/store_sqlite.go
@@ -237,6 +237,33 @@ WHERE job_id = ?
 	return nil
 }
 
+// TouchJobRun updates only the run-tracking columns for a job
+// (last_run_at, next_run_at, updated_at), leaving schedule, execution
+// config, status, timeout, and tags untouched. This is used by the
+// scheduler after firing a job so a concurrent user edit (or pause) is
+// never silently reverted by a full-row overwrite.
+func (s *SQLiteStore) TouchJobRun(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
+	res, err := s.db.ExecContext(ctx, `
+UPDATE cron_jobs SET last_run_at = ?, next_run_at = ?, updated_at = ? WHERE job_id = ?
+`,
+		nullableTimeString(lastRun),
+		nowString(nextRun),
+		nowString(updatedAt),
+		jobID,
+	)
+	if err != nil {
+		return fmt.Errorf("touch job run: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("touch job run rows affected: %w", err)
+	}
+	if rows == 0 {
+		return ErrJobNotFound
+	}
+	return nil
+}
+
 // DeleteJob performs a soft delete by setting status to deleted.
 // It also renames the job to free the unique name constraint,
 // allowing a new job with the same name to be created later.

--- a/internal/cron/store_sqlite_test.go
+++ b/internal/cron/store_sqlite_test.go
@@ -266,6 +266,70 @@ func TestUpdateJob(t *testing.T) {
 	}
 }
 
+// TestTouchJobRun_OnlyUpdatesRunTrackingColumns (BUG 2 fix) verifies that
+// TouchJobRun updates last_run_at, next_run_at, and updated_at, but leaves
+// every other column (schedule, status, tags, execution config, timeout)
+// exactly as it was — even when the in-memory Job struct passed elsewhere
+// disagrees. This is the core guarantee that lets the scheduler record a
+// fire without risking a silent revert of concurrent edits or resurrecting
+// a paused job.
+func TestTouchJobRun_OnlyUpdatesRunTrackingColumns(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+	job := testJob("touch-run-me")
+	job.Status = StatusPaused
+	job.Tags = "keep-me"
+	job.Schedule = "0 * * * *"
+
+	if _, err := store.CreateJob(ctx, job); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	lastRun := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	nextRun := time.Date(2025, 3, 1, 11, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2025, 3, 1, 10, 0, 1, 0, time.UTC)
+
+	if err := store.TouchJobRun(ctx, job.ID, lastRun, nextRun, updatedAt); err != nil {
+		t.Fatalf("TouchJobRun: %v", err)
+	}
+
+	// GetJob excludes deleted jobs but not paused ones, so this should succeed.
+	got, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+
+	if !got.LastRunAt.Equal(lastRun) {
+		t.Errorf("expected LastRunAt %v, got %v", lastRun, got.LastRunAt)
+	}
+	if !got.NextRunAt.Equal(nextRun) {
+		t.Errorf("expected NextRunAt %v, got %v", nextRun, got.NextRunAt)
+	}
+	if !got.UpdatedAt.Equal(updatedAt) {
+		t.Errorf("expected UpdatedAt %v, got %v", updatedAt, got.UpdatedAt)
+	}
+
+	// Everything else must be untouched — this is the whole point of the
+	// method existing instead of a full UpdateJob call.
+	if got.Status != StatusPaused {
+		t.Errorf("TouchJobRun must not change status; expected %q, got %q", StatusPaused, got.Status)
+	}
+	if got.Tags != "keep-me" {
+		t.Errorf("TouchJobRun must not change tags; expected %q, got %q", "keep-me", got.Tags)
+	}
+	if got.Schedule != "0 * * * *" {
+		t.Errorf("TouchJobRun must not change schedule; expected %q, got %q", "0 * * * *", got.Schedule)
+	}
+}
+
+func TestTouchJobRun_NotFound(t *testing.T) {
+	store := newTestStore(t)
+	err := store.TouchJobRun(context.Background(), "missing-job", time.Now(), time.Now(), time.Now())
+	if !IsJobNotFound(err) {
+		t.Fatalf("expected job not found, got %v", err)
+	}
+}
+
 func TestDeleteJob_SoftDelete(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/cron/store_sqlite_test.go
+++ b/internal/cron/store_sqlite_test.go
@@ -330,6 +330,119 @@ func TestTouchJobRun_NotFound(t *testing.T) {
 	}
 }
 
+// TestScheduler_FireJob_Integration_PreservesEditsViaRealSQLiteStore
+// (regression for BUG 2) drives Scheduler.fireJob against a real
+// SQLiteStore instead of the mockStore used by the red tests in
+// scheduler_test.go — a different angle that would fail if fireJob is
+// ever changed back to writing a full stale Job snapshot via UpdateJob.
+//
+// It schedules a job, edits it directly in the store (simulating a user
+// PATCH that lands after the job was captured by AddJob's closure), then
+// fires the STALE, pre-edit Job snapshot. The edit must survive in the
+// real database row.
+func TestScheduler_FireJob_Integration_PreservesEditsViaRealSQLiteStore(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	staleJob := testJob("integration-preserve-edits")
+	staleJob.Tags = "original-tag"
+	created, err := store.CreateJob(ctx, staleJob)
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	staleJob = created // this is what fireJob will be handed (pre-edit)
+
+	// Simulate a concurrent user edit landing after the job was scheduled.
+	edited := staleJob
+	edited.Tags = "edited-tag"
+	edited.Schedule = "0 * * * *"
+	edited.UpdatedAt = time.Now().UTC()
+	if err := store.UpdateJob(ctx, edited); err != nil {
+		t.Fatalf("UpdateJob (simulated concurrent edit): %v", err)
+	}
+
+	var executedTags string
+	executor := &mockExecutor{
+		ExecuteFunc: func(_ context.Context, job Job) (string, error) {
+			executedTags = job.Tags
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Now().UTC())
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}})
+	s.sleepFn = func(time.Duration) {}
+
+	// Fire using the STALE snapshot (as AddJob's closure would hand to
+	// fireJob) — the fix must re-read live state before acting on it.
+	s.fireJob(staleJob, 0)
+	s.wg.Wait()
+
+	if executedTags != "edited-tag" {
+		t.Fatalf("expected fireJob to execute with the live edited tags %q, got %q", "edited-tag", executedTags)
+	}
+
+	got, err := store.GetJob(ctx, staleJob.ID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if got.Tags != "edited-tag" {
+		t.Fatalf("fireJob reverted the concurrent edit: expected tags %q, got %q", "edited-tag", got.Tags)
+	}
+	if got.Schedule != "0 * * * *" {
+		t.Fatalf("fireJob reverted the concurrent schedule edit: expected %q, got %q", "0 * * * *", got.Schedule)
+	}
+}
+
+// TestScheduler_FireJob_Integration_DoesNotResurrectPausedJob (regression
+// for BUG 2) is the paused-job counterpart of the edit-preservation test
+// above, also driven against a real SQLiteStore. It would fail if fireJob
+// stops re-checking live status before firing.
+func TestScheduler_FireJob_Integration_DoesNotResurrectPausedJob(t *testing.T) {
+	store := newTestStore(t)
+	ctx := context.Background()
+
+	staleJob := testJob("integration-no-resurrect")
+	created, err := store.CreateJob(ctx, staleJob)
+	if err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	staleJob = created // captured as active — this is the stale snapshot
+
+	// Pause the job in the store after it was "scheduled".
+	paused := staleJob
+	paused.Status = StatusPaused
+	paused.UpdatedAt = time.Now().UTC()
+	if err := store.UpdateJob(ctx, paused); err != nil {
+		t.Fatalf("UpdateJob (pause): %v", err)
+	}
+
+	executed := false
+	executor := &mockExecutor{
+		ExecuteFunc: func(_ context.Context, _ Job) (string, error) {
+			executed = true
+			return "ok", nil
+		},
+	}
+	clock := newMockClock(time.Now().UTC())
+	s := NewScheduler(store, executor, clock, SchedulerConfig{MaxConcurrent: 1, Jitter: JitterConfig{Enabled: false}})
+	s.sleepFn = func(time.Duration) {}
+
+	s.fireJob(staleJob, 0)
+	s.wg.Wait()
+
+	if executed {
+		t.Fatal("fireJob resurrected a paused job: executor ran despite the job being paused in the store")
+	}
+
+	got, err := store.GetJob(ctx, staleJob.ID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if got.Status != StatusPaused {
+		t.Fatalf("fireJob resurrected the paused job: expected status %q, got %q", StatusPaused, got.Status)
+	}
+}
+
 func TestDeleteJob_SoftDelete(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()

--- a/internal/cron/t2_deterministic_test.go
+++ b/internal/cron/t2_deterministic_test.go
@@ -255,17 +255,12 @@ func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 		NextRunAt:  baseTime.Add(5 * time.Minute),
 	}
 
-	// Pre-populate jitter cache.
-	s.mu.Lock()
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
-	s.mu.Unlock()
-
 	// Fire N times sequentially, advancing the mock clock by 5 minutes each time
 	// so each iteration has a distinct and predictable endTime.
 	for i := 0; i < N; i++ {
 		fireTime := baseTime.Add(time.Duration(i+1) * 5 * time.Minute)
 		clock.Set(fireTime)
-		s.fireJob(job)
+		s.fireJob(job, 0)
 		s.wg.Wait() // ensure goroutine completes before next iteration
 	}
 
@@ -377,11 +372,8 @@ func TestFireJob_FailedExecution_NextRunAtStillAdvanced(t *testing.T) {
 		Status:     StatusActive,
 		NextRunAt:  fireTime, // stale — same as fire time
 	}
-	s.mu.Lock()
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
-	s.mu.Unlock()
 
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
@@ -449,11 +441,8 @@ func TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged(t *testing.T) {
 		ExecConfig: `{"command":"echo ok"}`,
 		Status:     StatusActive,
 	}
-	s.mu.Lock()
-	s.jitterCache[jitterCacheKey(job.ID, job.Schedule)] = 0
-	s.mu.Unlock()
 
-	s.fireJob(job)
+	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()

--- a/internal/cron/t2_deterministic_test.go
+++ b/internal/cron/t2_deterministic_test.go
@@ -187,16 +187,34 @@ func TestNextRunTime_MonotonicSequence(t *testing.T) {
 // (b) fireJob-driven execution across N manual calls
 // ---------------------------------------------------------------------------
 
-// fireJobTracker collects the full sequence of UpdateJob calls so each
-// iteration's state can be inspected independently.
+// touchCall records one TouchJobRun invocation.
+type touchCall struct {
+	jobID     string
+	lastRun   time.Time
+	nextRun   time.Time
+	updatedAt time.Time
+}
+
+// fireJobTracker collects the full sequence of TouchJobRun calls so each
+// iteration's state can be inspected independently. It also serves a live
+// Job via GetJobFunc, as fireJob now re-reads current job state before
+// firing (BUG 2 fix) instead of trusting the stale snapshot captured at
+// schedule time.
 type fireJobTracker struct {
 	mu          sync.Mutex
 	execUpdates []Execution // all UpdateExecution calls (both status transitions)
-	jobUpdates  []Job       // one per fireJob call
+	touches     []touchCall // one per fireJob call that actually fires
+	job         Job         // the "live" job state returned by GetJob
 }
 
 func (tr *fireJobTracker) store() *mockStore {
 	return &mockStore{
+		GetJobFunc: func(_ context.Context, id string) (Job, error) {
+			tr.mu.Lock()
+			j := tr.job
+			tr.mu.Unlock()
+			return j, nil
+		},
 		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
@@ -206,9 +224,9 @@ func (tr *fireJobTracker) store() *mockStore {
 			tr.mu.Unlock()
 			return nil
 		},
-		UpdateJobFunc: func(_ context.Context, job Job) error {
+		TouchJobRunFunc: func(_ context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			tr.mu.Lock()
-			tr.jobUpdates = append(tr.jobUpdates, job)
+			tr.touches = append(tr.touches, touchCall{jobID, lastRun, nextRun, updatedAt})
 			tr.mu.Unlock()
 			return nil
 		},
@@ -217,10 +235,10 @@ func (tr *fireJobTracker) store() *mockStore {
 
 // TestFireJob_NSequentialCallsAdvanceState fires a job N times and asserts:
 //   - exactly N execution pairs (running+success) are recorded, i.e. 2*N UpdateExecution calls
-//   - exactly N UpdateJob calls are recorded
-//   - each successive jobUpdate's LastRunAt is >= the previous one (monotonically non-decreasing)
-//   - each successive jobUpdate's NextRunAt is computed from the stored schedule and is
-//     strictly after the corresponding LastRunAt
+//   - exactly N TouchJobRun calls are recorded
+//   - each successive touch's lastRun is >= the previous one (monotonically non-decreasing)
+//   - each successive touch's nextRun is computed from the stored schedule and is
+//     strictly after the corresponding lastRun
 func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 	const N = 5
 	schedule := "*/5 * * * *"
@@ -254,6 +272,9 @@ func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 		TimeoutSec: 30,
 		NextRunAt:  baseTime.Add(5 * time.Minute),
 	}
+	tr.mu.Lock()
+	tr.job = job
+	tr.mu.Unlock()
 
 	// Fire N times sequentially, advancing the mock clock by 5 minutes each time
 	// so each iteration has a distinct and predictable endTime.
@@ -267,8 +288,8 @@ func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 	tr.mu.Lock()
 	execUpdates := make([]Execution, len(tr.execUpdates))
 	copy(execUpdates, tr.execUpdates)
-	jobUpdates := make([]Job, len(tr.jobUpdates))
-	copy(jobUpdates, tr.jobUpdates)
+	touches := make([]touchCall, len(tr.touches))
+	copy(touches, tr.touches)
 	tr.mu.Unlock()
 
 	// --- Assertion 1: execution update count ---
@@ -277,9 +298,9 @@ func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 		t.Fatalf("expected %d execution updates (2 per fireJob), got %d", 2*N, got)
 	}
 
-	// --- Assertion 2: job update count ---
-	if got := len(jobUpdates); got != N {
-		t.Fatalf("expected %d job updates (1 per fireJob), got %d", N, got)
+	// --- Assertion 2: TouchJobRun call count ---
+	if got := len(touches); got != N {
+		t.Fatalf("expected %d TouchJobRun calls (1 per fireJob), got %d", N, got)
 	}
 
 	// --- Assertion 3: execution status pairs ---
@@ -294,58 +315,73 @@ func TestFireJob_NSequentialCallsAdvanceState(t *testing.T) {
 		}
 	}
 
-	// --- Assertion 4: LastRunAt is monotonically non-decreasing ---
+	// --- Assertion 4: lastRun is monotonically non-decreasing ---
 	for i := 1; i < N; i++ {
-		prev := jobUpdates[i-1].LastRunAt
-		cur := jobUpdates[i].LastRunAt
+		prev := touches[i-1].lastRun
+		cur := touches[i].lastRun
 		if cur.Before(prev) {
-			t.Errorf("iteration %d: LastRunAt went backwards: %v < %v", i, cur, prev)
+			t.Errorf("iteration %d: lastRun went backwards: %v < %v", i, cur, prev)
 		}
 	}
 
-	// --- Assertion 5: NextRunAt is correctly recomputed after each execution ---
-	// NextRunAt = NextRunTime(schedule, endTime) where endTime = clock.Now() at fire time.
-	for i, ju := range jobUpdates {
+	// --- Assertion 5: nextRun is correctly recomputed after each execution ---
+	// nextRun = NextRunTime(schedule, endTime) where endTime = clock.Now() at fire time.
+	for i, tc := range touches {
 		endTime := baseTime.Add(time.Duration(i+1) * 5 * time.Minute)
 		want, err := NextRunTime(schedule, endTime)
 		if err != nil {
 			t.Fatalf("iteration %d: NextRunTime error: %v", i, err)
 		}
-		if ju.NextRunAt.IsZero() {
-			t.Errorf("iteration %d: NextRunAt is zero", i)
+		if tc.nextRun.IsZero() {
+			t.Errorf("iteration %d: nextRun is zero", i)
 			continue
 		}
-		if !ju.NextRunAt.Equal(want) {
-			t.Errorf("iteration %d: NextRunAt = %v, want %v (endTime %v, schedule %q)",
-				i, ju.NextRunAt, want, endTime, schedule)
+		if !tc.nextRun.Equal(want) {
+			t.Errorf("iteration %d: nextRun = %v, want %v (endTime %v, schedule %q)",
+				i, tc.nextRun, want, endTime, schedule)
 		}
 	}
 
-	// --- Assertion 6: each NextRunAt is strictly after the corresponding LastRunAt ---
-	for i, ju := range jobUpdates {
-		if !ju.NextRunAt.After(ju.LastRunAt) {
-			t.Errorf("iteration %d: NextRunAt %v is not after LastRunAt %v",
-				i, ju.NextRunAt, ju.LastRunAt)
+	// --- Assertion 6: each nextRun is strictly after the corresponding lastRun ---
+	for i, tc := range touches {
+		if !tc.nextRun.After(tc.lastRun) {
+			t.Errorf("iteration %d: nextRun %v is not after lastRun %v",
+				i, tc.nextRun, tc.lastRun)
 		}
 	}
 }
 
-// TestFireJob_FailedExecution_DoesNotChangeNextRunAt verifies that on executor
-// failure the updated job's NextRunAt is still recomputed (P1 fix applies
-// regardless of success/failure — scheduler.go unconditionally sets it after
-// endTime is known; only a schedule parse error leaves it unchanged).
+// TestFireJob_FailedExecution_NextRunAtStillAdvanced verifies that on executor
+// failure the touched nextRun is still recomputed (P1 fix applies regardless
+// of success/failure — scheduler.go unconditionally calls TouchJobRun after
+// endTime is known; only a schedule parse error leaves nextRun unchanged).
 func TestFireJob_FailedExecution_NextRunAtStillAdvanced(t *testing.T) {
 	var mu sync.Mutex
-	var jobUpdate Job
+	var touched touchCall
+	var touchCalled bool
+
+	schedule := "0 * * * *"
+	job := Job{
+		ID:         "fail-job",
+		Name:       "fail",
+		Schedule:   schedule,
+		ExecType:   ExecTypeShell,
+		ExecConfig: `{"command":"false"}`,
+		Status:     StatusActive,
+	}
 
 	store := &mockStore{
+		GetJobFunc: func(_ context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
 		UpdateExecutionFunc: func(_ context.Context, exec Execution) error { return nil },
-		UpdateJobFunc: func(_ context.Context, job Job) error {
+		TouchJobRunFunc: func(_ context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			mu.Lock()
-			jobUpdate = job
+			touched = touchCall{jobID, lastRun, nextRun, updatedAt}
+			touchCalled = true
 			mu.Unlock()
 			return nil
 		},
@@ -362,33 +398,27 @@ func TestFireJob_FailedExecution_NextRunAtStillAdvanced(t *testing.T) {
 	s := NewScheduler(store, executor, clock, cfg)
 	s.sleepFn = func(time.Duration) {}
 
-	schedule := "0 * * * *"
-	job := Job{
-		ID:         "fail-job",
-		Name:       "fail",
-		Schedule:   schedule,
-		ExecType:   ExecTypeShell,
-		ExecConfig: `{"command":"false"}`,
-		Status:     StatusActive,
-		NextRunAt:  fireTime, // stale — same as fire time
-	}
-
 	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
-	got := jobUpdate
+	got := touched
+	calledOK := touchCalled
 	mu.Unlock()
+
+	if !calledOK {
+		t.Fatal("expected TouchJobRun to be called even after a failed execution")
+	}
 
 	want, err := NextRunTime(schedule, fireTime)
 	if err != nil {
 		t.Fatalf("NextRunTime: %v", err)
 	}
-	if got.NextRunAt.IsZero() {
-		t.Fatal("NextRunAt is zero after failed execution")
+	if got.nextRun.IsZero() {
+		t.Fatal("nextRun is zero after failed execution")
 	}
-	if !got.NextRunAt.Equal(want) {
-		t.Fatalf("NextRunAt = %v, want %v", got.NextRunAt, want)
+	if !got.nextRun.Equal(want) {
+		t.Fatalf("nextRun = %v, want %v", got.nextRun, want)
 	}
 }
 
@@ -398,22 +428,38 @@ type errTestFailure string
 func (e errTestFailure) Error() string { return string(e) }
 
 // TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged verifies that when the
-// job's schedule cannot be parsed by NextRunTime, the UpdateJob call still
-// happens but NextRunAt is left at the original value (zero in this case).
+// job's schedule cannot be parsed by NextRunTime, TouchJobRun is still
+// called but nextRun is left at the job's current NextRunAt value (zero in
+// this case).
 func TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged(t *testing.T) {
 	var mu sync.Mutex
-	var jobUpdate Job
-	updated := false
+	var touched touchCall
+	touchCalled := false
+
+	// We can't add an invalid schedule via AddJob (it would error), so we
+	// call fireJob directly with a job whose Schedule field is
+	// intentionally invalid.
+	job := Job{
+		ID:         "bad-sched-job",
+		Name:       "bad-schedule",
+		Schedule:   "INVALID_SCHED",
+		ExecType:   ExecTypeShell,
+		ExecConfig: `{"command":"echo ok"}`,
+		Status:     StatusActive,
+	}
 
 	store := &mockStore{
+		GetJobFunc: func(_ context.Context, id string) (Job, error) {
+			return job, nil
+		},
 		CreateExecutionFunc: func(_ context.Context, exec Execution) (Execution, error) {
 			return exec, nil
 		},
 		UpdateExecutionFunc: func(_ context.Context, exec Execution) error { return nil },
-		UpdateJobFunc: func(_ context.Context, job Job) error {
+		TouchJobRunFunc: func(_ context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
 			mu.Lock()
-			jobUpdate = job
-			updated = true
+			touched = touchCall{jobID, lastRun, nextRun, updatedAt}
+			touchCalled = true
 			mu.Unlock()
 			return nil
 		},
@@ -430,29 +476,18 @@ func TestFireJob_InvalidSchedule_NextRunAtLeftUnchanged(t *testing.T) {
 	s := NewScheduler(store, executor, clock, cfg)
 	s.sleepFn = func(time.Duration) {}
 
-	// We can't add an invalid schedule via AddJob (it would error), so we
-	// pre-populate the jitter cache directly and call fireJob with a job
-	// whose Schedule field is intentionally invalid.
-	job := Job{
-		ID:         "bad-sched-job",
-		Name:       "bad-schedule",
-		Schedule:   "INVALID_SCHED",
-		ExecType:   ExecTypeShell,
-		ExecConfig: `{"command":"echo ok"}`,
-		Status:     StatusActive,
-	}
-
 	s.fireJob(job, 0)
 	s.wg.Wait()
 
 	mu.Lock()
 	defer mu.Unlock()
 
-	if !updated {
-		t.Fatal("expected UpdateJob to be called even with an invalid schedule")
+	if !touchCalled {
+		t.Fatal("expected TouchJobRun to be called even with an invalid schedule")
 	}
-	// NextRunAt should remain zero because NextRunTime returned an error.
-	if !jobUpdate.NextRunAt.IsZero() {
-		t.Fatalf("expected NextRunAt to remain zero for invalid schedule, got %v", jobUpdate.NextRunAt)
+	// nextRun should remain zero because NextRunTime returned an error and
+	// job.NextRunAt (the fallback) was never set.
+	if !touched.nextRun.IsZero() {
+		t.Fatalf("expected nextRun to remain zero for invalid schedule, got %v", touched.nextRun)
 	}
 }

--- a/internal/cron/testutil_test.go
+++ b/internal/cron/testutil_test.go
@@ -16,6 +16,7 @@ type mockStore struct {
 	GetJobByNameFunc   func(ctx context.Context, name string) (Job, error)
 	ListJobsFunc       func(ctx context.Context) ([]Job, error)
 	UpdateJobFunc      func(ctx context.Context, job Job) error
+	TouchJobRunFunc    func(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error
 	DeleteJobFunc      func(ctx context.Context, id string) error
 	CreateExecutionFunc func(ctx context.Context, exec Execution) (Execution, error)
 	UpdateExecutionFunc func(ctx context.Context, exec Execution) error
@@ -61,6 +62,13 @@ func (m *mockStore) ListJobs(ctx context.Context) ([]Job, error) {
 func (m *mockStore) UpdateJob(ctx context.Context, job Job) error {
 	if m.UpdateJobFunc != nil {
 		return m.UpdateJobFunc(ctx, job)
+	}
+	return nil
+}
+
+func (m *mockStore) TouchJobRun(ctx context.Context, jobID string, lastRun, nextRun, updatedAt time.Time) error {
+	if m.TouchJobRunFunc != nil {
+		return m.TouchJobRunFunc(ctx, jobID, lastRun, nextRun, updatedAt)
 	}
 	return nil
 }


### PR DESCRIPTION
Five verified findings in the cron scheduler and daemon shutdown path.

- **Fatal data race crashes the daemon (P1).** `fireJob` read `s.jitterCache` **without the mutex** while `AddJob` wrote it. Concurrent map read/write is an *unrecoverable* Go runtime error — it kills harnessd. Fires whenever a job triggers while another is added. Fixed by passing the computed jitter into `fireJob` so the shared map is never touched at fire time.
- **Stale snapshot silently reverts user edits and resurrects paused jobs (P1).** `fireJob` captured the whole `Job` at schedule time and wrote that snapshot back via `UpdateJob` to record last/next run — clobbering any edit made since, and writing `status=active` over a **paused** job. Replaced with a targeted `TouchJobRun` that updates only run-tracking columns, plus a re-read at fire time to skip jobs that are now paused/deleted.
- **Shutdown stalled up to 5 minutes (P1).** `Stop()` waited on in-flight `fireJob`s, which sat in an **uninterruptible** jitter sleep — so harnessd hung for minutes before HTTP drain even began. Jitter wait is now interruptible via a `done` channel (`sync.Once`-guarded so double-Stop can't panic); on shutdown the fire is skipped rather than executed mid-shutdown.
- **Paused job re-armed by a schedule-only PATCH (P2).** The re-arm gated on `req.Status` rather than the *effective* post-update status, so PATCHing only the schedule of a paused job started it firing while its stored status stayed `paused`.
- **Timed-out commands leaked workers forever (P2).** No `WaitDelay`: if a grandchild held the inherited pipes open, `Wait` blocked indefinitely, never releasing the scheduler semaphore — eventually starving the pool and preventing `Stop()` from completing. Added `WaitDelay` + process-group kill (matching the existing pattern in `script/loader.go` and `workflow/source.go`).

## Verification
`go build ./...`, `go vet` clean; `go test ./internal/cron/... -race -count=3` and `./cmd/harnessd/...` green. Each fix has a red test first — the map race was reproduced live under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6