### PR TITLE
fix(cli): SSE stream corruption on large tool output; authenticate every harnessd request

### DIFF
--- a/cmd/harnesscli/main.go
+++ b/cmd/harnesscli/main.go
@@ -489,6 +489,16 @@ func newTUIConfig(baseURL, workspace, resumeConversationID string) tui.TUIConfig
 	if colorProfile == "" {
 		colorProfile = "auto"
 	}
+	// Reuse the exact same harnessd auth key the rest of the CLI already
+	// uses (see auth.go's newAuthedRequest / loadConfig, populated by
+	// "harnesscli auth login"), so the TUI's requests — including the SSE
+	// event stream — authenticate the same way as every other harnesscli
+	// command. A missing or unreadable config file just means "no key",
+	// preserving today's unauthenticated-local default.
+	var apiKey string
+	if cfg, err := loadConfig(); err == nil && cfg != nil {
+		apiKey = cfg.APIKey
+	}
 	return tui.TUIConfig{
 		BaseURL:              baseURL,
 		Workspace:            workspace,
@@ -496,6 +506,7 @@ func newTUIConfig(baseURL, workspace, resumeConversationID string) tui.TUIConfig
 		ColorProfile:         colorProfile,
 		AltScreen:            true,
 		ResumeConversationID: resumeConversationID,
+		APIKey:               apiKey,
 	}
 }
 

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -37,12 +37,9 @@ func newHarnessRequest(ctx context.Context, method, url string, body io.Reader, 
 	if err != nil {
 		return nil, err
 	}
-	// TODO(fix/sse-bridge-resilience): set Authorization here. Left as a
-	// stub for the red commit — every caller already threads apiKey through,
-	// but the header is not attached yet, so TestAllHarnessdCallsAuthenticate
-	// fails for every endpoint at once (proving the single choke point this
-	// helper is meant to be).
-	_ = apiKey
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 	return req, nil
 }
 

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -16,6 +16,36 @@ import (
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
 )
 
+// newHarnessRequest builds an HTTP request targeting the harnessd server and,
+// if apiKey is non-empty, attaches it as "Authorization: Bearer <apiKey>".
+// EVERY request that targets harnessd (TUIConfig.BaseURL) MUST be built
+// through this helper (or StartSSEBridgeWithOptions's SSEBridgeOptions.APIKey
+// for the SSE stream) — that is what prevents a future endpoint from being
+// added without authentication. Do NOT use this for requests to external
+// services (e.g. fetchOpenRouterModelsFromURL's call to openrouter.ai),
+// which must keep sending their own provider-specific credentials, never the
+// harnessd key — conflating the two would leak the harnessd key to a third
+// party.
+//
+// ctx is typically context.Background(): none of the tea.Cmd closures in
+// this file currently carry a request-scoped context (that would require
+// threading context.Context through every model.go call site, which is a
+// separate, more invasive change) — see the package-level note in
+// api_auth_test.go for the full audit of what is and isn't context-aware.
+func newHarnessRequest(ctx context.Context, method, url string, body io.Reader, apiKey string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(fix/sse-bridge-resilience): set Authorization here. Left as a
+	// stub for the red commit — every caller already threads apiKey through,
+	// but the header is not attached yet, so TestAllHarnessdCallsAuthenticate
+	// fails for every endpoint at once (proving the single choke point this
+	// helper is meant to be).
+	_ = apiKey
+	return req, nil
+}
+
 type runCreateRequest struct {
 	Prompt          string `json:"prompt"`
 	ConversationID  string `json:"conversation_id,omitempty"`
@@ -84,7 +114,7 @@ type RemoteSubagent struct {
 // profile is the name of the capability profile to use (may be empty); it is
 // sent as the "profile" field so the server applies the profile's tool
 // restrictions and isolation.
-func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace string) tea.Cmd {
+func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		body, _ := json.Marshal(runCreateRequest{
 			Prompt:          prompt,
@@ -97,7 +127,12 @@ func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffo
 			AllowFallback:   true,
 		})
 		url := strings.TrimRight(baseURL, "/") + "/v1/runs"
-		resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, url, bytes.NewReader(body), apiKey)
+		if err != nil {
+			return RunFailedMsg{Error: "start run: build request: " + err.Error()}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return RunFailedMsg{Error: err.Error()}
 		}
@@ -113,9 +148,9 @@ func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffo
 	}
 }
 
-func fetchRunsCmd(baseURL string) tea.Cmd {
+func fetchRunsCmd(baseURL, apiKey string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := http.NewRequest(http.MethodGet, strings.TrimRight(baseURL, "/")+"/v1/runs", nil)
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, strings.TrimRight(baseURL, "/")+"/v1/runs", nil, apiKey)
 		if err != nil {
 			return RunsFetchedMsg{Err: "build request: " + err.Error()}
 		}
@@ -141,10 +176,10 @@ func fetchRunsCmd(baseURL string) tea.Cmd {
 	}
 }
 
-func cancelRunCmd(baseURL, runID string) tea.Cmd {
+func cancelRunCmd(baseURL, runID, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		endpoint := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/cancel"
-		req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, endpoint, nil, apiKey)
 		if err != nil {
 			return RunControlResultMsg{Kind: "cancel", RunID: runID, Err: "build request: " + err.Error()}
 		}
@@ -164,7 +199,7 @@ func cancelRunCmd(baseURL, runID string) tea.Cmd {
 	}
 }
 
-func replayRunCmd(baseURL, target string) tea.Cmd {
+func replayRunCmd(baseURL, target, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		body, err := json.Marshal(map[string]any{
 			"rollout_path": target,
@@ -174,7 +209,7 @@ func replayRunCmd(baseURL, target string) tea.Cmd {
 			return RunControlResultMsg{Kind: "replay", RunID: target, Err: "encode request: " + err.Error()}
 		}
 		endpoint := strings.TrimRight(baseURL, "/") + "/v1/runs/replay"
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body), apiKey)
 		if err != nil {
 			return RunControlResultMsg{Kind: "replay", RunID: target, Err: "build request: " + err.Error()}
 		}
@@ -200,14 +235,14 @@ func replayRunCmd(baseURL, target string) tea.Cmd {
 	}
 }
 
-func continueRunCmd(baseURL, runID, prompt string) tea.Cmd {
+func continueRunCmd(baseURL, runID, prompt, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		body, err := json.Marshal(map[string]string{"prompt": prompt})
 		if err != nil {
 			return RunFailedMsg{RunID: runID, Error: "continue: encode request: " + err.Error()}
 		}
 		endpoint := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/continue"
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body), apiKey)
 		if err != nil {
 			return RunFailedMsg{RunID: runID, Error: "continue: build request: " + err.Error()}
 		}
@@ -242,10 +277,14 @@ type modelsResponse struct {
 
 // fetchModelsCmd fetches the model list from the server's /v1/models endpoint.
 // On success it emits ModelsFetchedMsg; on failure it emits ModelsFetchErrorMsg.
-func fetchModelsCmd(baseURL string) tea.Cmd {
+func fetchModelsCmd(baseURL, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/models"
-		resp, err := http.Get(url) //nolint:noctx
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return ModelsFetchErrorMsg{Err: err.Error()}
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return ModelsFetchErrorMsg{Err: err.Error()}
 		}
@@ -265,6 +304,13 @@ func fetchModelsCmd(baseURL string) tea.Cmd {
 // This is called when the user has OpenRouter selected as their gateway.
 // Requires no authentication — the OpenRouter /models endpoint is public.
 // If apiKey is non-empty, the Authorization header is included for higher rate limits.
+//
+// IMPORTANT: apiKey here is the OpenRouter PROVIDER key (from
+// m.pendingAPIKeys["openrouter"]), never the harnessd auth key
+// (TUIConfig.APIKey). This call targets the external openrouter.ai API, not
+// harnessd — do NOT route it through newHarnessRequest or pass
+// TUIConfig.APIKey to it; that would leak the harnessd credential to a third
+// party.
 func fetchOpenRouterModelsCmd(apiKey string) tea.Cmd {
 	return fetchOpenRouterModelsFromURL("https://openrouter.ai/api/v1/models", apiKey)
 }
@@ -326,10 +372,14 @@ func fetchOpenRouterModelsFromURL(url, apiKey string) tea.Cmd {
 	}
 }
 
-func loadSubagentsCmd(baseURL string) tea.Cmd {
+func loadSubagentsCmd(baseURL, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/subagents"
-		resp, err := http.Get(url) //nolint:noctx
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return SubagentsLoadFailedMsg{Err: err.Error()}
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return SubagentsLoadFailedMsg{Err: err.Error()}
 		}
@@ -358,10 +408,14 @@ type providersResponse struct {
 
 // fetchProvidersCmd fetches the list of providers from the server's /v1/providers endpoint.
 // On success it emits ProvidersLoadedMsg; on failure it returns an empty list.
-func fetchProvidersCmd(baseURL string) tea.Cmd {
+func fetchProvidersCmd(baseURL, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/providers"
-		resp, err := http.Get(url) //nolint:noctx
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return ProvidersLoadedMsg{}
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return ProvidersLoadedMsg{}
 		}
@@ -387,11 +441,17 @@ func fetchProvidersCmd(baseURL string) tea.Cmd {
 
 // setProviderKeyCmd sends a provider API key to the server via PUT /v1/providers/{provider}/key.
 // On success (204) it emits APIKeySetMsg; on failure it returns a status message.
-func setProviderKeyCmd(baseURL, provider, apiKey string) tea.Cmd {
+//
+// providerKey is the key being configured for provider (e.g. an OpenAI or
+// Anthropic key) — it goes in the request BODY. harnessAPIKey is the
+// harnessd auth key (TUIConfig.APIKey) — it goes in the Authorization
+// header via newHarnessRequest. These are two distinct credentials; do not
+// conflate them.
+func setProviderKeyCmd(baseURL, provider, providerKey, harnessAPIKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/providers/" + provider + "/key"
-		body, _ := json.Marshal(map[string]string{"key": apiKey})
-		req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+		body, _ := json.Marshal(map[string]string{"key": providerKey})
+		req, err := newHarnessRequest(context.Background(), http.MethodPut, url, bytes.NewReader(body), harnessAPIKey)
 		if err != nil {
 			return ProvidersLoadedMsg{}
 		}
@@ -402,7 +462,7 @@ func setProviderKeyCmd(baseURL, provider, apiKey string) tea.Cmd {
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusOK {
-			return APIKeySetMsg{Provider: provider, Key: apiKey}
+			return APIKeySetMsg{Provider: provider, Key: providerKey}
 		}
 		return ProvidersLoadedMsg{}
 	}
@@ -422,10 +482,14 @@ type profilesListResponse struct {
 
 // loadProfilesCmd fetches profile list from GET /v1/profiles.
 // On success it emits ProfilesLoadedMsg; on failure it emits ProfilesLoadedMsg with Err set.
-func loadProfilesCmd(baseURL string) tea.Cmd {
+func loadProfilesCmd(baseURL, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/profiles"
-		resp, err := http.Get(url) //nolint:noctx
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return ProfilesLoadedMsg{Err: err}
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return ProfilesLoadedMsg{Err: err}
 		}
@@ -523,10 +587,14 @@ func flattenJSON(obj map[string]any, indent string) []string {
 // GET /v1/conversations/{id}/runs.  On success it emits a SessionRunsFetchedMsg;
 // on failure (including 501 Not Implemented) it emits a zero SessionRunsFetchedMsg
 // so callers can handle the empty case gracefully.
-func fetchSessionRunsCmd(baseURL, conversationID string) tea.Cmd {
+func fetchSessionRunsCmd(baseURL, conversationID, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		url := strings.TrimRight(baseURL, "/") + "/v1/conversations/" + conversationID + "/runs"
-		resp, err := http.Get(url) //nolint:noctx
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return SessionRunsFetchedMsg{}
+		}
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return SessionRunsFetchedMsg{}
 		}
@@ -554,10 +622,10 @@ func fetchSessionRunsCmd(baseURL, conversationID string) tea.Cmd {
 // fetchConversationMessagesCmd fetches the message history for a resumed
 // conversation from GET /v1/conversations/{id}/messages. On success it emits
 // ConversationHistoryMsg; on failure it emits ConversationHistoryErrorMsg.
-func fetchConversationMessagesCmd(baseURL, conversationID string) tea.Cmd {
+func fetchConversationMessagesCmd(baseURL, conversationID, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		endpoint := strings.TrimRight(baseURL, "/") + "/v1/conversations/" + url.PathEscape(conversationID) + "/messages"
-		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, endpoint, nil, apiKey)
 		if err != nil {
 			return ConversationHistoryErrorMsg{ConversationID: conversationID, Err: err.Error()}
 		}

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -595,20 +595,25 @@ func sseEventsURL(baseURL, runID string) string {
 	return strings.TrimRight(baseURL, "/") + "/v1/runs/" + runID + "/events"
 }
 
-// startSSEForRun starts the SSE bridge for the given run and returns the channel
-// and cancel func.
-func startSSEForRun(baseURL, runID string) (<-chan tea.Msg, func()) {
+// startSSEForRun starts the SSE bridge for the given run and returns the
+// channel and cancel func. apiKey, if non-empty, is sent as
+// "Authorization: Bearer <apiKey>" (see SSEBridgeOptions) — the same
+// harnessd auth key sourced from ~/.harness/config.json via
+// cmd/harnesscli/auth.go's newAuthedRequest pattern and threaded into
+// TUIConfig.APIKey by cmd/harnesscli/main.go's newTUIConfig.
+func startSSEForRun(baseURL, runID, apiKey string) (<-chan tea.Msg, func()) {
 	url := sseEventsURL(baseURL, runID)
-	return StartSSEBridge(context.Background(), url)
+	return StartSSEBridgeWithOptions(context.Background(), url, SSEBridgeOptions{APIKey: apiKey})
 }
 
 // startSSEForRunFrom starts the SSE bridge for the given run, resuming from
-// lastEventID via the Last-Event-ID header (see StartSSEBridgeFrom). Used to
-// reconnect after the stream drops mid-run without losing or duplicating
-// events.
-func startSSEForRunFrom(baseURL, runID, lastEventID string) (<-chan tea.Msg, func()) {
+// lastEventID via the Last-Event-ID header and authenticating with apiKey
+// (see SSEBridgeOptions). Used to reconnect after the stream drops mid-run
+// without losing or duplicating events, and without dropping authentication
+// on the resumed connection.
+func startSSEForRunFrom(baseURL, runID, lastEventID, apiKey string) (<-chan tea.Msg, func()) {
 	url := sseEventsURL(baseURL, runID)
-	return StartSSEBridgeFrom(context.Background(), url, lastEventID)
+	return StartSSEBridgeWithOptions(context.Background(), url, SSEBridgeOptions{LastEventID: lastEventID, APIKey: apiKey})
 }
 
 // maxSSEReconnectAttempts bounds how many times the TUI will automatically
@@ -635,14 +640,15 @@ func sseReconnectBackoff(attempt int) time.Duration {
 
 // reconnectSSECmd schedules a bounded, backed-off SSE reconnect attempt for
 // the given run that resumes exactly where the previous connection left off
-// via lastEventID (see startSSEForRunFrom and internal/server/http_runs.go's
-// Last-Event-ID handling). It always yields SSEReconnectedMsg so Update()
-// can decide whether the reconnect is still wanted — the run may have been
-// cancelled or completed while the backoff was pending.
-func reconnectSSECmd(baseURL, runID, lastEventID string, attempt int) tea.Cmd {
+// via lastEventID and re-authenticates with apiKey (see startSSEForRunFrom
+// and internal/server/http_runs.go's Last-Event-ID handling). It always
+// yields SSEReconnectedMsg so Update() can decide whether the reconnect is
+// still wanted — the run may have been cancelled or completed while the
+// backoff was pending.
+func reconnectSSECmd(baseURL, runID, lastEventID, apiKey string, attempt int) tea.Cmd {
 	delay := sseReconnectBackoff(attempt)
 	return tea.Tick(delay, func(time.Time) tea.Msg {
-		ch, cancel := startSSEForRunFrom(baseURL, runID, lastEventID)
+		ch, cancel := startSSEForRunFrom(baseURL, runID, lastEventID, apiKey)
 		return SSEReconnectedMsg{Ch: ch, Cancel: cancel}
 	})
 }

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -601,3 +601,48 @@ func startSSEForRun(baseURL, runID string) (<-chan tea.Msg, func()) {
 	url := sseEventsURL(baseURL, runID)
 	return StartSSEBridge(context.Background(), url)
 }
+
+// startSSEForRunFrom starts the SSE bridge for the given run, resuming from
+// lastEventID via the Last-Event-ID header (see StartSSEBridgeFrom). Used to
+// reconnect after the stream drops mid-run without losing or duplicating
+// events.
+func startSSEForRunFrom(baseURL, runID, lastEventID string) (<-chan tea.Msg, func()) {
+	url := sseEventsURL(baseURL, runID)
+	return StartSSEBridgeFrom(context.Background(), url, lastEventID)
+}
+
+// maxSSEReconnectAttempts bounds how many times the TUI will automatically
+// reconnect a dropped SSE stream for a single run before giving up and
+// surfacing a clear "connection lost" message to the user.
+const maxSSEReconnectAttempts = 5
+
+// sseReconnectBackoff returns the delay before reconnect attempt N
+// (1-indexed), growing exponentially from a short base and capped so the
+// TUI recovers quickly from a transient drop instead of leaving the user
+// staring at a dead stream for long.
+func sseReconnectBackoff(attempt int) time.Duration {
+	const base = 200 * time.Millisecond
+	const capDelay = 3 * time.Second
+	d := base
+	for i := 1; i < attempt; i++ {
+		d *= 2
+		if d >= capDelay {
+			return capDelay
+		}
+	}
+	return d
+}
+
+// reconnectSSECmd schedules a bounded, backed-off SSE reconnect attempt for
+// the given run that resumes exactly where the previous connection left off
+// via lastEventID (see startSSEForRunFrom and internal/server/http_runs.go's
+// Last-Event-ID handling). It always yields SSEReconnectedMsg so Update()
+// can decide whether the reconnect is still wanted — the run may have been
+// cancelled or completed while the backoff was pending.
+func reconnectSSECmd(baseURL, runID, lastEventID string, attempt int) tea.Cmd {
+	delay := sseReconnectBackoff(attempt)
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		ch, cancel := startSSEForRunFrom(baseURL, runID, lastEventID)
+		return SSEReconnectedMsg{Ch: ch, Cancel: cancel}
+	})
+}

--- a/cmd/harnesscli/tui/api_auth_test.go
+++ b/cmd/harnesscli/tui/api_auth_test.go
@@ -40,6 +40,9 @@ package tui
 // serves authenticated user/run data, so none are exempted.
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -247,5 +250,94 @@ func TestOpenRouterCallDoesNotReceiveHarnessKey(t *testing.T) {
 	}
 	if gotAuth == "Bearer "+harnessKey {
 		t.Fatal("the harnessd API key leaked to the external OpenRouter request")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Regression: statically prevents a future endpoint from bypassing
+// newHarnessRequest, which is the actual mechanism ("route every harnessd
+// call through ONE helper... that is what stops the next endpoint from
+// being added without auth") this task was asked to establish. A
+// table-driven header test only catches a gap once someone writes a test
+// case for it; this test catches the gap the moment a raw http.Get/
+// http.Post/http.NewRequest call is added anywhere in these files, with no
+// new test case required.
+// ---------------------------------------------------------------------------
+
+// rawHTTPCallAllowlist lists the functions permitted to build an HTTP
+// request without going through newHarnessRequest, and why:
+//   - newHarnessRequest itself is the one place http.NewRequestWithContext
+//     is allowed to appear directly.
+//   - fetchOpenRouterModelsFromURL targets the external openrouter.ai API,
+//     not harnessd, and must keep using its own provider-key header logic.
+var rawHTTPCallAllowlist = map[string]bool{
+	"newHarnessRequest":            true,
+	"fetchOpenRouterModelsFromURL": true,
+}
+
+// rawHTTPCallNames are the net/http package-level functions that build (and
+// in the Get/Post/Head/PostForm cases, also send) a request without going
+// through a caller-supplied *http.Request — exactly what newHarnessRequest
+// exists to replace so an Authorization header can be attached.
+var rawHTTPCallNames = map[string]bool{
+	"Get":        true,
+	"Head":       true,
+	"Post":       true,
+	"PostForm":   true,
+	"NewRequest": true, // NewRequestWithContext is fine; bare NewRequest has no ctx and, more importantly, callers historically forgot to attach auth to it too.
+}
+
+// TestRegression_AllHarnessdRequestsRouteThroughNewHarnessRequest statically
+// scans api.go, askuser.go, and approval.go for any function OTHER than the
+// allowlisted ones that calls a raw net/http request-building function. It
+// would fail immediately if a future PR added a new harnessd endpoint using
+// http.Get/http.Post/http.NewRequest directly instead of newHarnessRequest —
+// exactly the class of gap that caused this task (a dozen unauthenticated
+// calls that accumulated because nothing enforced the pattern).
+func TestRegression_AllHarnessdRequestsRouteThroughNewHarnessRequest(t *testing.T) {
+	files := []string{"api.go", "askuser.go", "approval.go"}
+
+	for _, file := range files {
+		file := file
+		t.Run(file, func(t *testing.T) {
+			fset := token.NewFileSet()
+			astFile, err := parser.ParseFile(fset, file, nil, 0)
+			if err != nil {
+				t.Fatalf("parse %s: %v", file, err)
+			}
+
+			for _, decl := range astFile.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				if rawHTTPCallAllowlist[fn.Name.Name] {
+					continue
+				}
+
+				ast.Inspect(fn.Body, func(n ast.Node) bool {
+					call, ok := n.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					sel, ok := call.Fun.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					pkgIdent, ok := sel.X.(*ast.Ident)
+					if !ok || pkgIdent.Name != "http" {
+						return true
+					}
+					if rawHTTPCallNames[sel.Sel.Name] {
+						pos := fset.Position(call.Pos())
+						t.Errorf(
+							"%s:%d: func %s calls http.%s directly instead of routing through newHarnessRequest — this bypasses harnessd authentication entirely",
+							file, pos.Line, fn.Name.Name, sel.Sel.Name,
+						)
+					}
+					return true
+				})
+			}
+		})
 	}
 }

--- a/cmd/harnesscli/tui/api_auth_test.go
+++ b/cmd/harnesscli/tui/api_auth_test.go
@@ -1,0 +1,251 @@
+package tui
+
+// api_auth_test.go — TASK: fix/sse-bridge-resilience (auth follow-up #2)
+//
+// A parallel agent is hardening harnessd's server-side auth (removing
+// query-param auth, enforcing tenant scoping). Once a user configures an
+// API key, every unauthenticated TUI request to harnessd would get a 401.
+// This file proves EVERY harnessd-targeting call in cmd/harnesscli/tui
+// authenticates via newHarnessRequest (bridge.go's SSEBridgeOptions.APIKey
+// covers the SSE stream itself and is tested in sse_bridge_resilience_test.go
+// — this file covers everything else in api.go, askuser.go, and approval.go).
+//
+// Full audit of every request-construction call site in cmd/harnesscli/tui/
+// (grep for http.Get/http.Post/http.NewRequest/NewRequestWithContext),
+// classified harnessd vs external:
+//
+//	FILE            FUNCTION                      TARGET      AUTH
+//	api.go          startRunCmd                    harnessd    yes (newHarnessRequest)
+//	api.go          fetchRunsCmd                    harnessd    yes
+//	api.go          cancelRunCmd                    harnessd    yes
+//	api.go          replayRunCmd                    harnessd    yes
+//	api.go          continueRunCmd                  harnessd    yes
+//	api.go          fetchModelsCmd                  harnessd    yes
+//	api.go          fetchOpenRouterModelsFromURL    EXTERNAL    no (provider key only — see below)
+//	api.go          loadSubagentsCmd                harnessd    yes
+//	api.go          fetchProvidersCmd               harnessd    yes
+//	api.go          setProviderKeyCmd               harnessd    yes (providerKey stays in the body)
+//	api.go          loadProfilesCmd                 harnessd    yes
+//	api.go          fetchSessionRunsCmd             harnessd    yes (currently unwired into any
+//	                                                              model.go call site — dead code —
+//	                                                              still authenticated for when it is)
+//	api.go          fetchConversationMessagesCmd    harnessd    yes
+//	bridge.go       runBridge (SSE events stream)   harnessd    yes (SSEBridgeOptions.APIKey,
+//	                                                              tested in sse_bridge_resilience_test.go)
+//	askuser.go      fetchAskUserPendingCmd          harnessd    yes
+//	askuser.go      submitAskUserAnswerCmd          harnessd    yes
+//	approval.go     toolApprovalDecisionCmd         harnessd    yes (backs approveToolCmd/denyToolCmd)
+//
+// No endpoint here is intentionally public (e.g. a health check) — every one
+// serves authenticated user/run data, so none are exempted.
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// harnessAuthCase describes one harnessd-targeting call: how to invoke it and
+// how to read back the Authorization header the mock server observed.
+type harnessAuthCase struct {
+	name string
+	// call issues exactly one HTTP request to ts.URL and returns the
+	// resulting tea.Msg, so the table can also sanity-check the happy path
+	// still decodes correctly (not just the header).
+	call func(ts *httptest.Server, apiKey string) any
+}
+
+func harnessAuthCases() []harnessAuthCase {
+	return []harnessAuthCase{
+		{
+			name: "startRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "default", "/tmp", apiKey)()
+			},
+		},
+		{
+			name: "fetchRunsCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchRunsCmd(ts.URL, apiKey)()
+			},
+		},
+		{
+			name: "cancelRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return cancelRunCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "replayRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return replayRunCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "continueRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return continueRunCmd(ts.URL, "run-1", "more please", apiKey)()
+			},
+		},
+		{
+			name: "fetchModelsCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchModelsCmd(ts.URL, apiKey)()
+			},
+		},
+		{
+			name: "loadSubagentsCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return loadSubagentsCmd(ts.URL, apiKey)()
+			},
+		},
+		{
+			name: "fetchProvidersCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchProvidersCmd(ts.URL, apiKey)()
+			},
+		},
+		{
+			name: "setProviderKeyCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return setProviderKeyCmd(ts.URL, "openai", "provider-secret", apiKey)()
+			},
+		},
+		{
+			name: "loadProfilesCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return loadProfilesCmd(ts.URL, apiKey)()
+			},
+		},
+		{
+			name: "fetchSessionRunsCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchSessionRunsCmd(ts.URL, "conv-1", apiKey)()
+			},
+		},
+		{
+			name: "fetchConversationMessagesCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchConversationMessagesCmd(ts.URL, "conv-1", apiKey)()
+			},
+		},
+		{
+			name: "fetchAskUserPendingCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return fetchAskUserPendingCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "submitAskUserAnswerCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return submitAskUserAnswerCmd(ts.URL, "run-1", map[string]string{"q": "a"}, apiKey)()
+			},
+		},
+		{
+			name: "approveToolCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return approveToolCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "denyToolCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return denyToolCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+	}
+}
+
+// newAuthEchoServer returns an httptest.Server that records the Authorization
+// header of the most recent request and replies with a minimal, valid body
+// for whichever endpoint hit it (each Cmd factory decodes a different shape,
+// so the handler returns a permissive JSON object that satisfies all of
+// them without erroring).
+func newAuthEchoServer(t *testing.T, gotAuth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPut:
+			w.WriteHeader(http.StatusNoContent)
+			return
+		default:
+			// A generic, empty-ish JSON object/array-friendly body: every
+			// Cmd factory in the table above either ignores decode errors
+			// for a "safe empty" fallback or only requires a run_id/models/
+			// providers/etc field that is fine to be absent (zero value).
+			_, _ = w.Write([]byte(`{"run_id":"run-echo","runs":[],"models":[],"providers":[],"profiles":[],"subagents":[],"messages":[],"questions":[]}`))
+		}
+	}))
+}
+
+// TestAllHarnessdCallsAuthenticate is the table-driven test the coordinator
+// asked for: every harnessd-targeting call in cmd/harnesscli/tui sends
+// "Authorization: Bearer <key>" when a key is configured, and sends no
+// Authorization header at all when it is not — preserving today's
+// unauthenticated-local default.
+func TestAllHarnessdCallsAuthenticate(t *testing.T) {
+	for _, tc := range harnessAuthCases() {
+		tc := tc
+		t.Run(tc.name+"/with_key", func(t *testing.T) {
+			t.Parallel()
+			var gotAuth string
+			ts := newAuthEchoServer(t, &gotAuth)
+			defer ts.Close()
+
+			tc.call(ts, "secret-harness-key")
+
+			if gotAuth != "Bearer secret-harness-key" {
+				t.Errorf("%s: Authorization header = %q, want %q", tc.name, gotAuth, "Bearer secret-harness-key")
+			}
+		})
+		t.Run(tc.name+"/without_key", func(t *testing.T) {
+			t.Parallel()
+			var gotAuth string
+			ts := newAuthEchoServer(t, &gotAuth)
+			defer ts.Close()
+
+			tc.call(ts, "")
+
+			if gotAuth != "" {
+				t.Errorf("%s: Authorization header = %q, want empty (no key configured)", tc.name, gotAuth)
+			}
+		})
+	}
+}
+
+// TestOpenRouterCallDoesNotReceiveHarnessKey is the explicit isolation test
+// the coordinator asked for: fetchOpenRouterModelsFromURL must send its own
+// OpenRouter provider key, and must never be handed (or leak) the harnessd
+// auth key. There is no code path that could pass TUIConfig.APIKey into it
+// today (fetchOpenRouterModelsCmd only ever takes m.pendingAPIKeys["openrouter"]
+// — see model.go's executeModelCommand) — this test pins that contract so a
+// future refactor cannot accidentally wire the harnessd key into it.
+func TestOpenRouterCallDoesNotReceiveHarnessKey(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	}))
+	defer ts.Close()
+
+	// Simulate the harnessd key being configured (as it would be for every
+	// other call in this file) alongside a distinct OpenRouter provider key.
+	// Only the OpenRouter key may ever appear on this request.
+	const harnessKey = "harnessd-secret-must-not-leak"
+	const openRouterKey = "or-provider-key"
+
+	msg := fetchOpenRouterModelsFromURL(ts.URL, openRouterKey)()
+	if _, ok := msg.(ModelsFetchedMsg); !ok {
+		t.Fatalf("expected ModelsFetchedMsg, got %T: %+v", msg, msg)
+	}
+
+	if gotAuth != "Bearer "+openRouterKey {
+		t.Errorf("OpenRouter request Authorization = %q, want %q (its own provider key)", gotAuth, "Bearer "+openRouterKey)
+	}
+	if gotAuth == "Bearer "+harnessKey {
+		t.Fatal("the harnessd API key leaked to the external OpenRouter request")
+	}
+}

--- a/cmd/harnesscli/tui/api_coverage_test.go
+++ b/cmd/harnesscli/tui/api_coverage_test.go
@@ -26,7 +26,7 @@ func TestStartRunCmdIncludesWorkspacePath(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "/tmp/project-root")()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "/tmp/project-root", "")()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}
@@ -51,7 +51,7 @@ func TestStartRunCmdSendsCapabilityProfileAsProfileField(t *testing.T) {
 	// A capability profile selected via /profiles (e.g. "researcher") must be
 	// sent in the "profile" field (harness.RunRequest.ProfileName), NOT in
 	// "prompt_profile" — the server rejects unknown prompt profiles with HTTP 400.
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "researcher", "/tmp/x")()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "researcher", "/tmp/x", "")()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}
@@ -83,7 +83,7 @@ func TestLoadSubagentsCmdReturnsDecodedSubagents(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := loadSubagentsCmd(ts.URL)()
+	msg := loadSubagentsCmd(ts.URL, "")()
 	loaded, ok := msg.(SubagentsLoadedMsg)
 	if !ok {
 		t.Fatalf("expected SubagentsLoadedMsg, got %T", msg)
@@ -158,7 +158,7 @@ func TestStartRunCmdSetsAllowFallback(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "")()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "", "")()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}

--- a/cmd/harnesscli/tui/api_session_test.go
+++ b/cmd/harnesscli/tui/api_session_test.go
@@ -33,7 +33,7 @@ func TestFetchSessionRunsCmd_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchSessionRunsCmd(ts.URL, "conv-abc")()
+	msg := fetchSessionRunsCmd(ts.URL, "conv-abc", "")()
 	got, ok := msg.(SessionRunsFetchedMsg)
 	if !ok {
 		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
@@ -65,7 +65,7 @@ func TestFetchSessionRunsCmd_501ReturnsEmptyMsg(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchSessionRunsCmd(ts.URL, "conv-xyz")()
+	msg := fetchSessionRunsCmd(ts.URL, "conv-xyz", "")()
 	got, ok := msg.(SessionRunsFetchedMsg)
 	if !ok {
 		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
@@ -87,7 +87,7 @@ func TestFetchSessionRunsCmd_NetworkErrorReturnsEmptyMsg(t *testing.T) {
 	t.Parallel()
 
 	// Use an address that will immediately refuse/error.
-	msg := fetchSessionRunsCmd("http://127.0.0.1:1", "conv-err")()
+	msg := fetchSessionRunsCmd("http://127.0.0.1:1", "conv-err", "")()
 	got, ok := msg.(SessionRunsFetchedMsg)
 	if !ok {
 		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
@@ -112,7 +112,7 @@ func TestFetchSessionRunsCmd_MalformedJSONReturnsEmptyMsg(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchSessionRunsCmd(ts.URL, "conv-json-err")()
+	msg := fetchSessionRunsCmd(ts.URL, "conv-json-err", "")()
 	got, ok := msg.(SessionRunsFetchedMsg)
 	if !ok {
 		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)
@@ -142,7 +142,7 @@ func TestFetchSessionRunsCmd_TrailingSlashNormalised(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchSessionRunsCmd(ts.URL+"/", "conv-slash")()
+	msg := fetchSessionRunsCmd(ts.URL+"/", "conv-slash", "")()
 	got, ok := msg.(SessionRunsFetchedMsg)
 	if !ok {
 		t.Fatalf("expected SessionRunsFetchedMsg, got %T", msg)

--- a/cmd/harnesscli/tui/approval.go
+++ b/cmd/harnesscli/tui/approval.go
@@ -8,8 +8,10 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -49,23 +51,28 @@ type ToolApprovalErrorMsg struct {
 // approveToolCmd sends POST /v1/runs/{id}/approve. On success it returns
 // ToolApprovalDecidedMsg{Decision: "approved"}; on failure it returns
 // ToolApprovalErrorMsg.
-func approveToolCmd(baseURL, runID string) tea.Cmd {
-	return toolApprovalDecisionCmd(baseURL, runID, "approve", "approved")
+func approveToolCmd(baseURL, runID, apiKey string) tea.Cmd {
+	return toolApprovalDecisionCmd(baseURL, runID, "approve", "approved", apiKey)
 }
 
 // denyToolCmd sends POST /v1/runs/{id}/deny. On success it returns
 // ToolApprovalDecidedMsg{Decision: "denied"}; on failure it returns
 // ToolApprovalErrorMsg.
-func denyToolCmd(baseURL, runID string) tea.Cmd {
-	return toolApprovalDecisionCmd(baseURL, runID, "deny", "denied")
+func denyToolCmd(baseURL, runID, apiKey string) tea.Cmd {
+	return toolApprovalDecisionCmd(baseURL, runID, "deny", "denied", apiKey)
 }
 
 // toolApprovalDecisionCmd posts an empty body to /v1/runs/{id}/{path} and
 // translates the response into ToolApprovalDecidedMsg or ToolApprovalErrorMsg.
-func toolApprovalDecisionCmd(baseURL, runID, path, decision string) tea.Cmd {
+func toolApprovalDecisionCmd(baseURL, runID, path, decision, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		postURL := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/" + path
-		resp, err := httpClientWithTimeout.Post(postURL, "application/json", bytes.NewReader(nil))
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, postURL, bytes.NewReader(nil), apiKey)
+		if err != nil {
+			return ToolApprovalErrorMsg{Err: fmt.Sprintf("%s tool call: %s", path, err.Error())}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClientWithTimeout.Do(req)
 		if err != nil {
 			return ToolApprovalErrorMsg{Err: fmt.Sprintf("%s tool call: %s", path, err.Error())}
 		}
@@ -95,15 +102,15 @@ func (m Model) handleToolApprovalKey(msg tea.KeyMsg) (toolApprovalState, tea.Cmd
 
 	switch msg.Type {
 	case tea.KeyEnter:
-		return toolApprovalState{}, approveToolCmd(m.config.BaseURL, runID)
+		return toolApprovalState{}, approveToolCmd(m.config.BaseURL, runID, m.config.APIKey)
 	case tea.KeyEsc:
-		return toolApprovalState{}, cancelRunCmd(m.config.BaseURL, runID)
+		return toolApprovalState{}, cancelRunCmd(m.config.BaseURL, runID, m.config.APIKey)
 	case tea.KeyRunes:
 		switch string(msg.Runes) {
 		case "a", "A", "y", "Y":
-			return toolApprovalState{}, approveToolCmd(m.config.BaseURL, runID)
+			return toolApprovalState{}, approveToolCmd(m.config.BaseURL, runID, m.config.APIKey)
 		case "d", "D", "n", "N":
-			return toolApprovalState{}, denyToolCmd(m.config.BaseURL, runID)
+			return toolApprovalState{}, denyToolCmd(m.config.BaseURL, runID, m.config.APIKey)
 		}
 	}
 	return st, nil

--- a/cmd/harnesscli/tui/askuser.go
+++ b/cmd/harnesscli/tui/askuser.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -90,10 +91,14 @@ type askUserState struct {
 
 // fetchAskUserPendingCmd fetches the pending AskUserQuestion for the given runID
 // via GET /v1/runs/{id}/input and returns an AskUserPendingMsg or askUserFetchErrorMsg.
-func fetchAskUserPendingCmd(baseURL, runID string) tea.Cmd {
+func fetchAskUserPendingCmd(baseURL, runID, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		fetchURL := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/input"
-		resp, err := httpClientWithTimeout.Get(fetchURL)
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, fetchURL, nil, apiKey)
+		if err != nil {
+			return askUserFetchErrorMsg{err: fmt.Sprintf("fetch pending input: %s", err.Error())}
+		}
+		resp, err := httpClientWithTimeout.Do(req)
 		if err != nil {
 			return askUserFetchErrorMsg{err: fmt.Sprintf("fetch pending input: %s", err.Error())}
 		}
@@ -123,12 +128,17 @@ func fetchAskUserPendingCmd(baseURL, runID string) tea.Cmd {
 
 // submitAskUserAnswerCmd sends POST /v1/runs/{id}/input with the given answers.
 // On success it returns AskUserSubmittedMsg; on failure it returns AskUserSubmitErrorMsg.
-func submitAskUserAnswerCmd(baseURL, runID string, answers map[string]string) tea.Cmd {
+func submitAskUserAnswerCmd(baseURL, runID string, answers map[string]string, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		postURL := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/input"
 		payload := map[string]interface{}{"answers": answers}
 		body, _ := json.Marshal(payload)
-		resp, err := httpClientWithTimeout.Post(postURL, "application/json", bytes.NewReader(body))
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, postURL, bytes.NewReader(body), apiKey)
+		if err != nil {
+			return AskUserSubmitErrorMsg{Err: fmt.Sprintf("submit answer: %s", err.Error())}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClientWithTimeout.Do(req)
 		if err != nil {
 			return AskUserSubmitErrorMsg{Err: fmt.Sprintf("submit answer: %s", err.Error())}
 		}
@@ -189,7 +199,7 @@ func (m Model) handleAskUserKey(msg tea.KeyMsg) (askUserState, tea.Cmd) {
 		}
 		// Dismiss overlay immediately.
 		runID := st.runID
-		return askUserState{}, submitAskUserAnswerCmd(m.config.BaseURL, runID, answers)
+		return askUserState{}, submitAskUserAnswerCmd(m.config.BaseURL, runID, answers, m.config.APIKey)
 	case tea.KeyEsc:
 		// Dismiss without answering — the server will timeout eventually.
 		return askUserState{}, nil

--- a/cmd/harnesscli/tui/bridge.go
+++ b/cmd/harnesscli/tui/bridge.go
@@ -44,35 +44,59 @@ const (
 // (and bounded memory) rather than one giant message at the very end.
 const maxCoalescedDeltaBytes = 32 * 1024
 
+// SSEBridgeOptions configures a single SSE bridge connection attempt.
+type SSEBridgeOptions struct {
+	// LastEventID, if non-empty, is sent as the Last-Event-ID request header
+	// so the server resumes the stream from that point (see
+	// internal/server/http_runs.go, which trims already-delivered history
+	// via harness.ParseEventID) instead of replaying everything from the
+	// start.
+	LastEventID string
+	// APIKey, if non-empty, is sent as "Authorization: Bearer <APIKey>" so
+	// the request authenticates the same way the rest of the harnesscli
+	// client does (see cmd/harnesscli/auth.go's newAuthedRequest, which
+	// sources this key from ~/.harness/config.json via "harnesscli auth
+	// login"). When empty, no Authorization header is sent at all,
+	// preserving today's unauthenticated-local behavior.
+	APIKey string
+}
+
 // StartSSEBridge connects to the SSE endpoint at url and delivers decoded
 // tea.Msg values on the returned channel. Call stop() to disconnect early.
 // The channel is closed when the stream ends or ctx is cancelled.
 //
-// This is equivalent to StartSSEBridgeFrom with an empty lastEventID (i.e.
-// a fresh connection with no resume point).
+// This is equivalent to StartSSEBridgeWithOptions with a zero-value
+// SSEBridgeOptions (i.e. a fresh, unauthenticated connection with no resume
+// point).
 func StartSSEBridge(ctx context.Context, url string) (<-chan tea.Msg, func()) {
-	return StartSSEBridgeFrom(ctx, url, "")
+	return StartSSEBridgeWithOptions(ctx, url, SSEBridgeOptions{})
 }
 
 // StartSSEBridgeFrom is like StartSSEBridge but sets the Last-Event-ID
 // request header to lastEventID (if non-empty) so the server resumes the
-// stream from that point (see internal/server/http_runs.go, which trims
-// already-delivered history via harness.ParseEventID) instead of replaying
-// everything from the start.
+// stream from that point instead of replaying everything from the start.
+//
+// This is equivalent to StartSSEBridgeWithOptions with only LastEventID set.
 func StartSSEBridgeFrom(ctx context.Context, url, lastEventID string) (<-chan tea.Msg, func()) {
+	return StartSSEBridgeWithOptions(ctx, url, SSEBridgeOptions{LastEventID: lastEventID})
+}
+
+// StartSSEBridgeWithOptions is the fully-configurable entry point: see
+// SSEBridgeOptions for what each field controls.
+func StartSSEBridgeWithOptions(ctx context.Context, url string, opts SSEBridgeOptions) (<-chan tea.Msg, func()) {
 	ch := make(chan tea.Msg, sseChanCap)
 	ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
 		defer cancel()
 		defer close(ch)
-		runBridge(ctx, url, lastEventID, ch)
+		runBridge(ctx, url, opts, ch)
 	}()
 
 	return ch, cancel
 }
 
-func runBridge(ctx context.Context, url, lastEventID string, ch chan<- tea.Msg) {
+func runBridge(ctx context.Context, url string, opts SSEBridgeOptions, ch chan<- tea.Msg) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		send(ctx, ch, SSEErrorMsg{Err: err})
@@ -80,8 +104,8 @@ func runBridge(ctx context.Context, url, lastEventID string, ch chan<- tea.Msg) 
 		return
 	}
 	req.Header.Set("Accept", "text/event-stream")
-	if lastEventID != "" {
-		req.Header.Set("Last-Event-ID", lastEventID)
+	if opts.LastEventID != "" {
+		req.Header.Set("Last-Event-ID", opts.LastEventID)
 	}
 
 	resp, err := http.DefaultClient.Do(req)

--- a/cmd/harnesscli/tui/bridge.go
+++ b/cmd/harnesscli/tui/bridge.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -107,6 +108,9 @@ func runBridge(ctx context.Context, url string, opts SSEBridgeOptions, ch chan<-
 	if opts.LastEventID != "" {
 		req.Header.Set("Last-Event-ID", opts.LastEventID)
 	}
+	if opts.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.APIKey)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -114,6 +118,30 @@ func runBridge(ctx context.Context, url string, opts SSEBridgeOptions, ch chan<-
 			send(ctx, ch, SSEErrorMsg{Err: err})
 			send(ctx, ch, SSEDoneMsg{EventType: "bridge.closed"})
 		}
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		if ctx.Err() != nil {
+			return
+		}
+		if isNonRetryableSSEStatus(resp.StatusCode) {
+			// A permanent rejection (bad/missing credentials, unknown run):
+			// retrying would just burn the bounded reconnect budget against
+			// the same outcome every time and confuse the user with 5
+			// backed-off attempts before finally giving up. Surface one
+			// clear, actionable error and end the run immediately instead.
+			send(ctx, ch, SSEErrorMsg{Err: nonRetryableSSEError(resp.StatusCode, body)})
+			send(ctx, ch, SSEDoneMsg{EventType: "bridge.fatal"})
+			return
+		}
+		// Anything else unexpected (5xx, unusual redirects, etc.) is treated
+		// as transient — recoverable via the caller's bounded reconnect,
+		// same as a dropped connection.
+		send(ctx, ch, SSEErrorMsg{Err: fmt.Errorf("SSE bridge: unexpected status %d from %s", resp.StatusCode, url)})
+		send(ctx, ch, SSEDoneMsg{EventType: "bridge.closed"})
 		return
 	}
 	defer resp.Body.Close()
@@ -214,6 +242,50 @@ func runBridge(ctx context.Context, url string, opts SSEBridgeOptions, ch chan<-
 	// recoverable and reconnects using Last-Event-ID rather than treating
 	// the run as finished.
 	send(ctx, ch, SSEDoneMsg{EventType: "bridge.closed"})
+}
+
+// isNonRetryableSSEStatus reports whether an HTTP status on the events
+// endpoint represents a permanent failure that a reconnect cannot fix:
+// 401/403 mean the credentials are missing or rejected, and 404 means the
+// run ID itself does not exist (or has expired) — none of these change on
+// retry. Everything else (5xx, unexpected redirects, etc.) is treated as
+// transient and keeps the caller's bounded reconnect behavior, since a
+// network blip or a momentarily overloaded server genuinely can recover.
+func isNonRetryableSSEStatus(status int) bool {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+// nonRetryableSSEError builds a single, actionable error message for a
+// non-retryable SSE status so the user sees one clear explanation instead of
+// a generic "stream error" (or, before this fix, a storm of them from
+// burning the whole reconnect budget against the same permanent failure).
+func nonRetryableSSEError(status int, body []byte) error {
+	detail := strings.TrimSpace(string(body))
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		msg := fmt.Sprintf("SSE bridge: authentication rejected (HTTP %d) — the harnessd API key is missing or invalid; run \"harnesscli auth login\" to set one", status)
+		if detail != "" {
+			msg += ": " + detail
+		}
+		return errors.New(msg)
+	case http.StatusNotFound:
+		msg := fmt.Sprintf("SSE bridge: run not found (HTTP %d) — the run ID is invalid or the run has expired", status)
+		if detail != "" {
+			msg += ": " + detail
+		}
+		return errors.New(msg)
+	default:
+		msg := fmt.Sprintf("SSE bridge: non-retryable status %d", status)
+		if detail != "" {
+			msg += ": " + detail
+		}
+		return errors.New(msg)
+	}
 }
 
 type sseEnvelope struct {

--- a/cmd/harnesscli/tui/bridge.go
+++ b/cmd/harnesscli/tui/bridge.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,30 +12,67 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// sseChanCap is the channel buffer depth for SSE messages.
-// The bridge uses non-blocking sends: if the TUI update loop falls behind
-// (e.g. heavy rendering), excess events emit SSEDropMsg rather than
-// stalling the HTTP scanner. 256 slots covers burst-heavy tool-call streams
-// without consuming significant memory (~8KB at 32 bytes/msg).
-const sseChanCap = 256
+// sseChanCap is the channel buffer depth for SSE messages. The bridge
+// delivers decoded events with blocking sends (see send) so that a lagging
+// TUI update loop applies natural backpressure to the HTTP scanner instead
+// of silently dropping real events; the capacity below just gives bursty
+// event types (e.g. many distinct tool.call.started events) headroom before
+// that backpressure kicks in. tool.output.delta chunks for the same call_id
+// are additionally coalesced in the scan loop below, which is what keeps
+// very large tool outputs (e.g. `ls -laR` in a big repo) cheap to deliver.
+const sseChanCap = 1024
+
+// sseScannerInitialBufferBytes/sseScannerMaxBufferBytes size the bufio.Scanner
+// used to read SSE lines. Without an explicit .Buffer() call, bufio.Scanner
+// defaults to a 64KB max token size — comfortably exceeded by real tool
+// output: merged stdout+stderr is capped at ~60KB
+// (internal/harness/tools/head_tail_buffer.go: 30KB head/tail per stream),
+// plus JSON escaping/envelope overhead, and a single tool.output.delta line
+// can be as large as 1MB (internal/harness/tools/bash_manager.go
+// defaultMaxStreamLineBytes). A single oversized line previously made
+// bufio.Scanner return bufio.ErrTooLong and stop scanning permanently,
+// killing the stream for the rest of the run. 4MB is comfortably above the
+// 1MB server-side per-line cap.
+const (
+	sseScannerInitialBufferBytes = 64 * 1024
+	sseScannerMaxBufferBytes     = 4 * 1024 * 1024
+)
+
+// maxCoalescedDeltaBytes bounds how much tool.output.delta content the
+// bridge accumulates for a single call_id before flushing it as a message,
+// so a very long-running streaming command still produces periodic updates
+// (and bounded memory) rather than one giant message at the very end.
+const maxCoalescedDeltaBytes = 32 * 1024
 
 // StartSSEBridge connects to the SSE endpoint at url and delivers decoded
 // tea.Msg values on the returned channel. Call stop() to disconnect early.
 // The channel is closed when the stream ends or ctx is cancelled.
+//
+// This is equivalent to StartSSEBridgeFrom with an empty lastEventID (i.e.
+// a fresh connection with no resume point).
 func StartSSEBridge(ctx context.Context, url string) (<-chan tea.Msg, func()) {
+	return StartSSEBridgeFrom(ctx, url, "")
+}
+
+// StartSSEBridgeFrom is like StartSSEBridge but sets the Last-Event-ID
+// request header to lastEventID (if non-empty) so the server resumes the
+// stream from that point (see internal/server/http_runs.go, which trims
+// already-delivered history via harness.ParseEventID) instead of replaying
+// everything from the start.
+func StartSSEBridgeFrom(ctx context.Context, url, lastEventID string) (<-chan tea.Msg, func()) {
 	ch := make(chan tea.Msg, sseChanCap)
 	ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
 		defer cancel()
 		defer close(ch)
-		runBridge(ctx, url, ch)
+		runBridge(ctx, url, lastEventID, ch)
 	}()
 
 	return ch, cancel
 }
 
-func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
+func runBridge(ctx context.Context, url, lastEventID string, ch chan<- tea.Msg) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		send(ctx, ch, SSEErrorMsg{Err: err})
@@ -42,6 +80,9 @@ func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
 		return
 	}
 	req.Header.Set("Accept", "text/event-stream")
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -54,9 +95,52 @@ func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
 	defer resp.Body.Close()
 
 	scanner := bufio.NewScanner(resp.Body)
-	var event string
+	scanner.Buffer(make([]byte, 0, sseScannerInitialBufferBytes), sseScannerMaxBufferBytes)
+
+	var event, id string
 	var dataParts []string
-	var consecutiveDrops int
+
+	// pendingDelta buffers consecutive tool.output.delta chunks for the same
+	// call_id so a burst of thousands of tiny chunks (e.g. `ls -laR` output)
+	// becomes a handful of merged messages instead of one channel send per
+	// line. It is flushed whenever a different event/call_id arrives, the
+	// accumulated content crosses maxCoalescedDeltaBytes, or the stream ends.
+	var pendingDelta map[string]any
+	var pendingCallID string
+	var pendingID string
+
+	flushPending := func() {
+		if pendingDelta == nil {
+			return
+		}
+		raw, err := json.Marshal(pendingDelta)
+		merged := pendingID
+		pendingDelta, pendingCallID, pendingID = nil, "", ""
+		if err != nil {
+			send(ctx, ch, SSEErrorMsg{Err: err})
+			return
+		}
+		send(ctx, ch, SSEEventMsg{EventType: "tool.output.delta", Raw: raw, ID: merged})
+	}
+
+	deliver := func(msg tea.Msg) {
+		if evt, ok := msg.(SSEEventMsg); ok && evt.EventType == "tool.output.delta" {
+			if callID, ok := toolDeltaCallID(evt.Raw); ok {
+				if pendingDelta != nil && pendingCallID != callID {
+					flushPending()
+				}
+				pendingDelta = mergeToolOutputDelta(pendingDelta, evt.Raw)
+				pendingCallID = callID
+				pendingID = evt.ID
+				if pendingDeltaContentLen(pendingDelta) >= maxCoalescedDeltaBytes {
+					flushPending()
+				}
+				return
+			}
+		}
+		flushPending()
+		send(ctx, ch, msg)
+	}
 
 	for scanner.Scan() {
 		if ctx.Err() != nil {
@@ -64,6 +148,8 @@ func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
 		}
 		line := scanner.Text()
 		switch {
+		case strings.HasPrefix(line, "id:"):
+			id = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
 		case strings.HasPrefix(line, "event:"):
 			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
 		case strings.HasPrefix(line, "data:"):
@@ -72,26 +158,15 @@ func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
 		case line == "":
 			if len(dataParts) > 0 {
 				data := strings.Join(dataParts, "\n")
-				msg := decodeSSE(event, data)
-				if !trySend(ch, msg) {
-					consecutiveDrops++
-					// Channel is full; send SSEDropMsg non-blocking too so
-					// we do not stall the scanner goroutine under sustained
-					// backpressure. If the drop notification also cannot fit
-					// it is silently discarded — the TUI is already lagging.
-					trySend(ch, SSEDropMsg{})
-					if consecutiveDrops >= 10 {
-						send(ctx, ch, SSEErrorMsg{Err: fmt.Errorf("SSE bridge: too many dropped messages, stream may be corrupt")})
-						consecutiveDrops = 0
-					}
-				} else {
-					consecutiveDrops = 0
-				}
+				msg := decodeSSE(event, data, id)
 				if _, ok := msg.(SSEDoneMsg); ok {
+					flushPending()
+					send(ctx, ch, msg)
 					return
 				}
+				deliver(msg)
 			}
-			event, dataParts = "", nil
+			event, id, dataParts = "", "", nil
 		}
 	}
 	// Flush any partial event buffered before EOF / connection drop.
@@ -99,15 +174,22 @@ func runBridge(ctx context.Context, url string, ch chan<- tea.Msg) {
 	// may close the connection abruptly; deliver whatever data was pending.
 	if len(dataParts) > 0 && ctx.Err() == nil {
 		data := strings.Join(dataParts, "\n")
-		msg := decodeSSE(event, data)
-		trySend(ch, msg) // best-effort; drop on backpressure at EOF
+		deliver(decodeSSE(event, data, id))
 	}
+	flushPending()
 	if err := scanner.Err(); err != nil && ctx.Err() == nil {
-		send(ctx, ch, SSEErrorMsg{Err: err})
+		if errors.Is(err, bufio.ErrTooLong) {
+			send(ctx, ch, SSEErrorMsg{Err: fmt.Errorf("SSE bridge: event exceeded max buffer size (%d bytes), connection will be retried: %w", sseScannerMaxBufferBytes, err)})
+		} else {
+			send(ctx, ch, SSEErrorMsg{Err: err})
+		}
 	}
-	// Signal stream end (covers normal EOF; run.completed/run.failed paths
-	// return above after sending their own SSEDoneMsg from decodeSSE).
-	send(ctx, ch, SSEDoneMsg{})
+	// Signal that this connection attempt ended without a run.completed/
+	// run.failed terminal event (covers normal EOF and connection drops).
+	// The caller (the TUI model's SSEDoneMsg handler) treats this as
+	// recoverable and reconnects using Last-Event-ID rather than treating
+	// the run as finished.
+	send(ctx, ch, SSEDoneMsg{EventType: "bridge.closed"})
 }
 
 type sseEnvelope struct {
@@ -115,7 +197,7 @@ type sseEnvelope struct {
 	Payload json.RawMessage `json:"payload"`
 }
 
-func decodeSSE(event, data string) tea.Msg {
+func decodeSSE(event, data, id string) tea.Msg {
 	var env sseEnvelope
 	if err := json.Unmarshal([]byte(data), &env); err != nil {
 		return SSEErrorMsg{Err: err}
@@ -135,21 +217,66 @@ func decodeSSE(event, data string) tea.Msg {
 	}
 	// Unknown event types are forwarded as SSEEventMsg so that consumers
 	// can inspect EventType and Raw. No silent discard.
-	return SSEEventMsg{EventType: env.Type, Raw: env.Payload}
+	return SSEEventMsg{EventType: env.Type, Raw: env.Payload, ID: id}
+}
+
+// toolDeltaCallID extracts the call_id field from a tool.output.delta
+// payload. It returns ok=false if the payload cannot be parsed or has no
+// call_id, in which case the caller must not attempt to coalesce it.
+func toolDeltaCallID(raw json.RawMessage) (callID string, ok bool) {
+	var p struct {
+		CallID string `json:"call_id"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil || p.CallID == "" {
+		return "", false
+	}
+	return p.CallID, true
+}
+
+// mergeToolOutputDelta merges a newly decoded tool.output.delta payload into
+// the pending accumulator for the same call_id, concatenating "content" and
+// otherwise taking the latest value for every other field (e.g. tool,
+// stream_index) so the merged message stays representative of the most
+// recent chunk.
+func mergeToolOutputDelta(pending map[string]any, raw json.RawMessage) map[string]any {
+	var next map[string]any
+	if err := json.Unmarshal(raw, &next); err != nil {
+		return pending
+	}
+	if pending == nil {
+		return next
+	}
+	merged := make(map[string]any, len(next))
+	for k, v := range next {
+		merged[k] = v
+	}
+	pc, pcOK := pending["content"].(string)
+	nc, ncOK := next["content"].(string)
+	switch {
+	case pcOK && ncOK:
+		merged["content"] = pc + nc
+	case pcOK:
+		merged["content"] = pc
+	}
+	return merged
+}
+
+// pendingDeltaContentLen returns the length of the accumulated "content"
+// field on a pending coalesced delta, used to bound how large a single
+// coalesced message is allowed to grow before being flushed.
+func pendingDeltaContentLen(pending map[string]any) int {
+	if pending == nil {
+		return 0
+	}
+	if c, ok := pending["content"].(string); ok {
+		return len(c)
+	}
+	return 0
 }
 
 func send(ctx context.Context, ch chan<- tea.Msg, msg tea.Msg) {
 	select {
 	case ch <- msg:
 	case <-ctx.Done():
-	}
-}
-
-func trySend(ch chan<- tea.Msg, msg tea.Msg) bool {
-	select {
-	case ch <- msg:
-		return true
-	default:
-		return false
 	}
 }

--- a/cmd/harnesscli/tui/config.go
+++ b/cmd/harnesscli/tui/config.go
@@ -28,6 +28,16 @@ type TUIConfig struct {
 	// uses a time-based seed for whimsical variety in real use; tests set a fixed
 	// non-zero seed so rendered snapshots are deterministic.
 	SpinnerSeed int64
+	// APIKey authenticates requests to the harnessd server
+	// ("Authorization: Bearer <APIKey>"), including the SSE event stream
+	// (see bridge.go's SSEBridgeOptions). Empty means unauthenticated,
+	// preserving today's default local behavior. The TUI package does not
+	// read this from disk itself — it is sourced from ~/.harness/config.json
+	// (written by "harnesscli auth login") and threaded in by
+	// cmd/harnesscli/main.go's newTUIConfig, reusing the same
+	// cmd/harnesscli/auth.go:loadConfig() the rest of the CLI already uses
+	// for this exact purpose.
+	APIKey string
 }
 
 // DefaultTUIConfig returns a TUIConfig with sensible defaults.

--- a/cmd/harnesscli/tui/conversation_history_api_test.go
+++ b/cmd/harnesscli/tui/conversation_history_api_test.go
@@ -8,9 +8,11 @@ import (
 
 // TestFetchConversationMessagesCmd_Success verifies that fetchConversationMessagesCmd
 // hits the correct path (GET /v1/conversations/{id}/messages), sends no
-// Authorization header (matching the unauthenticated pattern used by the other
-// plain api.go calls such as fetchSessionRunsCmd and cancelRunCmd), and decodes
-// the message list into ConversationHistoryMsg.
+// Authorization header when no API key is configured (preserving
+// unauthenticated-local behavior — see TestAllHarnessdCallsAuthenticate in
+// api_auth_test.go for the header-present case shared across every
+// harnessd-targeting call), and decodes the message list into
+// ConversationHistoryMsg.
 func TestFetchConversationMessagesCmd_Success(t *testing.T) {
 	t.Parallel()
 
@@ -24,7 +26,7 @@ func TestFetchConversationMessagesCmd_Success(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchConversationMessagesCmd(ts.URL, "conv-history-1")()
+	msg := fetchConversationMessagesCmd(ts.URL, "conv-history-1", "")()
 
 	if gotMethod != http.MethodGet {
 		t.Errorf("method: want GET, got %q", gotMethod)
@@ -33,7 +35,7 @@ func TestFetchConversationMessagesCmd_Success(t *testing.T) {
 		t.Errorf("path: want /v1/conversations/conv-history-1/messages, got %q", gotPath)
 	}
 	if gotAuth != "" {
-		t.Errorf("Authorization header: want empty (matching the unauthenticated api.go pattern), got %q", gotAuth)
+		t.Errorf("Authorization header: want empty when no API key is configured, got %q", gotAuth)
 	}
 
 	got, ok := msg.(ConversationHistoryMsg)
@@ -65,7 +67,7 @@ func TestFetchConversationMessagesCmd_ErrorStatus(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := fetchConversationMessagesCmd(ts.URL, "conv-missing")()
+	msg := fetchConversationMessagesCmd(ts.URL, "conv-missing", "")()
 	got, ok := msg.(ConversationHistoryErrorMsg)
 	if !ok {
 		t.Fatalf("expected ConversationHistoryErrorMsg, got %T", msg)
@@ -83,7 +85,7 @@ func TestFetchConversationMessagesCmd_ErrorStatus(t *testing.T) {
 func TestFetchConversationMessagesCmd_NetworkError(t *testing.T) {
 	t.Parallel()
 
-	msg := fetchConversationMessagesCmd("http://127.0.0.1:1", "conv-err")()
+	msg := fetchConversationMessagesCmd("http://127.0.0.1:1", "conv-err", "")()
 	got, ok := msg.(ConversationHistoryErrorMsg)
 	if !ok {
 		t.Fatalf("expected ConversationHistoryErrorMsg, got %T", msg)

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -4,28 +4,56 @@ import (
 	"encoding/json"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
 )
 
 // ─── SSE Stream Messages ────────────────────────────────────────────────────
 
 // SSEEventMsg carries a decoded harness event from the SSE stream.
+// ID is the SSE "id:" field for this event, in harness's per-run
+// "runID:seq" format (see harness.ParseEventID). It is empty if the server
+// did not send an id: line. The TUI model tracks the most recent non-empty
+// ID so that if the stream connection drops, a reconnect can resume exactly
+// where it left off via the Last-Event-ID request header (see
+// internal/server/http_runs.go).
 type SSEEventMsg struct {
 	EventType string
 	Raw       json.RawMessage
+	ID        string
 }
 
 // SSEErrorMsg signals a stream read/parse error.
 type SSEErrorMsg struct{ Err error }
 
-// SSEDoneMsg signals the stream ended (run.completed or run.failed).
+// SSEDoneMsg signals the stream ended. EventType is "run.completed" or
+// "run.failed" for a genuine terminal event delivered by the harness itself.
+// Any other value (including the empty string, or the sentinel
+// "bridge.closed" emitted when the underlying channel closes without ever
+// delivering a message) means the connection was lost or closed without the
+// run actually finishing — the TUI model treats that case as recoverable and
+// attempts a bounded, backed-off reconnect (see SSEReconnectedMsg) rather
+// than ending the run.
 type SSEDoneMsg struct {
 	EventType string
 	Error     string // non-empty on run.failed
 }
 
-// SSEDropMsg signals a message was dropped due to channel backpressure.
+// SSEDropMsg signals a message was dropped due to channel backpressure. The
+// bridge now delivers real events with blocking sends specifically so this
+// should not happen in normal operation; it remains as a diagnostic hook.
 type SSEDropMsg struct{}
+
+// SSEReconnectedMsg carries a freshly established SSE bridge channel and its
+// cancel func after an automatic reconnect attempt (see reconnectSSECmd)
+// following an unexpected stream disconnection. The model only adopts the
+// new channel if the run is still active; otherwise it cancels the new
+// connection immediately.
+type SSEReconnectedMsg struct {
+	Ch     <-chan tea.Msg
+	Cancel func()
+}
 
 // ─── Assistant Messages ──────────────────────────────────────────────────────
 

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -102,6 +102,18 @@ type Model struct {
 	// nil when no run is active.
 	sseCh <-chan tea.Msg
 
+	// lastEventID is the ID of the most recently delivered SSE event for the
+	// active run (format "runID:seq" — see harness.ParseEventID). Used to
+	// resume the stream via the Last-Event-ID header if the connection drops
+	// mid-run, so the server can skip already-delivered history instead of
+	// replaying it (see internal/server/http_runs.go).
+	lastEventID string
+
+	// sseReconnectAttempts counts how many automatic SSE reconnect attempts
+	// have been made for the current run. Bounded by maxSSEReconnectAttempts;
+	// once exhausted the stream is treated as terminally lost.
+	sseReconnectAttempts int
+
 	// toolExpanded tracks which tool calls are in the expanded view, keyed by
 	// tool call ID. True = expanded, absent/false = collapsed.
 	toolExpanded map[string]bool
@@ -2641,6 +2653,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// set (e.g. injected by tests via WithCancelRun). This avoids overwriting
 		// a test-supplied cancel with a real HTTP bridge.
 		if m.cancelRun == nil {
+			m.lastEventID = ""
+			m.sseReconnectAttempts = 0
 			ch, cancel := startSSEForRun(m.config.BaseURL, msg.RunID)
 			m.sseCh = ch
 			m.cancelRun = cancel
@@ -2774,6 +2788,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case SSEEventMsg:
+		// Track the most recent event ID so a mid-run reconnect (see the
+		// SSEDoneMsg case below) can resume exactly here via Last-Event-ID.
+		if msg.ID != "" {
+			m.lastEventID = msg.ID
+		}
 		// Route event to viewport based on type.
 		switch msg.EventType {
 		case "assistant.message.delta":
@@ -2900,6 +2919,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case SSEDoneMsg:
+		isTerminal := msg.EventType == "run.completed" || msg.EventType == "run.failed"
+
+		// The connection ended without a genuine run.completed/run.failed
+		// event — e.g. the server dropped the TCP connection mid-burst. The
+		// server supports resuming via Last-Event-ID (internal/server/
+		// http_runs.go), so reconnect instead of treating the run as
+		// finished, as long as the run is still active and we have not
+		// exhausted our bounded retry budget.
+		if !isTerminal && m.runActive && m.sseReconnectAttempts < maxSSEReconnectAttempts {
+			m.sseReconnectAttempts++
+			if m.cancelRun != nil {
+				m.cancelRun()
+				m.cancelRun = nil
+			}
+			m.sseCh = nil
+			cmds = append(cmds, reconnectSSECmd(m.config.BaseURL, m.RunID, m.lastEventID, m.sseReconnectAttempts))
+			return m, tea.Batch(cmds...)
+		}
+
+		if !isTerminal && m.sseReconnectAttempts >= maxSSEReconnectAttempts {
+			m.vp.AppendLine(fmt.Sprintf("⚠ SSE stream lost and could not be re-established after %d attempt(s)", m.sseReconnectAttempts))
+			m.vp.AppendLine("")
+		}
+		m.sseReconnectAttempts = 0
 		m.runActive = false
 		m.sseCh = nil
 		m.responseStarted = false
@@ -2923,6 +2966,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.vp.AppendLine("")
+
+	case SSEReconnectedMsg:
+		// A backed-off reconnect attempt (see reconnectSSECmd) has
+		// established a new connection. Only adopt it if the run is still
+		// active — it may have been cancelled or already finished while the
+		// reconnect backoff was pending, in which case the freshly-opened
+		// connection must be closed immediately rather than resurrecting a
+		// dead run.
+		if !m.runActive {
+			if msg.Cancel != nil {
+				msg.Cancel()
+			}
+			return m, nil
+		}
+		m.sseCh = msg.Ch
+		m.cancelRun = msg.Cancel
+		cmds = append(cmds, pollSSECmd(m.sseCh))
 
 	case SSEDropMsg:
 		// Dropped message — continue polling.

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -2655,7 +2655,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.cancelRun == nil {
 			m.lastEventID = ""
 			m.sseReconnectAttempts = 0
-			ch, cancel := startSSEForRun(m.config.BaseURL, msg.RunID)
+			ch, cancel := startSSEForRun(m.config.BaseURL, msg.RunID, m.config.APIKey)
 			m.sseCh = ch
 			m.cancelRun = cancel
 			cmds = append(cmds, pollSSECmd(m.sseCh))
@@ -2919,7 +2919,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case SSEDoneMsg:
-		isTerminal := msg.EventType == "run.completed" || msg.EventType == "run.failed"
+		// "bridge.fatal" marks a permanent failure (401/403/404 — see
+		// isNonRetryableSSEStatus in bridge.go) that a reconnect cannot fix;
+		// it is treated as terminal here specifically so it is NOT retried
+		// and does NOT get the generic "could not be re-established" message
+		// below (the SSEErrorMsg delivered immediately before this already
+		// carried a single, specific, actionable explanation).
+		isTerminal := msg.EventType == "run.completed" || msg.EventType == "run.failed" || msg.EventType == "bridge.fatal"
 
 		// The connection ended without a genuine run.completed/run.failed
 		// event — e.g. the server dropped the TCP connection mid-burst. The
@@ -2934,7 +2940,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cancelRun = nil
 			}
 			m.sseCh = nil
-			cmds = append(cmds, reconnectSSECmd(m.config.BaseURL, m.RunID, m.lastEventID, m.sseReconnectAttempts))
+			cmds = append(cmds, reconnectSSECmd(m.config.BaseURL, m.RunID, m.lastEventID, m.config.APIKey, m.sseReconnectAttempts))
 			return m, tea.Batch(cmds...)
 		}
 

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1451,12 +1451,14 @@ func executeModelCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 
 	var cmds []tea.Cmd
 	if m.selectedGateway == "openrouter" {
+		// External API — sends the OpenRouter provider key, never the
+		// harnessd key (see fetchOpenRouterModelsCmd's doc comment).
 		orKey := m.pendingAPIKeys["openrouter"]
 		cmds = append(cmds, fetchOpenRouterModelsCmd(orKey))
 	} else {
-		cmds = append(cmds, fetchModelsCmd(m.config.BaseURL))
+		cmds = append(cmds, fetchModelsCmd(m.config.BaseURL, m.config.APIKey))
 	}
-	cmds = append(cmds, fetchProvidersCmd(m.config.BaseURL))
+	cmds = append(cmds, fetchProvidersCmd(m.config.BaseURL, m.config.APIKey))
 	return cmds, false
 }
 
@@ -1466,13 +1468,13 @@ func executeKeysCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	m.apiKeyCursor = 0
 	m.apiKeyInput = ""
 	m.apiKeyInputMode = false
-	return []tea.Cmd{fetchProvidersCmd(m.config.BaseURL)}, false
+	return []tea.Cmd{fetchProvidersCmd(m.config.BaseURL, m.config.APIKey)}, false
 }
 
 func executeSubagentsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return []tea.Cmd{
 		m.setStatusMsg("Loading subagents..."),
-		loadSubagentsCmd(m.config.BaseURL),
+		loadSubagentsCmd(m.config.BaseURL, m.config.APIKey),
 	}, false
 }
 
@@ -1481,7 +1483,7 @@ func executeProfilesCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	m.activeOverlay = "profiles"
 	return []tea.Cmd{
 		m.setStatusMsg("Loading profiles..."),
-		loadProfilesCmd(m.config.BaseURL),
+		loadProfilesCmd(m.config.BaseURL, m.config.APIKey),
 	}, false
 }
 
@@ -1542,7 +1544,7 @@ func executeAttachCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 func executeRunsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return []tea.Cmd{
 		m.setStatusMsg("Loading runs..."),
-		fetchRunsCmd(m.config.BaseURL),
+		fetchRunsCmd(m.config.BaseURL, m.config.APIKey),
 	}, false
 }
 
@@ -1558,7 +1560,7 @@ func executeCancelCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	}
 	return []tea.Cmd{
 		m.setStatusMsg("Cancelling " + runID + "..."),
-		cancelRunCmd(m.config.BaseURL, runID),
+		cancelRunCmd(m.config.BaseURL, runID, m.config.APIKey),
 	}, false
 }
 
@@ -1569,7 +1571,7 @@ func executeReplayCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	target := cmd.Args[0]
 	return []tea.Cmd{
 		m.setStatusMsg("Replaying " + target + "..."),
-		replayRunCmd(m.config.BaseURL, target),
+		replayRunCmd(m.config.BaseURL, target, m.config.APIKey),
 	}, false
 }
 
@@ -1595,7 +1597,7 @@ func executeResumeCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	m.appendMessageBubble(messagebubble.RoleUser, prompt)
 	return []tea.Cmd{
 		m.setStatusMsg("Continuing " + runID + "..."),
-		continueRunCmd(m.config.BaseURL, runID, expandedPrompt),
+		continueRunCmd(m.config.BaseURL, runID, expandedPrompt, m.config.APIKey),
 	}, false
 }
 
@@ -1688,8 +1690,8 @@ func (m Model) viewSearchOverlay() string {
 // Init implements tea.Model.
 func (m Model) Init() tea.Cmd {
 	var cmds []tea.Cmd
-	for provider, apiKey := range m.pendingAPIKeys {
-		cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, apiKey))
+	for provider, providerKey := range m.pendingAPIKeys {
+		cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, providerKey, m.config.APIKey))
 	}
 	// Schedule a status message when plugin warnings were collected at startup.
 	if len(m.pluginWarnings) > 0 {
@@ -1746,7 +1748,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// exists (first init runs exactly once, since m.ready is now true),
 			// so the rendered history cannot be wiped by this viewport creation.
 			if m.config.ResumeConversationID != "" {
-				cmds = append(cmds, fetchConversationMessagesCmd(m.config.BaseURL, m.conversationID))
+				cmds = append(cmds, fetchConversationMessagesCmd(m.config.BaseURL, m.conversationID, m.config.APIKey))
 			}
 		}
 		// Preserve current history across window resizes: on subsequent resizes
@@ -1798,7 +1800,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// cancel the run both server-side and locally.
 				m.interruptBanner = m.interruptBanner.Hide()
 				if m.RunID != "" {
-					cmds = append(cmds, cancelRunCmd(m.config.BaseURL, m.RunID))
+					cmds = append(cmds, cancelRunCmd(m.config.BaseURL, m.RunID, m.config.APIKey))
 				}
 				if m.cancelRun != nil {
 					m.cancelRun()
@@ -2011,7 +2013,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					apiKey := m.apiKeyInput
 					m.apiKeyInputMode = false
 					m.apiKeyInput = ""
-					cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, apiKey))
+					cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, apiKey, m.config.APIKey))
 				} else if !m.apiKeyInputMode && len(m.apiKeyProviders) > 0 {
 					m.apiKeyInputMode = true
 				}
@@ -2039,7 +2041,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							key := m.modelConfigKeyInput
 							m.modelConfigKeyInputMode = false
 							m.modelConfigKeyInput = ""
-							cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, key))
+							cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, key, m.config.APIKey))
 						}
 						return m, tea.Batch(cmds...)
 					}
@@ -2586,7 +2588,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.appendMessageBubble(messagebubble.RoleUser, msg.Value)
 		// Fire off the run against the harness API with the expanded prompt.
 		effModel, effProvider := m.effectiveModelAndProvider()
-		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace))
+		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey))
 
 	case AssistantDeltaMsg:
 		m.lastAssistantText += msg.Delta
@@ -2901,7 +2903,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if err := json.Unmarshal(msg.Raw, &p); err == nil && p.RunID != "" {
 				m.askUser = askUserState{active: true, runID: p.RunID, callID: p.CallID}
-				cmds = append(cmds, fetchAskUserPendingCmd(m.config.BaseURL, p.RunID))
+				cmds = append(cmds, fetchAskUserPendingCmd(m.config.BaseURL, p.RunID, m.config.APIKey))
 			}
 		case "run.resumed":
 			// Dismiss the ask-user overlay when the run resumes.
@@ -3140,7 +3142,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		hcfg.APIKeys[msg.Provider] = msg.Key
 		_ = harnessconfig.Save(hcfg)
 		// Refresh provider list.
-		cmds = append(cmds, fetchProvidersCmd(m.config.BaseURL))
+		cmds = append(cmds, fetchProvidersCmd(m.config.BaseURL, m.config.APIKey))
 		cmds = append(cmds, m.setStatusMsg("Key saved for "+msg.Provider))
 
 	case statusTickMsg:

--- a/cmd/harnesscli/tui/sse_bridge_resilience_test.go
+++ b/cmd/harnesscli/tui/sse_bridge_resilience_test.go
@@ -398,3 +398,194 @@ func TestBridgeBug3_BurstDoesNotDropRealEventsUnderBackpressure(t *testing.T) {
 		t.Errorf("bridge reported %d 'dropped messages / stream corrupt' warning(s) under a burst; real events must never be dropped in the first place", corruptionWarnings)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Regression tests — each of these would fail if the corresponding fix above
+// were reverted or subtly broken, even though they exercise a different edge
+// than the primary behavioral test for that bug.
+// ---------------------------------------------------------------------------
+
+// TestRegression_SSEBridgeSurvives1MBEvent pins the scanner buffer at the
+// documented real-world upper bound: internal/harness/tools/bash_manager.go's
+// defaultMaxStreamLineBytes caps a single tool.output.delta line at 1MB. If
+// the scanner buffer ever regresses back toward bufio.Scanner's 64KB default
+// (or anything below 1MB), this line alone would kill the stream exactly as
+// BUG 1 originally described.
+func TestRegression_SSEBridgeSurvives1MBEvent(t *testing.T) {
+	bigContent := strings.Repeat("B", 1024*1024)
+	bigContentJSON, err := json.Marshal(bigContent)
+	if err != nil {
+		t.Fatalf("marshal content: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "id: run-1mb:0\nevent: message\ndata: {\"type\":\"tool.output.delta\",\"payload\":{\"call_id\":\"call-1mb\",\"content\":%s}}\n\n", bigContentJSON)
+		fmt.Fprintf(w, "id: run-1mb:1\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridge(ctx, srv.URL)
+	defer stop()
+
+	var gotLen int
+	var gotDone bool
+	for msg := range msgs {
+		switch m := msg.(type) {
+		case tui.SSEEventMsg:
+			if m.EventType == "tool.output.delta" {
+				var p struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(m.Raw, &p) == nil {
+					gotLen += len(p.Content)
+				}
+			}
+		case tui.SSEDoneMsg:
+			if m.EventType == "run.completed" {
+				gotDone = true
+			}
+		}
+	}
+	if gotLen != len(bigContent) {
+		t.Errorf("expected the full 1MB event content to survive, got %d bytes, want %d", gotLen, len(bigContent))
+	}
+	if !gotDone {
+		t.Error("expected run.completed to still arrive after a 1MB event")
+	}
+}
+
+// TestRegression_SSEBridgeReconnectGivesUpGracefullyAfterBoundedAttempts
+// pins the bound + single-message-on-abandonment contract: if a server
+// connection can never succeed (every attempt closes immediately), the
+// client must stop after exactly maxSSEReconnectAttempts retries, mark the
+// run inactive, and surface exactly one "could not be re-established"
+// message — not the repeated "stream error" storm the user originally
+// reported, and not an infinite reconnect loop.
+func TestRegression_SSEBridgeReconnectGivesUpGracefullyAfterBoundedAttempts(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connCount++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Close immediately without ever delivering an event or a terminal
+		// signal — every connection attempt (initial + every reconnect)
+		// fails the same way, forcing the retry budget to be exhausted.
+	}))
+	defer srv.Close()
+
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := m2.(tui.Model)
+
+	model2, cmd := model.Update(tui.RunStartedMsg{RunID: "run-give-up"})
+	model = model2.(tui.Model)
+
+	final := driveModel(t, model, cmd, 20*time.Second, func(m tui.Model, msg tea.Msg) bool {
+		return !m.RunActive()
+	})
+
+	if final.RunActive() {
+		t.Fatal("expected the run to eventually be marked inactive once reconnect attempts are exhausted")
+	}
+
+	view := final.View()
+	abandonCount := strings.Count(view, "could not be re-established")
+	if abandonCount != 1 {
+		t.Errorf("expected exactly one 'could not be re-established' message in the viewport, got %d — repeated messages would reproduce the original 'too many dropped messages' storm", abandonCount)
+	}
+
+	mu.Lock()
+	gotConns := connCount
+	mu.Unlock()
+	const wantConns = 1 + 5 // initial attempt + maxSSEReconnectAttempts
+	if gotConns != wantConns {
+		t.Errorf("expected exactly %d total connection attempts (1 initial + bounded reconnects), got %d — reconnects must be bounded, not infinite", wantConns, gotConns)
+	}
+}
+
+// TestRegression_SSEBridgeCoalescesPerCallIDWithoutCrossContamination
+// interleaves two distinct call_ids on every other event, forcing the
+// coalescer in bridge.go to flush and switch accumulators on almost every
+// message. This would fail if the merge logic ever concatenated content
+// across call_ids or dropped the pending accumulator's content when
+// switching, corrupting one or both call_ids' output.
+func TestRegression_SSEBridgeCoalescesPerCallIDWithoutCrossContamination(t *testing.T) {
+	const n = 200
+	const callA, callB = "call-a", "call-b"
+
+	var expectedA, expectedB strings.Builder
+	var events []burstEvent
+	for i := 0; i < n; i++ {
+		chunkA := fmt.Sprintf("A%03d", i)
+		chunkAJSON, _ := json.Marshal(chunkA)
+		expectedA.WriteString(chunkA)
+		events = append(events, burstEvent{
+			eventType: "tool.output.delta",
+			payload:   fmt.Sprintf(`{"call_id":%q,"content":%s}`, callA, chunkAJSON),
+		})
+
+		chunkB := fmt.Sprintf("B%03d", i)
+		chunkBJSON, _ := json.Marshal(chunkB)
+		expectedB.WriteString(chunkB)
+		events = append(events, burstEvent{
+			eventType: "tool.output.delta",
+			payload:   fmt.Sprintf(`{"call_id":%q,"content":%s}`, callB, chunkBJSON),
+		})
+	}
+	events = append(events, burstEvent{eventType: "run.completed", payload: "{}"})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeBurstEvents(w, events)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridge(ctx, srv.URL)
+	defer stop()
+
+	var gotA, gotB strings.Builder
+	for msg := range msgs {
+		evt, ok := msg.(tui.SSEEventMsg)
+		if !ok || evt.EventType != "tool.output.delta" {
+			continue
+		}
+		var p struct {
+			CallID  string `json:"call_id"`
+			Content string `json:"content"`
+		}
+		if json.Unmarshal(evt.Raw, &p) != nil {
+			continue
+		}
+		switch p.CallID {
+		case callA:
+			gotA.WriteString(p.Content)
+		case callB:
+			gotB.WriteString(p.Content)
+		}
+	}
+
+	if gotA.String() != expectedA.String() {
+		t.Errorf("call_id %q content corrupted by coalescing: got %d bytes, want %d bytes", callA, gotA.Len(), expectedA.Len())
+	}
+	if gotB.String() != expectedB.String() {
+		t.Errorf("call_id %q content corrupted by coalescing: got %d bytes, want %d bytes", callB, gotB.Len(), expectedB.Len())
+	}
+}

--- a/cmd/harnesscli/tui/sse_bridge_resilience_test.go
+++ b/cmd/harnesscli/tui/sse_bridge_resilience_test.go
@@ -589,3 +589,223 @@ func TestRegression_SSEBridgeCoalescesPerCallIDWithoutCrossContamination(t *test
 		t.Errorf("call_id %q content corrupted by coalescing: got %d bytes, want %d bytes", callB, gotB.Len(), expectedB.Len())
 	}
 }
+
+// ---------------------------------------------------------------------------
+// FOLLOW-UP: the SSE request must authenticate like the rest of the CLI, and
+// a rejected/unknown-run status must not burn the bounded reconnect budget.
+//
+// The events endpoint sends no Authorization header at all today (verified:
+// none of api.go's calls to the harnessd BaseURL set one; the only existing
+// Authorization-setting code, fetchOpenRouterModelsFromURL, authenticates to
+// the *external* openrouter.ai API with a provider key, not to harnessd
+// itself). The actual harnessd auth pattern lives in cmd/harnesscli/auth.go's
+// newAuthedRequest, which is only wired into the plain (non-TUI) harnesscli
+// commands. See the accompanying report for the minimal plumbing added to
+// reach the TUI (TUIConfig.APIKey + newTUIConfig loading
+// ~/.harness/config.json via the existing auth.go:loadConfig()).
+// ---------------------------------------------------------------------------
+
+// TestSSEBridgeAuth_InitialRequestCarriesAuthorizationWhenConfigured asserts
+// the bridge sends "Authorization: Bearer <key>" when a key is supplied via
+// SSEBridgeOptions.APIKey.
+func TestSSEBridgeAuth_InitialRequestCarriesAuthorizationWhenConfigured(t *testing.T) {
+	var gotAuth string
+	var sawRequest bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "id: run-auth:0\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridgeWithOptions(ctx, srv.URL, tui.SSEBridgeOptions{APIKey: "secret-key"})
+	defer stop()
+	for range msgs {
+	}
+
+	if !sawRequest {
+		t.Fatal("expected the server to receive a request")
+	}
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("expected Authorization header %q, got %q — the SSE request must authenticate the same way the rest of the CLI does", "Bearer secret-key", gotAuth)
+	}
+}
+
+// TestSSEBridgeAuth_NoAuthorizationHeaderWhenKeyEmpty asserts that when no
+// API key is configured, the request carries no Authorization header at
+// all — preserving today's unauthenticated-local behavior.
+func TestSSEBridgeAuth_NoAuthorizationHeaderWhenKeyEmpty(t *testing.T) {
+	var sawHeader bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawHeader = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "id: run-noauth:0\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridge(ctx, srv.URL) // no options => unauthenticated
+	defer stop()
+	for range msgs {
+	}
+
+	if sawHeader {
+		t.Error("expected no Authorization header when no API key is configured")
+	}
+}
+
+// TestSSEBridgeAuth_ReconnectCarriesAuthorizationAndLastEventID asserts a
+// single connection attempt that sets both LastEventID and APIKey (exactly
+// what a reconnect does — see reconnectSSECmd/startSSEForRunFrom in api.go)
+// carries both headers together, not just one or the other.
+func TestSSEBridgeAuth_ReconnectCarriesAuthorizationAndLastEventID(t *testing.T) {
+	var gotAuth, gotLastEventID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotLastEventID = r.Header.Get("Last-Event-ID")
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "id: run-reconnect-auth:1\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridgeWithOptions(ctx, srv.URL, tui.SSEBridgeOptions{
+		LastEventID: "run-reconnect-auth:0",
+		APIKey:      "secret-key",
+	})
+	defer stop()
+	for range msgs {
+	}
+
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("expected reconnect request Authorization = %q, got %q", "Bearer secret-key", gotAuth)
+	}
+	if gotLastEventID != "run-reconnect-auth:0" {
+		t.Errorf("expected reconnect request Last-Event-ID = %q, got %q", "run-reconnect-auth:0", gotLastEventID)
+	}
+}
+
+// TestSSEBridgeAuth_401IsNonRetryable asserts that a 401 response produces
+// exactly one connection attempt (no bounded-reconnect retries burned
+// against a permanent auth rejection) and a single clear error.
+func TestSSEBridgeAuth_401IsNonRetryable(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connCount++
+		mu.Unlock()
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":{"code":"unauthorized","message":"missing or invalid api key"}}`)
+	}))
+	defer srv.Close()
+
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := m2.(tui.Model)
+
+	model2, cmd := model.Update(tui.RunStartedMsg{RunID: "run-401"})
+	model = model2.(tui.Model)
+
+	final := driveModel(t, model, cmd, 10*time.Second, func(m tui.Model, msg tea.Msg) bool {
+		return !m.RunActive()
+	})
+
+	mu.Lock()
+	gotConns := connCount
+	mu.Unlock()
+	if gotConns != 1 {
+		t.Errorf("expected exactly 1 connection attempt on a 401 (non-retryable), got %d — burning the reconnect budget against a permanent auth rejection wastes time and confuses the user", gotConns)
+	}
+	if final.RunActive() {
+		t.Error("expected the run to be marked inactive after a non-retryable 401")
+	}
+
+	view := final.View()
+	errCount := strings.Count(view, "stream error")
+	if errCount != 1 {
+		t.Errorf("expected exactly one clear stream error message for a non-retryable 401, got %d", errCount)
+	}
+}
+
+// TestSSEBridgeAuth_5xxStillRetries is a regression guard proving the 401/403
+// non-retryable fix did not make everything non-retryable: a transient 5xx
+// (or a network-level failure — already covered by the reconnect tests
+// above) must still be retried per the existing bounded/backoff behavior.
+func TestSSEBridgeAuth_5xxStillRetries(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connCount++
+		n := connCount
+		mu.Unlock()
+
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"error":"internal"}`)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "id: run-5xx:0\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := m2.(tui.Model)
+
+	model2, cmd := model.Update(tui.RunStartedMsg{RunID: "run-5xx"})
+	model = model2.(tui.Model)
+
+	final := driveModel(t, model, cmd, 15*time.Second, func(m tui.Model, msg tea.Msg) bool {
+		if done, ok := msg.(tui.SSEDoneMsg); ok && done.EventType == "run.completed" {
+			return true
+		}
+		return !m.RunActive()
+	})
+
+	mu.Lock()
+	gotConns := connCount
+	mu.Unlock()
+	if gotConns != 3 {
+		t.Errorf("expected exactly 3 connection attempts (2 transient 5xx failures + 1 success), got %d", gotConns)
+	}
+	if final.RunActive() {
+		t.Error("expected run inactive after run.completed")
+	}
+}

--- a/cmd/harnesscli/tui/sse_bridge_resilience_test.go
+++ b/cmd/harnesscli/tui/sse_bridge_resilience_test.go
@@ -809,3 +809,86 @@ func TestSSEBridgeAuth_5xxStillRetries(t *testing.T) {
 		t.Error("expected run inactive after run.completed")
 	}
 }
+
+// TestRegression_SSEBridgeAuthEndToEndInitialAndReconnect proves the actual
+// TUIConfig.APIKey → model.go call sites → bridge.go wiring, not just the
+// low-level bridge mechanism exercised by the tests above. It would fail if
+// a future change correctly implements SSEBridgeOptions.APIKey in bridge.go
+// but forgets to actually pass m.config.APIKey through at either of
+// model.go's two call sites (the initial startSSEForRun in the
+// RunStartedMsg case, or reconnectSSECmd in the SSEDoneMsg case) — a
+// mistake the compiler cannot catch since both parameters default to the
+// empty string.
+func TestRegression_SSEBridgeAuthEndToEndInitialAndReconnect(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+	var firstAuth, secondAuth, secondLastEventID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connCount++
+		n := connCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		if n == 1 {
+			mu.Lock()
+			firstAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+			// Deliver one event, then close without a terminal event to force
+			// the model's reconnect path.
+			fmt.Fprint(w, "id: run-e2e-auth:0\nevent: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":\"hi\"}}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+
+		mu.Lock()
+		secondAuth = r.Header.Get("Authorization")
+		secondLastEventID = r.Header.Get("Last-Event-ID")
+		mu.Unlock()
+		fmt.Fprint(w, "id: run-e2e-auth:1\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	cfg.APIKey = "e2e-secret"
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := m2.(tui.Model)
+
+	model2, cmd := model.Update(tui.RunStartedMsg{RunID: "run-e2e-auth"})
+	model = model2.(tui.Model)
+
+	final := driveModel(t, model, cmd, 15*time.Second, func(m tui.Model, msg tea.Msg) bool {
+		if done, ok := msg.(tui.SSEDoneMsg); ok && done.EventType == "run.completed" {
+			return true
+		}
+		return !m.RunActive()
+	})
+
+	mu.Lock()
+	gotFirstAuth, gotSecondAuth, gotSecondLastID := firstAuth, secondAuth, secondLastEventID
+	mu.Unlock()
+
+	if gotFirstAuth != "Bearer e2e-secret" {
+		t.Errorf("expected initial connection Authorization = %q, got %q — TUIConfig.APIKey is not reaching the initial startSSEForRun call site", "Bearer e2e-secret", gotFirstAuth)
+	}
+	if gotSecondAuth != "Bearer e2e-secret" {
+		t.Errorf("expected reconnect Authorization = %q, got %q — TUIConfig.APIKey is not reaching reconnectSSECmd", "Bearer e2e-secret", gotSecondAuth)
+	}
+	if gotSecondLastID != "run-e2e-auth:0" {
+		t.Errorf("expected reconnect Last-Event-ID = %q, got %q", "run-e2e-auth:0", gotSecondLastID)
+	}
+	if final.RunActive() {
+		t.Error("expected run inactive after run.completed arrives via the authenticated reconnect")
+	}
+}

--- a/cmd/harnesscli/tui/sse_bridge_resilience_test.go
+++ b/cmd/harnesscli/tui/sse_bridge_resilience_test.go
@@ -1,0 +1,400 @@
+package tui_test
+
+// sse_bridge_resilience_test.go — TASK: fix/sse-bridge-resilience
+//
+// Reproduces three real, user-reported failure modes of the harnesscli TUI's
+// SSE client (cmd/harnesscli/tui/bridge.go) against local httptest SSE
+// servers:
+//
+//   - BUG 1 (P0): an SSE data: line larger than bufio.Scanner's default 64KB
+//     token limit kills the scanner permanently (bufio.ErrTooLong), so the
+//     bridge goroutine returns and every subsequent event on that run is
+//     lost.
+//   - BUG 2 (P1): the client never reconnects when the connection drops
+//     mid-run, even though the server supports resuming via the
+//     Last-Event-ID header (internal/server/http_runs.go +
+//     harness.ParseEventID).
+//   - BUG 3 (P1): the bridge's non-blocking trySend silently drops real
+//     events (including tool.call.completed) once its 256-slot channel
+//     fills up under a burst, which is why tool cards stayed stuck
+//     "in-progress" for the user.
+//
+// These tests are written FIRST (TDD "red" step) and are expected to FAIL
+// against the current (unfixed) implementation.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+// driveModel feeds messages produced by cmd (and any tea.Batch sub-commands
+// it contains, recursively) back into m.Update() until stop reports true or
+// timeout elapses. It mirrors — in a minimal, deterministic way — how the
+// real bubbletea runtime dispatches each returned tea.Cmd on its own
+// goroutine, which matters here because RunStartedMsg returns a batch
+// containing both a spinner tick command and the SSE poll command; a naive
+// synchronous driver would stall on whichever command is invoked first.
+func driveModel(t *testing.T, m tui.Model, cmd tea.Cmd, timeout time.Duration, stop func(tui.Model, tea.Msg) bool) tui.Model {
+	t.Helper()
+
+	msgCh := make(chan tea.Msg, 256)
+	deadline := time.Now().Add(timeout)
+
+	var dispatch func(tea.Cmd)
+	dispatch = func(c tea.Cmd) {
+		if c == nil {
+			return
+		}
+		go func() {
+			msg := c()
+			if batch, ok := msg.(tea.BatchMsg); ok {
+				for _, sub := range batch {
+					dispatch(sub)
+				}
+				return
+			}
+			select {
+			case msgCh <- msg:
+			case <-time.After(time.Until(deadline) + time.Second):
+			}
+		}()
+	}
+	dispatch(cmd)
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatalf("driveModel: timed out after %s waiting for stop condition", timeout)
+			return m
+		}
+		select {
+		case msg := <-msgCh:
+			model2, next := m.Update(msg)
+			m = model2.(tui.Model)
+			if stop(m, msg) {
+				return m
+			}
+			dispatch(next)
+		case <-time.After(remaining):
+			t.Fatalf("driveModel: timed out after %s waiting for stop condition", timeout)
+			return m
+		}
+	}
+}
+
+// burstEvent describes one synthetic SSE event used by the BUG 3 backpressure
+// test. deltaChunk / markerID are set (mutually exclusive with each other and
+// with neither) so the test can independently verify content reconstruction
+// for the coalesced tool.output.delta stream and zero loss for the
+// non-coalesced tool.call.completed markers, without racing on shared state
+// between the httptest handler goroutine and the test goroutine.
+type burstEvent struct {
+	eventType  string
+	payload    string
+	deltaChunk string
+	markerID   string
+}
+
+// buildBurstEvents constructs a deterministic sequence of tool.output.delta
+// chunks for a single call_id, interleaved with tool.call.completed markers
+// for distinct call_ids every markerEvery events, terminated by run.completed.
+// It is pure (no shared mutable state) so both the httptest handler and the
+// assertion code can safely range over the same slice concurrently.
+func buildBurstEvents(n, markerEvery int, callID string) []burstEvent {
+	events := make([]burstEvent, 0, n+n/markerEvery+1)
+	for i := 0; i < n; i++ {
+		chunk := fmt.Sprintf("[%05d]", i)
+		chunkJSON, _ := json.Marshal(chunk)
+		events = append(events, burstEvent{
+			eventType:  "tool.output.delta",
+			payload:    fmt.Sprintf(`{"call_id":%q,"content":%s}`, callID, chunkJSON),
+			deltaChunk: chunk,
+		})
+		if i%markerEvery == 0 {
+			markerID := fmt.Sprintf("call-marker-%d", i)
+			events = append(events, burstEvent{
+				eventType: "tool.call.completed",
+				payload:   fmt.Sprintf(`{"call_id":%q,"tool":"bash","output":"ok"}`, markerID),
+				markerID:  markerID,
+			})
+		}
+	}
+	events = append(events, burstEvent{eventType: "run.completed", payload: "{}"})
+	return events
+}
+
+func writeBurstEvents(w http.ResponseWriter, events []burstEvent) {
+	for i, e := range events {
+		fmt.Fprintf(w, "id: run-burst:%d\nevent: message\ndata: {\"type\":%q,\"payload\":%s}\n\n", i, e.eventType, e.payload)
+	}
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BUG 1 (P0): oversized events must not kill the stream permanently.
+// ---------------------------------------------------------------------------
+
+func TestBridgeBug1_OversizedEventDoesNotKillStream(t *testing.T) {
+	// 200KB comfortably exceeds bufio.Scanner's default 64KB max token size,
+	// and is realistic: merged stdout+stderr tool output is capped at ~60KB
+	// (internal/harness/tools/head_tail_buffer.go) plus JSON escaping and
+	// envelope overhead.
+	bigContent := strings.Repeat("A", 200*1024)
+	bigContentJSON, err := json.Marshal(bigContent)
+	if err != nil {
+		t.Fatalf("marshal big content: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "id: run-big:0\nevent: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":%s}}\n\n", bigContentJSON)
+		fmt.Fprintf(w, "id: run-big:1\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridge(ctx, srv.URL)
+	defer stop()
+
+	var gotBig bool
+	var gotDone bool
+	for msg := range msgs {
+		switch m := msg.(type) {
+		case tui.SSEEventMsg:
+			if m.EventType == "assistant.message.delta" {
+				var p struct {
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(m.Raw, &p) == nil && len(p.Content) == len(bigContent) {
+					gotBig = true
+				}
+			}
+		case tui.SSEDoneMsg:
+			if m.EventType == "run.completed" {
+				gotDone = true
+			}
+		}
+	}
+
+	if !gotBig {
+		t.Error("expected the 200KB event to be delivered intact; the scanner likely died with bufio.ErrTooLong before the fix (no .Buffer() call on the scanner)")
+	}
+	if !gotDone {
+		t.Error("expected the stream to survive the oversized event and still deliver the subsequent run.completed event; a dead scanner drops the rest of the run silently")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BUG 2 (P1): the client must reconnect using Last-Event-ID when the
+// connection drops mid-run, and must not duplicate or skip any event.
+// ---------------------------------------------------------------------------
+
+func TestSSEBridgeBug2_ReconnectsAndResumesWithLastEventID(t *testing.T) {
+	var mu sync.Mutex
+	connCount := 0
+	var secondReqLastEventID string
+	var secondReqSeen bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		connCount++
+		n := connCount
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		if n == 1 {
+			// First connection: deliver two events, then close the connection
+			// abruptly without ever sending run.completed/run.failed — this
+			// simulates the real-world "server dropped mid-stream" failure.
+			fmt.Fprint(w, "id: run-bug2:0\nevent: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":\"Hello\"}}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			fmt.Fprint(w, "id: run-bug2:1\nevent: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":\", world\"}}\n\n")
+			if flusher != nil {
+				flusher.Flush()
+			}
+			return
+		}
+
+		// Reconnect attempt: record the Last-Event-ID header the client sent,
+		// then deliver the remainder of the stream plus the terminal event.
+		mu.Lock()
+		secondReqLastEventID = r.Header.Get("Last-Event-ID")
+		secondReqSeen = true
+		mu.Unlock()
+
+		fmt.Fprint(w, "id: run-bug2:2\nevent: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":\"!\"}}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		fmt.Fprint(w, "id: run-bug2:3\nevent: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model := m2.(tui.Model)
+
+	model2, cmd := model.Update(tui.RunStartedMsg{RunID: "run-bug2"})
+	model = model2.(tui.Model)
+
+	final := driveModel(t, model, cmd, 15*time.Second, func(m tui.Model, msg tea.Msg) bool {
+		if done, ok := msg.(tui.SSEDoneMsg); ok && done.EventType == "run.completed" {
+			return true
+		}
+		// The unfixed client marks the run inactive as soon as the first
+		// (non-terminal) SSEDoneMsg arrives and never reconnects — stop as
+		// soon as that happens instead of waiting out the full timeout.
+		return !m.RunActive()
+	})
+
+	if final.LastAssistantText() != "Hello, world!" {
+		t.Errorf("expected assembled text to survive the reconnect intact, got %q, want %q (a naive reconnect without resume would re-deliver history and corrupt/duplicate this; no reconnect at all would truncate it)", final.LastAssistantText(), "Hello, world!")
+	}
+
+	mu.Lock()
+	gotSecondReq := secondReqSeen
+	gotHeader := secondReqLastEventID
+	mu.Unlock()
+
+	if !gotSecondReq {
+		t.Fatal("expected the bridge to automatically reconnect after the connection dropped mid-stream, but no second request was ever made")
+	}
+	if gotHeader != "run-bug2:1" {
+		t.Errorf("expected reconnect request to carry Last-Event-ID %q (the ID of the last event actually delivered), got %q", "run-bug2:1", gotHeader)
+	}
+	if final.RunActive() {
+		t.Error("expected the run to be inactive after run.completed arrives via the reconnected stream")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// BUG 3 (P1): real events must never be silently dropped under backpressure,
+// including tool.call.completed (which is why tool cards stayed stuck
+// in-progress) and tool.output.delta content (which corrupts accumulated
+// tool output).
+// ---------------------------------------------------------------------------
+
+func TestBridgeBug3_BurstDoesNotDropRealEventsUnderBackpressure(t *testing.T) {
+	const numDeltas = 900
+	const markerEvery = 150
+	const callID = "call-burst"
+
+	events := buildBurstEvents(numDeltas, markerEvery, callID)
+
+	var expectedContent strings.Builder
+	var expectedMarkers []string
+	for _, e := range events {
+		if e.deltaChunk != "" {
+			expectedContent.WriteString(e.deltaChunk)
+		}
+		if e.markerID != "" {
+			expectedMarkers = append(expectedMarkers, e.markerID)
+		}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		writeBurstEvents(w, events)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridge(ctx, srv.URL)
+	defer stop()
+
+	var gotContent strings.Builder
+	gotMarkers := map[string]bool{}
+	var gotDone bool
+	var corruptionWarnings int
+
+	for msg := range msgs {
+		// Simulate a slow consumer (e.g. heavy rendering) so the bridge's
+		// channel builds up backpressure, which is exactly the condition
+		// under which the non-blocking trySend used to drop messages.
+		time.Sleep(time.Millisecond)
+
+		switch m := msg.(type) {
+		case tui.SSEEventMsg:
+			switch m.EventType {
+			case "tool.output.delta":
+				var p struct {
+					CallID  string `json:"call_id"`
+					Content string `json:"content"`
+				}
+				if json.Unmarshal(m.Raw, &p) == nil && p.CallID == callID {
+					gotContent.WriteString(p.Content)
+				}
+			case "tool.call.completed":
+				var p struct {
+					CallID string `json:"call_id"`
+				}
+				if json.Unmarshal(m.Raw, &p) == nil {
+					gotMarkers[p.CallID] = true
+				}
+			}
+		case tui.SSEErrorMsg:
+			if strings.Contains(m.Err.Error(), "dropped") || strings.Contains(m.Err.Error(), "corrupt") {
+				corruptionWarnings++
+			}
+		case tui.SSEDoneMsg:
+			if m.EventType == "run.completed" {
+				gotDone = true
+			}
+		}
+	}
+
+	if gotContent.String() != expectedContent.String() {
+		t.Errorf("tool.output.delta content was lost or corrupted under backpressure: got %d bytes, want %d bytes", gotContent.Len(), expectedContent.Len())
+	}
+	missing := 0
+	for _, id := range expectedMarkers {
+		if !gotMarkers[id] {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Errorf("%d/%d tool.call.completed markers were dropped under backpressure — this is exactly what leaves tool cards stuck in-progress", missing, len(expectedMarkers))
+	}
+	if !gotDone {
+		t.Error("the terminal run.completed event was dropped under backpressure")
+	}
+	if corruptionWarnings > 0 {
+		t.Errorf("bridge reported %d 'dropped messages / stream corrupt' warning(s) under a burst; real events must never be dropped in the first place", corruptionWarnings)
+	}
+}


### PR DESCRIPTION
Fixes a bug hit during live testing: running `ls -laR` in a large repo produced a storm of `⚠ stream error: SSE bridge: too many dropped messages, stream may be corrupt` with tool cards stuck in-progress.

## Root causes (the error message was the symptom, not the disease)
- **Real events were being silently dropped (P1).** The bridge used a *non-blocking* send into a 256-slot channel. Under a burst of `tool.output.delta` lines, it discarded real events — including `tool.call.completed`, which is exactly why tool cards hung "in progress". Output chunks were dropped too, corrupting accumulated output. Now: blocking sends (backpressure applies to the HTTP body instead of destroying data), 1024-slot buffer, and consecutive deltas **coalesced per `call_id`** so a huge output doesn't drown the channel. Verified deadlock-free (`m.sseCh` is only read from an async `tea.Cmd`).
- **Oversized events killed the stream outright (P0).** `bufio.Scanner` with its default **64KB** line limit, but tool results can carry ~60KB+ and per-line output deltas up to 1MB → `ErrTooLong` silently ended the bridge goroutine for the rest of the run. Now a 4MB buffer + explicit `ErrTooLong` handling.
- **The client never reconnected (P1).** `StartSSEBridge` ran once per run and never parsed the SSE `id:` field — **even though the server already supported `Last-Event-ID` resume**. Any stream death mid-run was permanent. Now: bounded reconnect (5 attempts, 200ms→3s backoff) that resumes from the last event ID.

## Authentication (blocks the server-hardening PR)
While wiring auth onto the SSE stream we found the TUI sent **no `Authorization` header on *any* harnessd call** — not just SSE. Once #710 enforces auth, the TUI couldn't even start a run.

All ~16 harnessd requests (start-run, list, cancel, replay, continue, models, subagents, providers, profiles, conversations, ask-user, tool-approval, SSE) now authenticate through **one** `newHarnessRequest` helper — so the next endpoint can't be added without auth. A static regression test enforces that. The openrouter.ai call deliberately keeps its own **provider** key and never receives the harnessd key.

401/403/404 are treated as **permanent** (one clear message, no retry); 5xx and network drops keep the bounded retry.

## Verification
`go build ./cmd/harnesscli/...`, `go vet`, `go test ./cmd/harnesscli/... -race -count=2` — all 27 packages green. Tests assert **zero event loss** across a 900-delta burst with a slow consumer, and survival of a 1MB event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6