### PR TITLE
fix(tui): model switcher scroll lock, stale catalog, and invisible/colliding search

### DIFF
--- a/cmd/harnesscli/tui/components/modelswitcher/bugA_scroll_regression_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugA_scroll_regression_test.go
@@ -1,0 +1,73 @@
+package modelswitcher_test
+
+// Additional regression coverage for BUG A that exercises the two render
+// loops NOT covered by bugA_scroll_test.go's level-1 (viewModelsForProvider)
+// reproduction: the level-0 provider list (viewProviderList) and the flat
+// cross-provider search view (viewFlatModelList). All three loops had the
+// same independent "shrink windowEnd by up to two rows" duplication before
+// the fix, so a regression in any one of them would reintroduce the stuck
+// cursor for that specific view even if the other two remained correct.
+// These tests would fail if scrollWindow()/effectiveContentRows() stopped
+// being the single shared budget for all three render loops.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// manyProviderModels returns n synthetic models spread across n distinct
+// providers (one model each), so the provider list itself — not any single
+// provider's model list — is long enough to require scrolling.
+func manyProviderModels(n int) []modelswitcher.ServerModelEntry {
+	entries := make([]modelswitcher.ServerModelEntry, 0, n)
+	for i := 0; i < n; i++ {
+		entries = append(entries, modelswitcher.ServerModelEntry{
+			ID:       fmt.Sprintf("provmodel-%03d", i),
+			Provider: fmt.Sprintf("prov%03d", i),
+		})
+	}
+	return entries
+}
+
+// TestBugA_Regression_ProviderListCursorNeverLosesVisibility covers the
+// level-0 provider list scroll window (viewProviderList), which is a
+// separate render loop from the level-1 model list covered by
+// bugA_scroll_test.go.
+func TestBugA_Regression_ProviderListCursorNeverLosesVisibility(t *testing.T) {
+	const total = 50
+	m := modelswitcher.New("provmodel-000").
+		WithModels(manyProviderModels(total)).
+		Open().
+		WithMaxHeight(20)
+
+	for i := 0; i < total; i++ {
+		m = m.ProviderDown()
+		view := m.View(80)
+		if !strings.Contains(view, "> ") {
+			t.Fatalf("ProviderDown() press %d of %d: cursor marker '> ' missing from provider-list View():\n%s", i+1, total, view)
+		}
+	}
+}
+
+// TestBugA_Regression_SearchViewCursorNeverLosesVisibility covers the flat
+// cross-provider search view (viewFlatModelList), the third render loop
+// that independently duplicated the scroll-indicator reservation logic.
+func TestBugA_Regression_SearchViewCursorNeverLosesVisibility(t *testing.T) {
+	const total = 80
+	m := modelswitcher.New("test-model-000").
+		WithModels(longSyntheticModelList(total)).
+		Open().
+		WithMaxHeight(25).
+		SetSearch("test-model") // matches every synthetic entry -> flat search view
+
+	for i := 0; i < total; i++ {
+		m = m.SelectDown()
+		view := m.View(80)
+		if !strings.Contains(view, "> ") {
+			t.Fatalf("SelectDown() press %d of %d in search view: cursor marker '> ' missing from View():\n%s", i+1, total, view)
+		}
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/bugA_scroll_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugA_scroll_test.go
@@ -1,0 +1,110 @@
+package modelswitcher_test
+
+// Regression coverage for user-reported BUG A (P1): in a long model list the
+// highlighted cursor stops moving and never returns, while the "... N more
+// below" counter keeps ticking down on each keypress.
+//
+// Root cause: a scroll-window budget mismatch. model.go's
+// maxVisibleContentRows() computes one row budget, and adjustScroll() uses
+// that budget verbatim to decide when to shift scrollOffset. But each of the
+// three render loops in view.go independently shrinks the *rendered* window
+// by up to two rows to make room for the "... more above" / "... more below"
+// indicator lines. adjustScroll never learns about that shrinkage, so once
+// both indicators are showing, the selected row can fall permanently outside
+// the window actually rendered — freezing the visible cursor.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// longSyntheticModelList returns n synthetic server models all under a single
+// provider, so drilling into that provider produces a list far longer than
+// any reasonable terminal window.
+func longSyntheticModelList(n int) []modelswitcher.ServerModelEntry {
+	entries := make([]modelswitcher.ServerModelEntry, 0, n)
+	for i := 0; i < n; i++ {
+		entries = append(entries, modelswitcher.ServerModelEntry{
+			ID:       fmt.Sprintf("test-model-%03d", i),
+			Provider: "testprov",
+		})
+	}
+	return entries
+}
+
+// TestBugA_CursorNeverLosesVisibility_LongList is the required regression
+// test: with a list much longer than the window, call SelectDown()
+// repeatedly through the entire list and assert the "> " cursor marker is
+// present in View() output at EVERY step.
+func TestBugA_CursorNeverLosesVisibility_LongList(t *testing.T) {
+	const total = 80
+	m := modelswitcher.New("test-model-000").
+		WithModels(longSyntheticModelList(total)).
+		Open().
+		WithMaxHeight(30) // matches the MaxHeight used in the verified bug reproduction
+
+	provs := m.Providers()
+	if len(provs) != 1 {
+		t.Fatalf("test setup: expected exactly one synthetic provider, got %d: %+v", len(provs), provs)
+	}
+	m = m.DrillIntoProvider()
+
+	for i := 0; i < total; i++ {
+		m = m.SelectDown()
+		view := m.View(80)
+		if !strings.Contains(view, "> ") {
+			t.Fatalf("SelectDown() press %d of %d: cursor marker '> ' missing from View() — cursor is stuck/invisible:\n%s", i+1, total, view)
+		}
+	}
+}
+
+// TestBugA_SelectUpFromZeroWrapsAndStaysVisible verifies that SelectUp() from
+// index 0 wraps around to the last entry and that entry remains visible
+// (rather than landing outside the rendered scroll window).
+func TestBugA_SelectUpFromZeroWrapsAndStaysVisible(t *testing.T) {
+	const total = 80
+	m := modelswitcher.New("test-model-000").
+		WithModels(longSyntheticModelList(total)).
+		Open().
+		WithMaxHeight(30)
+
+	m = m.DrillIntoProvider() // Selected == 0
+
+	m = m.SelectUp() // wraps to the last entry (index total-1)
+	view := m.View(80)
+	if !strings.Contains(view, "> ") {
+		t.Fatalf("SelectUp() wrap from index 0 to last entry: cursor marker '> ' missing from View():\n%s", view)
+	}
+}
+
+// TestBugA_ScrollBudgetSharedBetweenModelAndView is a narrower reproduction
+// of the reported symptom: at the exact MaxHeight from the bug report, once
+// both scroll indicators are showing, continuing to press SelectDown() must
+// never leave the cursor stuck at the same rendered position while the
+// "more below" counter keeps changing.
+func TestBugA_ScrollBudgetSharedBetweenModelAndView(t *testing.T) {
+	const total = 60
+	m := modelswitcher.New("test-model-000").
+		WithModels(longSyntheticModelList(total)).
+		Open().
+		WithMaxHeight(30)
+	m = m.DrillIntoProvider()
+
+	sawBothIndicators := false
+	for i := 0; i < total-1; i++ {
+		m = m.SelectDown()
+		view := m.View(80)
+		if strings.Contains(view, "more above") && strings.Contains(view, "more below") {
+			sawBothIndicators = true
+		}
+		if !strings.Contains(view, "> ") {
+			t.Fatalf("press %d: cursor vanished from view (both indicators seen so far: %v):\n%s", i+1, sawBothIndicators, view)
+		}
+	}
+	if !sawBothIndicators {
+		t.Fatalf("test setup did not exercise the both-indicators-showing case that triggers the bug; adjust total/MaxHeight")
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/bugB_catalog_sync_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugB_catalog_sync_test.go
@@ -1,0 +1,140 @@
+package modelswitcher_test
+
+// Regression coverage for user-reported BUG B (P2): the client-side model
+// switcher shows a stale model set.
+//
+// DefaultModels is the hardcoded client fallback shown by New() and whenever
+// the live GET /v1/models fetch has not yet completed or has failed. It had
+// drifted from catalog/models.json — e.g. only listing gpt-4.1 and
+// gpt-4.1-mini for OpenAI while the canonical catalog already contains
+// gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5.1-codex-max, gpt-5.2-codex,
+// gpt-5.3-codex, and computer-use-preview.
+//
+// TestBugB_DefaultModelsMatchesCatalog fails whenever DefaultModels drifts
+// from catalog/models.json again for the "built-in" providers (the ones
+// DefaultModels hardcodes as an offline fallback). This is the safety net
+// requested when full build-time generation from the catalog would be an
+// invasive build-tooling change (out of scope for this fix).
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// catalogFile mirrors just the fields of catalog/models.json needed to check
+// DefaultModels for drift.
+type catalogFile struct {
+	Providers map[string]struct {
+		DisplayName string `json:"display_name"`
+		Models      map[string]struct {
+			DisplayName string `json:"display_name"`
+		} `json:"models"`
+	} `json:"providers"`
+}
+
+// builtInSyncProviders are the provider keys DefaultModels hardcodes as an
+// offline/client-side fallback. OpenRouter, Together, Ollama, and LM Studio
+// entries are always fetched live (or are local-only) and are intentionally
+// excluded from this drift check.
+var builtInSyncProviders = map[string]bool{
+	"openai":    true,
+	"anthropic": true,
+	"gemini":    true,
+	"deepseek":  true,
+	"xai":       true,
+	"groq":      true,
+	"qwen":      true,
+	"kimi":      true,
+}
+
+// catalogPath is relative to this package directory
+// (cmd/harnesscli/tui/components/modelswitcher) up to the repo root.
+const catalogPath = "../../../../../catalog/models.json"
+
+func loadCatalog(t *testing.T) catalogFile {
+	t.Helper()
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", catalogPath, err)
+	}
+	var cat catalogFile
+	if err := json.Unmarshal(data, &cat); err != nil {
+		t.Fatalf("parsing %s: %v", catalogPath, err)
+	}
+	return cat
+}
+
+// TestBugB_DefaultModelsMatchesCatalog fails whenever the hardcoded
+// client-side DefaultModels fallback drifts from catalog/models.json for the
+// built-in providers, in either direction (catalog has a model DefaultModels
+// is missing, or DefaultModels has a stale model no longer in the catalog).
+func TestBugB_DefaultModelsMatchesCatalog(t *testing.T) {
+	cat := loadCatalog(t)
+
+	fallback := make(map[string]map[string]string) // provider -> id -> displayName
+	for _, dm := range modelswitcher.DefaultModels {
+		if fallback[dm.Provider] == nil {
+			fallback[dm.Provider] = make(map[string]string)
+		}
+		fallback[dm.Provider][dm.ID] = dm.DisplayName
+	}
+
+	// Catalog -> DefaultModels: every built-in-provider catalog model must be
+	// present in DefaultModels with a matching display name.
+	for provider, pdata := range cat.Providers {
+		if !builtInSyncProviders[provider] {
+			continue
+		}
+		for id, cm := range pdata.Models {
+			got, ok := fallback[provider][id]
+			if !ok {
+				t.Errorf("DefaultModels is missing catalog model %q for provider %q (display_name %q) — client fallback is stale",
+					id, provider, cm.DisplayName)
+				continue
+			}
+			if got != cm.DisplayName {
+				t.Errorf("DefaultModels[%q].DisplayName = %q, catalog/models.json says %q", id, got, cm.DisplayName)
+			}
+		}
+	}
+
+	// DefaultModels -> catalog: every built-in-provider DefaultModels entry
+	// must still exist in the catalog (no dead models lingering client-side).
+	for provider := range builtInSyncProviders {
+		catModels := cat.Providers[provider].Models
+		for id := range fallback[provider] {
+			if _, ok := catModels[id]; !ok {
+				t.Errorf("DefaultModels has model %q for provider %q that no longer exists in catalog/models.json", id, provider)
+			}
+		}
+	}
+}
+
+// TestBugB_OpenAIFallbackIncludesCodexModels is a narrower, human-readable
+// reproduction of the originally reported symptom: the OpenAI section of the
+// client fallback listed only gpt-4.1 / gpt-4.1-mini, hiding every 5.x codex
+// model already present in the canonical catalog.
+func TestBugB_OpenAIFallbackIncludesCodexModels(t *testing.T) {
+	want := []string{
+		"gpt-5.1-codex",
+		"gpt-5.1-codex-mini",
+		"gpt-5.1-codex-max",
+		"gpt-5.2-codex",
+		"gpt-5.3-codex",
+		"computer-use-preview",
+	}
+	got := make(map[string]bool)
+	for _, dm := range modelswitcher.DefaultModels {
+		if dm.Provider == "openai" {
+			got[dm.ID] = true
+		}
+	}
+	for _, id := range want {
+		if !got[id] {
+			t.Errorf("DefaultModels (OpenAI) is missing %q — offline fallback is stale relative to catalog/models.json", id)
+		}
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/bugB_offline_marker_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugB_offline_marker_test.go
@@ -1,0 +1,76 @@
+package modelswitcher_test
+
+// Second half of BUG B (P2): when the live GET /v1/models fetch fails,
+// ModelsFetchErrorMsg only set a loadError string. At browseLevel==0 and in
+// the flat search view, an error replaces the entire list — that already
+// makes the failure obvious. But at browseLevel==1 (drilled into a specific
+// provider) view.go's viewModelsForProvider never looked at loadError at
+// all, so a user who had already drilled in (or drills in after the error
+// arrives) kept browsing the stale DefaultModels list with zero indication
+// it wasn't live data.
+
+import (
+	"strings"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// TestBugB_Level1ShowsOfflineMarkerOnLoadError verifies that once a fetch
+// error is recorded, browsing a provider's model list (level 1) still works
+// (the fallback list remains usable) but is visibly marked as offline/stale
+// so it can't be mistaken for freshly fetched data.
+func TestBugB_Level1ShowsOfflineMarkerOnLoadError(t *testing.T) {
+	m := modelswitcher.New("gpt-4.1").Open()
+
+	provs := m.Providers()
+	found := false
+	for i := range provs {
+		if provs[i].Label == "OpenAI" {
+			for m.ProviderCursorIndex() != i {
+				m = m.ProviderDown()
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("test setup: OpenAI provider not found")
+	}
+	m = m.DrillIntoProvider()
+	m = m.SetLoadError("Error loading models: connection refused")
+
+	v := m.View(80)
+
+	// The fallback list must still be usable/browsable.
+	if !strings.Contains(v, "GPT-4.1") {
+		t.Errorf("level-1 view should still show the fallback model list when a background fetch fails:\n%s", v)
+	}
+	// ...but must be visibly marked as offline/stale so it is never
+	// indistinguishable from a successful live fetch.
+	if !strings.Contains(v, "offline") {
+		t.Errorf("level-1 view should visibly mark the list as an offline/stale fallback on fetch error:\n%s", v)
+	}
+}
+
+// TestBugB_Level1NoOfflineMarkerWhenNoError is the inverse regression check:
+// when there is no load error, the offline marker must not appear (it would
+// be misleading noise on a successful live fetch).
+func TestBugB_Level1NoOfflineMarkerWhenNoError(t *testing.T) {
+	m := modelswitcher.New("gpt-4.1").Open()
+	provs := m.Providers()
+	for i := range provs {
+		if provs[i].Label == "OpenAI" {
+			for m.ProviderCursorIndex() != i {
+				m = m.ProviderDown()
+			}
+			break
+		}
+	}
+	m = m.DrillIntoProvider()
+
+	v := m.View(80)
+	if strings.Contains(v, "offline") {
+		t.Errorf("level-1 view should not show an offline marker when there is no load error:\n%s", v)
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/bugB_regression_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugB_regression_test.go
@@ -1,0 +1,44 @@
+package modelswitcher_test
+
+// Additional regression coverage for BUG B: guards a detail the primary
+// drift test (bugB_catalog_sync_test.go) does not check, since catalog/
+// models.json has no dedicated "reasoning effort" field to compare against.
+// ModelEntry.ReasoningMode is set by hand in DefaultModels and by
+// reasoningModelIDs when enriching server-fetched entries; hand-editing
+// DefaultModels to sync display names/new models (as the BUG B fix did) is
+// exactly the kind of change that could accidentally drop a ReasoningMode:
+// true flag on an existing entry. This test would fail if that happened.
+
+import (
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// TestBugB_Regression_ReasoningModelsRetainFlagAfterSync verifies that the
+// known reasoning-capable models still have ReasoningMode == true in
+// DefaultModels after the catalog sync.
+func TestBugB_Regression_ReasoningModelsRetainFlagAfterSync(t *testing.T) {
+	wantReasoning := map[string]bool{
+		"deepseek-reasoner":       true,
+		"grok-4-1-fast-reasoning": true,
+		"qwen-qwq-32b":            true,
+	}
+
+	found := make(map[string]bool)
+	for _, dm := range modelswitcher.DefaultModels {
+		if want, ok := wantReasoning[dm.ID]; ok {
+			found[dm.ID] = true
+			if dm.ReasoningMode != want {
+				t.Errorf("DefaultModels[%q].ReasoningMode = %v, want %v", dm.ID, dm.ReasoningMode, want)
+			}
+		} else if dm.ReasoningMode {
+			t.Errorf("DefaultModels[%q].ReasoningMode = true unexpectedly (not in the known reasoning-model set)", dm.ID)
+		}
+	}
+	for id := range wantReasoning {
+		if !found[id] {
+			t.Errorf("expected reasoning model %q not found in DefaultModels at all", id)
+		}
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/bugC_search_test.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/bugC_search_test.go
@@ -1,0 +1,131 @@
+package modelswitcher_test
+
+// Regression coverage for user-reported BUG C (P2): "search is invisible and
+// collides with the star key".
+//
+// (1) The footer advertises "/ search" but '/' was a dead key — nothing in
+//     the component or in tui/model.go ever entered a discoverable search
+//     mode. Search only "worked" by accident: any other printable rune fell
+//     through to HandleSearchKey.
+// (2) At browse level 1 with no active search, 's' toggles star, so typing a
+//     query like "sonnet" starred the highlighted model on the very first
+//     keystroke instead of starting a query.
+// (3) Search used plain substring matching only, which is poor for large
+//     catalogs (OpenRouter has 300+ models) — a query like "gp4m" for
+//     "gpt-4.1-mini" would find nothing.
+//
+// This file covers the component-level pieces of the fix: EnterSearch() /
+// SearchActive() as an explicit, discoverable search-mode signal, and
+// improved (fuzzy/subsequence) match ranking. The '/' key wiring and the
+// s/star disambiguation live in tui/model.go and are covered by
+// cmd/harnesscli/tui/model_bugC_search_test.go.
+
+import (
+	"strings"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+)
+
+// TestBugC_EnterSearchActivatesFlatViewEvenWithEmptyQuery verifies that
+// EnterSearch() makes the search UI visible (SearchActive() true, and the
+// "Filter:" search bar rendered) even before the user has typed a single
+// character. Today there is no way to reach this state at all — the only
+// way search becomes visible is by accident, once SearchQuery() is already
+// non-empty.
+func TestBugC_EnterSearchActivatesFlatViewEvenWithEmptyQuery(t *testing.T) {
+	m := modelswitcher.New("gpt-4.1").Open()
+	if m.SearchActive() {
+		t.Fatal("precondition: SearchActive() should be false before EnterSearch()")
+	}
+
+	m2 := m.EnterSearch()
+	if !m2.SearchActive() {
+		t.Error("EnterSearch() should set SearchActive() to true")
+	}
+	if m2.SearchQuery() != "" {
+		t.Errorf("EnterSearch() should not itself add any text to the query, got %q", m2.SearchQuery())
+	}
+
+	v := m2.View(80)
+	if !strings.Contains(v, "Filter:") {
+		t.Errorf("View() after EnterSearch() should render the 'Filter:' search bar even with an empty query:\n%s", v)
+	}
+}
+
+// TestBugC_SetSearchEmptyClearsSearchActive verifies that clearing the query
+// back to "" (e.g. via Escape in tui/model.go, which calls SetSearch(""))
+// also exits explicit search mode, so browsing returns to the normal
+// provider/model list view instead of leaving an empty, orphaned search bar.
+func TestBugC_SetSearchEmptyClearsSearchActive(t *testing.T) {
+	m := modelswitcher.New("gpt-4.1").Open().EnterSearch().SetSearch("claude")
+	if !m.SearchActive() {
+		t.Fatal("precondition: SearchActive() should be true while a query is set")
+	}
+
+	m2 := m.SetSearch("")
+	if m2.SearchActive() {
+		t.Error("SetSearch(\"\") should clear SearchActive()")
+	}
+}
+
+// TestBugC_MatchRanking_ExactPrefixSubstringFuzzy verifies the requested
+// match-quality ordering (exact > prefix > substring/fuzzy) and that a
+// subsequence ("fuzzy") match is surfaced at all — previously an entry that
+// matched only as a non-contiguous subsequence was excluded from results
+// entirely, which is the core complaint for large catalogs like OpenRouter.
+func TestBugC_MatchRanking_ExactPrefixSubstringFuzzy(t *testing.T) {
+	entries := []modelswitcher.ServerModelEntry{
+		// Fuzzy: "gpt" appears as a subsequence (g_p_t) but not contiguously,
+		// and its DisplayName has no relation to the query.
+		{ID: "zzz-gxpxtx", Provider: "synth", DisplayName: "BBB Fuzzy"},
+		// Substring: "gpt" appears mid-string but not as a prefix.
+		{ID: "xxgptxx", Provider: "synth", DisplayName: "MMM Substring"},
+		// Prefix: ID starts with "gpt" but is not an exact match. DisplayName
+		// is deliberately alphabetically EARLIER than the exact entry's, so a
+		// pass that only used alphabetical/DisplayName ordering (rather than
+		// real match-quality tiering) would rank this ahead of the exact
+		// match — which must not happen.
+		{ID: "gpt-turbo", Provider: "synth", DisplayName: "AAA Prefix"},
+		// Exact: ID is exactly the query.
+		{ID: "gpt", Provider: "synth", DisplayName: "ZZZ Exact"},
+	}
+
+	m := modelswitcher.New("gpt").WithModels(entries).Open().EnterSearch().SetSearch("gpt")
+
+	var order []string
+	cur := m
+	for i := 0; i < len(entries); i++ {
+		e, _ := cur.Accept()
+		order = append(order, e.ID)
+		cur = cur.SelectDown()
+	}
+
+	want := []string{"gpt", "gpt-turbo", "xxgptxx", "zzz-gxpxtx"}
+	if len(order) != len(want) {
+		t.Fatalf("visible result count = %d, want %d; order=%v", len(order), len(want), order)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Errorf("result[%d] = %q, want %q (full order: %v)", i, order[i], want[i], order)
+		}
+	}
+}
+
+// TestBugC_FuzzyMatchFindsNonContiguousSubsequence is a narrower,
+// human-readable reproduction of the autocomplete complaint: a query typed
+// as an abbreviation (letters in order, not contiguous) should still surface
+// the model it identifies, which matters most for a 300+ entry list like
+// OpenRouter's.
+func TestBugC_FuzzyMatchFindsNonContiguousSubsequence(t *testing.T) {
+	entries := []modelswitcher.ServerModelEntry{
+		{ID: "openai/gpt-4.1-mini", Provider: "openrouter", DisplayName: "GPT-4.1 Mini (via OpenRouter)"},
+		{ID: "anthropic/claude-opus-4-6", Provider: "openrouter", DisplayName: "Claude Opus 4.6 (via OpenRouter)"},
+	}
+	m := modelswitcher.New("openai/gpt-4.1-mini").WithModels(entries).Open().EnterSearch().SetSearch("gp4m")
+
+	entry, _ := m.Accept()
+	if entry.ID != "openai/gpt-4.1-mini" {
+		t.Errorf("fuzzy query 'gp4m' should surface openai/gpt-4.1-mini, got %q", entry.ID)
+	}
+}

--- a/cmd/harnesscli/tui/components/modelswitcher/model.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/model.go
@@ -287,22 +287,75 @@ func (m Model) adjustProviderScroll(total int) Model {
 	return m
 }
 
+// effectiveContentRows returns the number of item rows that can actually be
+// rendered within maxVisible once room for the "... N more above/below"
+// scroll indicator lines is set aside. This is the single source of truth
+// for the render-window budget: adjustScroll() (below) and every render loop
+// in view.go call scrollWindow(), which is built on this same function, so
+// the budget used to decide *when* to scroll and the budget used to decide
+// *what* to render can never drift apart again.
+//
+// Bug history: view.go used to shrink its own rendered window independently
+// (by up to two rows) whenever the "above"/"below" indicators were shown,
+// but adjustScroll() never learned about that shrinkage. Once both
+// indicators were showing at once, the selected row could fall permanently
+// outside the window actually rendered, freezing the visible cursor while
+// the "... N more below" counter kept changing on every keypress.
+//
+// The reservation here is deterministic — it depends only on whether the
+// list overflows the window at all (total > maxVisible), never on the
+// current scroll offset — so it cannot oscillate as the user scrolls. When
+// the list fits without scrolling, no rows are reserved (no indicators are
+// ever shown). When it doesn't fit, two rows are always reserved, even at
+// the very top or bottom of the list where only one indicator actually
+// renders; that trades a little density at the extremes for a budget that
+// can never point the render window past where the cursor is.
+func effectiveContentRows(total, maxVisible int) int {
+	if total <= maxVisible {
+		return maxVisible
+	}
+	reserved := maxVisible - 2
+	if reserved < 1 {
+		reserved = 1
+	}
+	return reserved
+}
+
+// scrollWindow computes the render window for a scrollable list: the
+// half-open [start, end) slice of the underlying list to render, and
+// whether the "more above" / "more below" indicators should be shown. Every
+// render loop in view.go calls this instead of independently shrinking its
+// own window, so the rendered window always agrees with the budget
+// adjustScroll() used to position scrollOffset.
+func scrollWindow(offset, total, maxVisible int) (start, end int, showAbove, showBelow bool) {
+	content := effectiveContentRows(total, maxVisible)
+	start = offset
+	end = start + content
+	if end > total {
+		end = total
+	}
+	showAbove = start > 0
+	showBelow = end < total
+	return start, end, showAbove, showBelow
+}
+
 // adjustScroll ensures the selected index is visible within the scroll window.
 // Follows the pattern from profilepicker/model.go.
 func adjustScroll(offset, selected, total, maxVisible int) int {
-	if total <= maxVisible {
+	content := effectiveContentRows(total, maxVisible)
+	if total <= content {
 		return 0
 	}
 	// Scroll down if selected moved below visible window.
-	if selected >= offset+maxVisible {
-		offset = selected - maxVisible + 1
+	if selected >= offset+content {
+		offset = selected - content + 1
 	}
 	// Scroll up if selected moved above visible window.
 	if selected < offset {
 		offset = selected
 	}
 	// Clamp offset to valid range.
-	maxOffset := total - maxVisible
+	maxOffset := total - content
 	if offset > maxOffset {
 		offset = maxOffset
 	}

--- a/cmd/harnesscli/tui/components/modelswitcher/model.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/model.go
@@ -211,6 +211,17 @@ type Model struct {
 	// providerScrollOffset tracks the starting index of the visible window
 	// in the provider list (level 0).
 	providerScrollOffset int
+
+	// searchActive is true once search mode has been explicitly entered
+	// (via EnterSearch(), wired to the "/" key in tui/model.go), even
+	// before any character has been typed. searchQuery != "" always
+	// implies search is active too (see SearchActive()); this flag exists
+	// so pressing "/" makes the search UI (and the flat cross-provider
+	// list) visible immediately, and so the FIRST keystroke afterwards —
+	// including keys like "s" that otherwise toggle star or "j"/"k" that
+	// otherwise navigate — is treated as a literal query character rather
+	// than a browse-level shortcut.
+	searchActive bool
 }
 
 // New constructs a Model pre-loaded with DefaultModels, marking the entry
@@ -262,6 +273,7 @@ func (m Model) Close() Model {
 	m.IsOpen = false
 	m.reasoningMode = false
 	m.searchQuery = ""
+	m.searchActive = false
 	m.browseLevel = 0
 	m.activeProvider = ""
 	m.providerCursor = 0
@@ -484,23 +496,82 @@ func (m Model) modelsForActiveProvider() []ModelEntry {
 	return result
 }
 
+// matchTier ranks how well a query matched a field, best (lowest) first.
+type matchTier int
+
+const (
+	matchTierNone matchTier = iota - 1 // no match at all
+	matchTierExact
+	matchTierPrefix
+	matchTierSubstring
+	matchTierFuzzy // non-contiguous subsequence match
+)
+
+// bestMatchTier returns the best (lowest) matchTier across fields for query
+// q, or matchTierNone if q doesn't match any field at all. Callers pass
+// already-lowercased fields and q.
+func bestMatchTier(fields []string, q string) matchTier {
+	best := matchTierNone
+	for _, f := range fields {
+		var tier matchTier
+		switch {
+		case f == q:
+			tier = matchTierExact
+		case strings.HasPrefix(f, q):
+			tier = matchTierPrefix
+		case strings.Contains(f, q):
+			tier = matchTierSubstring
+		case isFuzzySubsequence(f, q):
+			tier = matchTierFuzzy
+		default:
+			continue
+		}
+		if best == matchTierNone || tier < best {
+			best = tier
+		}
+	}
+	return best
+}
+
+// isFuzzySubsequence reports whether every rune of q appears in f in order,
+// not necessarily contiguously (a "subsequence" match). This is the
+// last-resort autocomplete tier for large catalogs — e.g. OpenRouter's 300+
+// models — where a query like "gp4m" should still surface
+// "openai/gpt-4.1-mini" even though it is not a literal substring.
+func isFuzzySubsequence(f, q string) bool {
+	if q == "" {
+		return false
+	}
+	qr := []rune(q)
+	qi := 0
+	for _, r := range f {
+		if qi < len(qr) && r == qr[qi] {
+			qi++
+		}
+	}
+	return qi == len(qr)
+}
+
 // visibleModels returns the filtered + ordered model list.
-// - When searchQuery != "": flat cross-provider list filtered by query.
-// - When browseLevel == 1: models filtered to activeProvider only.
+// - When searchActive (query non-empty, or explicit EnterSearch()): flat
+//   cross-provider list filtered by query.
+// - When browseLevel == 1 and search is not active: models filtered to
+//   activeProvider only.
 // - When browseLevel == 0: all models (for Accept() compatibility).
 // Starred models appear first in all cases, filtered by searchQuery.
 // IsCurrent is set dynamically based on currentModelID.
 //
-// Search matches across DisplayName, ProviderLabel, Provider key, and model ID.
-// Results are ranked: prefix matches before substring matches, with starred
-// models first within each tier. This ensures queries like "d" or "de" surface
-// DeepSeek models ahead of e.g. Anthropic models that merely contain "d"/"de"
-// in their DisplayName.
+// Search matches across DisplayName, ProviderLabel, Provider key, and model
+// ID. Results are ranked exact > prefix > substring > fuzzy (non-contiguous
+// subsequence), with starred models first within each tier. This ensures
+// queries like "d" or "de" surface DeepSeek models ahead of e.g. Anthropic
+// models that merely contain "d"/"de" in their DisplayName, and abbreviated
+// queries like "gp4m" still surface a result instead of finding nothing.
 func (m Model) visibleModels() []ModelEntry {
 	q := strings.ToLower(m.searchQuery)
 
-	// When in level 1 with no search: return filtered-to-provider list (starred first).
-	if m.browseLevel == 1 && q == "" {
+	// When in level 1 with no active search: return filtered-to-provider list (starred first).
+	if m.browseLevel == 1 && q == "" && !m.searchActive {
 		providerModels := m.modelsForActiveProvider()
 		var starred, rest []ModelEntry
 		for _, e := range providerModels {
@@ -514,9 +585,8 @@ func (m Model) visibleModels() []ModelEntry {
 	}
 
 	// For browseLevel==0 OR search active: use full model list (with search filter when active).
-	// Search matches against DisplayName, ProviderLabel, Provider key, and model ID.
-	// Rank: prefix matches first (starred, then rest), then substring matches (starred, then rest).
-	var prefixStarred, prefixRest, substrStarred, substrRest []ModelEntry
+	var exactStarred, exactRest, prefixStarred, prefixRest []ModelEntry
+	var substrStarred, substrRest, fuzzyStarred, fuzzyRest []ModelEntry
 	for _, e := range m.Models {
 		e.IsCurrent = e.ID == m.currentModelID
 		if q != "" {
@@ -526,55 +596,57 @@ func (m Model) visibleModels() []ModelEntry {
 				strings.ToLower(e.Provider),
 				strings.ToLower(e.ID),
 			}
-			matched := false
-			isPrefix := false
-			for _, f := range queryFields {
-				if strings.HasPrefix(f, q) {
-					matched = true
-					isPrefix = true
-					break
-				}
-			}
-			if !isPrefix {
-				for _, f := range queryFields {
-					if strings.Contains(f, q) {
-						matched = true
-						break
-					}
-				}
-			}
-			if !matched {
+			tier := bestMatchTier(queryFields, q)
+			if tier == matchTierNone {
 				continue
 			}
 			starred := m.starred[e.ID]
-			if isPrefix {
+			switch tier {
+			case matchTierExact:
+				if starred {
+					exactStarred = append(exactStarred, e)
+				} else {
+					exactRest = append(exactRest, e)
+				}
+			case matchTierPrefix:
 				if starred {
 					prefixStarred = append(prefixStarred, e)
 				} else {
 					prefixRest = append(prefixRest, e)
 				}
-			} else {
+			case matchTierSubstring:
 				if starred {
 					substrStarred = append(substrStarred, e)
 				} else {
 					substrRest = append(substrRest, e)
 				}
+			case matchTierFuzzy:
+				if starred {
+					fuzzyStarred = append(fuzzyStarred, e)
+				} else {
+					fuzzyRest = append(fuzzyRest, e)
+				}
 			}
 		} else {
-			// No search query: preserve original order.
+			// No search query (browsing with search mode merely armed via
+			// EnterSearch(), no characters typed yet): preserve original order.
 			if m.starred[e.ID] {
-				prefixStarred = append(prefixStarred, e) // reuse prefixStarred for starred
+				exactStarred = append(exactStarred, e) // reuse exactStarred for starred
 			} else {
-				prefixRest = append(prefixRest, e) // reuse prefixRest for rest
+				exactRest = append(exactRest, e) // reuse exactRest for rest
 			}
 		}
 	}
 	// Concatenate in priority order.
 	var result []ModelEntry
+	result = append(result, exactStarred...)
+	result = append(result, exactRest...)
 	result = append(result, prefixStarred...)
 	result = append(result, prefixRest...)
 	result = append(result, substrStarred...)
 	result = append(result, substrRest...)
+	result = append(result, fuzzyStarred...)
+	result = append(result, fuzzyRest...)
 	return result
 }
 
@@ -952,12 +1024,39 @@ func (m Model) HandleSearchKey(key string) Model {
 }
 
 // SetSearch sets the search query and resets Selected and scroll offset to 0.
+// Setting a non-empty query implies search mode is active. Clearing the
+// query back to "" also exits explicit search mode (mirrors pressing
+// Escape / backspacing an empty query) so callers don't have to separately
+// track search-active state.
 func (m Model) SetSearch(q string) Model {
 	result := m
 	result.searchQuery = q
+	result.searchActive = q != ""
 	result.Selected = 0
 	result.scrollOffset = 0
 	return result
+}
+
+// EnterSearch explicitly activates search mode (wired to the "/" key in
+// tui/model.go), even before any character has been typed. This makes the
+// search UI (the flat cross-provider list with the "Filter:" bar)
+// discoverable and visible immediately, and — critically — means the very
+// first keystroke afterwards is routed as a literal query character rather
+// than a browse-level shortcut (fixes the "typing 'sonnet' stars the
+// highlighted model on the leading 's'" collision).
+func (m Model) EnterSearch() Model {
+	result := m
+	result.searchActive = true
+	result.Selected = 0
+	result.scrollOffset = 0
+	return result
+}
+
+// SearchActive reports whether search mode is active — either because a
+// query has been typed (SearchQuery() != "") or because EnterSearch() was
+// called explicitly (e.g. via "/") and no character has been typed yet.
+func (m Model) SearchActive() bool {
+	return m.searchActive || m.searchQuery != ""
 }
 
 // SearchQuery returns the current search query.

--- a/cmd/harnesscli/tui/components/modelswitcher/model.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/model.go
@@ -20,11 +20,25 @@ type ModelEntry struct {
 	Available bool
 }
 
-// DefaultModels is the list of available models shown by New(), grouped by provider.
+// DefaultModels is the list of available models shown by New(), grouped by
+// provider. This is the offline/client-side fallback shown whenever the live
+// GET /v1/models fetch has not yet completed or has failed, so it must be
+// kept in sync with catalog/models.json for every "built-in" provider (see
+// bugB_catalog_sync_test.go, which fails on drift). Entries below mirror
+// catalog/models.json's display_name field exactly for these providers:
+// openai, anthropic, gemini, deepseek, xai, groq, qwen, kimi. OpenRouter and
+// Together models are always fetched live and are intentionally not
+// hardcoded here.
 var DefaultModels = []ModelEntry{
 	// OpenAI
 	{ID: "gpt-4.1", DisplayName: "GPT-4.1", Provider: "openai", ProviderLabel: "OpenAI"},
 	{ID: "gpt-4.1-mini", DisplayName: "GPT-4.1 Mini", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "gpt-5.1-codex", DisplayName: "GPT-5.1 Codex", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "gpt-5.1-codex-mini", DisplayName: "GPT-5.1 Codex Mini", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "gpt-5.1-codex-max", DisplayName: "GPT-5.1 Codex Max", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "gpt-5.2-codex", DisplayName: "GPT-5.2 Codex", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "gpt-5.3-codex", DisplayName: "GPT-5.3 Codex", Provider: "openai", ProviderLabel: "OpenAI"},
+	{ID: "computer-use-preview", DisplayName: "Computer Use Preview", Provider: "openai", ProviderLabel: "OpenAI"},
 	// Anthropic
 	{ID: "claude-sonnet-4-6", DisplayName: "Claude Sonnet 4.6", Provider: "anthropic", ProviderLabel: "Anthropic"},
 	{ID: "claude-opus-4-6", DisplayName: "Claude Opus 4.6", Provider: "anthropic", ProviderLabel: "Anthropic"},
@@ -32,15 +46,18 @@ var DefaultModels = []ModelEntry{
 	// Google
 	{ID: "gemini-2.5-flash", DisplayName: "Gemini 2.5 Flash", Provider: "gemini", ProviderLabel: "Google"},
 	{ID: "gemini-2.0-flash", DisplayName: "Gemini 2.0 Flash", Provider: "gemini", ProviderLabel: "Google"},
+	{ID: "gemini-2.5-flash-preview-04-17", DisplayName: "Gemini 2.5 Flash Preview", Provider: "gemini", ProviderLabel: "Google"},
 	// DeepSeek
-	{ID: "deepseek-chat", DisplayName: "DeepSeek Chat", Provider: "deepseek", ProviderLabel: "DeepSeek"},
-	{ID: "deepseek-reasoner", DisplayName: "DeepSeek Reasoner", Provider: "deepseek", ProviderLabel: "DeepSeek", ReasoningMode: true},
+	{ID: "deepseek-chat", DisplayName: "DeepSeek Chat (V3)", Provider: "deepseek", ProviderLabel: "DeepSeek"},
+	{ID: "deepseek-reasoner", DisplayName: "DeepSeek Reasoner (R1)", Provider: "deepseek", ProviderLabel: "DeepSeek", ReasoningMode: true},
+	{ID: "deepseek-v4-pro", DisplayName: "DeepSeek V4 Pro (direct)", Provider: "deepseek", ProviderLabel: "DeepSeek"},
+	{ID: "deepseek-v4-flash", DisplayName: "DeepSeek V4 Flash (direct)", Provider: "deepseek", ProviderLabel: "DeepSeek"},
 	// xAI
 	{ID: "grok-3-mini", DisplayName: "Grok 3 Mini", Provider: "xai", ProviderLabel: "xAI"},
-	{ID: "grok-4-1-fast-reasoning", DisplayName: "Grok 4.1 Fast", Provider: "xai", ProviderLabel: "xAI", ReasoningMode: true},
+	{ID: "grok-4-1-fast-reasoning", DisplayName: "Grok 4.1 Fast Reasoning", Provider: "xai", ProviderLabel: "xAI", ReasoningMode: true},
 	// Groq
-	{ID: "llama-3.3-70b-versatile", DisplayName: "Llama 3.3 70B", Provider: "groq", ProviderLabel: "Groq"},
-	{ID: "qwen-qwq-32b", DisplayName: "QwQ 32B", Provider: "groq", ProviderLabel: "Groq", ReasoningMode: true},
+	{ID: "llama-3.3-70b-versatile", DisplayName: "Llama 3.3 70B Versatile", Provider: "groq", ProviderLabel: "Groq"},
+	{ID: "qwen-qwq-32b", DisplayName: "Qwen QwQ 32B", Provider: "groq", ProviderLabel: "Groq", ReasoningMode: true},
 	// Qwen
 	{ID: "qwen-plus", DisplayName: "Qwen Plus", Provider: "qwen", ProviderLabel: "Qwen"},
 	{ID: "qwen-turbo", DisplayName: "Qwen Turbo", Provider: "qwen", ProviderLabel: "Qwen"},
@@ -49,24 +66,34 @@ var DefaultModels = []ModelEntry{
 }
 
 // modelDisplayNames maps model ID to human-readable display name.
-// Used to enrich server-fetched model entries.
+// Used to enrich server-fetched model entries. Kept in sync with
+// DefaultModels (see comment above).
 var modelDisplayNames = map[string]string{
-	"gpt-4.1":                   "GPT-4.1",
-	"gpt-4.1-mini":              "GPT-4.1 Mini",
-	"claude-sonnet-4-6":         "Claude Sonnet 4.6",
-	"claude-opus-4-6":           "Claude Opus 4.6",
-	"claude-haiku-4-5-20251001": "Claude Haiku 4.5",
-	"gemini-2.5-flash":          "Gemini 2.5 Flash",
-	"gemini-2.0-flash":          "Gemini 2.0 Flash",
-	"deepseek-chat":             "DeepSeek Chat",
-	"deepseek-reasoner":         "DeepSeek Reasoner",
-	"grok-3-mini":               "Grok 3 Mini",
-	"grok-4-1-fast-reasoning":   "Grok 4.1 Fast",
-	"llama-3.3-70b-versatile":   "Llama 3.3 70B",
-	"qwen-qwq-32b":              "QwQ 32B",
-	"qwen-plus":                 "Qwen Plus",
-	"qwen-turbo":                "Qwen Turbo",
-	"kimi-k2.5":                 "Kimi K2.5",
+	"gpt-4.1":                        "GPT-4.1",
+	"gpt-4.1-mini":                   "GPT-4.1 Mini",
+	"gpt-5.1-codex":                  "GPT-5.1 Codex",
+	"gpt-5.1-codex-mini":             "GPT-5.1 Codex Mini",
+	"gpt-5.1-codex-max":              "GPT-5.1 Codex Max",
+	"gpt-5.2-codex":                  "GPT-5.2 Codex",
+	"gpt-5.3-codex":                  "GPT-5.3 Codex",
+	"computer-use-preview":           "Computer Use Preview",
+	"claude-sonnet-4-6":              "Claude Sonnet 4.6",
+	"claude-opus-4-6":                "Claude Opus 4.6",
+	"claude-haiku-4-5-20251001":      "Claude Haiku 4.5",
+	"gemini-2.5-flash":               "Gemini 2.5 Flash",
+	"gemini-2.0-flash":               "Gemini 2.0 Flash",
+	"gemini-2.5-flash-preview-04-17": "Gemini 2.5 Flash Preview",
+	"deepseek-chat":                  "DeepSeek Chat (V3)",
+	"deepseek-reasoner":              "DeepSeek Reasoner (R1)",
+	"deepseek-v4-pro":                "DeepSeek V4 Pro (direct)",
+	"deepseek-v4-flash":              "DeepSeek V4 Flash (direct)",
+	"grok-3-mini":                    "Grok 3 Mini",
+	"grok-4-1-fast-reasoning":        "Grok 4.1 Fast Reasoning",
+	"llama-3.3-70b-versatile":        "Llama 3.3 70B Versatile",
+	"qwen-qwq-32b":                   "Qwen QwQ 32B",
+	"qwen-plus":                      "Qwen Plus",
+	"qwen-turbo":                     "Qwen Turbo",
+	"kimi-k2.5":                      "Kimi K2.5",
 }
 
 // reasoningModelIDs contains model IDs that support reasoning effort selection.

--- a/cmd/harnesscli/tui/components/modelswitcher/testdata/snapshots/TUI-057-modelswitcher-120x40.txt
+++ b/cmd/harnesscli/tui/components/modelswitcher/testdata/snapshots/TUI-057-modelswitcher-120x40.txt
@@ -2,11 +2,11 @@
 │ Switch Model                                                                                                       │
 │                                                                                                                    │
 │   Anthropic                                                                                                    (3) │
-│   DeepSeek                                                                                                     (2) │
-│   Google                                                                                                       (2) │
+│   DeepSeek                                                                                                     (4) │
+│   Google                                                                                                       (3) │
 │   Groq                                                                                                         (2) │
 │   Kimi                                                                                                         (1) │
-│ > OpenAI  ← current                                                                                            (2) │
+│ > OpenAI  ← current                                                                                            (8) │
 │   Qwen                                                                                                         (2) │
 │   xAI                                                                                                          (2) │
 │                                                                                                                    │

--- a/cmd/harnesscli/tui/components/modelswitcher/testdata/snapshots/TUI-057-modelswitcher-80x24.txt
+++ b/cmd/harnesscli/tui/components/modelswitcher/testdata/snapshots/TUI-057-modelswitcher-80x24.txt
@@ -2,11 +2,11 @@
 │ Switch Model                                                               │
 │                                                                            │
 │   Anthropic                                                            (3) │
-│   DeepSeek                                                             (2) │
-│   Google                                                               (2) │
+│   DeepSeek                                                             (4) │
+│   Google                                                               (3) │
 │   Groq                                                                 (2) │
 │   Kimi                                                                 (1) │
-│ > OpenAI  ← current                                                    (2) │
+│ > OpenAI  ← current                                                    (8) │
 │   Qwen                                                                 (2) │
 │   xAI                                                                  (2) │
 │                                                                            │

--- a/cmd/harnesscli/tui/components/modelswitcher/view.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/view.go
@@ -74,8 +74,10 @@ func (m Model) viewModelList(width int) string {
 	if width <= 0 {
 		width = 60
 	}
-	// When searching (any level): flat cross-provider search results.
-	if m.searchQuery != "" {
+	// When search is active (any level) — either a query has been typed, or
+	// search mode was explicitly entered via "/" and nothing has been typed
+	// yet — show the flat cross-provider search results.
+	if m.SearchActive() {
 		return m.viewFlatModelList(width)
 	}
 	// Level 0: provider list.
@@ -359,9 +361,10 @@ func (m Model) viewModelsForProvider(width int) string {
 		}
 	}
 
-	// Footer.
+	// Footer. Documents "/" (previously undocumented here even though any
+	// other printable key already started a search — see BUG C).
 	sb.WriteByte('\n')
-	sb.WriteString(dimStyle.Render("↑/↓ navigate  enter select  s star  esc back"))
+	sb.WriteString(dimStyle.Render("↑/↓ navigate  enter select  s star  / search  esc back"))
 
 	return boxStyle.Width(innerWidth).BorderForeground(lipgloss.Color("240")).Render(sb.String())
 }
@@ -383,8 +386,14 @@ func (m Model) viewFlatModelList(width int) string {
 	sb.WriteString(titleStyle.Render("Switch Model"))
 	sb.WriteByte('\n')
 	sb.WriteByte('\n')
+	// "Filter: " + query + a trailing cursor glyph. The cursor is rendered
+	// even with an empty query (immediately after "/" enters search mode)
+	// so the box is unambiguously a live, editable text field rather than a
+	// static label — the persistent "Filter: _" affordance called for by
+	// BUG C.
 	sb.WriteString(dimStyle.Render("Filter: "))
 	sb.WriteString(m.searchQuery)
+	sb.WriteString("▏")
 	sb.WriteByte('\n')
 	sb.WriteByte('\n')
 

--- a/cmd/harnesscli/tui/components/modelswitcher/view.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/view.go
@@ -240,6 +240,16 @@ func (m Model) viewModelsForProvider(width int) string {
 	// Breadcrumb title: "< Back  [ProviderName]"
 	sb.WriteString(dimStyle.Render("< Back"))
 	sb.WriteString("  [" + m.activeProvider + "]")
+	// BUG B: a background models fetch may have failed after this list was
+	// already rendered (or the user drilled in after the failure). Unlike
+	// the level-0 and search views — which replace the whole screen with an
+	// error message, making the failure obvious — this level-1 list keeps
+	// browsing the fallback DefaultModels so the switcher stays usable.
+	// Mark it visibly as offline/stale so it is never mistaken for a fresh
+	// live fetch.
+	if m.loadError != "" {
+		sb.WriteString(dimStyle.Render("  (offline — showing built-in list)"))
+	}
 	sb.WriteByte('\n')
 	sb.WriteByte('\n')
 

--- a/cmd/harnesscli/tui/components/modelswitcher/view.go
+++ b/cmd/harnesscli/tui/components/modelswitcher/view.go
@@ -135,22 +135,12 @@ func (m Model) viewProviderList(width int) string {
 			textWidth = 8
 		}
 
-		// Compute scroll window for providers (Issue #572).
+		// Compute scroll window for providers (Issue #572). scrollWindow()
+		// shares the same row budget as adjustProviderScroll() (BUG A —
+		// cursor freezes mid-scroll) so the rendered window can never fall
+		// out of sync with where adjustScroll() thinks the cursor is.
 		maxVisible := m.maxVisibleContentRows()
-		windowStart := m.providerScrollOffset
-		windowEnd := windowStart + maxVisible
-		if windowEnd > len(provs) {
-			windowEnd = len(provs)
-		}
-		// Reserve room for scroll indicators when items are hidden.
-		showAbove := windowStart > 0
-		showBelow := windowEnd < len(provs)
-		if showAbove && windowEnd > windowStart {
-			windowEnd--
-		}
-		if showBelow && windowEnd > windowStart {
-			windowEnd--
-		}
+		windowStart, windowEnd, showAbove, showBelow := scrollWindow(m.providerScrollOffset, len(provs), maxVisible)
 
 		if showAbove {
 			sb.WriteString(scrollIndicatorStyle.Render("... " + itoa(windowStart) + " more above"))
@@ -258,22 +248,12 @@ func (m Model) viewModelsForProvider(width int) string {
 		sb.WriteString(dimStyle.Render("No models available"))
 		sb.WriteByte('\n')
 	} else {
-		// Compute scroll window for models (Issue #572).
+		// Compute scroll window for models (Issue #572). scrollWindow()
+		// shares the same row budget as adjustModelScroll() (BUG A — cursor
+		// freezes mid-scroll) so the rendered window can never fall out of
+		// sync with where adjustScroll() thinks the cursor is.
 		maxVisible := m.maxVisibleContentRows()
-		windowStart := m.scrollOffset
-		windowEnd := windowStart + maxVisible
-		if windowEnd > len(visible) {
-			windowEnd = len(visible)
-		}
-		// Reserve room for scroll indicators when items are hidden.
-		showAbove := windowStart > 0
-		showBelow := windowEnd < len(visible)
-		if showAbove && windowEnd > windowStart {
-			windowEnd--
-		}
-		if showBelow && windowEnd > windowStart {
-			windowEnd--
-		}
+		windowStart, windowEnd, showAbove, showBelow := scrollWindow(m.scrollOffset, len(visible), maxVisible)
 
 		if showAbove {
 			sb.WriteString(scrollIndicatorStyle.Render("... " + itoa(windowStart) + " more above"))
@@ -420,21 +400,12 @@ func (m Model) viewFlatModelList(width int) string {
 		sb.WriteByte('\n')
 	} else {
 		// Compute scroll window for search results (Issue #572).
+		// scrollWindow() shares the same row budget as adjustModelScroll()
+		// (BUG A — cursor freezes mid-scroll) so the rendered window can
+		// never fall out of sync with where adjustScroll() thinks the
+		// cursor is.
 		maxVisible := m.maxVisibleContentRows()
-		windowStart := m.scrollOffset
-		windowEnd := windowStart + maxVisible
-		if windowEnd > len(visible) {
-			windowEnd = len(visible)
-		}
-		// Reserve room for scroll indicators when items are hidden.
-		showAbove := windowStart > 0
-		showBelow := windowEnd < len(visible)
-		if showAbove && windowEnd > windowStart {
-			windowEnd--
-		}
-		if showBelow && windowEnd > windowStart {
-			windowEnd--
-		}
+		windowStart, windowEnd, showAbove, showBelow := scrollWindow(m.scrollOffset, len(visible), maxVisible)
 
 		if showAbove {
 			sb.WriteString(scrollIndicatorStyle.Render("... " + itoa(windowStart) + " more above"))

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1858,8 +1858,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.modelConfigMode = false
 					return m, tea.Batch(cmds...)
 				}
-				// Escape with active search (any level): clear search, return to browse level state.
-				if m.modelSwitcher.SearchQuery() != "" {
+				// Escape with active search (any level, including right
+				// after "/" before any character has been typed): clear
+				// search, return to browse level state.
+				if m.modelSwitcher.SearchActive() {
 					m.modelSwitcher = m.modelSwitcher.SetSearch("")
 					return m, tea.Batch(cmds...)
 				}
@@ -2051,8 +2053,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					})
 					return m, tea.Batch(cmds...)
 				}
-				// Level 0 (provider list) with no search: Enter drills into the selected provider.
-				if m.modelSwitcher.BrowseLevel() == 0 && m.modelSwitcher.SearchQuery() == "" {
+				// Level 0 (provider list) with no active search: Enter drills into the selected provider.
+				if m.modelSwitcher.BrowseLevel() == 0 && !m.modelSwitcher.SearchActive() {
 					m.modelSwitcher = m.modelSwitcher.DrillIntoProvider()
 					return m, tea.Batch(cmds...)
 				}
@@ -2308,7 +2310,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// When the model overlay is active, Up navigates based on browse level and search state.
 			if m.overlayActive && m.activeOverlay == "model" && !m.modelConfigMode {
-				if m.modelSwitcher.BrowseLevel() == 0 && m.modelSwitcher.SearchQuery() == "" {
+				if m.modelSwitcher.BrowseLevel() == 0 && !m.modelSwitcher.SearchActive() {
 					m.modelSwitcher = m.modelSwitcher.ProviderUp()
 				} else {
 					m.modelSwitcher = m.modelSwitcher.SelectUp()
@@ -2339,7 +2341,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// When the model overlay is active, Down navigates based on browse level and search state.
 			if m.overlayActive && m.activeOverlay == "model" && !m.modelConfigMode {
-				if m.modelSwitcher.BrowseLevel() == 0 && m.modelSwitcher.SearchQuery() == "" {
+				if m.modelSwitcher.BrowseLevel() == 0 && !m.modelSwitcher.SearchActive() {
 					m.modelSwitcher = m.modelSwitcher.ProviderDown()
 				} else {
 					m.modelSwitcher = m.modelSwitcher.SelectDown()
@@ -2446,8 +2448,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					return m, tea.Batch(cmds...)
 				case tea.KeyRunes:
-					// j/k vim-style navigation when no search is active.
-					if m.modelSwitcher.SearchQuery() == "" {
+					// "/" explicitly enters search mode (matches what the
+					// level-0 and level-1 footers advertise). It never
+					// leaks into the query itself — HandleSearchKey also
+					// swallows it (fixes #667) — but unlike before, it now
+					// actually does something: it activates SearchActive()
+					// immediately so the very next keystroke (even "s" or
+					// "j"/"k") is treated as a literal query character
+					// instead of a browse-level shortcut (fixes BUG C:
+					// typing "sonnet" no longer stars the highlighted
+					// model on the leading "s").
+					if msg.String() == "/" {
+						m.modelSwitcher = m.modelSwitcher.EnterSearch()
+						return m, tea.Batch(cmds...)
+					}
+					// j/k vim-style navigation only when search is not active.
+					if !m.modelSwitcher.SearchActive() {
 						if msg.String() == "k" {
 							if m.modelSwitcher.BrowseLevel() == 0 {
 								m.modelSwitcher = m.modelSwitcher.ProviderUp()
@@ -2466,9 +2482,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					}
 					// 's' toggles star only when browsing at level 1 with no active search.
-					// During search, 's' is treated as a literal character so users
-					// can type queries containing "s" (e.g. "deeps").
-					if msg.String() == "s" && m.modelSwitcher.BrowseLevel() == 1 && m.modelSwitcher.SearchQuery() == "" {
+					// Once search mode is active (explicitly via "/", or because a
+					// query is already non-empty), 's' is a literal character so users
+					// can type queries containing "s" (e.g. "sonnet", "deeps").
+					if msg.String() == "s" && m.modelSwitcher.BrowseLevel() == 1 && !m.modelSwitcher.SearchActive() {
 						m.modelSwitcher = m.modelSwitcher.ToggleStar()
 						// Persist to config.
 						if persistCfg, err := harnessconfig.Load(); err == nil {

--- a/cmd/harnesscli/tui/model_bugC_regression_test.go
+++ b/cmd/harnesscli/tui/model_bugC_regression_test.go
@@ -1,0 +1,44 @@
+package tui_test
+
+// Additional regression coverage for BUG C: pressing '/' while a search
+// query is already in progress must not wipe the text the user already
+// typed. EnterSearch() only sets searchActive = true and does not touch
+// searchQuery, but this guards the actual key-routing wiring in
+// tui/model.go end-to-end, since a user might plausibly hit '/' again out
+// of habit (e.g. thinking of it as a generic "focus search" key) while
+// already mid-query.
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// TestBugC_Regression_SlashWhileAlreadySearchingKeepsQuery verifies that
+// pressing '/' again after some text has already been typed does not clear
+// or otherwise corrupt the in-progress query.
+func TestBugC_Regression_SlashWhileAlreadySearchingKeepsQuery(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = m2.(tui.Model)
+	m = typeIntoModel(m, "claude")
+
+	if got := m.ModelSwitcher().SearchQuery(); got != "claude" {
+		t.Fatalf("precondition: expected query %q, got %q", "claude", got)
+	}
+
+	// Press '/' again mid-query.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = m3.(tui.Model)
+
+	if got := m.ModelSwitcher().SearchQuery(); got != "claude" {
+		t.Errorf("pressing '/' again mid-query should not change the query; got %q, want %q", got, "claude")
+	}
+	if !m.ModelSwitcher().SearchActive() {
+		t.Error("search should still be active after pressing '/' again mid-query")
+	}
+}

--- a/cmd/harnesscli/tui/model_bugC_search_test.go
+++ b/cmd/harnesscli/tui/model_bugC_search_test.go
@@ -1,0 +1,157 @@
+package tui_test
+
+// Tests for user-reported BUG C (P2) — the model switcher's search key
+// routing in the model-overlay region of model.go:
+//
+//   (1) '/' is advertised by the level-0 footer ("/ search") but was a dead
+//       key — nothing in model.go ever entered a discoverable search mode.
+//   (2) At browse level 1 with no active search, 's' toggles star, so typing
+//       a query starting with "sonnet" starred the highlighted model on the
+//       very first keystroke instead of starting a filter.
+//   (3) The level-1 footer never mentioned search at all, even though any
+//       other printable key silently started one.
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// TestBugC_SlashEntersSearchMode verifies that pressing '/' while the model
+// overlay is open activates search mode (matching what the footer already
+// advertises), even before any character has been typed.
+func TestBugC_SlashEntersSearchMode(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+	if !m.OverlayActive() || m.ActiveOverlay() != "model" {
+		t.Fatal("precondition: model overlay must be open after /model")
+	}
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	after := m2.(tui.Model)
+
+	if !after.ModelSwitcher().SearchActive() {
+		t.Error("pressing '/' should activate search mode (ModelSwitcher().SearchActive())")
+	}
+	if after.ModelSwitcher().SearchQuery() != "" {
+		t.Errorf("pressing '/' alone must not add text to the query, got %q", after.ModelSwitcher().SearchQuery())
+	}
+
+	v := after.View()
+	if !strings.Contains(v, "Filter:") {
+		t.Errorf("View() after pressing '/' should show the Filter search bar:\n%s", v)
+	}
+}
+
+// TestBugC_TypingSonnetAfterSlashDoesNotStar reproduces the exact user
+// complaint: typing "sonnet" to search for a Claude model must not star the
+// highlighted model on the first keystroke ('s'). Once search mode is
+// explicitly entered via '/', every printable rune (including 's') is a
+// literal query character.
+func TestBugC_TypingSonnetAfterSlashDoesNotStar(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+
+	// Drill into the first provider so we're at browse level 1, where 's'
+	// would otherwise toggle star.
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	if m.ModelSwitcher().BrowseLevel() != 1 {
+		t.Fatal("precondition: expected browseLevel == 1 after drilling into a provider")
+	}
+
+	selected, _ := m.ModelSwitcher().Accept()
+	wasStarred := m.ModelSwitcher().IsStarred(selected.ID)
+
+	// Enter search mode explicitly via '/'.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = m3.(tui.Model)
+
+	// Now type "sonnet" — the leading 's' must be treated as a literal query
+	// character, not a star toggle.
+	m = typeIntoModel(m, "sonnet")
+
+	got := m.ModelSwitcher().SearchQuery()
+	if got != "sonnet" {
+		t.Errorf("after '/' then typing 'sonnet', SearchQuery() = %q, want %q", got, "sonnet")
+	}
+	if m.ModelSwitcher().IsStarred(selected.ID) != wasStarred {
+		t.Errorf("typing 'sonnet' after explicit search entry must not toggle star on %q", selected.ID)
+	}
+}
+
+// TestBugC_SKeyStillStarsWhileMerelyBrowsing is the regression guard for
+// existing behavior: without pressing '/' first, 's' at browse level 1 must
+// still toggle star exactly as before.
+func TestBugC_SKeyStillStarsWhileMerelyBrowsing(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	if m.ModelSwitcher().BrowseLevel() != 1 {
+		t.Fatal("precondition: expected browseLevel == 1 after drilling into a provider")
+	}
+	if m.ModelSwitcher().SearchActive() {
+		t.Fatal("precondition: search must not be active yet")
+	}
+
+	selected, _ := m.ModelSwitcher().Accept()
+	wasStarred := m.ModelSwitcher().IsStarred(selected.ID)
+
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = m3.(tui.Model)
+
+	if m.ModelSwitcher().SearchQuery() != "" {
+		t.Errorf("'s' while merely browsing should not start a search, got query %q", m.ModelSwitcher().SearchQuery())
+	}
+	if m.ModelSwitcher().IsStarred(selected.ID) == wasStarred {
+		t.Error("'s' while merely browsing (no search active) should still toggle star")
+	}
+}
+
+// TestBugC_Level1FooterMentionsSearch verifies the level-1 footer documents
+// the '/' search shortcut, instead of leaving it as an undocumented side
+// effect of typing any other character.
+func TestBugC_Level1FooterMentionsSearch(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	if m.ModelSwitcher().BrowseLevel() != 1 {
+		t.Fatal("precondition: expected browseLevel == 1 after drilling into a provider")
+	}
+
+	v := m.View()
+	if !strings.Contains(v, "/ search") {
+		t.Errorf("level-1 footer should document the '/' search shortcut:\n%s", v)
+	}
+}
+
+// TestBugC_EscapeExitsEmptySearchMode verifies that pressing Escape right
+// after '/' (before any character is typed) exits search mode rather than
+// leaving an orphaned, empty search bar or jumping back an extra level.
+func TestBugC_EscapeExitsEmptySearchMode(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/model")
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	m = m2.(tui.Model)
+	if !m.ModelSwitcher().SearchActive() {
+		t.Fatal("precondition: search must be active after '/'")
+	}
+
+	m, _ = sendEscape(m)
+
+	if m.ModelSwitcher().SearchActive() {
+		t.Error("Escape right after '/' should exit search mode")
+	}
+	// The overlay itself must still be open (Escape only backs out one level).
+	if !m.OverlayActive() || m.ActiveOverlay() != "model" {
+		t.Error("Escape out of empty search mode should not close the whole model overlay")
+	}
+}

--- a/cmd/harnesscli/tui/model_command_test.go
+++ b/cmd/harnesscli/tui/model_command_test.go
@@ -507,6 +507,11 @@ func TestTUI137_ModelSelectedMsgSetsStatusMsg(t *testing.T) {
 
 // TestTUI137_ModelOverlayUpDownNavigates verifies Up/Down keys navigate the provider list
 // at level 0, and navigate the model list at level 1.
+//
+// This deliberately does not hardcode which two OpenAI models are adjacent —
+// the OpenAI catalog grows over time (see catalog/models.json), so the test
+// asserts the navigational behavior (Down moves forward, Up returns to the
+// starting model) rather than baking in a specific pair of model names.
 func TestTUI137_ModelOverlayUpDownNavigates(t *testing.T) {
 	m := initModel(t, 80, 24)
 	m = sendSlashCommand(m, "/model")
@@ -525,25 +530,31 @@ func TestTUI137_ModelOverlayUpDownNavigates(t *testing.T) {
 	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = m3.(tui.Model)
 
-	// At level 1: Down moves model cursor. OpenAI has gpt-4.1 and gpt-4.1-mini.
-	// Navigate to gpt-4.1-mini by pressing Down.
+	startEntry, _ := m.ModelSwitcher().Accept()
+
+	// At level 1: Down moves the model cursor to a different model.
 	m4, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = m4.(tui.Model)
 
-	// The view should now show gpt-4.1-mini highlighted.
-	v := m.View()
-	if !strings.Contains(v, "GPT-4.1 Mini") {
-		t.Errorf("view must contain 'GPT-4.1 Mini' after Down at level 1:\n%s", v)
+	movedEntry, _ := m.ModelSwitcher().Accept()
+	if movedEntry.ID == startEntry.ID {
+		t.Fatalf("Down at level 1 should move the cursor to a different model, still on %q", movedEntry.ID)
 	}
 
-	// Press Up to go back to gpt-4.1.
+	// The view should now show the newly selected model's display name.
+	v := m.View()
+	if !strings.Contains(v, movedEntry.DisplayName) {
+		t.Errorf("view must contain %q after Down at level 1:\n%s", movedEntry.DisplayName, v)
+	}
+
+	// Press Up to go back to the starting model.
 	m5, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	m = m5.(tui.Model)
 
-	// Verify gpt-4.1 is selected.
+	// Verify the starting model is selected again.
 	entry, _ := m.ModelSwitcher().Accept()
-	if entry.ID != "gpt-4.1" {
-		t.Errorf("after Down+Up at level 1: selected model = %q, want %q", entry.ID, "gpt-4.1")
+	if entry.ID != startEntry.ID {
+		t.Errorf("after Down+Up at level 1: selected model = %q, want %q", entry.ID, startEntry.ID)
 	}
 }
 


### PR DESCRIPTION
Three bugs found during live testing of the model switcher.

## Scroll lock (P1) — reproduced deterministically
Scrolling a long list froze the cursor: the highlight stopped moving while `... 303 more below` kept ticking down on every keypress.

**Root cause:** a scroll-window *budget mismatch*. `adjustScroll()` budgeted `maxVisible` rows, but each of the three render loops in `view.go` independently shrank its own window by 1–2 rows to make space for the `... more above/below` indicator lines — and never told `adjustScroll`. Once **both** indicators showed, the selected row fell permanently outside the window actually rendered.

**Fix:** one shared `effectiveContentRows`/`scrollWindow` used by both the scroll math and all three render loops. The reservation is **deterministic** (depends only on whether the list overflows, never on the current offset) so it cannot oscillate while scrolling. Regression tests cover all three render loops.

## Stale catalog (P2)
The client-side `DefaultModels` fallback had drifted from `catalog/models.json` — missing the gpt-5.x codex family, computer-use-preview, DeepSeek V4, etc. Synced all 8 built-in providers and added a **drift test** so client and server can never silently diverge again. On live-fetch failure the list is now visibly marked `(offline — showing built-in list)` instead of presenting stale data as if it were live.

## Search was invisible and collided with the star key (P2)
- The footer advertised `/ search`, but `/` was a **dead key** — `HandleSearchKey` explicitly ignored it and no parent handler existed.
- Search actually triggered on *any other* printable rune — undocumented anywhere.
- At level 1, `s` **starred** the highlighted model, so typing "sonnet" starred something and produced the query `onnet`.

Now `/` genuinely enters search mode; once active, **all** printable keys (including `s`) are literal query characters, while `s` still stars when merely browsing. Matching is ranked exact > prefix > substring > fuzzy subsequence, so `gp4m` finds `gpt-4.1-mini` — which matters for OpenRouter's 300+ entries.

## Verification
`go build`, `go vet`, `go test ./cmd/harnesscli/... -race` green (1350 TUI tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6