### PR TITLE
fix(tui): /cost overlay showed a stale model name after switching models

### DIFF
--- a/cmd/harnesscli/tui/cost_config_overlay_test.go
+++ b/cmd/harnesscli/tui/cost_config_overlay_test.go
@@ -71,6 +71,43 @@ func TestCost_EscapeClosesOverlay(t *testing.T) {
 	}
 }
 
+// TestCost_OverlayRefreshesModelOnSwitchWhileOpen verifies that the /cost
+// overlay reflects a newly selected model immediately, even if no
+// usage.delta event arrives after the switch. Regression coverage: the /cost
+// overlay's snapshot was previously refreshed only on open or on
+// usage.delta, so switching models while the overlay was already open left
+// it showing the stale model name.
+func TestCost_OverlayRefreshesModelOnSwitchWhileOpen(t *testing.T) {
+	cfg := tui.DefaultTUIConfig()
+	cfg.Model = "gpt-4.1-mini"
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = m2.(tui.Model)
+
+	m = sendSlashCommand(m, "/cost")
+	if !m.OverlayActive() || m.ActiveOverlay() != "cost" {
+		t.Fatal("precondition: cost overlay must be open")
+	}
+
+	// Precondition: overlay shows the initial model.
+	if !strings.Contains(m.View(), "gpt-4.1-mini") {
+		t.Fatalf("precondition: cost overlay should show initial model gpt-4.1-mini; got:\n%s", m.View())
+	}
+
+	// Switch model while the cost overlay remains open, with no intervening
+	// usage.delta event.
+	m3, _ := m.Update(tui.ModelSelectedMsg{ModelID: "claude-3-7-sonnet-20250219", Provider: "anthropic"})
+	m = m3.(tui.Model)
+
+	v := m.View()
+	if strings.Contains(v, "gpt-4.1-mini") {
+		t.Errorf("cost overlay must not still show the old model gpt-4.1-mini after switch; got:\n%s", v)
+	}
+	if !strings.Contains(v, "claude-3-7-sonnet-20250219") {
+		t.Errorf("cost overlay must show the newly selected model claude-3-7-sonnet-20250219 after switch; got:\n%s", v)
+	}
+}
+
 // TestConfig_SlashCommandActivatesOverlay verifies that /config opens the
 // config overlay and that View() lists the current session's config values.
 func TestConfig_SlashCommandActivatesOverlay(t *testing.T) {

--- a/cmd/harnesscli/tui/cost_config_overlay_test.go
+++ b/cmd/harnesscli/tui/cost_config_overlay_test.go
@@ -108,6 +108,60 @@ func TestCost_OverlayRefreshesModelOnSwitchWhileOpen(t *testing.T) {
 	}
 }
 
+// TestCost_OverlayModelStaysCurrentAcrossRepeatedSwitchesAndUsageDelta is a
+// regression test covering a different angle than the switch-while-open
+// test above: it exercises multiple consecutive model switches (to make
+// sure the fix in the ModelSelectedMsg handler isn't a one-shot correction
+// that only happens to work for the first switch) interleaved with a
+// usage.delta event, verifying the /cost overlay always converges on the
+// latest model and never resurrects a stale one. If the ModelSelectedMsg
+// handler stopped refreshing costDisplay, the second switch below would
+// still show the first switch's model.
+func TestCost_OverlayModelStaysCurrentAcrossRepeatedSwitchesAndUsageDelta(t *testing.T) {
+	cfg := tui.DefaultTUIConfig()
+	cfg.Model = "gpt-4.1-mini"
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = m2.(tui.Model)
+
+	m = sendSlashCommand(m, "/cost")
+	if !m.OverlayActive() || m.ActiveOverlay() != "cost" {
+		t.Fatal("precondition: cost overlay must be open")
+	}
+
+	// First switch: gpt-4.1-mini -> claude-3-7-sonnet-20250219.
+	m3, _ := m.Update(tui.ModelSelectedMsg{ModelID: "claude-3-7-sonnet-20250219", Provider: "anthropic"})
+	m = m3.(tui.Model)
+
+	// Second switch, before any usage.delta: claude-3-7-sonnet-20250219 -> gpt-4.1.
+	m4, _ := m.Update(tui.ModelSelectedMsg{ModelID: "gpt-4.1", Provider: "openai"})
+	m = m4.(tui.Model)
+
+	v := m.View()
+	if strings.Contains(v, "gpt-4.1-mini") || strings.Contains(v, "claude-3-7-sonnet-20250219") {
+		t.Errorf("cost overlay must not show a stale model after two switches; got:\n%s", v)
+	}
+	if !strings.Contains(v, "[gpt-4.1]") {
+		t.Errorf("cost overlay must show the latest model gpt-4.1 after two switches; got:\n%s", v)
+	}
+
+	// A subsequent usage.delta must preserve the (already-current) model
+	// label alongside the new cost figures.
+	m5, _ := m.Update(tui.SSEEventMsg{
+		EventType: "usage.delta",
+		Raw:       []byte(`{"cumulative_usage":{"total_tokens":42},"cumulative_cost_usd":0.0099}`),
+	})
+	m = m5.(tui.Model)
+
+	v = m.View()
+	if !strings.Contains(v, "[gpt-4.1]") {
+		t.Errorf("cost overlay must still show gpt-4.1 after usage.delta; got:\n%s", v)
+	}
+	if !strings.Contains(v, "0.0099") {
+		t.Errorf("cost overlay must reflect the latest cost after usage.delta; got:\n%s", v)
+	}
+}
+
 // TestConfig_SlashCommandActivatesOverlay verifies that /config opens the
 // config overlay and that View() lists the current session's config values.
 func TestConfig_SlashCommandActivatesOverlay(t *testing.T) {

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -3011,6 +3011,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.modelSwitcher = m.modelSwitcher.WithCurrentReasoning(msg.ReasoningEffort)
 		m.modelSwitcher = m.modelSwitcher.WithStarred(currentStarred)
 		m.statusBar.SetModel(m.statusBarModelLabel())
+		// Keep the /cost overlay's model label current even if it is already
+		// open and no usage.delta event arrives before the next render.
+		m.costDisplay = m.costDisplay.Update(costSnapshotFromModel(&m))
 		label := displayModelName(msg.ModelID)
 		if msg.ReasoningEffort != "" {
 			label += " (" + msg.ReasoningEffort + ")"


### PR DESCRIPTION
Small fix found while investigating a report that the TUI didn't show the current model.

**Investigation result:** both surfaces already existed on `main` — the status bar renders the active model (`statusBar.SetModel`/`statusBarModelLabel`) and the cost overlay renders `[model]`. The original report predated that work.

**The real gap:** if `/cost` was already **open** when the user switched models, the overlay kept showing the **stale** model name — `ModelSelectedMsg` never refreshed `costSnapshotFromModel`, so it only corrected itself if/when a later `usage.delta` event happened to arrive.

Three-line fix reusing the existing single source of truth (no new state, no second code path), with a red test and a regression test that survives repeated switches interleaved with usage updates.

`go build ./cmd/harnesscli/...` and `go test ./cmd/harnesscli/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6