### PR TITLE
fix(workflow): P0 crash on client disconnect, CPU busy-loop, fatal map race, double-execution, event loss

### DIFF
--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -327,6 +327,75 @@ func TestConcurrentResumeExecutesScriptExactlyOnce(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------
+// BUG 5: Subscribe history/live gap loses terminal events
+// ---------------------------------------------------------------------
+//
+// Subscribe read history via store.GetEvents and only THEN registered its
+// channel in e.subs. An event emitted in that gap is in neither the
+// returned history nor delivered on the channel -- permanently lost. If
+// the lost event is the terminal workflow.completed/failed event, an SSE
+// client hangs forever.
+//
+// This test races emit() against Subscribe() for the same runID many
+// times (alternating which starts first) and asserts the event is always
+// observed either in history or on the live channel -- never neither.
+func TestSubscribeNeverMissesConcurrentEmit(t *testing.T) {
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
+	const iterations = 500
+
+	for i := 0; i < iterations; i++ {
+		runID := fmt.Sprintf("run-%d", i)
+
+		var emitWG sync.WaitGroup
+		emitWG.Add(1)
+		fireEmit := func() {
+			defer emitWG.Done()
+			e.emit(runID, EventWorkflowCompleted, map[string]any{"i": i})
+		}
+
+		var history []Event
+		var ch <-chan Event
+		var cancel func()
+		var subErr error
+
+		if i%2 == 0 {
+			go fireEmit()
+			history, ch, cancel, subErr = e.Subscribe(runID)
+		} else {
+			history, ch, cancel, subErr = e.Subscribe(runID)
+			go fireEmit()
+		}
+		if subErr != nil {
+			t.Fatalf("iteration %d: Subscribe: %v", i, subErr)
+		}
+
+		emitWG.Wait()
+
+		found := false
+		for _, ev := range history {
+			if ev.Type == EventWorkflowCompleted {
+				found = true
+				break
+			}
+		}
+		if !found {
+			select {
+			case ev := <-ch:
+				if ev.Type == EventWorkflowCompleted {
+					found = true
+				}
+			case <-time.After(200 * time.Millisecond):
+			}
+		}
+		cancel()
+
+		if !found {
+			t.Fatalf("iteration %d: terminal event lost — not in history and not delivered live", i)
+		}
+	}
+}
+
 // waitForStatus polls GetRun until the run reaches want or the deadline
 // expires.
 func waitForStatus(t *testing.T, e *Engine, runID string, want RunStatus) {

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -254,10 +254,22 @@ func TestConcurrentRegisterAndContextWorkflowNoRace(t *testing.T) {
 func TestConcurrentResumeExecutesScriptExactlyOnce(t *testing.T) {
 	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
 
+	// The first execution (triggered by Start) fails immediately, putting
+	// the run into RunStatusFailed. Any subsequent execution (triggered by
+	// a successful Resume) blocks on `release` until the test has
+	// collected results from ALL concurrent Resume attempts. This keeps
+	// the run's status at RunStatusRunning for the whole race window, so
+	// a genuine (fast) re-failure can never masquerade as a second
+	// legitimate Resume — isolating the TOCTOU bug specifically.
 	var executions atomic.Int64
+	release := make(chan struct{})
 	e.Register("flaky", func(*Context) (any, error) {
-		executions.Add(1)
-		return nil, fmt.Errorf("boom")
+		n := executions.Add(1)
+		if n == 1 {
+			return nil, fmt.Errorf("boom")
+		}
+		<-release
+		return nil, fmt.Errorf("boom again")
 	})
 
 	run, err := e.Start(context.Background(), "flaky", nil)
@@ -298,9 +310,14 @@ func TestConcurrentResumeExecutesScriptExactlyOnce(t *testing.T) {
 		}
 	}
 	if successCount != 1 {
+		close(release)
 		t.Fatalf("expected exactly 1 successful Resume, got %d (errs=%v)", successCount, errs)
 	}
 
+	// All 8 concurrent Resume calls have now returned. Only the winner's
+	// `go e.execute` is (or could be) in flight, blocked on `release`.
+	// Let it proceed and reach a terminal status.
+	close(release)
 	waitForTerminal(t, e, run.ID)
 
 	// executions started at 1 (the initial failed Start). Exactly one more

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -99,12 +99,85 @@ func TestEmitCancelRaceDoesNotPanic(t *testing.T) {
 // `default:` branch, so it never blocked — it spun at 100% CPU polling
 // Get() for the entire lifetime of every in-flight subagent.
 //
-// countingRunningMgr's subagent never completes. We bound the Context's
-// own ctx with a short timeout (instead of relying on the poll interval,
-// which the fix has not introduced yet) and assert the number of Get()
-// calls made in that window is small. A busy-loop produces many hundreds
-// of thousands of calls in even a few milliseconds; a properly-blocking
-// poll makes only a handful.
+// slowPollMgr simulates a subagent that stays "running" for a fixed
+// duration before completing. We shrink subagentPollInterval so the test
+// runs fast, then assert the number of Get() calls over that duration is
+// bounded (roughly duration/interval), not the thousands/millions a
+// busy-loop would produce.
+type slowPollMgr struct {
+	getCalls      atomic.Int64
+	createdAt     time.Time
+	completeAfter time.Duration
+}
+
+func (m *slowPollMgr) Create(context.Context, SubagentRequest) (SubagentResult, error) {
+	m.createdAt = time.Now()
+	return SubagentResult{ID: "agent-1", Status: "running"}, nil
+}
+
+func (m *slowPollMgr) Get(_ context.Context, id string) (SubagentResult, error) {
+	m.getCalls.Add(1)
+	if time.Since(m.createdAt) >= m.completeAfter {
+		return SubagentResult{ID: id, Status: "completed", Output: "done"}, nil
+	}
+	return SubagentResult{ID: id, Status: "running"}, nil
+}
+
+func TestAgentPollDoesNotBusyLoop(t *testing.T) {
+	orig := subagentPollInterval
+	subagentPollInterval = 5 * time.Millisecond
+	t.Cleanup(func() { subagentPollInterval = orig })
+
+	mgr := &slowPollMgr{completeAfter: 60 * time.Millisecond}
+	e := NewEngine(EngineOptions{Subagents: mgr, MaxConcurrency: 1})
+	wfCtx := newContext(context.Background(), e, "run-poll", nil, newBudget(0))
+
+	_, err := wfCtx.Agent("do work", nil)
+	if err != nil {
+		t.Fatalf("Agent: %v", err)
+	}
+
+	gets := mgr.getCalls.Load()
+	// Busy-looping would produce many thousands of Get() calls in 60ms.
+	// A bounded poll at 5ms intervals over ~60ms should produce roughly
+	// 12 calls; allow generous headroom for scheduling jitter, but reject
+	// anything that looks like a spin.
+	if gets > 100 {
+		t.Fatalf("expected a bounded number of poll calls, got %d (looks like a busy-loop)", gets)
+	}
+	if gets < 2 {
+		t.Fatalf("expected at least a couple of poll calls, got %d", gets)
+	}
+}
+
+// TestAgentPollBlocksBetweenPolls is a second, more direct proof of the
+// fix: it uses the un-shrunk default subagentPollInterval and bounds the
+// Context's own ctx with a short timeout while the subagent never
+// completes. With a properly-blocking poll, at most 2 Get() calls happen
+// in that window (the immediate first check, plus possibly one more right
+// at the boundary). A busy-loop would produce orders of magnitude more.
+func TestAgentPollBlocksBetweenPolls(t *testing.T) {
+	mgr := &countingRunningMgr{}
+	e := NewEngine(EngineOptions{Subagents: mgr, MaxConcurrency: 1})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	wfCtx := newContext(ctx, e, "run-poll-blocking", nil, newBudget(0))
+
+	_, err := wfCtx.Agent("do work", nil)
+	if err == nil {
+		t.Fatalf("expected Agent to return an error when its context deadline expires")
+	}
+
+	gets := mgr.getCalls.Load()
+	if gets > 1000 {
+		t.Fatalf("expected a bounded number of poll calls within ~50ms, got %d (looks like a busy-loop)", gets)
+	}
+}
+
+// countingRunningMgr is a subagent manager whose subagent never completes;
+// used by TestAgentPollBlocksBetweenPolls to count how many times Get() is
+// called within a bounded time window.
 type countingRunningMgr struct {
 	getCalls atomic.Int64
 }
@@ -116,26 +189,4 @@ func (m *countingRunningMgr) Create(context.Context, SubagentRequest) (SubagentR
 func (m *countingRunningMgr) Get(_ context.Context, id string) (SubagentResult, error) {
 	m.getCalls.Add(1)
 	return SubagentResult{ID: id, Status: "running"}, nil
-}
-
-func TestAgentPollDoesNotBusyLoop(t *testing.T) {
-	mgr := &countingRunningMgr{}
-	e := NewEngine(EngineOptions{Subagents: mgr, MaxConcurrency: 1})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	wfCtx := newContext(ctx, e, "run-poll", nil, newBudget(0))
-
-	_, err := wfCtx.Agent("do work", nil)
-	if err == nil {
-		t.Fatalf("expected Agent to return an error when its context deadline expires")
-	}
-
-	gets := mgr.getCalls.Load()
-	// A busy-loop with no blocking will issue an enormous number of Get()
-	// calls in 50ms (typically well over a million on modern hardware). A
-	// properly-blocking poll should issue only a handful in that window.
-	if gets > 1000 {
-		t.Fatalf("expected a bounded number of poll calls within ~50ms, got %d (looks like a busy-loop)", gets)
-	}
 }

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -47,30 +47,46 @@ func (noopSubagentManager) Get(context.Context, string) (SubagentResult, error) 
 // channel and panics. A `select`/`default` guard does NOT protect against
 // this — it only guards a full channel, not a closed one.
 //
-// This test concurrently emits (continuously) while subscribing and
-// immediately cancelling, many times, to force the interleaving that
-// triggers the panic. A panic in this non-recovered emitter goroutine will
-// crash the whole test binary — exactly the harnessd crash the bug causes
-// in production when an SSE client disconnects mid-stream.
+// This test concurrently emits (continuously, up to a bound) while
+// subscribing and immediately cancelling, many times, to force the
+// interleaving that triggers the panic. A panic in this non-recovered
+// emitter goroutine will crash the whole test binary — exactly the
+// harnessd crash the bug causes in production when an SSE client
+// disconnects mid-stream.
+//
+// The emitter is capped at maxEmits (rather than running unbounded until
+// `stop` closes) as a deliberate, environment-independent bound on this
+// run's event history. Earlier this test ran the emitter with NO cap: on
+// a machine where the surrounding Subscribe/cancel loop is slow (e.g.
+// under heavy contention or -race overhead), the emitter would keep
+// emitting for however long that takes, so the run's history could grow
+// completely unbounded — measured at over 9 MILLION events during
+// investigation of a real regression this caused (see the follow-up
+// review of fix/workflow-engine-concurrency: Subscribe's O(history)
+// store read, even after being moved outside e.mu, still made each
+// Subscribe call progressively more expensive as history grew, which in
+// turn gave the emitter more time to emit even more between Subscribes —
+// a runaway feedback loop). Capping the emitter keeps this a meaningful,
+// bounded stress test of the BUG 1 race regardless of how fast or slow
+// the machine running it is.
 func TestEmitCancelRaceDoesNotPanic(t *testing.T) {
 	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
 	const runID = "race-run"
 	const iterations = 2000
+	const maxEmits = 20000
 
 	stop := make(chan struct{})
 	var emitterWG sync.WaitGroup
 	emitterWG.Add(1)
 	go func() {
 		defer emitterWG.Done()
-		i := 0
-		for {
+		for i := 0; i < maxEmits; i++ {
 			select {
 			case <-stop:
 				return
 			default:
 			}
 			e.emit(runID, EventWorkflowLog, map[string]any{"i": i})
-			i++
 		}
 	}()
 

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -327,6 +327,120 @@ func TestConcurrentResumeExecutesScriptExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestConcurrentResumeCriticalSectionIsAtomic hardens BUG 4's coverage.
+// Follow-up review found TestConcurrentResumeExecutesScriptExactlyOnce
+// above passes even against the TOCTOU-buggy Resume when run WITHOUT
+// -race: the buggy window is a few instructions wide, and 8 goroutines
+// mostly serialize on e.mu anyway, so successCount==1 by luck, not by
+// proof. It only goes red under -race, and even then via "race detected
+// during execution of test", not via its own assertions -- so a
+// regression that reintroduces the TOCTOU without a literal data race
+// (e.g. an atomic-typed Status field checked-then-unlocked-then-set)
+// would ship silently.
+//
+// This test uses resumePreTransitionHook (a test-only seam, nil/no-op in
+// production) to deterministically pause the WINNING Resume call
+// mid-critical-section -- after it has passed the status check but
+// before it transitions the run -- and asserts that NONE of several
+// concurrently-racing Resume calls can complete while it's paused there.
+// That is only true if the check-and-transition genuinely holds e.mu for
+// its entire span; it does not depend on -race, timing luck, or how many
+// goroutines happen to serialize on the mutex by chance.
+func TestConcurrentResumeCriticalSectionIsAtomic(t *testing.T) {
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
+
+	var executions atomic.Int64
+	release := make(chan struct{})
+	e.Register("flaky-det", func(*Context) (any, error) {
+		n := executions.Add(1)
+		if n == 1 {
+			return nil, fmt.Errorf("boom")
+		}
+		<-release
+		return "resumed-ok", nil
+	})
+
+	run, err := e.Start(context.Background(), "flaky-det", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForStatus(t, e, run.ID, RunStatusFailed)
+
+	hookEntered := make(chan struct{})
+	hookRelease := make(chan struct{})
+	var hookCalls atomic.Int64
+	var hookEnteredOnce sync.Once
+	resumePreTransitionHook = func() {
+		// sync.Once here guards ONLY against a spurious double-close
+		// panic if this hook is somehow entered concurrently by more
+		// than one goroutine (which is exactly what happens against a
+		// non-atomic/buggy Resume) -- it does not affect the load-bearing
+		// assertions below (hookCalls, finishedCount, successCount),
+		// which still observe and report every entry.
+		hookCalls.Add(1)
+		hookEnteredOnce.Do(func() { close(hookEntered) })
+		<-hookRelease
+	}
+	t.Cleanup(func() { resumePreTransitionHook = nil })
+
+	const concurrentResumes = 8
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentResumes)
+	var finishedCount atomic.Int64
+	begin := make(chan struct{})
+	for i := 0; i < concurrentResumes; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-begin
+			_, resumeErr := e.Resume(context.Background(), run.ID, nil)
+			finishedCount.Add(1)
+			errs[idx] = resumeErr
+		}(i)
+	}
+	close(begin)
+
+	select {
+	case <-hookEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no Resume call reached resumePreTransitionHook within 2s")
+	}
+
+	// While the winner is paused inside the hook (holding e.mu, if the
+	// critical section is genuinely atomic), give the other goroutines
+	// ample time to attempt Resume. None of them can have finished yet --
+	// they're all blocked trying to acquire e.mu, which the winner still
+	// holds.
+	time.Sleep(150 * time.Millisecond)
+	if got := finishedCount.Load(); got != 0 {
+		t.Fatalf("expected 0 Resume calls to finish while the winner is paused mid-critical-section, got %d -- check-and-transition is not atomic", got)
+	}
+
+	close(hookRelease)
+	wg.Wait()
+
+	if got := hookCalls.Load(); got != 1 {
+		t.Fatalf("expected resumePreTransitionHook to fire exactly once, got %d", got)
+	}
+
+	successCount := 0
+	for _, resumeErr := range errs {
+		if resumeErr == nil {
+			successCount++
+		}
+	}
+	if successCount != 1 {
+		close(release)
+		t.Fatalf("expected exactly 1 successful Resume, got %d (errs=%v)", successCount, errs)
+	}
+
+	close(release)
+	waitForTerminal(t, e, run.ID)
+	if got := executions.Load(); got != 2 {
+		t.Fatalf("total script executions = %d, want 2 (1 initial + 1 resume)", got)
+	}
+}
+
 // ---------------------------------------------------------------------
 // BUG 5: Subscribe history/live gap loses terminal events
 // ---------------------------------------------------------------------

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -11,13 +11,16 @@ package workflow
 // red-then-green order, matching the commit trail.
 //
 //   BUG 1 (P0): send on closed channel in emit() vs Subscribe cancel()
+//   BUG 2 (P1): Context.Agent busy-loop polling
 
 import (
 	"context"
 	"fmt"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // noopSubagentManager satisfies SubagentManager for tests that never call
@@ -86,4 +89,53 @@ func TestEmitCancelRaceDoesNotPanic(t *testing.T) {
 
 	close(stop)
 	emitterWG.Wait()
+}
+
+// ---------------------------------------------------------------------
+// BUG 2: busy-loop poll pegs a CPU core
+// ---------------------------------------------------------------------
+//
+// Context.Agent's completion-wait loop selected on ctx.Done() with a
+// `default:` branch, so it never blocked — it spun at 100% CPU polling
+// Get() for the entire lifetime of every in-flight subagent.
+//
+// countingRunningMgr's subagent never completes. We bound the Context's
+// own ctx with a short timeout (instead of relying on the poll interval,
+// which the fix has not introduced yet) and assert the number of Get()
+// calls made in that window is small. A busy-loop produces many hundreds
+// of thousands of calls in even a few milliseconds; a properly-blocking
+// poll makes only a handful.
+type countingRunningMgr struct {
+	getCalls atomic.Int64
+}
+
+func (m *countingRunningMgr) Create(context.Context, SubagentRequest) (SubagentResult, error) {
+	return SubagentResult{ID: "agent-1", Status: "running"}, nil
+}
+
+func (m *countingRunningMgr) Get(_ context.Context, id string) (SubagentResult, error) {
+	m.getCalls.Add(1)
+	return SubagentResult{ID: id, Status: "running"}, nil
+}
+
+func TestAgentPollDoesNotBusyLoop(t *testing.T) {
+	mgr := &countingRunningMgr{}
+	e := NewEngine(EngineOptions{Subagents: mgr, MaxConcurrency: 1})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	wfCtx := newContext(ctx, e, "run-poll", nil, newBudget(0))
+
+	_, err := wfCtx.Agent("do work", nil)
+	if err == nil {
+		t.Fatalf("expected Agent to return an error when its context deadline expires")
+	}
+
+	gets := mgr.getCalls.Load()
+	// A busy-loop with no blocking will issue an enormous number of Get()
+	// calls in 50ms (typically well over a million on modern hardware). A
+	// properly-blocking poll should issue only a handful in that window.
+	if gets > 1000 {
+		t.Fatalf("expected a bounded number of poll calls within ~50ms, got %d (looks like a busy-loop)", gets)
+	}
 }

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -1,0 +1,89 @@
+package workflow
+
+// Tests in this file exercise internal Engine/Context state directly
+// (package workflow, not workflow_test) because reproducing each bug
+// requires either unexported access (subagentPollInterval, e.emit,
+// e.scripts) or precise timing control that the public API does not
+// expose.
+//
+// Each test corresponds to one of the five bugs tracked for
+// fix/workflow-engine-concurrency. Bugs are added test-by-test, in
+// red-then-green order, matching the commit trail.
+//
+//   BUG 1 (P0): send on closed channel in emit() vs Subscribe cancel()
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// noopSubagentManager satisfies SubagentManager for tests that never call
+// Context.Agent and just need a valid Engine.
+type noopSubagentManager struct{}
+
+func (noopSubagentManager) Create(context.Context, SubagentRequest) (SubagentResult, error) {
+	return SubagentResult{}, fmt.Errorf("noopSubagentManager: Create not implemented")
+}
+
+func (noopSubagentManager) Get(context.Context, string) (SubagentResult, error) {
+	return SubagentResult{}, fmt.Errorf("noopSubagentManager: Get not implemented")
+}
+
+// ---------------------------------------------------------------------
+// BUG 1: send on closed channel crashes harnessd
+// ---------------------------------------------------------------------
+//
+// emit() historically snapshotted subscriber channels under e.mu, released
+// the lock, then sent on each channel outside the lock. Subscribe's cancel
+// func takes the lock, deletes the channel from e.subs, and closes it. If
+// emit captured the channel before cancel ran, but cancel's close() happens
+// before emit's send loop reaches that channel, emit sends on a closed
+// channel and panics. A `select`/`default` guard does NOT protect against
+// this — it only guards a full channel, not a closed one.
+//
+// This test concurrently emits (continuously) while subscribing and
+// immediately cancelling, many times, to force the interleaving that
+// triggers the panic. A panic in this non-recovered emitter goroutine will
+// crash the whole test binary — exactly the harnessd crash the bug causes
+// in production when an SSE client disconnects mid-stream.
+func TestEmitCancelRaceDoesNotPanic(t *testing.T) {
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
+	const runID = "race-run"
+	const iterations = 2000
+
+	stop := make(chan struct{})
+	var emitterWG sync.WaitGroup
+	emitterWG.Add(1)
+	go func() {
+		defer emitterWG.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			e.emit(runID, EventWorkflowLog, map[string]any{"i": i})
+			i++
+		}
+	}()
+
+	for i := 0; i < iterations; i++ {
+		_, _, cancel, err := e.Subscribe(runID)
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+		if i%5 == 0 {
+			// Occasionally yield so the emitter goroutine has a chance to
+			// capture this channel before we cancel it.
+			runtime.Gosched()
+		}
+		cancel()
+	}
+
+	close(stop)
+	emitterWG.Wait()
+}

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -241,3 +241,100 @@ func TestConcurrentRegisterAndContextWorkflowNoRace(t *testing.T) {
 	close(stop)
 	registerWG.Wait()
 }
+
+// ---------------------------------------------------------------------
+// BUG 4: Resume TOCTOU allows double execution
+// ---------------------------------------------------------------------
+//
+// Resume checked run.Status != RunStatusFailed, unlocked, THEN mutated the
+// shared Run and spawned execution. Two concurrent Resume calls on the
+// same failed run both pass the check before either mutates state, so
+// both spawn `go e.execute` -- the script runs twice for one Resume
+// "event".
+func TestConcurrentResumeExecutesScriptExactlyOnce(t *testing.T) {
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
+
+	var executions atomic.Int64
+	e.Register("flaky", func(*Context) (any, error) {
+		executions.Add(1)
+		return nil, fmt.Errorf("boom")
+	})
+
+	run, err := e.Start(context.Background(), "flaky", nil)
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitForStatus(t, e, run.ID, RunStatusFailed)
+	if got := executions.Load(); got != 1 {
+		t.Fatalf("initial execution count = %d, want 1", got)
+	}
+
+	const concurrentResumes = 8
+	var wg sync.WaitGroup
+	errs := make([]error, concurrentResumes)
+	var ready sync.WaitGroup
+	ready.Add(concurrentResumes)
+	start := make(chan struct{})
+	for i := 0; i < concurrentResumes; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ready.Done()
+			<-start
+			_, resumeErr := e.Resume(context.Background(), run.ID, nil)
+			errs[idx] = resumeErr
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	// Exactly one Resume call should have succeeded in transitioning the
+	// run; the rest must observe it's no longer Failed and error out.
+	successCount := 0
+	for _, resumeErr := range errs {
+		if resumeErr == nil {
+			successCount++
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("expected exactly 1 successful Resume, got %d (errs=%v)", successCount, errs)
+	}
+
+	waitForTerminal(t, e, run.ID)
+
+	// executions started at 1 (the initial failed Start). Exactly one more
+	// execution should have happened from the single successful Resume.
+	if got := executions.Load(); got != 2 {
+		t.Fatalf("total script executions = %d, want 2 (1 initial + 1 resume)", got)
+	}
+}
+
+// waitForStatus polls GetRun until the run reaches want or the deadline
+// expires.
+func waitForStatus(t *testing.T, e *Engine, runID string, want RunStatus) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		run, err := e.GetRun(runID)
+		if err == nil && run.Status == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach status %s in time", runID, want)
+}
+
+// waitForTerminal polls GetRun until the run reaches a terminal status.
+func waitForTerminal(t *testing.T, e *Engine, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		run, err := e.GetRun(runID)
+		if err == nil && (run.Status == RunStatusCompleted || run.Status == RunStatusFailed) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach a terminal status in time", runID)
+}

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -190,3 +190,54 @@ func (m *countingRunningMgr) Get(_ context.Context, id string) (SubagentResult, 
 	m.getCalls.Add(1)
 	return SubagentResult{ID: id, Status: "running"}, nil
 }
+
+// ---------------------------------------------------------------------
+// BUG 3: unlocked map read races registration
+// ---------------------------------------------------------------------
+//
+// Context.Workflow reads c.engine.scripts[name] without holding
+// c.engine.mu, while Engine.Register writes that same map. Concurrent
+// unsynchronized map read/write is a FATAL Go runtime error (not a
+// recoverable panic) -- this test, run with -race, must not trigger it.
+func TestConcurrentRegisterAndContextWorkflowNoRace(t *testing.T) {
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
+	e.Register("base", func(*Context) (any, error) { return "ok", nil })
+
+	wfCtx := newContext(context.Background(), e, "run-workflow-race", nil, newBudget(0))
+
+	stop := make(chan struct{})
+	var registerWG sync.WaitGroup
+	registerWG.Add(1)
+	go func() {
+		defer registerWG.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			name := fmt.Sprintf("dyn-%d", i)
+			e.Register(name, func(*Context) (any, error) { return nil, nil })
+			i++
+		}
+	}()
+
+	const iterations = 2000
+	for i := 0; i < iterations; i++ {
+		result, err := wfCtx.Workflow("base", nil)
+		if err != nil {
+			close(stop)
+			registerWG.Wait()
+			t.Fatalf("Workflow: %v", err)
+		}
+		if result != "ok" {
+			close(stop)
+			registerWG.Wait()
+			t.Fatalf("Workflow result = %v, want %q", result, "ok")
+		}
+	}
+
+	close(stop)
+	registerWG.Wait()
+}

--- a/internal/workflow/concurrency_bugs_internal_test.go
+++ b/internal/workflow/concurrency_bugs_internal_test.go
@@ -468,8 +468,13 @@ func TestConcurrentResumeCriticalSectionIsAtomic(t *testing.T) {
 // client hangs forever.
 //
 // This test races emit() against Subscribe() for the same runID many
-// times (alternating which starts first) and asserts the event is always
-// observed either in history or on the live channel -- never neither.
+// times (alternating which starts first) and asserts the event is
+// observed EXACTLY ONCE across history + live channel -- never neither
+// (lost) and never both (duplicated). Third-round review correctly noted
+// the original version of this test only checked "found in history OR
+// live", which would have silently passed even if an event appeared in
+// BOTH sets -- the history/live split (Subscribe's Seq <= recordedSeq
+// trim) is load-bearing but was unguarded against double-counting.
 func TestSubscribeNeverMissesConcurrentEmit(t *testing.T) {
 	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}})
 	const iterations = 500
@@ -502,26 +507,36 @@ func TestSubscribeNeverMissesConcurrentEmit(t *testing.T) {
 
 		emitWG.Wait()
 
-		found := false
+		foundInHistory := 0
 		for _, ev := range history {
 			if ev.Type == EventWorkflowCompleted {
-				found = true
-				break
+				foundInHistory++
 			}
 		}
-		if !found {
+
+		foundLive := 0
+	drain:
+		for {
 			select {
-			case ev := <-ch:
+			case ev, ok := <-ch:
+				if !ok {
+					break drain
+				}
 				if ev.Type == EventWorkflowCompleted {
-					found = true
+					foundLive++
 				}
 			case <-time.After(200 * time.Millisecond):
+				break drain
 			}
 		}
 		cancel()
 
-		if !found {
+		total := foundInHistory + foundLive
+		if total == 0 {
 			t.Fatalf("iteration %d: terminal event lost — not in history and not delivered live", i)
+		}
+		if total > 1 {
+			t.Fatalf("iteration %d: terminal event duplicated — appeared %d times across history+live (history=%d live=%d)", i, total, foundInHistory, foundLive)
 		}
 	}
 }

--- a/internal/workflow/concurrency_regression_test.go
+++ b/internal/workflow/concurrency_regression_test.go
@@ -1,0 +1,189 @@
+package workflow_test
+
+// This is a black-box regression test for the fix/workflow-engine-concurrency
+// bug batch (BUG 1-5 in internal/workflow/concurrency_bugs_internal_test.go).
+// Unlike the bug-specific tests, which each isolate a single race with
+// direct/internal access, this test drives the Engine purely through its
+// public API the way the HTTP layer (internal/server/http_script_workflows.go)
+// actually does: Start a workflow, have many SSE-style subscribers
+// connect and disconnect at random points while it runs (mirroring an SSE
+// client disconnecting mid-stream), run nested Workflow() calls
+// concurrently with new Register() calls, and fire concurrent Resume
+// calls against a failed run.
+//
+// If any of the BUG 1-5 fixes are reverted, this test:
+//   - panics the whole test binary (BUG 1: send on closed channel),
+//   - times out or takes drastically longer (BUG 2: busy-loop poll),
+//   - crashes with a fatal Go runtime error under -race (BUG 3: unlocked
+//     map read/write),
+//   - observes more than one successful concurrent Resume / more than the
+//     expected number of script executions (BUG 4: TOCTOU double exec),
+//   - or fails to observe the terminal event for a subscriber connected
+//     at exactly the wrong moment (BUG 5: history/live gap).
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/workflow"
+)
+
+func TestWorkflowEngineSurvivesConcurrentSubscribersRegistrationAndResume(t *testing.T) {
+	mgr := newMockMgr()
+	mgr.delay = 2 * time.Millisecond // force Context.Agent's poll loop to iterate at least once
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr, MaxConcurrency: 4})
+
+	eng.Register("nested-leaf", func(ctx *workflow.Context) (any, error) {
+		return "leaf-ok", nil
+	})
+
+	// "main" exercises: real agent() polling (BUG 2), several log/emit
+	// calls that concurrent subscribers race against (BUG 1 + BUG 5), and
+	// repeated nested workflow() lookups racing against concurrent
+	// Register() calls from outside (BUG 3).
+	eng.Register("main", func(ctx *workflow.Context) (any, error) {
+		for i := 0; i < 20; i++ {
+			ctx.Log(fmt.Sprintf("step %d", i))
+			if _, err := ctx.Workflow("nested-leaf", nil); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := ctx.Agent("do work", nil); err != nil {
+			return nil, err
+		}
+		return "main-ok", nil
+	})
+
+	run, err := eng.Start(context.Background(), "main", nil)
+	require.NoError(t, err)
+
+	// SSE-style subscribers: connect, maybe read a bit, then disconnect
+	// at a randomized moment — this is exactly the pattern that triggers
+	// BUG 1 (panic) and stresses BUG 5 (lost terminal event) in
+	// production when a browser tab closes mid-stream.
+	var subWG sync.WaitGroup
+	stopSubs := make(chan struct{})
+	for s := 0; s < 20; s++ {
+		subWG.Add(1)
+		go func(id int) {
+			defer subWG.Done()
+			for {
+				select {
+				case <-stopSubs:
+					return
+				default:
+				}
+				_, ch, cancel, err := eng.Subscribe(run.ID)
+				if err != nil {
+					return
+				}
+				// Randomized dwell time before disconnecting, to hit a
+				// wide spread of race windows against emit().
+				select {
+				case <-ch:
+				case <-time.After(time.Duration(rand.Intn(2)) * time.Millisecond):
+				}
+				cancel()
+			}
+		}(s)
+	}
+
+	// Concurrently register new (unrelated) workflows while "main" is
+	// repeatedly calling ctx.Workflow("nested-leaf", ...) — races
+	// Engine.Register's map write against Context.Workflow's map read.
+	var registerWG sync.WaitGroup
+	stopRegister := make(chan struct{})
+	registerWG.Add(1)
+	go func() {
+		defer registerWG.Done()
+		i := 0
+		for {
+			select {
+			case <-stopRegister:
+				return
+			default:
+			}
+			eng.RegisterWithMeta(workflow.Meta{Name: fmt.Sprintf("extra-%d", i)}, func(*workflow.Context) (any, error) {
+				return nil, nil
+			})
+			i++
+		}
+	}()
+
+	waitForRun(t, eng, run.ID, workflow.RunStatusCompleted)
+
+	close(stopRegister)
+	registerWG.Wait()
+	close(stopSubs)
+	subWG.Wait()
+
+	final, err := eng.GetRun(run.ID)
+	require.NoError(t, err)
+	require.Equal(t, workflow.RunStatusCompleted, final.Status)
+	require.Contains(t, final.ResultJSON, "main-ok")
+
+	// A subscriber connecting strictly after completion must still see
+	// the terminal event in history — proves BUG 5 stays fixed even
+	// after the run has settled.
+	history, _, cancel, err := eng.Subscribe(run.ID)
+	require.NoError(t, err)
+	defer cancel()
+	foundTerminal := false
+	for _, ev := range history {
+		if ev.Type == workflow.EventWorkflowCompleted {
+			foundTerminal = true
+			break
+		}
+	}
+	require.True(t, foundTerminal, "terminal event missing from history after completion")
+
+	// --- Concurrent Resume regression (BUG 4) ---
+	var executions atomic.Int64
+	release := make(chan struct{})
+	eng.Register("flaky-regression", func(*workflow.Context) (any, error) {
+		n := executions.Add(1)
+		if n == 1 {
+			return nil, fmt.Errorf("boom")
+		}
+		<-release
+		return "resumed-ok", nil
+	})
+	flakyRun, err := eng.Start(context.Background(), "flaky-regression", nil)
+	require.NoError(t, err)
+	waitForRun(t, eng, flakyRun.ID, workflow.RunStatusFailed)
+
+	const concurrentResumes = 6
+	var resumeWG sync.WaitGroup
+	resumeErrs := make([]error, concurrentResumes)
+	begin := make(chan struct{})
+	for i := 0; i < concurrentResumes; i++ {
+		resumeWG.Add(1)
+		go func(idx int) {
+			defer resumeWG.Done()
+			<-begin
+			_, resumeErr := eng.Resume(context.Background(), flakyRun.ID, nil)
+			resumeErrs[idx] = resumeErr
+		}(i)
+	}
+	close(begin)
+	resumeWG.Wait()
+
+	successes := 0
+	for _, resumeErr := range resumeErrs {
+		if resumeErr == nil {
+			successes++
+		}
+	}
+	require.Equal(t, 1, successes, "exactly one concurrent Resume should succeed, errs=%v", resumeErrs)
+
+	close(release)
+	waitForRun(t, eng, flakyRun.ID, workflow.RunStatusCompleted)
+	require.Equal(t, int64(2), executions.Load(), "flaky-regression script should execute exactly twice total")
+}

--- a/internal/workflow/context.go
+++ b/internal/workflow/context.go
@@ -85,7 +85,12 @@ func (c *Context) Agent(prompt string, opts *AgentOpts) (*AgentResult, error) {
 
 	phase := opts.Phase
 	if phase == "" {
+		// c.phase is written by Phase() under c.mu; Parallel()/Pipeline()
+		// goroutines share this Context, so a concurrent Phase() call
+		// from another thunk makes this a real race without the lock.
+		c.mu.Lock()
 		phase = c.phase
+		c.mu.Unlock()
 	}
 
 	c.emit(EventWorkflowAgentStarted, map[string]any{

--- a/internal/workflow/context.go
+++ b/internal/workflow/context.go
@@ -397,7 +397,13 @@ func (c *Context) Question(prompt string, choices []QuestionOption) (any, error)
 // Returns the nested workflow's result. Errors from the nested workflow
 // are propagated.
 func (c *Context) Workflow(name string, args any) (any, error) {
+	// c.engine.scripts is mutated by Engine.Register from arbitrary
+	// goroutines, so it must only be read under c.engine.mu — exactly as
+	// Engine.Start does. Copy the value out while holding the lock, then
+	// unlock before proceeding.
+	c.engine.mu.Lock()
 	meta, ok := c.engine.scripts[name]
+	c.engine.mu.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("nested workflow %q not found", name)
 	}

--- a/internal/workflow/context.go
+++ b/internal/workflow/context.go
@@ -5,9 +5,15 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 )
+
+// subagentPollInterval controls how often Context.Agent polls a subagent's
+// status while waiting for it to complete. It is a var (not a const) so
+// tests can shrink it to keep polling tests fast and deterministic.
+var subagentPollInterval = 250 * time.Millisecond
 
 // Context is the execution context passed to workflow scripts.
 // It provides all orchestration primitives: agent(), parallel(), pipeline(),
@@ -112,15 +118,13 @@ func (c *Context) Agent(prompt string, opts *AgentOpts) (*AgentResult, error) {
 		return nil, err
 	}
 
-	// Wait for the subagent to complete by polling its status.
+	// Wait for the subagent to complete by polling its status. Each
+	// iteration blocks on either context cancellation or the poll
+	// interval elapsing — it must never spin, since this loop runs for
+	// the entire lifetime of every in-flight subagent.
 	completed := false
 	var finalResult SubagentResult
 	for !completed {
-		select {
-		case <-c.ctx.Done():
-			return nil, c.ctx.Err()
-		default:
-		}
 		finalResult, err = c.engine.subagents.Get(c.ctx, result.ID)
 		if err != nil {
 			c.emit(EventWorkflowAgentFailed, map[string]any{
@@ -135,11 +139,11 @@ func (c *Context) Agent(prompt string, opts *AgentOpts) (*AgentResult, error) {
 			completed = true
 		}
 		if !completed {
-			// Simple backoff polling — in production this would use streaming events.
+			// Backoff polling — in production this would use streaming events.
 			select {
 			case <-c.ctx.Done():
 				return nil, c.ctx.Err()
-			default:
+			case <-time.After(subagentPollInterval):
 			}
 		}
 	}

--- a/internal/workflow/context_phase_race_test.go
+++ b/internal/workflow/context_phase_race_test.go
@@ -1,0 +1,49 @@
+package workflow_test
+
+// Strongly recommended by third-round review of fix/workflow-engine-
+// concurrency: Context.Phase() writes c.phase under c.mu, but
+// Context.Agent() reads c.phase with NO lock. Parallel()/Pipeline()
+// goroutines share a single *Context, so a script that calls ctx.Phase()
+// in one thunk and ctx.Agent() in another is a genuine data race,
+// confirmed under -race. This is byte-identical at the fork point (not a
+// regression introduced by this branch), but since this IS the
+// concurrency-hardening branch for this package, it's folded in here.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/workflow"
+)
+
+// TestParallelPhaseAndAgentDoNotRace calls ctx.Phase() and ctx.Agent()
+// concurrently from two Parallel() thunks sharing the same *Context. Run
+// with -race, this must not report a data race.
+func TestParallelPhaseAndAgentDoNotRace(t *testing.T) {
+	eng, _ := newEngine(t)
+	eng.Register("phase-agent-race", func(ctx *workflow.Context) (any, error) {
+		_, _ = ctx.Parallel([]func() (any, error){
+			func() (any, error) {
+				for i := 0; i < 200; i++ {
+					ctx.Phase("phase")
+				}
+				return nil, nil
+			},
+			func() (any, error) {
+				for i := 0; i < 200; i++ {
+					if _, err := ctx.Agent("hello", nil); err != nil {
+						return nil, err
+					}
+				}
+				return nil, nil
+			},
+		})
+		return nil, nil
+	})
+
+	run, err := eng.Start(context.Background(), "phase-agent-race", nil)
+	require.NoError(t, err)
+	waitForRun(t, eng, run.ID, workflow.RunStatusCompleted)
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -254,14 +254,22 @@ func (e *Engine) GetRun(runID string) (*Run, error) {
 //
 // If the run completes or fails, the channel will stop receiving events;
 // subscribers should use the cancel function to clean up.
+//
+// The history read and the channel registration happen atomically under
+// e.mu, matching how emit() holds e.mu across its store append and
+// subscriber fan-out. This closes the gap where an event emitted between
+// "read history" and "register channel" would previously land in
+// neither — permanently lost, which is fatal if it's the terminal
+// workflow.completed/failed event (an SSE client would hang forever).
 func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) {
+	ch := make(chan Event, 64)
+
+	e.mu.Lock()
 	history, err := e.store.GetEvents(context.Background(), runID, -1)
 	if err != nil {
+		e.mu.Unlock()
 		return nil, nil, nil, err
 	}
-
-	ch := make(chan Event, 64)
-	e.mu.Lock()
 	if _, ok := e.subs[runID]; !ok {
 		e.subs[runID] = make(map[chan Event]struct{})
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -139,6 +140,26 @@ func (e *Engine) List() []Meta {
 	return out
 }
 
+// scriptFor looks up a registered script by name under e.mu. It is the
+// single shared, defer-safe way to read e.scripts from a standalone
+// caller (Start, Context.Workflow). Callers that already hold e.mu for a
+// larger compound operation (e.g. Resume's check-and-transition) must NOT
+// call this — sync.Mutex is not reentrant, and doing so would deadlock.
+// Those callers read e.scripts directly under their own lock instead.
+func (e *Engine) scriptFor(name string) (registeredScript, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	reg, ok := e.scripts[name]
+	return reg, ok
+}
+
+// registerRun records a newly-created run under e.mu.
+func (e *Engine) registerRun(run *Run) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.runs[run.ID] = run
+}
+
 // Start begins executing a workflow by name with the given args.
 // The workflow runs asynchronously in a goroutine. The returned Run has
 // status RunStatusRunning and can be monitored via Subscribe.
@@ -146,9 +167,7 @@ func (e *Engine) List() []Meta {
 // Start creates a new run ID, persists it via the Store, emits a
 // workflow.started event, then executes the script in a goroutine.
 func (e *Engine) Start(ctx context.Context, name string, args any) (*Run, error) {
-	e.mu.Lock()
-	reg, ok := e.scripts[name]
-	e.mu.Unlock()
+	reg, ok := e.scriptFor(name)
 	if !ok {
 		return nil, fmt.Errorf("workflow %q not found", name)
 	}
@@ -161,9 +180,7 @@ func (e *Engine) Start(ctx context.Context, name string, args any) (*Run, error)
 		UpdatedAt:    e.now().UTC(),
 	}
 
-	e.mu.Lock()
-	e.runs[run.ID] = run
-	e.mu.Unlock()
+	e.registerRun(run)
 
 	if err := e.store.CreateRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("persist run: %w", err)
@@ -180,6 +197,19 @@ func (e *Engine) Start(ctx context.Context, name string, args any) (*Run, error)
 	return &cp, nil
 }
 
+// resumePreTransitionHook is a test-only seam. When non-nil, Resume calls
+// it after the status check passes (run.Status == RunStatusFailed, script
+// still registered) but before it transitions the run to
+// RunStatusRunning — while STILL HOLDING e.mu. It is nil (a no-op) in
+// production.
+//
+// This lets tests deterministically pause Resume mid-critical-section and
+// assert that no concurrently-racing Resume call can complete until this
+// one does, proving the check-and-transition is genuinely atomic rather
+// than relying on winning a timing race under -race. See
+// TestConcurrentResumeCriticalSectionIsAtomic.
+var resumePreTransitionHook func()
+
 // Resume continues a previously failed workflow run. The args are passed to
 // the script, which should use them to pick up where it left off.
 //
@@ -189,44 +219,58 @@ func (e *Engine) Start(ctx context.Context, name string, args any) (*Run, error)
 // Only runs with status RunStatusFailed can be resumed. The run's error is
 // cleared and its status reset to RunStatusRunning before re-execution.
 func (e *Engine) Resume(ctx context.Context, runID string, args any) (*Run, error) {
-	// The status check and the transition to RunStatusRunning must be
-	// atomic under e.mu. Otherwise two concurrent Resume calls can both
-	// observe RunStatusFailed before either mutates the run, and both
-	// spawn `go e.execute` — running the script twice for one Resume.
-	e.mu.Lock()
-	run, ok := e.runs[runID]
-	if !ok {
-		e.mu.Unlock()
-		return nil, fmt.Errorf("workflow run %q not found", runID)
-	}
-	if run.Status != RunStatusFailed {
-		e.mu.Unlock()
-		return nil, fmt.Errorf("workflow run %q has status %s, can only resume failed runs", runID, run.Status)
-	}
-	reg, ok := e.scripts[run.WorkflowName]
-	if !ok {
-		e.mu.Unlock()
-		return nil, fmt.Errorf("workflow %q no longer registered", run.WorkflowName)
-	}
+	// The status check, the registered-script lookup, and the transition
+	// to RunStatusRunning are one atomic critical section under e.mu.
+	// Otherwise two concurrent Resume calls could both observe
+	// RunStatusFailed before either mutates the run, and both spawn
+	// `go e.execute` — running the script twice for one Resume. e.scripts
+	// is read directly here (not via scriptFor) because this goroutine
+	// already holds e.mu and sync.Mutex is not reentrant.
+	reg, cp, err := func() (registeredScript, Run, error) {
+		e.mu.Lock()
+		defer e.mu.Unlock()
 
-	run.Status = RunStatusRunning
-	run.Error = ""
-	run.UpdatedAt = e.now().UTC()
-	// Copy while still holding the lock so later readers of the shared
-	// *Run (e.g. GetRun, or another goroutine) never race with this
-	// mutation, and so the persisted/emitted view matches what we just
-	// committed.
-	cp := *run
-	e.mu.Unlock()
+		run, ok := e.runs[runID]
+		if !ok {
+			return registeredScript{}, Run{}, fmt.Errorf("workflow run %q not found", runID)
+		}
+		if run.Status != RunStatusFailed {
+			return registeredScript{}, Run{}, fmt.Errorf("workflow run %q has status %s, can only resume failed runs", runID, run.Status)
+		}
+		reg, ok := e.scripts[run.WorkflowName]
+		if !ok {
+			return registeredScript{}, Run{}, fmt.Errorf("workflow %q no longer registered", run.WorkflowName)
+		}
+
+		if resumePreTransitionHook != nil {
+			resumePreTransitionHook()
+		}
+
+		run.Status = RunStatusRunning
+		run.Error = ""
+		run.UpdatedAt = e.now().UTC()
+		// Copy while still holding the lock. This is what actually
+		// prevents a race with concurrent readers of the shared *Run:
+		// every other engine.go call site that reads or writes a run
+		// (GetRun, and executeScriptAsync's terminal transition via
+		// finishRun/transitionRunTerminal) also only ever touches a
+		// private copy taken under e.mu, or the map entry itself under
+		// e.mu — never this pointer after it's released. Passing &cp
+		// (not run) to store.UpdateRun below is what closes that loop.
+		return reg, *run, nil
+	}()
+	if err != nil {
+		return nil, err
+	}
 
 	_ = e.store.UpdateRun(ctx, &cp)
 
-	e.emit(run.ID, EventWorkflowStarted, map[string]any{
+	e.emit(cp.ID, EventWorkflowStarted, map[string]any{
 		"workflow": reg.Meta.Name,
 		"resumed":  true,
 	})
 
-	go e.execute(run.ID, reg, args)
+	go e.execute(cp.ID, reg, args)
 	return &cp, nil
 }
 
@@ -234,13 +278,12 @@ func (e *Engine) Resume(ctx context.Context, runID string, args any) (*Run, erro
 // The returned Run is a copy, safe for concurrent reading.
 func (e *Engine) GetRun(runID string) (*Run, error) {
 	e.mu.Lock()
+	defer e.mu.Unlock()
 	run, ok := e.runs[runID]
 	if !ok {
-		e.mu.Unlock()
 		return nil, fmt.Errorf("workflow run %q not found", runID)
 	}
 	cp := *run // copy while holding the lock
-	e.mu.Unlock()
 	return &cp, nil
 }
 
@@ -265,16 +308,16 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 	ch := make(chan Event, 64)
 
 	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	history, err := e.store.GetEvents(context.Background(), runID, -1)
 	if err != nil {
-		e.mu.Unlock()
 		return nil, nil, nil, err
 	}
 	if _, ok := e.subs[runID]; !ok {
 		e.subs[runID] = make(map[chan Event]struct{})
 	}
 	e.subs[runID][ch] = struct{}{}
-	e.mu.Unlock()
 
 	cancel := func() {
 		e.mu.Lock()
@@ -294,11 +337,30 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 func (e *Engine) execute(runID string, reg registeredScript, args any) {
 	// Defense in depth: this runs on a bare `go e.execute(...)` goroutine
 	// with no caller to recover a panic. executeScript already recovers
-	// panics from the script body itself, but this guards against any
-	// panic elsewhere in the execution/emit path (e.g. a future bug in
-	// emit) so it can never take down the whole process.
+	// panics from the script body itself; this guards against a panic
+	// ANYWHERE ELSE in the execution/emit path (e.g. a panicking
+	// MarshalJSON on the script's result, invoked by json.Marshal in
+	// executeScriptAsync).
+	//
+	// This must NEVER be a bare `recover()` that discards the panic: a
+	// swallowed panic here leaves the run stuck at RunStatusRunning
+	// forever with no persisted error and no terminal event, which hangs
+	// every SSE subscriber and every status poll indefinitely — worse
+	// than not recovering at all. So this recover makes the run terminal
+	// and observable: it logs the panic, marks the run Failed via the
+	// same finishRun/transitionRunTerminal helper executeScriptAsync
+	// uses for a normal script error, persists it, and emits
+	// workflow.failed.
+	//
+	// json.Marshal is deliberately called OUTSIDE e.mu in
+	// executeScriptAsync (see below) specifically so a panic there is
+	// caught here with no lock held — finishRun's own e.mu.Lock() below
+	// is therefore guaranteed to succeed, never self-deadlock.
 	defer func() {
-		_ = recover()
+		if r := recover(); r != nil {
+			log.Printf("workflow: recovered panic in Engine.execute for run %s: %v", runID, r)
+			e.finishRun(runID, reg, fmt.Errorf("workflow engine panic: %v", r), "")
+		}
 	}()
 
 	budget := newBudget(e.defaultBudget)
@@ -342,40 +404,86 @@ func (e *Engine) executeScript(ctx *Context, reg registeredScript) (any, error) 
 func (e *Engine) executeScriptAsync(runID string, reg registeredScript, ctx *Context) {
 	result, err := e.executeScript(ctx, reg)
 
-	e.mu.Lock()
-	run, ok := e.runs[runID]
+	// json.Marshal is called BEFORE taking e.mu and is NOT wrapped in its
+	// own recover here. It can invoke arbitrary user-supplied
+	// MarshalJSON/String methods on the script's result, and
+	// encoding/json only recovers its OWN internal sentinel error type —
+	// any other panic (e.g. a MarshalJSON that indexes a nil map) is
+	// re-panicked out of json.Marshal. No user-supplied code may EVER
+	// run while e.mu is held (a MarshalJSON that itself calls ctx.Log()
+	// would re-enter emit() -> e.mu on this same, non-reentrant mutex and
+	// self-deadlock even with e.mu correctly scoped). If it panics, it
+	// propagates to execute()'s outer recover, which converts it into a
+	// terminal Failed run via this same finishRun helper — so the
+	// failure mode is "run fails with a descriptive error", never "run
+	// hangs" or "process wedges".
+	var resultJSON string
+	if err == nil && result != nil {
+		if raw, marshalErr := json.Marshal(result); marshalErr == nil {
+			resultJSON = string(raw)
+		}
+		// A normal (non-panic) marshal error is non-fatal, exactly as
+		// before: ResultJSON simply stays empty and the run still
+		// completes.
+	}
+
+	e.finishRun(runID, reg, err, resultJSON)
+}
+
+// finishRun applies the terminal status transition for a run and persists
+// + emits it. It is used both by the normal executeScriptAsync path and
+// by execute()'s outer panic recovery, so every terminal transition goes
+// through the same, single code path.
+//
+// scriptErr nil means the script (and marshaling) succeeded; non-nil
+// means it failed (including a recovered panic, wrapped by the caller).
+func (e *Engine) finishRun(runID string, reg registeredScript, scriptErr error, resultJSON string) {
+	cp, ok := e.transitionRunTerminal(runID, scriptErr, resultJSON)
 	if !ok {
-		e.mu.Unlock()
+		// Run no longer tracked (e.g. removed concurrently) — nothing to
+		// persist or emit.
 		return
 	}
 
-	if err != nil {
-		run.Status = RunStatusFailed
-		run.Error = err.Error()
-	} else {
-		run.Status = RunStatusCompleted
-		if result != nil {
-			raw, marshalErr := json.Marshal(result)
-			if marshalErr == nil {
-				run.ResultJSON = string(raw)
-			}
-		}
-	}
-	run.UpdatedAt = e.now().UTC()
-	e.mu.Unlock()
+	_ = e.store.UpdateRun(context.Background(), &cp)
 
-	_ = e.store.UpdateRun(context.Background(), run)
-
-	if err != nil {
+	if scriptErr != nil {
 		e.emit(runID, EventWorkflowFailed, map[string]any{
 			"workflow": reg.Meta.Name,
-			"error":    err.Error(),
+			"error":    scriptErr.Error(),
 		})
 	} else {
 		e.emit(runID, EventWorkflowCompleted, map[string]any{
 			"workflow": reg.Meta.Name,
 		})
 	}
+}
+
+// transitionRunTerminal mutates the run's status under e.mu and returns a
+// private copy for the caller to persist/emit OUTSIDE the lock. Passing
+// this copy (never the shared *Run pointer) to store.UpdateRun is what
+// prevents it from racing a concurrent Resume's mutation of the same run
+// under e.mu.
+func (e *Engine) transitionRunTerminal(runID string, scriptErr error, resultJSON string) (Run, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	run, ok := e.runs[runID]
+	if !ok {
+		return Run{}, false
+	}
+
+	if scriptErr != nil {
+		run.Status = RunStatusFailed
+		run.Error = scriptErr.Error()
+	} else {
+		run.Status = RunStatusCompleted
+		if resultJSON != "" {
+			run.ResultJSON = resultJSON
+		}
+	}
+	run.UpdatedAt = e.now().UTC()
+	return *run, true
 }
 
 // emit sends an event to all subscribers of a run and persists it via the Store.

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -55,9 +55,32 @@ type Engine struct {
 	now            func() time.Time
 
 	mu        sync.Mutex
-	subs      map[string]map[chan Event]struct{}
+	subs      map[string]map[chan Event]*subEntry
 	eventSeqs map[string]int64
 	runs      map[string]*Run
+}
+
+// subEntry tracks one Subscribe call's live channel and, while it is
+// still copying history (the window between registration and Subscribe
+// returning), a buffer of events that arrived during that window.
+//
+// emit()'s fan-out send is non-blocking into a 64-slot channel, and the
+// subscribing goroutine cannot drain that channel until Subscribe()
+// itself returns (it hasn't been given the channel yet). So without this
+// buffer, any burst of more than 64 events emitted during the
+// (deliberately unlocked, O(history)) store.GetEvents copy would
+// overflow the channel send AND be excluded from Subscribe's history
+// trim (their Seq is > recordedSeq) -- reaching neither set. That is a
+// real gap, just a different route to it than the one BUG 5 originally
+// closed.
+//
+// pending non-nil means "this subscriber is still initializing": emit()
+// appends to it instead of attempting the channel send. Subscribe sets
+// it back to nil (under e.mu) once it has drained pending into the
+// returned history, after which emit() delivers live via the channel as
+// normal.
+type subEntry struct {
+	pending []Event
 }
 
 type registeredScript struct {
@@ -88,7 +111,7 @@ func NewEngine(opts EngineOptions) *Engine {
 		store:          opts.Store,
 		questions:      opts.QuestionResponder,
 		now:            opts.Now,
-		subs:           make(map[string]map[chan Event]struct{}),
+		subs:           make(map[string]map[chan Event]*subEntry),
 		eventSeqs:      make(map[string]int64),
 		runs:           make(map[string]*Run),
 	}
@@ -319,29 +342,45 @@ func (e *Engine) GetRun(runID string) (*Run, error) {
 // full event history under the global engine lock, blocking emits for
 // every run engine-wide."
 //
-// The gap-free property does not actually require holding the lock
-// across the copy — only across the *split point*. recordedSeq is read
-// atomically with channel registration, so:
+// Exactly-once guarantee, precisely: recordedSeq is read atomically with
+// channel registration, so:
 //   - any event with Seq <= recordedSeq was fully appended (AppendEvent
 //     runs under e.mu, before the seq counter that produced it could
 //     have been observed) before this Subscribe's critical section ran,
 //     and is therefore present in whatever store.GetEvents returns below;
 //   - any event with Seq > recordedSeq is emitted by a call to emit()
 //     that acquires e.mu strictly after this Subscribe's critical
-//     section released it — and since the channel is already registered
-//     in e.subs at that point, that emit()'s fan-out will deliver it
-//     live on ch.
-// history is trimmed to Seq <= recordedSeq so those two sets never
-// overlap: no event is ever lost (the gap this closes) and none is ever
-// duplicated.
+//     section released it.
+//
+// That second bullet is NOT the same as "delivered live on ch", and an
+// earlier version of this comment incorrectly claimed it was: emit()'s
+// fan-out send is non-blocking into ch's 64-slot buffer
+// (select/default), and this goroutine cannot drain ch until Subscribe
+// returns — it hasn't been given the channel yet. More than 64 events
+// emitted during the store.GetEvents call would silently overflow that
+// send AND be excluded from the history trim below (Seq > recordedSeq),
+// reaching neither set.
+//
+// The actual fix: every subscriber has a subEntry with a pending buffer
+// that starts non-nil ("still initializing"). While pending != nil,
+// emit()'s fan-out appends to it instead of attempting the channel send
+// — an unbounded, always-succeeding operation, unlike the fixed-size
+// channel. Once store.GetEvents returns, Subscribe folds pending (all
+// Seq > recordedSeq, accumulated in emit order) onto the trimmed
+// history and sets pending back to nil, after which emit() delivers
+// live via the channel as normal. The two sets (history, pending) never
+// overlap (the trim uses the same recordedSeq the pending buffer starts
+// capturing after), so no event is ever lost and none is ever
+// duplicated — including bursts far larger than the channel's buffer.
 func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) {
 	ch := make(chan Event, 64)
+	entry := &subEntry{pending: []Event{}} // non-nil: this subscriber is initializing
 
 	e.mu.Lock()
 	if _, ok := e.subs[runID]; !ok {
-		e.subs[runID] = make(map[chan Event]struct{})
+		e.subs[runID] = make(map[chan Event]*subEntry)
 	}
-	e.subs[runID][ch] = struct{}{}
+	e.subs[runID][ch] = entry
 	recordedSeq := e.eventSeqs[runID]
 	e.mu.Unlock()
 
@@ -356,8 +395,12 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 	}
 
 	// allEvents is in append (ascending Seq) order; find the split
-	// point and trim. Events after it are (or will be) delivered live
-	// on ch instead — including them here too would duplicate them.
+	// point and trim. Events after it are captured in entry.pending
+	// instead (folded in below) — including them here too would
+	// duplicate them. The capped 3-index slice bounds capacity to
+	// length so the append below always allocates a fresh backing
+	// array, never silently reusing/overwriting allEvents' excluded
+	// tail.
 	cutoff := len(allEvents)
 	for i, ev := range allEvents {
 		if ev.Seq > recordedSeq {
@@ -365,7 +408,25 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 			break
 		}
 	}
-	history := allEvents[:cutoff]
+	history := allEvents[:cutoff:cutoff]
+
+	// Finalize: stop buffering into entry.pending and fold whatever
+	// accumulated there (all Seq > recordedSeq, in emit order) onto
+	// history. Read/reset entry.pending via the entry pointer captured
+	// at registration above — NOT a fresh e.subs[runID][ch] lookup —
+	// because a terminal event arriving while we were still
+	// initializing may already have caused emit() to close ch and
+	// delete this run's entire e.subs[runID] map (see emit()'s terminal
+	// handling below). entry itself remains valid and still holds
+	// whatever was buffered for us regardless of whether it's still
+	// reachable from e.subs.
+	e.mu.Lock()
+	pending := entry.pending
+	entry.pending = nil
+	e.mu.Unlock()
+	if len(pending) > 0 {
+		history = append(history, pending...)
+	}
 
 	cancel := func() {
 		e.mu.Lock()
@@ -603,7 +664,18 @@ func (e *Engine) emit(runID string, eventType EventType, payload map[string]any)
 
 	_ = e.store.AppendEvent(context.Background(), &event)
 
-	for ch := range e.subs[runID] {
+	for ch, entry := range e.subs[runID] {
+		if entry.pending != nil {
+			// This subscriber is still inside Subscribe's O(history)
+			// copy (its channel isn't drainable yet — Subscribe hasn't
+			// returned it to the caller). Buffer instead of the lossy
+			// channel send: pending grows unbounded, so a burst larger
+			// than the channel's 64-slot buffer is never dropped. See
+			// Subscribe's doc comment for the full exactly-once
+			// argument.
+			entry.pending = append(entry.pending, event)
+			continue
+		}
 		select {
 		case ch <- event:
 		default:

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -189,6 +189,10 @@ func (e *Engine) Start(ctx context.Context, name string, args any) (*Run, error)
 // Only runs with status RunStatusFailed can be resumed. The run's error is
 // cleared and its status reset to RunStatusRunning before re-execution.
 func (e *Engine) Resume(ctx context.Context, runID string, args any) (*Run, error) {
+	// The status check and the transition to RunStatusRunning must be
+	// atomic under e.mu. Otherwise two concurrent Resume calls can both
+	// observe RunStatusFailed before either mutates the run, and both
+	// spawn `go e.execute` — running the script twice for one Resume.
 	e.mu.Lock()
 	run, ok := e.runs[runID]
 	if !ok {
@@ -200,23 +204,27 @@ func (e *Engine) Resume(ctx context.Context, runID string, args any) (*Run, erro
 		return nil, fmt.Errorf("workflow run %q has status %s, can only resume failed runs", runID, run.Status)
 	}
 	reg, ok := e.scripts[run.WorkflowName]
-	e.mu.Unlock()
 	if !ok {
+		e.mu.Unlock()
 		return nil, fmt.Errorf("workflow %q no longer registered", run.WorkflowName)
 	}
 
 	run.Status = RunStatusRunning
 	run.Error = ""
 	run.UpdatedAt = e.now().UTC()
-	_ = e.store.UpdateRun(ctx, run)
+	// Copy while still holding the lock so later readers of the shared
+	// *Run (e.g. GetRun, or another goroutine) never race with this
+	// mutation, and so the persisted/emitted view matches what we just
+	// committed.
+	cp := *run
+	e.mu.Unlock()
+
+	_ = e.store.UpdateRun(ctx, &cp)
 
 	e.emit(run.ID, EventWorkflowStarted, map[string]any{
 		"workflow": reg.Meta.Name,
 		"resumed":  true,
 	})
-
-	// Return a copy so callers don't race with the execution goroutine.
-	cp := *run
 
 	go e.execute(run.ID, reg, args)
 	return &cp, nil

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -28,6 +28,13 @@ type EngineOptions struct {
 
 	// Store is an optional persistence backend. When nil, an in-memory store
 	// is used. The store persists workflow runs and events.
+	//
+	// A custom Store's AppendEvent is called while the Engine holds its
+	// own internal global lock: it MUST NOT block on unbounded I/O and
+	// MUST NOT call back into the Engine (Subscribe/GetRun/Start/etc.),
+	// or it will stall every concurrently-running workflow (or
+	// self-deadlock, since the Engine's lock is not reentrant). See the
+	// Store interface doc for the full contract.
 	Store Store
 
 	// QuestionResponder handles workflow questions that need a parent/user
@@ -315,15 +322,26 @@ func (e *Engine) GetRun(runID string) (*Run, error) {
 // The returned slice contains all events emitted for this run so far.
 // The channel receives new events as they are emitted during execution.
 //
-// The cancel function unsubscribes and closes the channel. Callers MUST call
-// cancel when done to avoid goroutine leaks; it is always safe to call even
-// if the channel was already closed by a terminal event (see emit()).
+// The cancel function unsubscribes and closes the channel. Callers MUST
+// ALWAYS call cancel when done, to avoid goroutine/channel leaks; it is
+// always safe to call even if the channel was already closed by a
+// terminal event (see emit()).
 //
-// On a terminal event (workflow.completed/workflow.failed), emit() closes
-// and deregisters every subscriber channel for the run, so the channel
-// will also close on its own once the run finishes — subscribers don't
-// strictly need to call cancel() to observe termination, only to clean up
-// early/non-terminal subscriptions.
+// On a terminal event (workflow.completed/workflow.failed), emit()
+// closes and deregisters every subscriber channel for the run that was
+// registered BEFORE that event. A subscriber whose channel was already
+// registered when the terminal event fires will see the channel close
+// on its own, without needing to call cancel() first to observe
+// termination. But a Subscribe call that happens AFTER the run already
+// went terminal does NOT get this: emit() only closes channels it
+// currently knows about, and by the time such a late Subscribe
+// registers, e.subs[runID] has already been deleted — nothing will
+// ever close its channel. Both current callers of Subscribe
+// (internal/server's SSE handler, and TestSubscribeNeverMissesConcurrentEmit)
+// handle this correctly by checking the returned history for a terminal
+// event before relying on the channel at all, and always call cancel()
+// regardless — do the same in any new caller; do not rely on the
+// channel closing itself.
 //
 // Locking: e.mu is held ONLY long enough to register the channel and
 // record the current per-run sequence number (recordedSeq) — both O(1).
@@ -376,21 +394,30 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 	ch := make(chan Event, 64)
 	entry := &subEntry{pending: []Event{}} // non-nil: this subscriber is initializing
 
-	e.mu.Lock()
-	if _, ok := e.subs[runID]; !ok {
-		e.subs[runID] = make(map[chan Event]*subEntry)
-	}
-	e.subs[runID][ch] = entry
-	recordedSeq := e.eventSeqs[runID]
-	e.mu.Unlock()
+	// Each of Subscribe's critical sections is a separate, short-lived
+	// lock scope (the lock must be released between them to call
+	// store.GetEvents without holding e.mu) — an IIFE per section keeps
+	// every one defer-based, so no future panic on any of these code
+	// paths can leak e.mu, matching the rest of engine.go.
+	recordedSeq := func() int64 {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		if _, ok := e.subs[runID]; !ok {
+			e.subs[runID] = make(map[chan Event]*subEntry)
+		}
+		e.subs[runID][ch] = entry
+		return e.eventSeqs[runID]
+	}()
 
 	allEvents, err := e.store.GetEvents(context.Background(), runID, -1)
 	if err != nil {
-		e.mu.Lock()
-		if subsForRun, ok := e.subs[runID]; ok {
-			delete(subsForRun, ch)
-		}
-		e.mu.Unlock()
+		func() {
+			e.mu.Lock()
+			defer e.mu.Unlock()
+			if subsForRun, ok := e.subs[runID]; ok {
+				delete(subsForRun, ch)
+			}
+		}()
 		return nil, nil, nil, err
 	}
 
@@ -420,10 +447,13 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 	// handling below). entry itself remains valid and still holds
 	// whatever was buffered for us regardless of whether it's still
 	// reachable from e.subs.
-	e.mu.Lock()
-	pending := entry.pending
-	entry.pending = nil
-	e.mu.Unlock()
+	pending := func() []Event {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		p := entry.pending
+		entry.pending = nil
+		return p
+	}()
 	if len(pending) > 0 {
 		history = append(history, pending...)
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -276,6 +276,15 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 // means unlimited tokens. The budget can be further constrained by
 // RunRequest-level configuration (handled by the API layer before calling Start).
 func (e *Engine) execute(runID string, reg registeredScript, args any) {
+	// Defense in depth: this runs on a bare `go e.execute(...)` goroutine
+	// with no caller to recover a panic. executeScript already recovers
+	// panics from the script body itself, but this guards against any
+	// panic elsewhere in the execution/emit path (e.g. a future bug in
+	// emit) so it can never take down the whole process.
+	defer func() {
+		_ = recover()
+	}()
+
 	budget := newBudget(e.defaultBudget)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -358,15 +367,31 @@ func (e *Engine) executeScriptAsync(runID string, reg registeredScript, ctx *Con
 // Events are sequenced per run. Subscribers that are too slow (channel full)
 // have the event dropped rather than blocking the emitter. This prevents a
 // slow subscriber from stalling workflow execution.
+//
+// The sequence bump, the store append, and the subscriber fan-out all
+// happen while holding e.mu. This is required for correctness, not just
+// convenience:
+//   - Subscribe's cancel() also closes the channel under e.mu. Holding the
+//     lock across the send loop here makes "send" and "close" mutually
+//     exclusive, so emit can never send on a channel that cancel is in the
+//     process of (or has already) closed.
+//   - Subscribe itself reads history (via the store) and registers its
+//     channel under e.mu (see Subscribe below). Holding the lock across
+//     AppendEvent + fan-out here makes "append+deliver" atomic against
+//     "read-history+register", so an event can never land in the gap
+//     between a subscriber's history snapshot and its channel
+//     registration.
+//
+// The default in-memory Store has no I/O and never calls back into the
+// Engine, so holding e.mu across AppendEvent is bounded and safe. Sends to
+// subscriber channels remain non-blocking (select/default), so the
+// critical section stays bounded even if a store implementation is slower.
 func (e *Engine) emit(runID string, eventType EventType, payload map[string]any) {
 	e.mu.Lock()
+	defer e.mu.Unlock()
+
 	e.eventSeqs[runID]++
 	seq := e.eventSeqs[runID]
-	liveSubs := make([]chan Event, 0, len(e.subs[runID]))
-	for ch := range e.subs[runID] {
-		liveSubs = append(liveSubs, ch)
-	}
-	e.mu.Unlock()
 
 	event := Event{
 		Seq:       seq,
@@ -378,7 +403,7 @@ func (e *Engine) emit(runID string, eventType EventType, payload map[string]any)
 
 	_ = e.store.AppendEvent(context.Background(), &event)
 
-	for _, ch := range liveSubs {
+	for ch := range e.subs[runID] {
 		select {
 		case ch <- event:
 		default:

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -302,26 +302,70 @@ func (e *Engine) GetRun(runID string) (*Run, error) {
 // strictly need to call cancel() to observe termination, only to clean up
 // early/non-terminal subscriptions.
 //
-// The history read and the channel registration happen atomically under
-// e.mu, matching how emit() holds e.mu across its store append and
-// subscriber fan-out. This closes the gap where an event emitted between
-// "read history" and "register channel" would previously land in
-// neither — permanently lost, which is fatal if it's the terminal
-// workflow.completed/failed event (an SSE client would hang forever).
+// Locking: e.mu is held ONLY long enough to register the channel and
+// record the current per-run sequence number (recordedSeq) — both O(1).
+// The store.GetEvents call, which is O(history) and can be arbitrarily
+// large for a long-running run, happens AFTER releasing e.mu.
+//
+// This is deliberate: an earlier version held e.mu across the
+// store.GetEvents call too, on the theory that "read-history +
+// register-channel" needed to be one atomic step to avoid losing an
+// event emitted in between (see BUG 5). That was correct for closing the
+// gap, but wrong for performance — since emit() also needs e.mu for
+// every event on every run, an O(history) Subscribe blocked ALL emits
+// engine-wide for its duration, and repeated Subscribes against a
+// growing-history run made the total cost O(history^2). This is exactly
+// the production hazard: "every SSE client connect/reconnect copies the
+// full event history under the global engine lock, blocking emits for
+// every run engine-wide."
+//
+// The gap-free property does not actually require holding the lock
+// across the copy — only across the *split point*. recordedSeq is read
+// atomically with channel registration, so:
+//   - any event with Seq <= recordedSeq was fully appended (AppendEvent
+//     runs under e.mu, before the seq counter that produced it could
+//     have been observed) before this Subscribe's critical section ran,
+//     and is therefore present in whatever store.GetEvents returns below;
+//   - any event with Seq > recordedSeq is emitted by a call to emit()
+//     that acquires e.mu strictly after this Subscribe's critical
+//     section released it — and since the channel is already registered
+//     in e.subs at that point, that emit()'s fan-out will deliver it
+//     live on ch.
+// history is trimmed to Seq <= recordedSeq so those two sets never
+// overlap: no event is ever lost (the gap this closes) and none is ever
+// duplicated.
 func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) {
 	ch := make(chan Event, 64)
 
 	e.mu.Lock()
-	defer e.mu.Unlock()
-
-	history, err := e.store.GetEvents(context.Background(), runID, -1)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	if _, ok := e.subs[runID]; !ok {
 		e.subs[runID] = make(map[chan Event]struct{})
 	}
 	e.subs[runID][ch] = struct{}{}
+	recordedSeq := e.eventSeqs[runID]
+	e.mu.Unlock()
+
+	allEvents, err := e.store.GetEvents(context.Background(), runID, -1)
+	if err != nil {
+		e.mu.Lock()
+		if subsForRun, ok := e.subs[runID]; ok {
+			delete(subsForRun, ch)
+		}
+		e.mu.Unlock()
+		return nil, nil, nil, err
+	}
+
+	// allEvents is in append (ascending Seq) order; find the split
+	// point and trim. Events after it are (or will be) delivered live
+	// on ch instead — including them here too would duplicate them.
+	cutoff := len(allEvents)
+	for i, ev := range allEvents {
+		if ev.Seq > recordedSeq {
+			cutoff = i
+			break
+		}
+	}
+	history := allEvents[:cutoff]
 
 	cancel := func() {
 		e.mu.Lock()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -293,10 +293,14 @@ func (e *Engine) GetRun(runID string) (*Run, error) {
 // The channel receives new events as they are emitted during execution.
 //
 // The cancel function unsubscribes and closes the channel. Callers MUST call
-// cancel when done to avoid goroutine leaks.
+// cancel when done to avoid goroutine leaks; it is always safe to call even
+// if the channel was already closed by a terminal event (see emit()).
 //
-// If the run completes or fails, the channel will stop receiving events;
-// subscribers should use the cancel function to clean up.
+// On a terminal event (workflow.completed/workflow.failed), emit() closes
+// and deregisters every subscriber channel for the run, so the channel
+// will also close on its own once the run finishes — subscribers don't
+// strictly need to call cancel() to observe termination, only to clean up
+// early/non-terminal subscriptions.
 //
 // The history read and the channel registration happen atomically under
 // e.mu, matching how emit() holds e.mu across its store append and
@@ -322,8 +326,22 @@ func (e *Engine) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 	cancel := func() {
 		e.mu.Lock()
 		defer e.mu.Unlock()
-		delete(e.subs[runID], ch)
-		close(ch)
+		// Membership in e.subs is the single source of truth for
+		// "has this channel already been closed" — emit() removes a
+		// channel from e.subs in the SAME critical section where it
+		// closes it on a terminal event (see emit() below), so if
+		// it's already gone here, emit() got there first; closing
+		// again would panic ("close of closed channel"). Both close
+		// sites only ever mutate e.subs under e.mu, so this
+		// check-then-close is race-free without needing a separate
+		// sync.Once per channel — the existing map+lock already is
+		// the single point of coordination between the two closers.
+		if subsForRun, ok := e.subs[runID]; ok {
+			if _, present := subsForRun[ch]; present {
+				delete(subsForRun, ch)
+				close(ch)
+			}
+		}
 	}
 	return history, ch, cancel, nil
 }
@@ -510,6 +528,20 @@ func (e *Engine) transitionRunTerminal(runID string, scriptErr error, resultJSON
 // Engine, so holding e.mu across AppendEvent is bounded and safe. Sends to
 // subscriber channels remain non-blocking (select/default), so the
 // critical section stays bounded even if a store implementation is slower.
+//
+// On a terminal event (workflow.completed/workflow.failed), every
+// subscriber channel for the run is closed and deregistered, in the same
+// critical section, right after the fan-out. This makes the terminal
+// event undroppable: a subscriber whose 64-slot buffer is already full
+// silently loses the SEND above (by design, to avoid blocking the
+// emitter), but the immediately-following close() still reaches it — a
+// closed channel read (`ev, ok := <-ch`) returns immediately with
+// ok=false, which every subscriber (e.g. the SSE handler in
+// internal/server/http_script_workflows.go) already treats as "stream
+// ended". Without this, a slow subscriber that fills its buffer right
+// before completion would hang forever waiting for a completion that
+// already happened — the same failure mode BUG 5 fixed for the
+// history/live gap, via a different route.
 func (e *Engine) emit(runID string, eventType EventType, payload map[string]any) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -534,5 +566,12 @@ func (e *Engine) emit(runID string, eventType EventType, payload map[string]any)
 			// Drop event if subscriber channel is full — prevents a slow
 			// subscriber from stalling workflow execution.
 		}
+	}
+
+	if eventType == EventWorkflowCompleted || eventType == EventWorkflowFailed {
+		for ch := range e.subs[runID] {
+			close(ch)
+		}
+		delete(e.subs, runID)
 	}
 }

--- a/internal/workflow/engine_lock_safety_test.go
+++ b/internal/workflow/engine_lock_safety_test.go
@@ -1,0 +1,245 @@
+package workflow_test
+
+// This file covers a follow-up review round on fix/workflow-engine-concurrency
+// that found the BUG1 defense-in-depth recover() (added in ff7c96c) traded a
+// loud, restartable crash for a silent, permanent wedge of the whole Engine.
+// See the individual tests below for the specific failure modes.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/workflow"
+)
+
+// panickyMarshaler's MarshalJSON panics with a genuine Go runtime panic
+// (assignment to entry in a nil map) rather than returning an error.
+// encoding/json's top-level recover only converts its OWN internal
+// sentinel error type back into a normal error; any other panic value
+// (like this one) is re-panicked out of json.Marshal, exactly as it would
+// be for any real user-supplied MarshalJSON that misbehaves.
+type panickyMarshaler struct{}
+
+func (panickyMarshaler) MarshalJSON() ([]byte, error) {
+	var m map[string]int
+	m["x"] = 1 // panics: assignment to entry in nil map
+	return nil, nil
+}
+
+// TestExecuteScriptAsyncPanicDuringMarshalDoesNotWedgeEngine reproduces
+// BLOCKING 1 + BLOCKING 2 from the follow-up review: executeScriptAsync
+// used to hold e.mu across json.Marshal(result), which can invoke
+// arbitrary user-supplied MarshalJSON code and panic. The BUG1
+// defense-in-depth recover() at the top of execute() then swallowed that
+// panic silently -- with e.mu still locked (manual Unlock(), no defer) and
+// with no status transition, no persisted error, and no terminal event.
+// Net effect: the run stays "running" forever, and every subsequent
+// engine call that needs e.mu (Start, Resume, Subscribe, GetRun, List,
+// emit) blocks forever too.
+//
+// Every blocking wait below is guarded by a short select/timeout so this
+// test fails fast and cleanly instead of hanging the whole `go test`
+// process if the engine is genuinely wedged.
+func TestExecuteScriptAsyncPanicDuringMarshalDoesNotWedgeEngine(t *testing.T) {
+	mgr := newMockMgr()
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr})
+
+	eng.Register("panicky-marshal", func(*workflow.Context) (any, error) {
+		return panickyMarshaler{}, nil
+	})
+
+	run, err := eng.Start(context.Background(), "panicky-marshal", nil)
+	require.NoError(t, err)
+
+	// (i) The engine must NOT wedge: the run must reach a terminal status
+	// promptly, and it must be Failed (a panic anywhere in the
+	// execution/emit path is a failure, not a silent success).
+	terminalStatus := make(chan workflow.RunStatus, 1)
+	go func() {
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			r, gerr := eng.GetRun(run.ID)
+			if gerr == nil && (r.Status == workflow.RunStatusCompleted || r.Status == workflow.RunStatusFailed) {
+				terminalStatus <- r.Status
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		// Give up quietly; the select below has its own timeout and will
+		// report the failure from the main test goroutine.
+	}()
+
+	select {
+	case status := <-terminalStatus:
+		require.Equal(t, workflow.RunStatusFailed, status,
+			"a panic anywhere in the execution/emit path must leave the run Failed, not stuck non-terminal")
+	case <-time.After(3 * time.Second):
+		t.Fatal("engine appears wedged: run did not reach a terminal status within 3s of a panicking MarshalJSON")
+	}
+
+	// (i, continued) The engine's lock itself must not be leaked: a
+	// totally unrelated call must also return promptly afterward.
+	listDone := make(chan struct{})
+	go func() {
+		eng.List()
+		close(listDone)
+	}()
+	select {
+	case <-listDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine appears wedged: List() did not return within 2s after the panicking marshal")
+	}
+
+	startDone := make(chan struct{})
+	eng.Register("noop", func(*workflow.Context) (any, error) { return "ok", nil })
+	go func() {
+		_, _ = eng.Start(context.Background(), "noop", nil)
+		close(startDone)
+	}()
+	select {
+	case <-startDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine appears wedged: Start() did not return within 2s after the panicking marshal")
+	}
+
+	// (ii) The run must be observably terminal: status Failed with a
+	// descriptive error, AND a workflow.failed event actually emitted
+	// (not just the status flipped silently).
+	final, err := eng.GetRun(run.ID)
+	require.NoError(t, err)
+	require.Equal(t, workflow.RunStatusFailed, final.Status)
+	require.Contains(t, final.Error, "panic", "expected the run's Error to mention the panic, got %q", final.Error)
+
+	history, _, cancel, err := eng.Subscribe(run.ID)
+	require.NoError(t, err)
+	defer cancel()
+	sawFailed := false
+	for _, ev := range history {
+		if ev.Type == workflow.EventWorkflowFailed {
+			sawFailed = true
+		}
+	}
+	require.True(t, sawFailed, "expected a workflow.failed terminal event in history, got %+v", history)
+}
+
+// raceStore is a minimal workflow.Store implementation whose UpdateRun
+// call sleeps briefly before reading the *Run it was given. This widens
+// (without needing thousands of iterations) the race window described in
+// BLOCKING 3: executeScriptAsync used to release e.mu and then pass the
+// SHARED *Run pointer (still reachable and mutable by a concurrent
+// Resume, under e.mu) into store.UpdateRun, which reads it unsynchronized
+// (memoryStore.UpdateRun does `cp := *run`). If executeScriptAsync passes
+// a private copy taken under the lock instead, this is race-free
+// regardless of how long UpdateRun takes to get around to reading it.
+type raceStore struct {
+	mu          sync.Mutex
+	runs        map[string]*workflow.Run
+	events      map[string][]workflow.Event
+	updateDelay time.Duration
+}
+
+func newRaceStore(delay time.Duration) *raceStore {
+	return &raceStore{
+		runs:        make(map[string]*workflow.Run),
+		events:      make(map[string][]workflow.Event),
+		updateDelay: delay,
+	}
+}
+
+func (s *raceStore) CreateRun(_ context.Context, run *workflow.Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *raceStore) UpdateRun(_ context.Context, run *workflow.Run) error {
+	if s.updateDelay > 0 {
+		time.Sleep(s.updateDelay)
+	}
+	// The unsynchronized read: if `run` is still a pointer some other
+	// goroutine can concurrently mutate under e.mu, -race will catch it
+	// here.
+	cp := *run
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *raceStore) GetRun(_ context.Context, id string) (*workflow.Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.runs[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *raceStore) AppendEvent(_ context.Context, ev *workflow.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events[ev.RunID] = append(s.events[ev.RunID], *ev)
+	return nil
+}
+
+func (s *raceStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]workflow.Event, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]workflow.Event, 0)
+	for _, ev := range s.events[runID] {
+		if ev.Seq > afterSeq {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// TestExecuteScriptAsyncNeverPassesSharedRunPointerToStore reproduces
+// BLOCKING 3: it starts a run that fails immediately, then races a
+// GetRun-poll-then-Resume loop against executeScriptAsync's own
+// (artificially delayed) store.UpdateRun call for that same failure. Must
+// be run with -race.
+func TestExecuteScriptAsyncNeverPassesSharedRunPointerToStore(t *testing.T) {
+	mgr := newMockMgr()
+	st := newRaceStore(20 * time.Millisecond)
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr, Store: st, MaxConcurrency: 4})
+
+	eng.Register("flaky-race", func(*workflow.Context) (any, error) {
+		return nil, fmt.Errorf("boom")
+	})
+
+	run, err := eng.Start(context.Background(), "flaky-race", nil)
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, gerr := eng.GetRun(run.ID)
+		if gerr == nil && r.Status == workflow.RunStatusFailed {
+			_, _ = eng.Resume(context.Background(), run.ID, nil)
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// Drain to a terminal status so the test doesn't leave a dangling
+	// goroutine; the interesting assertion here is "did -race fire",
+	// which the test runner reports independently of this poll.
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, gerr := eng.GetRun(run.ID)
+		if gerr == nil && (r.Status == workflow.RunStatusCompleted || r.Status == workflow.RunStatusFailed) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("run did not reach a terminal status in time")
+}

--- a/internal/workflow/perf_regression_internal_test.go
+++ b/internal/workflow/perf_regression_internal_test.go
@@ -1,0 +1,369 @@
+package workflow
+
+// Third-round follow-up review on fix/workflow-engine-concurrency found
+// that the round-2 performance fix (Subscribe releasing e.mu before its
+// O(history) store.GetEvents copy, and memoryStore moving to a per-run
+// lock) left two real problems:
+//
+//   - REQUIRED 1: emit()'s fan-out send is non-blocking into a 64-slot
+//     channel, and a Subscribe()-ing goroutine cannot drain that channel
+//     until Subscribe() itself returns (it hasn't been given the channel
+//     yet). So more than 64 events emitted DURING the now-unlocked
+//     GetEvents copy overflow the channel send AND are excluded from the
+//     history trim (their Seq > recordedSeq) -- reaching neither set.
+//     Fixed by giving each initializing subscriber a `pending []Event`
+//     buffer (see engine.go).
+//
+//   - REQUIRED 2: memoryStore.GetEvents held its per-run RLock for the
+//     WHOLE O(history) copy. emit() on that SAME run takes e.mu and then
+//     blocks on that per-run lock's Lock() behind the reader -- WHILE
+//     HOLDING e.mu. Every other run's emit (and GetRun/List/Start/Resume)
+//     then blocks on e.mu too, for the full duration of that one run's
+//     history copy. Fixed by having GetEvents hold the per-run lock only
+//     long enough to take an O(1) capped slice-header snapshot, then
+//     copying outside any lock (see types.go).
+//
+// This file's tests need direct access to the unexported e.emit and
+// e.subs to control exactly when events are emitted relative to a slow
+// Subscribe, and so live in package workflow rather than workflow_test.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// gatedRunEvents and gatedStore are a minimal, hand-rolled Store whose
+// GetEvents can be held open on a test-controlled channel (never a
+// wall-clock sleep) for exactly one targeted run, while still giving
+// every run its own independent per-run lock -- mirroring memoryStore's
+// real structure closely enough to reproduce (or fail to reproduce) the
+// exact lock-contention mechanism under test, without depending on real
+// hardware being slow enough to make a large copy measurably slow.
+type gatedRunEvents struct {
+	mu     sync.RWMutex
+	events []Event
+}
+
+type gatedStore struct {
+	mu     sync.Mutex // protects runs + perRun map structure only, never O(history) work
+	runs   map[string]*Run
+	perRun map[string]*gatedRunEvents
+
+	blockRunID string        // GetEvents for this run blocks until release is closed
+	entered    chan struct{} // closed the first time GetEvents(blockRunID) is called
+	release    chan struct{} // GetEvents(blockRunID) blocks reading from this before proceeding
+}
+
+func newGatedStore(blockRunID string) *gatedStore {
+	return &gatedStore{
+		runs:       make(map[string]*Run),
+		perRun:     make(map[string]*gatedRunEvents),
+		blockRunID: blockRunID,
+		entered:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+}
+
+func (s *gatedStore) runEventsFor(runID string) *gatedRunEvents {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	re, ok := s.perRun[runID]
+	if !ok {
+		re = &gatedRunEvents{}
+		s.perRun[runID] = re
+	}
+	return re
+}
+
+func (s *gatedStore) CreateRun(_ context.Context, run *Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *gatedStore) UpdateRun(_ context.Context, run *Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *gatedStore) GetRun(_ context.Context, id string) (*Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.runs[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *gatedStore) AppendEvent(_ context.Context, event *Event) error {
+	re := s.runEventsFor(event.RunID)
+	re.mu.Lock()
+	defer re.mu.Unlock()
+	re.events = append(re.events, *event)
+	return nil
+}
+
+// GetEvents, for the targeted run, holds the per-run RLock across the
+// ENTIRE call -- exactly what pre-REQUIRED-2 memoryStore.GetEvents did --
+// so this store can prove whether the Engine (via emit()'s AppendEvent
+// call, still made under e.mu) is still vulnerable to that specific
+// mechanism, independent of memoryStore's own fix.
+func (s *gatedStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]Event, error) {
+	re := s.runEventsFor(runID)
+	if runID == s.blockRunID {
+		re.mu.RLock()
+		defer re.mu.RUnlock()
+		select {
+		case <-s.entered:
+		default:
+			close(s.entered)
+		}
+		<-s.release
+		out := make([]Event, 0, len(re.events))
+		for _, ev := range re.events {
+			if ev.Seq > afterSeq {
+				out = append(out, ev)
+			}
+		}
+		return out, nil
+	}
+	re.mu.RLock()
+	defer re.mu.RUnlock()
+	out := make([]Event, 0, len(re.events))
+	for _, ev := range re.events {
+		if ev.Seq > afterSeq {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun reproduces
+// REQUIRED 2 precisely: it holds run A's GetEvents open (via
+// gatedStore, RLock included, matching the real pre-fix
+// memoryStore.GetEvents), fires emit() on run A itself (which -- via
+// AppendEvent needing run A's write lock, held under e.mu -- transitively
+// blocks e.mu for as long as GetEvents(A) is open), and then asserts
+// emit() on a completely unrelated run B still completes promptly. If
+// e.mu is transitively stuck behind run A's blocked GetEvents, emit(B)
+// can't even acquire e.mu and will not complete in time.
+func TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun(t *testing.T) {
+	const runA = "run-a"
+	const runB = "run-b"
+	st := newGatedStore(runA)
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}, Store: st})
+
+	subDone := make(chan struct{})
+	go func() {
+		defer close(subDone)
+		_, _, cancel, err := e.Subscribe(runA)
+		if err == nil {
+			cancel()
+		}
+	}()
+
+	select {
+	case <-st.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe's GetEvents for run A never started")
+	}
+
+	// emit() on run A itself: needs e.mu, then blocks trying to
+	// AppendEvent(A), which needs run A's write lock -- held read-locked
+	// by the still-open GetEvents(A) above. Since emit() holds e.mu the
+	// whole time it's blocked there, this is the exact mechanism under
+	// test.
+	emitADone := make(chan struct{})
+	go func() {
+		defer close(emitADone)
+		e.emit(runA, EventWorkflowLog, map[string]any{"x": 1})
+	}()
+
+	// Give emit(A) a moment to actually reach (and block inside)
+	// AppendEvent, so it is genuinely holding e.mu when run B is
+	// measured below.
+	time.Sleep(50 * time.Millisecond)
+
+	emitBDone := make(chan struct{})
+	go func() {
+		defer close(emitBDone)
+		e.emit(runB, EventWorkflowLog, map[string]any{"x": 2})
+	}()
+
+	select {
+	case <-emitBDone:
+	case <-time.After(1 * time.Second):
+		close(st.release) // unblock everything so goroutines don't leak past this test
+		t.Fatal("emit() on an unrelated run B did not complete within 1s while run A's GetEvents was still deliberately blocked — e.mu appears to be transitively held for the duration of run A's history copy")
+	}
+
+	close(st.release)
+	<-subDone
+	<-emitADone
+}
+
+// blockedGetEventsStore gates GetEvents on a test-controlled channel with
+// NO lock held during the wait, so a concurrent AppendEvent for the same
+// run is never blocked by it. This isolates testing REQUIRED 1 (the
+// pending-buffer mechanism in Subscribe/emit) from REQUIRED 2 (the
+// per-run store lock, tested separately above by
+// TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun using gatedStore,
+// which DOES hold the lock to match the real pre-fix memoryStore): with
+// gatedStore, the very first emit() in the burst below would itself block
+// on AppendEvent (since it contends with GetEvents' held lock), which
+// tests REQUIRED 2, not REQUIRED 1. This store lets the burst of emits
+// complete immediately so the test isolates the channel-overflow /
+// pending-buffer behavior specifically.
+type blockedGetEventsStore struct {
+	mu     sync.Mutex
+	runs   map[string]*Run
+	events map[string][]Event
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockedGetEventsStore() *blockedGetEventsStore {
+	return &blockedGetEventsStore{
+		runs:    make(map[string]*Run),
+		events:  make(map[string][]Event),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *blockedGetEventsStore) CreateRun(_ context.Context, run *Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *blockedGetEventsStore) UpdateRun(_ context.Context, run *Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *blockedGetEventsStore) GetRun(_ context.Context, id string) (*Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.runs[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *blockedGetEventsStore) AppendEvent(_ context.Context, event *Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events[event.RunID] = append(s.events[event.RunID], *event)
+	return nil
+}
+
+func (s *blockedGetEventsStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]Event, error) {
+	select {
+	case <-s.entered:
+	default:
+		close(s.entered)
+	}
+	<-s.release
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Event, 0, len(s.events[runID]))
+	for _, ev := range s.events[runID] {
+		if ev.Seq > afterSeq {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// TestSubscribeCapturesBurstDuringSlowHistoryCopyExactlyOnce reproduces
+// REQUIRED 1: it holds a Subscribe's GetEvents open (via
+// blockedGetEventsStore) and emits far more than the channel's 64-slot
+// buffer during that window, then asserts every one of those events
+// appears EXACTLY ONCE across (returned history + live channel) once
+// Subscribe returns -- never zero times (lost), never twice (duplicated).
+func TestSubscribeCapturesBurstDuringSlowHistoryCopyExactlyOnce(t *testing.T) {
+	const runID = "burst-run"
+	st := newBlockedGetEventsStore()
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}, Store: st})
+
+	type subResult struct {
+		history []Event
+		ch      <-chan Event
+		cancel  func()
+		err     error
+	}
+	resultCh := make(chan subResult, 1)
+	go func() {
+		h, ch, cancel, err := e.Subscribe(runID)
+		resultCh <- subResult{h, ch, cancel, err}
+	}()
+
+	select {
+	case <-st.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe's GetEvents never started")
+	}
+
+	const burst = 300 // far more than the channel's 64-slot buffer
+	for i := 0; i < burst; i++ {
+		e.emit(runID, EventWorkflowLog, map[string]any{"i": i})
+	}
+
+	close(st.release)
+
+	var result subResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe did not return after GetEvents was released")
+	}
+	if result.err != nil {
+		t.Fatalf("Subscribe: %v", result.err)
+	}
+	defer result.cancel()
+
+	seen := make(map[int64]int)
+	for _, ev := range result.history {
+		seen[ev.Seq]++
+	}
+	draining := true
+	for draining {
+		select {
+		case ev, ok := <-result.ch:
+			if !ok {
+				draining = false
+				break
+			}
+			seen[ev.Seq]++
+		case <-time.After(200 * time.Millisecond):
+			draining = false
+		}
+	}
+
+	if len(seen) != burst {
+		t.Fatalf("expected exactly %d distinct events captured across history+live, got %d distinct seqs (history=%d)", burst, len(seen), len(result.history))
+	}
+	for seq, count := range seen {
+		if count != 1 {
+			t.Fatalf("event seq %d observed %d times (want exactly 1) — duplicated across history+live", seq, count)
+		}
+	}
+}

--- a/internal/workflow/perf_regression_internal_test.go
+++ b/internal/workflow/perf_regression_internal_test.go
@@ -34,133 +34,36 @@ import (
 	"time"
 )
 
-// gatedRunEvents and gatedStore are a minimal, hand-rolled Store whose
-// GetEvents can be held open on a test-controlled channel (never a
-// wall-clock sleep) for exactly one targeted run, while still giving
-// every run its own independent per-run lock -- mirroring memoryStore's
-// real structure closely enough to reproduce (or fail to reproduce) the
-// exact lock-contention mechanism under test, without depending on real
-// hardware being slow enough to make a large copy measurably slow.
-type gatedRunEvents struct {
-	mu     sync.RWMutex
-	events []Event
-}
-
-type gatedStore struct {
-	mu     sync.Mutex // protects runs + perRun map structure only, never O(history) work
-	runs   map[string]*Run
-	perRun map[string]*gatedRunEvents
-
-	blockRunID string        // GetEvents for this run blocks until release is closed
-	entered    chan struct{} // closed the first time GetEvents(blockRunID) is called
-	release    chan struct{} // GetEvents(blockRunID) blocks reading from this before proceeding
-}
-
-func newGatedStore(blockRunID string) *gatedStore {
-	return &gatedStore{
-		runs:       make(map[string]*Run),
-		perRun:     make(map[string]*gatedRunEvents),
-		blockRunID: blockRunID,
-		entered:    make(chan struct{}),
-		release:    make(chan struct{}),
-	}
-}
-
-func (s *gatedStore) runEventsFor(runID string) *gatedRunEvents {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	re, ok := s.perRun[runID]
-	if !ok {
-		re = &gatedRunEvents{}
-		s.perRun[runID] = re
-	}
-	return re
-}
-
-func (s *gatedStore) CreateRun(_ context.Context, run *Run) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *run
-	s.runs[run.ID] = &cp
-	return nil
-}
-
-func (s *gatedStore) UpdateRun(_ context.Context, run *Run) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	cp := *run
-	s.runs[run.ID] = &cp
-	return nil
-}
-
-func (s *gatedStore) GetRun(_ context.Context, id string) (*Run, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	r, ok := s.runs[id]
-	if !ok {
-		return nil, nil
-	}
-	cp := *r
-	return &cp, nil
-}
-
-func (s *gatedStore) AppendEvent(_ context.Context, event *Event) error {
-	re := s.runEventsFor(event.RunID)
-	re.mu.Lock()
-	defer re.mu.Unlock()
-	re.events = append(re.events, *event)
-	return nil
-}
-
-// GetEvents, for the targeted run, holds the per-run RLock across the
-// ENTIRE call -- exactly what pre-REQUIRED-2 memoryStore.GetEvents did --
-// so this store can prove whether the Engine (via emit()'s AppendEvent
-// call, still made under e.mu) is still vulnerable to that specific
-// mechanism, independent of memoryStore's own fix.
-func (s *gatedStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]Event, error) {
-	re := s.runEventsFor(runID)
-	if runID == s.blockRunID {
-		re.mu.RLock()
-		defer re.mu.RUnlock()
-		select {
-		case <-s.entered:
-		default:
-			close(s.entered)
-		}
-		<-s.release
-		out := make([]Event, 0, len(re.events))
-		for _, ev := range re.events {
-			if ev.Seq > afterSeq {
-				out = append(out, ev)
-			}
-		}
-		return out, nil
-	}
-	re.mu.RLock()
-	defer re.mu.RUnlock()
-	out := make([]Event, 0, len(re.events))
-	for _, ev := range re.events {
-		if ev.Seq > afterSeq {
-			out = append(out, ev)
-		}
-	}
-	return out, nil
-}
-
 // TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun reproduces
-// REQUIRED 2 precisely: it holds run A's GetEvents open (via
-// gatedStore, RLock included, matching the real pre-fix
-// memoryStore.GetEvents), fires emit() on run A itself (which -- via
-// AppendEvent needing run A's write lock, held under e.mu -- transitively
-// blocks e.mu for as long as GetEvents(A) is open), and then asserts
-// emit() on a completely unrelated run B still completes promptly. If
-// e.mu is transitively stuck behind run A's blocked GetEvents, emit(B)
-// can't even acquire e.mu and will not complete in time.
+// REQUIRED 2 using the REAL default memoryStore (not a synthetic gated
+// one): it builds a large (200,000-event) history for run A, then
+// concurrently Subscribes to run A (triggering a real O(history)
+// GetEvents copy) and emits on a completely unrelated run B, asserting
+// emit(B) completes within a generous, environment-tolerant bound.
+//
+// This deliberately does NOT use a store that blocks GetEvents
+// indefinitely on a test channel (an earlier version of this test did,
+// and it was wrong: it made AppendEvent for the SAME run also block for
+// the same lock, which -- since emit() calls AppendEvent while holding
+// e.mu -- transitively holds e.mu regardless of how well-behaved
+// memoryStore.GetEvents itself is. That tests whether the ENGINE
+// tolerates an arbitrarily slow/blocking Store, which is explicitly out
+// of contract: see the Store interface doc -- AppendEvent runs under
+// e.mu and must never block on unbounded I/O). REQUIRED 2's actual fix
+// only needs to bound memoryStore's OWN lock-hold time to O(1); with
+// that fix, a real (even very large) history no longer matters, because
+// the per-run RLock is only held for a slice-header snapshot rather than
+// the whole copy -- so a genuinely large real history is precisely what
+// exercises the fix, without needing an artificial gate at all.
 func TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun(t *testing.T) {
 	const runA = "run-a"
 	const runB = "run-b"
-	st := newGatedStore(runA)
-	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}, Store: st})
+	e := NewEngine(EngineOptions{Subagents: noopSubagentManager{}}) // real default memoryStore
+
+	const historySize = 200000
+	for i := 0; i < historySize; i++ {
+		e.emit(runA, EventWorkflowLog, map[string]any{"i": i})
+	}
 
 	subDone := make(chan struct{})
 	go func() {
@@ -171,28 +74,6 @@ func TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun(t *testing.T) {
 		}
 	}()
 
-	select {
-	case <-st.entered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Subscribe's GetEvents for run A never started")
-	}
-
-	// emit() on run A itself: needs e.mu, then blocks trying to
-	// AppendEvent(A), which needs run A's write lock -- held read-locked
-	// by the still-open GetEvents(A) above. Since emit() holds e.mu the
-	// whole time it's blocked there, this is the exact mechanism under
-	// test.
-	emitADone := make(chan struct{})
-	go func() {
-		defer close(emitADone)
-		e.emit(runA, EventWorkflowLog, map[string]any{"x": 1})
-	}()
-
-	// Give emit(A) a moment to actually reach (and block inside)
-	// AppendEvent, so it is genuinely holding e.mu when run B is
-	// measured below.
-	time.Sleep(50 * time.Millisecond)
-
 	emitBDone := make(chan struct{})
 	go func() {
 		defer close(emitBDone)
@@ -201,14 +82,11 @@ func TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun(t *testing.T) {
 
 	select {
 	case <-emitBDone:
-	case <-time.After(1 * time.Second):
-		close(st.release) // unblock everything so goroutines don't leak past this test
-		t.Fatal("emit() on an unrelated run B did not complete within 1s while run A's GetEvents was still deliberately blocked — e.mu appears to be transitively held for the duration of run A's history copy")
+	case <-time.After(2 * time.Second):
+		t.Fatal("emit() on an unrelated run B did not complete within 2s of a concurrent Subscribe against run A's 200,000-event history — e.mu appears to be transitively held for the duration of run A's history copy")
 	}
 
-	close(st.release)
 	<-subDone
-	<-emitADone
 }
 
 // blockedGetEventsStore gates GetEvents on a test-controlled channel with

--- a/internal/workflow/store_coverage_test.go
+++ b/internal/workflow/store_coverage_test.go
@@ -41,3 +41,38 @@ func TestMemoryStoreGetRunAndMaxConcurrency(t *testing.T) {
 		t.Fatalf("expected nil missing run, got %#v", missing)
 	}
 }
+
+// TestMemoryStorePerRunEventLockIsIndependentPerRun pins the structural
+// property behind the fix for the follow-up-review performance
+// regression: memoryStore.AppendEvent/GetEvents used to share ONE
+// RWMutex across every run's events, so a slow GetEvents (O(history),
+// unbounded for a long-running/high-frequency run) for run A would force
+// AppendEvent for a completely unrelated run B to wait too --
+// sync.RWMutex.Lock() must wait for all current readers regardless of
+// which run they're reading. In production this meant one long-running
+// workflow's Subscribe traffic could stall event delivery for every
+// other concurrently-running workflow.
+//
+// This is deliberately a structural assertion, not a timing test (timing
+// tests on shared/loaded CI hardware are exactly what caused the
+// regression this fix addresses to go unnoticed -- see the
+// fix/workflow-engine-concurrency branch history). Two different runs
+// must get two DIFFERENT *runEvents (and therefore two independent
+// locks, making cross-run blocking structurally impossible); the same
+// run must always get back the SAME *runEvents instance (otherwise the
+// per-run lock would be meaningless -- a fresh lock every call protects
+// nothing).
+func TestMemoryStorePerRunEventLockIsIndependentPerRun(t *testing.T) {
+	m := newMemoryStore()
+
+	reA := m.runEventsFor("run-a")
+	reB := m.runEventsFor("run-b")
+	if reA == reB {
+		t.Fatal("expected different runs to get independent *runEvents (and therefore independent locks); got the same instance for run-a and run-b")
+	}
+
+	reAAgain := m.runEventsFor("run-a")
+	if reA != reAAgain {
+		t.Fatal("expected repeated runEventsFor calls for the same run to return the same *runEvents instance (a fresh lock every call would protect nothing)")
+	}
+}

--- a/internal/workflow/store_coverage_test.go
+++ b/internal/workflow/store_coverage_test.go
@@ -76,3 +76,74 @@ func TestMemoryStorePerRunEventLockIsIndependentPerRun(t *testing.T) {
 		t.Fatal("expected repeated runEventsFor calls for the same run to return the same *runEvents instance (a fresh lock every call would protect nothing)")
 	}
 }
+
+// TestMemoryStoreGetEventsReleasesLockBeforeCopy is REQUIRED 2's
+// deterministic proof: third-round review found that
+// TestMemoryStorePerRunEventLockIsIndependentPerRun above, while true,
+// does not actually establish that GetEvents releases its per-run lock
+// before the O(history) copy -- it passed even when GetEvents held the
+// RLock for the whole call (the actual bug: emit() calls AppendEvent
+// while holding e.mu, so a concurrent AppendEvent for the SAME run
+// blocked behind that RLock transitively held e.mu for every other run
+// too).
+//
+// Using memoryStoreGetEventsPostSnapshotHook (a test-only seam, nil/
+// no-op in production, mirroring the same pattern used elsewhere in this
+// package for subagentPollInterval and resumePreTransitionHook), this
+// test holds GetEvents open AFTER its snapshot step and asserts a
+// concurrent AppendEvent for the SAME run completes near-instantly --
+// which is only possible if the per-run RLock was already released
+// before the hook fired.
+func TestMemoryStoreGetEventsReleasesLockBeforeCopy(t *testing.T) {
+	m := newMemoryStore()
+	ctx := context.Background()
+	const runID = "gated-run"
+
+	if err := m.AppendEvent(ctx, &Event{RunID: runID, Seq: 1}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	memoryStoreGetEventsPostSnapshotHook = func() {
+		close(entered)
+		<-release
+	}
+	t.Cleanup(func() { memoryStoreGetEventsPostSnapshotHook = nil })
+
+	getEventsDone := make(chan struct{})
+	go func() {
+		defer close(getEventsDone)
+		if _, err := m.GetEvents(ctx, runID, -1); err != nil {
+			t.Errorf("GetEvents: %v", err)
+		}
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetEvents never reached the post-snapshot hook")
+	}
+
+	// The per-run RLock must already be released by this point (the hook
+	// fires strictly after re.mu.RUnlock() in the fixed implementation).
+	// A concurrent AppendEvent for the SAME run should therefore complete
+	// near-instantly, not block for as long as the hook is held.
+	appendDone := make(chan struct{})
+	go func() {
+		defer close(appendDone)
+		if err := m.AppendEvent(ctx, &Event{RunID: runID, Seq: 2}); err != nil {
+			t.Errorf("AppendEvent: %v", err)
+		}
+	}()
+
+	select {
+	case <-appendDone:
+	case <-time.After(200 * time.Millisecond):
+		close(release)
+		t.Fatal("AppendEvent for the same run did not complete within 200ms while GetEvents was mid-copy — the per-run lock appears to still be held during the copy")
+	}
+
+	close(release)
+	<-getEventsDone
+}

--- a/internal/workflow/subscribe_lock_scope_test.go
+++ b/internal/workflow/subscribe_lock_scope_test.go
@@ -144,16 +144,19 @@ func TestSubscribeDoesNotHoldEngineLockDuringHistoryCopy(t *testing.T) {
 }
 
 // A second, related property -- that a slow Subscribe on one run must not
-// block emits for a completely unrelated run, via memoryStore's per-run
-// locking -- is pinned structurally (not with wall-clock timing) by
-// TestMemoryStorePerRunEventLockIsIndependentPerRun in
-// store_coverage_test.go. An earlier version of this file attempted to
-// pin that property with a real-timing test (a Subscribe against a
-// 500,000-event run's history, asserting an unrelated run's Start
-// completed within a wall-clock bound); it was removed because, on
-// shared/loaded CI hardware, both the setup cost (building a 500k-event
-// history) and the comparison threshold were unreliable -- exactly the
-// class of flakiness the coordinator asked to avoid ("do not write a
-// timing test so tight it flakes in CI"), and exactly the class of
-// environmental noise that made the original regression this branch
-// fixes hard to diagnose in the first place.
+// block emits for a completely unrelated run -- was previously pinned only
+// by TestMemoryStorePerRunEventLockIsIndependentPerRun in
+// store_coverage_test.go, which asserts distinct runs get distinct lock
+// pointers. Third-round review correctly flagged that as a near-tautology:
+// it does not actually exercise the property (it passes even when
+// memoryStore.GetEvents holds its per-run RLock for the whole O(history)
+// copy, which -- via emit()'s AppendEvent call still running under e.mu --
+// transitively blocks e.mu, and therefore every OTHER run, for the same
+// duration). TestSlowSubscribeOnOneRunDoesNotBlockEmitOnAnotherRun in
+// engine_lock_safety_test.go (package workflow, not workflow_test --
+// it needs direct access to the unexported e.emit to control exactly
+// when an event is emitted on run A relative to the blocked GetEvents
+// call) replaces that coverage with a deterministic, non-timing-based
+// test: a Store whose GetEvents blocks on a test-controlled channel, so
+// there is no threshold to tune and nothing to flake on loaded CI
+// hardware.

--- a/internal/workflow/subscribe_lock_scope_test.go
+++ b/internal/workflow/subscribe_lock_scope_test.go
@@ -1,0 +1,144 @@
+package workflow_test
+
+// Follow-up review (second round) on fix/workflow-engine-concurrency found
+// a NEW, REPRODUCIBLE performance regression introduced by the BUG 5 fix
+// (commit a4e2b34): Subscribe() calls store.GetEvents(ctx, runID, -1) --
+// an O(history) copy of the run's ENTIRE event history -- WHILE HOLDING
+// e.mu, the engine's single global lock. Since emit() also needs e.mu for
+// every event (any run, not just this one), a Subscribe against a run
+// with a large or growing history blocks ALL emits engine-wide for the
+// duration of the copy. Repeated Subscribes against a run whose history
+// keeps growing (e.g. TestEmitCancelRaceDoesNotPanic's 2000 iterations
+// against a continuously-emitting run) is O(n^2) overall, and manifested
+// as `go test ./internal/workflow/... -race -count=5` timing out (it
+// completed in ~56s before this regression).
+//
+// The fix: Subscribe now holds e.mu only long enough to (a) register the
+// subscriber channel and (b) record the current sequence number, then
+// releases the lock and does the O(history) copy OUTSIDE it, trimming the
+// result to events at-or-before the recorded sequence number. Events
+// after that point arrive live on the channel (already registered before
+// the lock was released) instead. See TestSubscribeNeverMissesConcurrentEmit
+// in concurrency_bugs_internal_test.go for the invariant this must not
+// reintroduce a gap in.
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/workflow"
+)
+
+// slowHistoryStore is a minimal workflow.Store whose GetEvents call
+// sleeps before returning, simulating a large/slow history copy. Used to
+// prove Subscribe does NOT hold e.mu for the duration of that copy: if it
+// did, a concurrent, otherwise-trivial engine call (List) would also be
+// blocked for the same duration.
+type slowHistoryStore struct {
+	mu             sync.Mutex
+	runs           map[string]*workflow.Run
+	events         map[string][]workflow.Event
+	getEventsDelay time.Duration
+}
+
+func newSlowHistoryStore(delay time.Duration) *slowHistoryStore {
+	return &slowHistoryStore{
+		runs:           make(map[string]*workflow.Run),
+		events:         make(map[string][]workflow.Event),
+		getEventsDelay: delay,
+	}
+}
+
+func (s *slowHistoryStore) CreateRun(_ context.Context, run *workflow.Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *slowHistoryStore) UpdateRun(_ context.Context, run *workflow.Run) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := *run
+	s.runs[run.ID] = &cp
+	return nil
+}
+
+func (s *slowHistoryStore) GetRun(_ context.Context, id string) (*workflow.Run, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.runs[id]
+	if !ok {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (s *slowHistoryStore) AppendEvent(_ context.Context, ev *workflow.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events[ev.RunID] = append(s.events[ev.RunID], *ev)
+	return nil
+}
+
+func (s *slowHistoryStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]workflow.Event, error) {
+	// Simulate an expensive/slow history copy -- e.g. a large in-memory
+	// history, or a real persistence backend.
+	if s.getEventsDelay > 0 {
+		time.Sleep(s.getEventsDelay)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]workflow.Event, 0, len(s.events[runID]))
+	for _, ev := range s.events[runID] {
+		if ev.Seq > afterSeq {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}
+
+// TestSubscribeDoesNotHoldEngineLockDuringHistoryCopy asserts that a slow
+// Subscribe (its store.GetEvents call takes 300ms) does not block an
+// unrelated, otherwise-instant engine call (List) for anywhere close to
+// that duration. If Subscribe still holds e.mu across the store read,
+// List -- which also needs e.mu -- would be forced to wait for the full
+// 300ms too.
+func TestSubscribeDoesNotHoldEngineLockDuringHistoryCopy(t *testing.T) {
+	mgr := newMockMgr()
+	st := newSlowHistoryStore(300 * time.Millisecond)
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr, Store: st})
+	eng.Register("noop", func(*workflow.Context) (any, error) { return "ok", nil })
+
+	run, err := eng.Start(context.Background(), "noop", nil)
+	require.NoError(t, err)
+	waitForRun(t, eng, run.ID, workflow.RunStatusCompleted)
+
+	subDone := make(chan struct{})
+	go func() {
+		defer close(subDone)
+		_, _, cancel, subErr := eng.Subscribe(run.ID)
+		require.NoError(t, subErr)
+		cancel()
+	}()
+
+	// Give the Subscribe goroutine a moment to start (and, if buggy,
+	// acquire and hold e.mu across its slow store call).
+	time.Sleep(20 * time.Millisecond)
+
+	start := time.Now()
+	eng.List()
+	elapsed := time.Since(start)
+
+	require.Less(t, elapsed, 150*time.Millisecond,
+		"List() took %v while a concurrent Subscribe's 300ms history copy was in flight — "+
+			"Subscribe appears to still be holding the engine lock across the store read", elapsed)
+
+	<-subDone
+}

--- a/internal/workflow/subscribe_lock_scope_test.go
+++ b/internal/workflow/subscribe_lock_scope_test.go
@@ -142,3 +142,18 @@ func TestSubscribeDoesNotHoldEngineLockDuringHistoryCopy(t *testing.T) {
 
 	<-subDone
 }
+
+// A second, related property -- that a slow Subscribe on one run must not
+// block emits for a completely unrelated run, via memoryStore's per-run
+// locking -- is pinned structurally (not with wall-clock timing) by
+// TestMemoryStorePerRunEventLockIsIndependentPerRun in
+// store_coverage_test.go. An earlier version of this file attempted to
+// pin that property with a real-timing test (a Subscribe against a
+// 500,000-event run's history, asserting an unrelated run's Start
+// completed within a wall-clock bound); it was removed because, on
+// shared/loaded CI hardware, both the setup cost (building a 500k-event
+// history) and the comparison threshold were unreliable -- exactly the
+// class of flakiness the coordinator asked to avoid ("do not write a
+// timing test so tight it flakes in CI"), and exactly the class of
+// environmental noise that made the original regression this branch
+// fixes hard to diagnose in the first place.

--- a/internal/workflow/subscriber_terminal_close_test.go
+++ b/internal/workflow/subscriber_terminal_close_test.go
@@ -1,0 +1,104 @@
+package workflow_test
+
+// Optional hardening (follow-up review, "strongly recommended"): the
+// fan-out in emit() is `select { case ch <- event: default: }` on a
+// 64-slot buffered channel. A slow subscriber whose buffer is already
+// full silently LOSES the send -- including the terminal
+// workflow.completed/workflow.failed event -- and the engine never
+// closes the channel either, so that subscriber hangs forever waiting
+// for a completion that already happened. This is a second route to the
+// exact "SSE client hangs forever" failure mode BUG 5 fixed for the
+// history/live gap, via a different mechanism (a full buffer instead of
+// a registration-timing gap).
+//
+// The fix: on a terminal event, emit() closes and deregisters every
+// subscriber channel for the run, in the same critical section, right
+// after the (possibly-dropped) send. A closed channel read
+// (`ev, ok := <-ch`) returns immediately with ok=false regardless of
+// buffer state, which every subscriber (e.g. the SSE handler in
+// internal/server/http_script_workflows.go, which already does
+// `case ev, ok := <-stream: if !ok { return }`) already treats as
+// "stream ended". This requires zero changes to internal/server.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go-agent-harness/internal/workflow"
+)
+
+// TestSubscriberChannelClosesOnTerminalEventEvenWithFullBuffer subscribes
+// to a run BEFORE starting it, then never drains the channel while the
+// run emits far more than 64 (the channel's buffer capacity) events,
+// guaranteeing some sends are dropped. It then asserts that draining the
+// channel after the run reaches a terminal status eventually yields
+// ok=false (closed), rather than hanging.
+func TestSubscriberChannelClosesOnTerminalEventEvenWithFullBuffer(t *testing.T) {
+	mgr := newMockMgr()
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr})
+
+	eng.Register("chatty", func(ctx *workflow.Context) (any, error) {
+		for i := 0; i < 100; i++ {
+			ctx.Log(fmt.Sprintf("line %d", i))
+		}
+		return "done", nil
+	})
+
+	run, err := eng.Start(context.Background(), "chatty", nil)
+	require.NoError(t, err)
+
+	_, ch, cancel, err := eng.Subscribe(run.ID)
+	require.NoError(t, err)
+	defer cancel()
+
+	// Deliberately never drain ch while the run is in flight, so its
+	// 64-slot buffer fills and later sends -- including, with high
+	// probability, the terminal one -- are dropped by design.
+	waitForRun(t, eng, run.ID, "")
+
+	// Now drain whatever is left. Regardless of how many (if any)
+	// buffered events remain, this must eventually observe the channel
+	// closed -- not hang.
+	closed := false
+	deadline := time.Now().Add(2 * time.Second)
+	for !closed && time.Now().Before(deadline) {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				closed = true
+			}
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	require.True(t, closed, "subscriber channel never closed after the run reached a terminal state — a slow subscriber with a full buffer would hang forever waiting for a completion that already happened")
+}
+
+// TestCancelAfterTerminalCloseIsSafe verifies that calling cancel() after
+// emit() has already closed the channel on a terminal event does not
+// panic (double-close).
+func TestCancelAfterTerminalCloseIsSafe(t *testing.T) {
+	mgr := newMockMgr()
+	eng := workflow.NewEngine(workflow.EngineOptions{Subagents: mgr})
+
+	eng.Register("quick", func(*workflow.Context) (any, error) {
+		return "ok", nil
+	})
+
+	run, err := eng.Start(context.Background(), "quick", nil)
+	require.NoError(t, err)
+
+	_, _, cancel, err := eng.Subscribe(run.ID)
+	require.NoError(t, err)
+
+	waitForRun(t, eng, run.ID, workflow.RunStatusCompleted)
+
+	// By now emit() has (per the fix) already closed and deregistered
+	// this subscriber's channel on the terminal event. Calling cancel()
+	// afterward must be a safe no-op, not a "close of closed channel"
+	// panic.
+	require.NotPanics(t, func() { cancel() })
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -243,17 +243,34 @@ type Store interface {
 	GetEvents(ctx context.Context, runID string, afterSeq int64) ([]Event, error)
 }
 
+// runEvents holds one run's event history behind its own lock, so a slow
+// GetEvents (O(history), can be large for a long-running/high-frequency
+// run) on one run never blocks AppendEvent -- or GetEvents -- on any
+// OTHER run. Before this, memoryStore used a single RWMutex shared across
+// every run's events; a slow read for run A would force AppendEvent for
+// run B to wait too, since sync.RWMutex.Lock() must wait for all current
+// readers regardless of which run they're reading. That was a real
+// engine-wide production hazard: a Subscribe against one long-running
+// workflow's large history could stall event delivery for every other
+// concurrently-running workflow.
+type runEvents struct {
+	mu     sync.RWMutex
+	events []Event
+}
+
 // memoryStore is an in-memory Store implementation.
 type memoryStore struct {
-	mu     sync.RWMutex
-	runs   map[string]*Run
-	events map[string][]Event
+	mu   sync.Mutex // protects only the two maps below (run lookups/creation), never the O(history) work
+	runs map[string]*Run
+
+	eventsMu sync.Mutex // protects perRun (creation of new per-run entries) — never held during a history copy
+	perRun   map[string]*runEvents
 }
 
 func newMemoryStore() *memoryStore {
 	return &memoryStore{
 		runs:   make(map[string]*Run),
-		events: make(map[string][]Event),
+		perRun: make(map[string]*runEvents),
 	}
 }
 
@@ -274,8 +291,8 @@ func (m *memoryStore) UpdateRun(_ context.Context, run *Run) error {
 }
 
 func (m *memoryStore) GetRun(_ context.Context, id string) (*Run, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	run, ok := m.runs[id]
 	if !ok {
 		return nil, nil
@@ -284,19 +301,34 @@ func (m *memoryStore) GetRun(_ context.Context, id string) (*Run, error) {
 	return &cp, nil
 }
 
+// runEventsFor returns the per-run event log, creating it on first use.
+// Only the O(1) map lookup/creation happens under eventsMu; the returned
+// *runEvents has its own independent lock for the actual O(history) work.
+func (m *memoryStore) runEventsFor(runID string) *runEvents {
+	m.eventsMu.Lock()
+	defer m.eventsMu.Unlock()
+	re, ok := m.perRun[runID]
+	if !ok {
+		re = &runEvents{}
+		m.perRun[runID] = re
+	}
+	return re
+}
+
 func (m *memoryStore) AppendEvent(_ context.Context, event *Event) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.events[event.RunID] = append(m.events[event.RunID], *event)
+	re := m.runEventsFor(event.RunID)
+	re.mu.Lock()
+	defer re.mu.Unlock()
+	re.events = append(re.events, *event)
 	return nil
 }
 
 func (m *memoryStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]Event, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	source := m.events[runID]
-	out := make([]Event, 0, len(source))
-	for _, ev := range source {
+	re := m.runEventsFor(runID)
+	re.mu.RLock()
+	defer re.mu.RUnlock()
+	out := make([]Event, 0, len(re.events))
+	for _, ev := range re.events {
 		if ev.Seq > afterSeq {
 			out = append(out, ev)
 		}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -235,6 +235,22 @@ type QuestionResponder interface {
 type PipelineStage func(prev any, item any, index int) (any, error)
 
 // Store is an optional persistence interface for workflow runs and events.
+//
+// IMPORTANT — locking contract: AppendEvent is called by Engine.emit
+// while the Engine holds its own internal global lock (guarding run
+// registration, subscriber fan-out, etc.). Implementations of
+// AppendEvent (and, transitively, anything it shares a lock or resource
+// with) MUST NOT block on unbounded I/O and MUST NOT call back into the
+// Engine (e.g. Subscribe, GetRun, Start) — the Engine's lock is a
+// sync.Mutex, which is not reentrant, so a re-entrant call from inside
+// AppendEvent self-deadlocks. A Store that blocks for a long time in
+// AppendEvent will stall the Engine's global lock, and therefore every
+// concurrently-running workflow, for the duration of that block. The
+// default in-memory Store meets this contract (AppendEvent is an O(1)
+// amortized slice append, no I/O, no callback); a persistent Store
+// implementation should offload slow writes (e.g. queue them and flush
+// asynchronously) rather than perform them synchronously inside
+// AppendEvent.
 type Store interface {
 	CreateRun(ctx context.Context, run *Run) error
 	UpdateRun(ctx context.Context, run *Run) error

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -243,20 +243,23 @@ type Store interface {
 	GetEvents(ctx context.Context, runID string, afterSeq int64) ([]Event, error)
 }
 
-// runEvents holds one run's event history behind its own lock, so a slow
-// GetEvents (O(history), can be large for a long-running/high-frequency
-// run) on one run never blocks AppendEvent -- or GetEvents -- on any
-// OTHER run. Before this, memoryStore used a single RWMutex shared across
+// runEvents holds one run's event history behind its own lock. Before
+// this type existed, memoryStore used a single RWMutex shared across
 // every run's events; a slow read for run A would force AppendEvent for
 // run B to wait too, since sync.RWMutex.Lock() must wait for all current
-// readers regardless of which run they're reading. That was a real
-// engine-wide production hazard: a Subscribe against one long-running
-// workflow's large history could stall event delivery for every other
-// concurrently-running workflow.
+// readers regardless of which run they're reading. Splitting the lock
+// per-run fixed THAT specific cross-run case, but on its own does NOT
+// make a slow GetEvents engine-wide-safe: see the comment on GetEvents
+// below for why the per-run RLock must also only be held for an O(1)
+// snapshot, not the whole O(history) copy.
 type runEvents struct {
 	mu     sync.RWMutex
 	events []Event
 }
+
+// memoryStoreGetEventsPostSnapshotHook is a test-only seam. See
+// memoryStore.GetEvents for where it fires and why.
+var memoryStoreGetEventsPostSnapshotHook func()
 
 // memoryStore is an in-memory Store implementation.
 type memoryStore struct {
@@ -323,12 +326,45 @@ func (m *memoryStore) AppendEvent(_ context.Context, event *Event) error {
 	return nil
 }
 
+// GetEvents holds the per-run RLock only long enough to take an O(1)
+// snapshot of the events slice header, then copies OUTSIDE any lock.
+//
+// This matters because emit() (engine.go) calls AppendEvent while
+// holding e.mu, the engine's single global lock. If GetEvents held its
+// per-run RLock for the whole O(history) copy (as an earlier version of
+// this method did), a concurrent emit() on THAT SAME run would acquire
+// e.mu and then block on AppendEvent's Lock() behind this RLock --
+// transitively holding e.mu, and therefore blocking every OTHER run's
+// emit (and GetRun/List/Start/Resume), for the full duration of this
+// one run's history copy. A per-run lock alone only narrows the
+// trigger (which run has to be "slow" to cause it); it does not narrow
+// the blast radius (every run stalls regardless), because the stall
+// propagates back through e.mu.
+//
+// Race-free by the append-only invariant: AppendEvent only ever writes
+// at index >= len(snapshot) (either into existing spare capacity, which
+// the snapshot's capped 3-index slice expression makes invisible to
+// this read, or into a freshly-allocated array on realloc, which never
+// touches the old one). This reader only ever touches [0, len(snapshot)),
+// which is disjoint from anything a concurrent append can write to.
 func (m *memoryStore) GetEvents(_ context.Context, runID string, afterSeq int64) ([]Event, error) {
 	re := m.runEventsFor(runID)
 	re.mu.RLock()
-	defer re.mu.RUnlock()
-	out := make([]Event, 0, len(re.events))
-	for _, ev := range re.events {
+	snapshot := re.events[:len(re.events):len(re.events)]
+	re.mu.RUnlock()
+
+	// Test-only seam (nil/no-op in production): fires after the per-run
+	// RLock above has already been released, letting a test hold up the
+	// "slow copy" part of GetEvents deterministically while proving the
+	// lock itself is not held during it (a concurrent AppendEvent for the
+	// same run should complete immediately). See
+	// TestMemoryStoreGetEventsReleasesLockBeforeCopy.
+	if memoryStoreGetEventsPostSnapshotHook != nil {
+		memoryStoreGetEventsPostSnapshotHook()
+	}
+
+	out := make([]Event, 0, len(snapshot))
+	for _, ev := range snapshot {
 		if ev.Seq > afterSeq {
 			out = append(out, ev)
 		}


### PR DESCRIPTION
Fixes 5 verified concurrency bugs in the workflow engine. **This branch went through 4 review rounds** — twice the *fix* introduced something worse than the bug, and both times a fully green `-race` suite was blind to it. Documenting that here because it's the most useful thing in this PR.

## The bugs

- **P0 — a client disconnect could kill the whole `harnessd` process.** `emit()` snapshotted subscriber channels, released the lock, then sent on them — while a disconnecting SSE client's `cancel()` closed those same channels under the lock. Send on a closed channel panics (a `select`/`default` does **not** protect against this — only against a full channel), and because the terminal emit runs on an unrecovered goroutine, it took the process down with every in-flight run.
- **P1 — a CPU core pegged per in-flight subagent.** `Context.Agent` polled status in a zero-delay loop. Measured **264,249 polls in 50ms**.
- **P1 — fatal map race.** `Context.Workflow` read the scripts map with no lock while `Register` wrote it. Concurrent map read/write is an *unrecoverable* Go runtime error.
- **P2 — `Resume` double-executed a run** (TOCTOU between the status check and the transition).
- **P2 — `Subscribe` lost terminal events**, hanging SSE clients forever.

## What review caught (the interesting part)

**Round 1** — the defensive `recover()` I asked for made things *worse*: `json.Marshal` of a script's result runs arbitrary user `MarshalJSON` code, that ran under the engine lock, the lock was released manually rather than with `defer`, so a panic skipped the unlock — and the new `recover()` swallowed it. The engine wedged **permanently and silently**. The old code at least crashed loudly and could be restarted. Reproduced, then fixed: marshal outside the lock, one shared terminal-transition path, and the recover now marks the run failed and emits `workflow.failed`.

**Round 2** — closing the history/live gap by holding the lock across the history read made `Subscribe` O(history) under the *global* lock, so repeated subscribes went O(n²) and starved every emit. `-race -count=5` went from 56s to **not finishing in 900s**.

**Round 3** — moving the copy back outside the lock reintroduced event loss by a *different* door: the fan-out is a non-blocking send into a 64-slot buffer, and the subscriber can't drain it until `Subscribe` returns — so events beyond 64 emitted during the copy were dropped by the fan-out **and** trimmed out of the history. They reached neither. Measured **120,463 of 147,717 events lost**. Separately, the per-run store lock did *not* close the engine-wide stall: `emit()` still held the global lock across `AppendEvent`, so one run's history copy stalled **every** run — 113ms at 400k history, 700× baseline.

## The final design

`Subscribe` holds the engine lock only long enough to register the subscriber and record a sequence number, then copies history outside the lock. Events emitted during that window go into a per-subscriber `pending` buffer (not the lossy channel), which is folded onto the trimmed history when the copy completes. `memoryStore.GetEvents` snapshots the slice header under the lock and copies outside it (race-free by the append-only invariant).

**Independently verified** (probes written from scratch, not the branch's own tests):
- Exactly-once: a 500-event burst during a 150k-history copy → `missing=0, duplicated=0`.
- No engine-wide stall: unrelated-run emit latency **156µs** (was 113ms).

Also fixes a **pre-existing** data race the review surfaced: `ctx.Phase()` writes `c.phase` under a lock while `ctx.Agent()` read it without one — reachable by any script calling both inside `Parallel()`.

## Verification
`go build ./...`, `go vet`, `go test ./internal/workflow/... -race -count=5` (110s), `go test ./internal/server/...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6