### PR TITLE
fix(subagents): guard managed.Status accesses against data race

### DIFF
--- a/internal/subagents/manager.go
+++ b/internal/subagents/manager.go
@@ -287,13 +287,13 @@ func (m *manager) Create(ctx context.Context, req Request) (Subagent, error) {
 		}
 		return Subagent{}, err
 	}
+
+	m.mu.Lock()
 	managed.RunID = run.ID
 	managed.Status = run.Status
 	managed.Output = run.Output
 	managed.Error = run.Error
 	managed.UpdatedAt = time.Now().UTC()
-
-	m.mu.Lock()
 	m.subagents[id] = managed
 	// Snapshot the Subagent value while holding the lock and before the monitor
 	// goroutine starts. This prevents a data race between Create returning the
@@ -348,7 +348,10 @@ func (m *manager) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	m.refresh(managed)
-	if managed.Status == harness.RunStatusQueued || managed.Status == harness.RunStatusRunning || managed.Status == harness.RunStatusWaitingForUser {
+	m.mu.RLock()
+	status := managed.Status
+	m.mu.RUnlock()
+	if status == harness.RunStatusQueued || status == harness.RunStatusRunning || status == harness.RunStatusWaitingForUser {
 		return ErrActive
 	}
 	if err := m.cleanupWorkspace(ctx, managed); err != nil {
@@ -367,8 +370,12 @@ func (m *manager) Cancel(ctx context.Context, id string) error {
 	}
 
 	m.refresh(managed)
-	if !isSubagentTerminalStatus(managed.Status) {
-		if err := managed.runner.CancelRun(managed.RunID); err != nil {
+	m.mu.RLock()
+	status := managed.Status
+	runID := managed.RunID
+	m.mu.RUnlock()
+	if !isSubagentTerminalStatus(status) {
+		if err := managed.runner.CancelRun(runID); err != nil {
 			return err
 		}
 	}

--- a/internal/subagents/manager_status_race_test.go
+++ b/internal/subagents/manager_status_race_test.go
@@ -1,0 +1,60 @@
+package subagents
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+)
+
+// TestManagerDeleteStatusDataRace reproduces a data race on managed.Status.
+// Delete calls refresh() (which writes Status under m.mu) and then reads
+// managed.Status without holding the lock. A concurrent refresh() goroutine on
+// the same subagent writes the same field, so the race detector flags the read.
+func TestManagerDeleteStatusDataRace(t *testing.T) {
+	t.Parallel()
+
+	engine := &statefulRunEngine{
+		status: harness.RunStatusRunning,
+	}
+
+	mgr, err := NewManager(Options{InlineRunner: engine})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	ctx := context.Background()
+	item, err := mgr.Create(ctx, Request{Prompt: "race me"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	m := mgr.(*manager)
+	managed, err := m.getManaged(item.ID)
+	if err != nil {
+		t.Fatalf("getManaged: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	const iters = 1000
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			m.refresh(managed)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			// Status is running, so Delete always returns ErrActive and never
+			// removes the subagent from the map.
+			_ = mgr.Delete(ctx, item.ID)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes a data race (Item 2 deferred finding) in `internal/subagents/manager.go`.

`refresh()` writes `managed.Status` under `m.mu`, but `Delete()` and `Cancel()` read it (and
`Cancel` reads `managed.RunID`) with no lock, and `Create()` wrote those fields outside the lock.
`managed` is a shared pointer in the `m.subagents` map, so concurrent Delete/Cancel/refresh race.

Fix: snapshot `Status`/`RunID` under `m.mu.RLock()` (Create writes under `Lock()`), keeping the I/O
calls (`cleanupWorkspace`, `CancelRun`, `StartRun`) outside the lock. Confirmed via a red
`-race` test first; `go test ./internal/subagents/ -race -count=3` is clean.

Implemented by Devin SWE-1.7; independently reviewed and `-race`-verified by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6