### PR TITLE
fix(security): dynamic MCP tools bypassed ApprovalPolicyDestructive

### DIFF
--- a/internal/harness/registry.go
+++ b/internal/harness/registry.go
@@ -294,6 +294,9 @@ func (r *Registry) RegisterMCPTools(serverName string, toolDefs []htools.MCPTool
 			Name:        toolName,
 			Description: td.Description,
 			Parameters:  deepClonePayload(td.Parameters),
+			// MCP servers are external, untrusted code; treat every tool as
+			// mutating unless explicitly proven otherwise.
+			Mutating: true,
 		}
 		handler := ToolHandler(func(ctx context.Context, args json.RawMessage) (string, error) {
 			return mcpReg.CallTool(ctx, regServer, origName, args)
@@ -304,6 +307,8 @@ func (r *Registry) RegisterMCPTools(serverName string, toolDefs []htools.MCPTool
 			tier:      htools.TierDeferred,
 			tags:      []string{"mcp", "integration", "external", "dynamic", "mcp_server:" + serverName},
 			inflight:  &sync.WaitGroup{},
+			// Conservative default: every MCP tool is mutating.
+			mutating:  true,
 			mcpServer: serverName,
 		}
 		registered = append(registered, toolName)

--- a/internal/harness/registry_mcp_test.go
+++ b/internal/harness/registry_mcp_test.go
@@ -379,6 +379,32 @@ func TestRegistry_ReplaceByTagWaitsForInFlightExecution(t *testing.T) {
 	}
 }
 
+// TestRegistry_RegisterMCPTools_IsMutating verifies that every tool registered
+// via RegisterMCPTools is treated as mutating by default. External MCP servers
+// cannot prove a tool is read-only, so under ApprovalPolicyDestructive they
+// must require approval.
+func TestRegistry_RegisterMCPTools_IsMutating(t *testing.T) {
+	r := NewRegistry()
+	caller := &mockMCPReg{}
+
+	toolDefs := []htools.MCPToolDefinition{
+		{Name: "safe_read", Description: "Read-only-ish tool", Parameters: map[string]any{}},
+	}
+
+	registered, err := r.RegisterMCPTools("safe_server", toolDefs, caller)
+	if err != nil {
+		t.Fatalf("RegisterMCPTools failed: %v", err)
+	}
+	if len(registered) != 1 {
+		t.Fatalf("expected 1 registered tool, got %d", len(registered))
+	}
+
+	toolName := registered[0]
+	if !r.IsMutating(toolName) {
+		t.Fatalf("expected MCP tool %q to be mutating", toolName)
+	}
+}
+
 // TestRegistry_RegisterMCPTools_Concurrency verifies RegisterMCPTools is safe under concurrent access.
 func TestRegistry_RegisterMCPTools_Concurrency(t *testing.T) {
 	r := NewRegistry()


### PR DESCRIPTION
**Security fix** (Item 1 P2, Opus-confirmed). Dynamically-connected MCP-server tools were **not
gated by `ApprovalPolicyDestructive`**.

`RegisterMCPTools` built each `registeredTool` without setting the `mutating` field (unlike
`Register`/`RegisterWithOptions`), and `MCPToolDefinition` carries no mutating/destructive signal at
all — so every tool from a dynamically-connected MCP server defaulted to `mutating=false` and ran
without approval, even under a destructive-approval policy. A prompt-injected or malicious MCP
server's tools executed unchecked.

Fix (conservative, safety-first): treat every tool registered via `RegisterMCPTools` as **mutating
by default**. An MCP server is external, untrusted code with no per-tool read-only signal, so under
`ApprovalPolicyDestructive` it must require approval unless proven otherwise. Low blast radius — only
affects runs that opted into destructive-approval; `ApprovalPolicyNone` is unchanged.

Red test first (`TestRegistry_RegisterMCPTools_IsMutating`); registry/approval/MCP tests pass under
`-race -count=2`; full `go build ./...` clean. (The `TestWorktreeContainment_ToolCwdIsWorktree`
failure in the harness package is a pre-existing flake — reproduces on unmodified `main`.)

Implemented by Devin SWE-1.7 to an exact spec; the mutating-default policy decision and review are
the orchestrator's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6