### PR TITLE
fix(provider): bound error-path response-body reads (idle-stream watchdog)

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -376,8 +376,18 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 
 	if payload.Stream {
 		if httpRes.StatusCode >= 300 {
-			responseBody, readErr := io.ReadAll(httpRes.Body)
+			var errBodyStalled atomic.Bool
+			idleErrBody := newIdleTimeoutReader(httpRes.Body, cancelStream, &errBodyStalled)
+			defer idleErrBody.stop()
+			responseBody, readErr := io.ReadAll(idleErrBody)
 			if readErr != nil {
+				if errBodyStalled.Load() {
+					return harness.CompletionResult{}, &harness.ProviderHTTPError{
+						Provider:   c.providerName,
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       fmt.Sprintf("stream stalled: no data received for %s", idleStreamTimeout),
+					}
+				}
 				return harness.CompletionResult{}, fmt.Errorf("read error response body: %w", readErr)
 			}
 			return harness.CompletionResult{}, &harness.ProviderHTTPError{

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -322,8 +322,18 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 
 	if payload.Stream {
 		if httpRes.StatusCode >= 300 {
-			responseBody, readErr := io.ReadAll(httpRes.Body)
+			var errBodyStalled atomic.Bool
+			idleErrBody := newIdleTimeoutReader(httpRes.Body, cancelStream, &errBodyStalled)
+			defer idleErrBody.stop()
+			responseBody, readErr := io.ReadAll(idleErrBody)
 			if readErr != nil {
+				if errBodyStalled.Load() {
+					return harness.CompletionResult{}, &harness.ProviderHTTPError{
+						Provider:   c.providerName,
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       fmt.Sprintf("stream stalled: no data received for %s", idleStreamTimeout),
+					}
+				}
 				return harness.CompletionResult{}, fmt.Errorf("read error response body: %w", readErr)
 			}
 			return harness.CompletionResult{}, &harness.ProviderHTTPError{
@@ -1389,8 +1399,18 @@ func (c *Client) completeWithResponsesAPI(ctx context.Context, req harness.Compl
 
 	if payload.Stream {
 		if httpRes.StatusCode >= 300 {
-			responseBody, readErr := io.ReadAll(httpRes.Body)
+			var errBodyStalled atomic.Bool
+			idleErrBody := newIdleTimeoutReader(httpRes.Body, cancelStream, &errBodyStalled)
+			defer idleErrBody.stop()
+			responseBody, readErr := io.ReadAll(idleErrBody)
 			if readErr != nil {
+				if errBodyStalled.Load() {
+					return harness.CompletionResult{}, &harness.ProviderHTTPError{
+						Provider:   c.providerName,
+						StatusCode: http.StatusServiceUnavailable,
+						Body:       fmt.Sprintf("stream stalled: no data received for %s", idleStreamTimeout),
+					}
+				}
 				return harness.CompletionResult{}, fmt.Errorf("read error response body: %w", readErr)
 			}
 			return harness.CompletionResult{}, &harness.ProviderHTTPError{

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -445,6 +445,62 @@ func TestClientCompleteNonStreamingStallTimesOutWithoutHanging(t *testing.T) {
 	}
 }
 
+// TestClientCompleteStreamingErrorStallTimesOutWithoutHanging is the
+// error-path counterpart to the stall tests: a provider that returns an HTTP
+// error status (e.g. 429) plus a partial error body and then goes silent must
+// fail with a typed error within the idle interval, not hang on the raw
+// io.ReadAll(httpRes.Body) the error path used.
+//
+// NOT t.Parallel(): mutates the shared idleStreamTimeout package var.
+func TestClientCompleteStreamingErrorStallTimesOutWithoutHanging(t *testing.T) {
+	withShrunkIdleStreamTimeout(t, 60*time.Millisecond)
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("test server ResponseWriter does not support flushing")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		// Partial error body — proves the server returned an error status and
+		// started sending a body, then goes silent forever.
+		_, _ = io.WriteString(w, `{\"error":`)
+		flusher.Flush()
+
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Second):
+		}
+	}))
+	defer testServer.Close()
+
+	client, err := NewClient(Config{APIKey: "test-key", BaseURL: testServer.URL, Retry: &provider.RetryConfig{MaxAttempts: 1}})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	start := time.Now()
+	_, err = client.Complete(context.Background(), harness.CompletionRequest{
+		Messages: []harness.Message{{Role: "user", Content: "hi"}},
+		Stream:   func(harness.CompletionDelta) {},
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a stall error, got success")
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("expected the idle-stream watchdog to bound the error-body read (~60ms), took %s", elapsed)
+	}
+	var phe *harness.ProviderHTTPError
+	if !errors.As(err, &phe) {
+		t.Fatalf("expected *harness.ProviderHTTPError, got %T: %v", err, err)
+	}
+	if !strings.Contains(phe.Body, "stall") {
+		t.Fatalf("expected error body to mention the stall, got %q", phe.Body)
+	}
+}
+
 // TestClientCompleteStreamSlowButContinuousSurvivesLongerThanIdleTimeout is
 // the regression guard proving the idle timeout is gap-based, not a
 // disguised total-duration cap: the server never goes silent for longer than


### PR DESCRIPTION
Item 3 residual debt. The streaming `>=300` error-body reads did a raw
`io.ReadAll(httpRes.Body)` with no timeout. Since the whole-request `Client.Timeout` was removed,
a provider that sends error headers and then stalls the body hung unbounded (the idle-stream
watchdog only covered the success paths).

Fix: wrap the three unwrapped streaming error-path reads (openai Chat Completions, openai Responses
API, anthropic) with the same `idleTimeoutReader` the success paths use, returning a 503
`ProviderHTTPError` on stall. The non-streaming error path was already covered by the earlier
watchdog work.

Red test first (`TestClientCompleteStreamingErrorStallTimesOutWithoutHanging`): a 5xx + partial body
then silence returns an error within the shrunk idle interval instead of hanging. Provider tests pass
under `-race`; full `go build ./...` clean.

Implemented by Devin SWE-1.7; independently reviewed and verified by the orchestrator (confirmed all
error-path reads are now wrapped and none were missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6