### PR TITLE
fix(harness): recorder no longer stalls forever on a dropped event

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -5021,7 +5021,22 @@ func startRecorderGoroutine(state *runState, rec *rollout.Recorder) {
 			for {
 				ev, ok := pending[nextSeq]
 				if !ok {
-					return
+					if len(pending) == 0 {
+						return
+					}
+					// We are holding a strictly-later event, so nextSeq can never
+					// arrive. The send must have been dropped; skip the gap to keep
+					// forward progress.
+					minSeq := nextSeq
+					first := true
+					for seq := range pending {
+						if first || seq < minSeq {
+							minSeq = seq
+							first = false
+						}
+					}
+					nextSeq = minSeq
+					continue
 				}
 				delete(pending, nextSeq)
 				record(ev)

--- a/internal/harness/runner_recorder_gap_test.go
+++ b/internal/harness/runner_recorder_gap_test.go
@@ -1,0 +1,85 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/rollout"
+)
+
+// TestStartRecorderGoroutine_GapSkipForwardProgress verifies that when a Seq
+// is dropped (simulated by never sending Seq 2), later events still get
+// recorded instead of stalling the recorder forever.
+func TestStartRecorderGoroutine_GapSkipForwardProgress(t *testing.T) {
+	t.Parallel()
+
+	runID := "gap-test"
+	rolloutDir := t.TempDir()
+	now := time.Now().UTC()
+
+	rec, err := rollout.NewRecorderAt(rollout.RecorderConfig{Dir: rolloutDir, RunID: runID}, now)
+	if err != nil {
+		t.Fatalf("NewRecorderAt: %v", err)
+	}
+
+	state := &runState{}
+	startRecorderGoroutine(state, rec)
+
+	// Send Seq 0, 1, then deliberately skip Seq 2 (drop), then send 3 and 4.
+	for _, seq := range []uint64{0, 1, 3, 4} {
+		ev := rollout.RecordableEvent{
+			ID:        fmt.Sprintf("%s:%d", runID, seq),
+			RunID:     runID,
+			Type:      "test.gap",
+			Timestamp: now,
+			Seq:       seq,
+		}
+		state.recorderCh <- ev
+	}
+
+	state.closeRecorderOnce()
+
+	select {
+	case <-state.recorderDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recorderDone did not close after closeRecorderOnce()")
+	}
+
+	jsonlPath := filepath.Join(rolloutDir, now.Format("2006-01-02"), runID+".jsonl")
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("reading JSONL file: %v", err)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var seqs []uint64
+	for {
+		var e struct {
+			Seq uint64 `json:"seq"`
+		}
+		err := dec.Decode(&e)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode JSONL line: %v", err)
+		}
+		seqs = append(seqs, e.Seq)
+	}
+
+	want := []uint64{0, 1, 3, 4}
+	if len(seqs) != len(want) {
+		t.Fatalf("recorded %d events, want %d: got %v, want %v", len(seqs), len(want), seqs, want)
+	}
+	for i := range want {
+		if seqs[i] != want[i] {
+			t.Fatalf("recorded seq mismatch at index %d: got %v, want %v", i, seqs, want)
+		}
+	}
+}


### PR DESCRIPTION
Item 1 P2 (Opus-confirmed). The per-run JSONL rollout recorder recorded events in strict `Seq`
order and returned from `flush()` the instant `pending[nextSeq]` was missing. A dropped send — when
**both** the event and its same-`Seq` drop-marker fail (sustained channel-full) — left a permanent
gap, so `flush` stalled there forever and every later event piled up in `pending` **unrecorded**:
silent, total loss of the rest of the run's rollout.

Fix: when `flush` finds `pending[nextSeq]` missing but is holding strictly-later events, advance
`nextSeq` past the gap instead of returning. This is provably safe: recorder sends happen **in
ascending `Seq` order under the runner lock** (`prepareLocked`) and the channel is FIFO, so a
buffered later `Seq` means the earlier one was genuinely dropped, never merely in-flight. Complements
the existing drop-marker mechanism as a backstop.

Red test first (deliver `Seq 0,1`, skip `2`, then `3,4`; assert `3,4` are recorded — fails before,
passes after). Recorder + event-ledger-invariant tests pass under `-race`; full `go build ./...`
clean.

Implemented by Devin SWE-1.7; the in-order/FIFO safety argument was independently verified against
`runner_event_journal.go` by the orchestrator before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6