### PR TITLE
fix(provider): stream Responses API tool-call argument deltas (item_id vs call_id)

### DIFF
--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -1497,6 +1497,7 @@ type responsesStreamState struct {
 	content      strings.Builder
 	toolCalls    map[string]*responsesStreamedToolCall // keyed by call_id
 	toolCallKeys []string                              // preserves insertion order
+	itemToCall   map[string]string                     // item_id -> call_id
 	usage        *responsesUsage
 }
 
@@ -1513,7 +1514,8 @@ func (c *Client) decodeResponsesStreamingResponse(model string, body io.Reader, 
 	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
 
 	state := &responsesStreamState{
-		toolCalls: make(map[string]*responsesStreamedToolCall),
+		toolCalls:  make(map[string]*responsesStreamedToolCall),
+		itemToCall: make(map[string]string),
 	}
 
 	var currentEvent string
@@ -1598,12 +1600,14 @@ type responsesTextDeltaEvent struct {
 
 // responsesFuncArgsDeltaEvent is the payload of response.function_call_arguments.delta events.
 type responsesFuncArgsDeltaEvent struct {
+	ItemID string `json:"item_id"`
 	CallID string `json:"call_id"`
 	Delta  string `json:"delta"`
 }
 
 // responsesFuncArgsDoneEvent is the payload of response.function_call_arguments.done events.
 type responsesFuncArgsDoneEvent struct {
+	ItemID    string `json:"item_id"`
 	CallID    string `json:"call_id"`
 	Name      string `json:"name"`
 	Arguments string `json:"arguments"`
@@ -1612,6 +1616,12 @@ type responsesFuncArgsDoneEvent struct {
 // responsesOutputItemDoneEvent is the payload of response.output_item.done events.
 // Used to capture function_call metadata (name, call_id) for tool calls.
 type responsesOutputItemDoneEvent struct {
+	Item responsesOutputItem `json:"item"`
+}
+
+// responsesOutputItemAddedEvent is the payload of response.output_item.added events.
+// Used to establish the item_id -> call_id mapping for streaming tool calls.
+type responsesOutputItemAddedEvent struct {
 	Item responsesOutputItem `json:"item"`
 }
 
@@ -1698,14 +1708,18 @@ func processResponsesSSEBlock(event, data string, state *responsesStreamState, s
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return false, fmt.Errorf("decode response.function_call_arguments.delta: %w", err)
 		}
-		if ev.CallID != "" {
-			tc := state.ensureToolCall(ev.CallID)
+		callID := ev.CallID
+		if callID == "" {
+			callID = state.itemToCall[ev.ItemID]
+		}
+		if callID != "" {
+			tc := state.ensureToolCall(callID)
 			if ev.Delta != "" {
 				tc.Arguments.WriteString(ev.Delta)
 				if streamFn != nil {
 					streamFn(harness.CompletionDelta{
 						ToolCall: harness.ToolCallDelta{
-							ID:        ev.CallID,
+							ID:        callID,
 							Arguments: ev.Delta,
 						},
 					})
@@ -1718,8 +1732,12 @@ func processResponsesSSEBlock(event, data string, state *responsesStreamState, s
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return false, fmt.Errorf("decode response.function_call_arguments.done: %w", err)
 		}
-		if ev.CallID != "" {
-			tc := state.ensureToolCall(ev.CallID)
+		callID := ev.CallID
+		if callID == "" {
+			callID = state.itemToCall[ev.ItemID]
+		}
+		if callID != "" {
+			tc := state.ensureToolCall(callID)
 			if ev.Name != "" {
 				tc.Name = ev.Name
 			}
@@ -1728,6 +1746,20 @@ func processResponsesSSEBlock(event, data string, state *responsesStreamState, s
 			if ev.Arguments != "" {
 				tc.Arguments.Reset()
 				tc.Arguments.WriteString(ev.Arguments)
+			}
+		}
+
+	case "response.output_item.added":
+		// This event carries the initial item metadata including id and call_id for function calls.
+		var ev responsesOutputItemAddedEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return false, fmt.Errorf("decode response.output_item.added: %w", err)
+		}
+		if ev.Item.Type == "function_call" && ev.Item.ID != "" && ev.Item.CallID != "" {
+			state.itemToCall[ev.Item.ID] = ev.Item.CallID
+			tc := state.ensureToolCall(ev.Item.CallID)
+			if ev.Item.Name != "" {
+				tc.Name = ev.Item.Name
 			}
 		}
 

--- a/internal/provider/openai/client_test.go
+++ b/internal/provider/openai/client_test.go
@@ -1768,6 +1768,85 @@ func TestResponsesAPIStreamingTextAndToolCalls(t *testing.T) {
 	}
 }
 
+// TestResponsesAPIStreamingToolCallDeltasByItemID verifies that the streaming
+// parser streams tool-call argument deltas keyed by item_id, not call_id.
+// OpenAI's Responses API sends function_call_arguments.delta/done events with
+// an item_id and no call_id; output_item.added provides the item_id -> call_id
+// mapping, and output_item.done carries the final call_id. This regresses the
+// bug where every delta was dropped because the handler only looked at call_id.
+func TestResponsesAPIStreamingToolCallDeltasByItemID(t *testing.T) {
+	t.Parallel()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"stream":true`) {
+			t.Fatalf("expected stream=true in request, got: %s", body)
+		}
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		_, _ = io.WriteString(w, strings.Join([]string{
+			`event: response.output_item.added`,
+			`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_123","call_id":"call_123","name":"get_weather","arguments":""}}`,
+			``,
+			`event: response.function_call_arguments.delta`,
+			`data: {"type":"response.function_call_arguments.delta","item_id":"fc_123","output_index":0,"delta":"{\""}`,
+			``,
+			`event: response.function_call_arguments.delta`,
+			`data: {"type":"response.function_call_arguments.delta","item_id":"fc_123","output_index":0,"delta":"location"}`,
+			``,
+			`event: response.function_call_arguments.done`,
+			`data: {"type":"response.function_call_arguments.done","item_id":"fc_123","output_index":0,"arguments":"{\"location\":\"Paris\"}"}`,
+			``,
+			`event: response.output_item.done`,
+			`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_123","call_id":"call_123","name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}`,
+			``,
+			`event: response.completed`,
+			`data: {"response":{"id":"resp_abc","output":[],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15}}}`,
+			``,
+		}, "\n"))
+	}))
+	defer testServer.Close()
+
+	client := newResponsesClient(t, testServer.URL)
+
+	var deltas []harness.CompletionDelta
+	result, err := client.Complete(context.Background(), harness.CompletionRequest{
+		Model:    "gpt-5.1-codex-mini",
+		Messages: []harness.Message{{Role: "user", Content: "weather"}},
+		Stream: func(delta harness.CompletionDelta) {
+			deltas = append(deltas, delta)
+		},
+	})
+	if err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(result.ToolCalls))
+	}
+	if result.ToolCalls[0].ID != "call_123" {
+		t.Fatalf("unexpected tool call ID: %q", result.ToolCalls[0].ID)
+	}
+	if result.ToolCalls[0].Name != "get_weather" {
+		t.Fatalf("unexpected tool call name: %q", result.ToolCalls[0].Name)
+	}
+	if result.ToolCalls[0].Arguments != `{"location":"Paris"}` {
+		t.Fatalf("unexpected tool call arguments: %q", result.ToolCalls[0].Arguments)
+	}
+
+	var toolArgDeltas []string
+	for _, d := range deltas {
+		if d.ToolCall.Arguments != "" {
+			toolArgDeltas = append(toolArgDeltas, d.ToolCall.Arguments)
+		}
+	}
+	if len(toolArgDeltas) == 0 {
+		t.Fatal("expected streamed tool-call argument deltas, got none")
+	}
+	if !slices.Equal(toolArgDeltas, []string{`{"`, "location"}) {
+		t.Fatalf("unexpected tool arg deltas: %v", toolArgDeltas)
+	}
+}
+
 // TestResponsesAPINonStreamingErrorReturnsTypedFailure is a BUG4 test: the
 // non-streaming Responses API error branch returned a plain fmt.Errorf
 // instead of the typed *harness.ProviderHTTPError the Chat Completions path


### PR DESCRIPTION
Item 2/B4 deferred P3. The OpenAI Responses API streams `response.function_call_arguments.delta`/`.done`
events keyed by **`item_id`, not `call_id`** (schema confirmed against OpenAI docs); the handlers read
`ev.CallID`, which is always empty, so **every tool-call argument delta was dropped** — arguments only
appeared at the end via `output_item.done`. Tool calls worked, but their arguments never streamed.

Fix: handle `response.output_item.added` (which carries both the item `id` and `call_id`) to build an
`item_id -> call_id` map, and resolve the delta/done events through it (direct `call_id` kept as a
fallback). Added `item_id` to the event structs and `itemToCall` to the stream state.

Red test asserts the **streamed** delta chunks arrive (`["{\"", "location"]`), not just the final tool
call — so it fails when deltas are dropped. openai tests pass under `-race`; full `go build ./...` clean.

Implemented by Devin SWE-1.7 to a doc-verified spec; the streaming assertion and schema were checked by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6