### PR TITLE
fix(harness): context-reset leaks later tool results; auto-compact drops rule/runtime injections

### DIFF
--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -209,6 +209,7 @@ func (se *stepEngine) run() {
 		if injected := injectedRuleContent.String(); injected != "" {
 			turnMessages = append(turnMessages, Message{Role: "system", Content: injected})
 		}
+		var runtimeContext string
 		if resolvedPrompt != nil && r.config.PromptEngine != nil {
 			usageTotals, costTotals := r.accountingTotals(runID)
 
@@ -234,7 +235,7 @@ func (se *stepEngine) run() {
 					}
 				}
 			}
-			runtimeContext := strings.TrimSpace(r.config.PromptEngine.RuntimeContext(systemprompt.RuntimeContextInput{
+			runtimeContext = strings.TrimSpace(r.config.PromptEngine.RuntimeContext(systemprompt.RuntimeContextInput{
 				RunStartedAt:           runStartedAt,
 				Now:                    time.Now().UTC(),
 				Step:                   step,
@@ -298,6 +299,12 @@ func (se *stepEngine) run() {
 					}
 					if systemPrompt != "" {
 						turnMessages = append(turnMessages, Message{Role: "system", Content: systemPrompt})
+					}
+					if injected := injectedRuleContent.String(); injected != "" {
+						turnMessages = append(turnMessages, Message{Role: "system", Content: injected})
+					}
+					if runtimeContext != "" {
+						turnMessages = append(turnMessages, Message{Role: "system", Content: runtimeContext})
 					}
 					turnMessages = append(turnMessages, copyMessages(messages)...)
 					r.emit(runID, EventAutoCompactCompleted, map[string]any{
@@ -1221,7 +1228,7 @@ func (se *stepEngine) run() {
 					}
 					messages = resetMessages
 					r.setMessages(runID, messages)
-					continue
+					break
 				}
 			}
 

--- a/internal/harness/runner_step_engine_test.go
+++ b/internal/harness/runner_step_engine_test.go
@@ -1,8 +1,13 @@
 package harness
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
+
+	"go-agent-harness/internal/systemprompt"
 )
 
 // TestRunnerStepLoop_SteeringDrainBeforeTurnRequest characterizes the current
@@ -111,4 +116,154 @@ func TestRunnerStepLoop_SteeringDrainBeforeTurnRequest(t *testing.T) {
 	if !found {
 		t.Fatalf("steering message not found in second LLM call messages: %v", secondCallMsgs)
 	}
+}
+
+// TestRunnerStepEngine_ResetContextBreaksRemainingToolResults verifies that
+// when a reset_context result is returned by a non-first tool call in a turn,
+// the remaining tool results of that turn are not appended to the reset seed.
+func TestRunnerStepEngine_ResetContextBreaksRemainingToolResults(t *testing.T) {
+	t.Parallel()
+
+	reg := makeResetContextRegistry()
+	for _, name := range []string{"toolA", "toolB"} {
+		n := name
+		if err := reg.Register(ToolDefinition{
+			Name:        n,
+			Description: "test tool",
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+		}, func(_ context.Context, _ json.RawMessage) (string, error) {
+			return n + "-output", nil
+		}); err != nil {
+			t.Fatalf("Register %s: %v", n, err)
+		}
+	}
+
+	provider := &capturingProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{
+					{ID: "c1", Name: "toolA", Arguments: `{}`},
+					{ID: "c2", Name: "reset_context", Arguments: `{"persist":{}}`},
+					{ID: "c3", Name: "toolB", Arguments: `{}`},
+				},
+			},
+			{Content: "all done"},
+		},
+	}
+
+	runner := NewRunner(provider, reg, RunnerConfig{
+		DefaultModel:        "test",
+		DefaultSystemPrompt: "system prompt",
+		MaxSteps:            10,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "start"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForRunCompletion(t, runner, run.ID)
+
+	msgs := runner.GetRunMessages(run.ID)
+	foundReset := false
+	for _, m := range msgs {
+		if m.Role == "user" && strings.Contains(m.Content, "Context Reset") {
+			foundReset = true
+		}
+		if m.Role == "tool" {
+			t.Errorf("unexpected tool message after reset: name=%s content=%q", m.Name, m.Content)
+		}
+		if strings.Contains(m.Content, "toolA-output") || strings.Contains(m.Content, "toolB-output") {
+			t.Errorf("tool output leaked into messages after reset: %q", m.Content)
+		}
+	}
+	if !foundReset {
+		t.Errorf("reset opening message not found in messages: %+v", msgs)
+	}
+}
+
+// TestRunnerStepEngine_AutoCompactRebuildPreservesDynamicRuleAndRuntimeContext
+// verifies that the auto-compact rebuild block re-injects the dynamic-rule
+// content and the runtime-context block that were computed for the turn.
+func TestRunnerStepEngine_AutoCompactRebuildPreservesDynamicRuleAndRuntimeContext(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "trigger_tool",
+		Description: "test tool",
+		Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return "trigger result", nil
+	}); err != nil {
+		t.Fatalf("Register trigger_tool: %v", err)
+	}
+
+	provider := &capturingProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{ID: "c1", Name: "trigger_tool", Arguments: `{}`}},
+			},
+			{Content: "done"},
+		},
+	}
+
+	engine := &promptEngineStub{resolved: systemprompt.ResolvedPrompt{
+		StaticPrompt:   "STATIC_PROMPT",
+		ResolvedIntent: "general",
+	}}
+
+	// Large prompt forces auto-compaction on step 2.
+	largePrompt := strings.Repeat("word ", 200)
+
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel:         "test",
+		DefaultAgentIntent:   "general",
+		MaxSteps:             5,
+		PromptEngine:         engine,
+		AutoCompactEnabled:   true,
+		ModelContextWindow:   20,
+		AutoCompactThreshold: 0.5,
+		AutoCompactKeepLast:  10,
+		AutoCompactMode:      "strip",
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: largePrompt,
+		DynamicRules: []DynamicRule{
+			{
+				ID:       "fire-once-rule",
+				Trigger:  RuleTrigger{ToolNames: []string{"trigger_tool"}},
+				Content:  "INJECTED-RULE-CONTENT",
+				FireOnce: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForRunCompletion(t, runner, run.ID)
+
+	if len(provider.calls) < 2 {
+		t.Fatalf("expected at least 2 provider calls, got %d", len(provider.calls))
+	}
+	step2Req := provider.calls[1]
+
+	foundRule := false
+	foundRuntime := false
+	for _, m := range step2Req.Messages {
+		if m.Role == "system" && strings.Contains(m.Content, "INJECTED-RULE-CONTENT") {
+			foundRule = true
+		}
+		if m.Role == "system" && strings.Contains(m.Content, "runtime-step-2") {
+			foundRuntime = true
+		}
+	}
+	if !foundRule {
+		t.Errorf("dynamic rule content missing from step 2 request messages: %+v", step2Req.Messages)
+	}
+	if !foundRuntime {
+		t.Errorf("runtime context missing from step 2 request messages: %+v", step2Req.Messages)
+	}
+
+	_ = run
 }


### PR DESCRIPTION
Two step-engine bugs (Opus-confirmed via investigation).

1. **Context-reset pollution.** When a `reset_context` tool call fired mid-turn, the handler used
`continue`, which resumed the per-tool-result loop — so the remaining tool calls of that same turn
appended their outputs onto the just-reset fresh segment. Fixed with `break` (the wholesale message
replacement means no dangling tool messages survive).

2. **Auto-compact drops injections.** After auto-compaction, the turn rebuild re-added working memory,
memory, and system prompt but **dropped the dynamic-rule injected content and the runtime-context
block**. Fixed by re-adding both, **reusing the already-computed local values** — re-invoking the
rule evaluator would silently drop fire-once rule content (the fired flag is already set) and
double-fire the rest. `runtimeContext` was hoisted so it is in scope at the rebuild site.

Red tests for both (a leaking tool result; missing rule/runtime content on the post-compaction step)
fail before and pass after under `-race`. Full `go build ./...` clean.

Implemented by Devin SWE-1.7 to a spec that called out both traps; verified by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6