### PR TITLE
fix(provider): propagate anthropic content-marshal errors instead of sending null

### DIFF
--- a/internal/provider/anthropic/client.go
+++ b/internal/provider/anthropic/client.go
@@ -847,22 +847,26 @@ func mapMessages(messages []harness.Message) ([]message, error) {
 
 	var pending []pendingMsg
 
-	flush := func() []message {
+	flush := func() ([]message, error) {
 		out := make([]message, 0, len(pending))
 		for _, p := range pending {
 			var contentJSON json.RawMessage
+			var err error
 			if len(p.blocks) == 1 && p.blocks[0].Type == "text" {
 				// Simple text — can use a plain string for efficiency
-				contentJSON, _ = json.Marshal(p.blocks[0].Text)
+				contentJSON, err = json.Marshal(p.blocks[0].Text)
 			} else {
-				contentJSON, _ = json.Marshal(p.blocks)
+				contentJSON, err = json.Marshal(p.blocks)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("marshal anthropic message content: %w", err)
 			}
 			out = append(out, message{
 				Role:    p.role,
 				Content: contentJSON,
 			})
 		}
-		return out
+		return out, nil
 	}
 
 	addBlock := func(role string, block contentBlock) {
@@ -922,7 +926,7 @@ func mapMessages(messages []harness.Message) ([]message, error) {
 		}
 	}
 
-	return flush(), nil
+	return flush()
 }
 
 func mapTools(definitions []harness.ToolDefinition) []toolDef {

--- a/internal/provider/anthropic/client_test.go
+++ b/internal/provider/anthropic/client_test.go
@@ -1497,6 +1497,31 @@ func TestMapMessagesAssistantWithToolCall(t *testing.T) {
 	}
 }
 
+func TestMapMessagesPropagatesMarshalError(t *testing.T) {
+	t.Parallel()
+
+	msgs := []harness.Message{
+		{
+			Role: "assistant",
+			ToolCalls: []harness.ToolCall{
+				{ID: "bad", Name: "mytool", Arguments: "{not valid json}"},
+			},
+		},
+	}
+
+	out, err := mapMessages(msgs)
+	if err == nil {
+		content := "nil"
+		if len(out) > 0 {
+			content = string(out[0].Content)
+		}
+		t.Fatalf("expected marshal error for invalid tool-use input, got nil error with content=%q", content)
+	}
+	if !strings.Contains(err.Error(), "marshal") {
+		t.Fatalf("expected error to mention marshal, got: %v", err)
+	}
+}
+
 // --- Retry ---
 
 func testRetryConfig() *provider.RetryConfig {


### PR DESCRIPTION
`mapMessages` discarded `json.Marshal` errors (`contentJSON, _ = json.Marshal(...)`), so an
unmarshalable content block (e.g. a tool-use block with invalid `Input` JSON) produced an outgoing
request with `"content": null` and an opaque downstream Anthropic API error, with no diagnostic.

Fix: `flush` now returns an error and `mapMessages` propagates it, so a bad block fails loudly.

Red test (`TestMapMessagesPropagatesMarshalError`) asserts a non-nil error for an invalid tool-use
input instead of null content. anthropic tests pass under `-race`; full `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6