### PR TITLE
test: cover the six 0%-coverage functions failing the regression CI gate

### DIFF
--- a/cmd/harnesscli/tui/bridge_from_test.go
+++ b/cmd/harnesscli/tui/bridge_from_test.go
@@ -1,0 +1,75 @@
+package tui_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// TestStartSSEBridgeFrom_SendsLastEventID verifies that StartSSEBridgeFrom
+// forwards its lastEventID argument as the Last-Event-ID request header and
+// still delivers SSE events to the returned channel.
+func TestStartSSEBridgeFrom_SendsLastEventID(t *testing.T) {
+	var mu sync.Mutex
+	var gotLastEventID string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotLastEventID = r.Header.Get("Last-Event-ID")
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, _ := w.(http.Flusher)
+		flusher.Flush()
+
+		fmt.Fprint(w, "event: message\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":\"hello\"}}\n\n")
+		flusher.Flush()
+		fmt.Fprint(w, "event: message\ndata: {\"type\":\"run.completed\",\"payload\":{}}\n\n")
+		flusher.Flush()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	msgs, stop := tui.StartSSEBridgeFrom(ctx, srv.URL, "resume-id-42")
+	defer stop()
+
+	var gotEvent bool
+	var gotDone bool
+	for msg := range msgs {
+		switch m := msg.(type) {
+		case tui.SSEEventMsg:
+			if m.EventType == "assistant.message.delta" {
+				gotEvent = true
+			}
+		case tui.SSEDoneMsg:
+			if m.EventType == "run.completed" {
+				gotDone = true
+			}
+		}
+	}
+
+	mu.Lock()
+	header := gotLastEventID
+	mu.Unlock()
+
+	if header != "resume-id-42" {
+		t.Errorf("Last-Event-ID header = %q, want %q", header, "resume-id-42")
+	}
+	if !gotEvent {
+		t.Error("expected an SSEEventMsg to be delivered")
+	}
+	if !gotDone {
+		t.Error("expected run.completed SSEDoneMsg")
+	}
+}

--- a/internal/mcp/http_conn_resources_test.go
+++ b/internal/mcp/http_conn_resources_test.go
@@ -1,0 +1,130 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/mcp"
+)
+
+func newHTTPResourceServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var req struct {
+			JSONRPC string          `json:"jsonrpc"`
+			Method  string          `json:"method"`
+			ID      json.RawMessage `json:"id"`
+			Params  json.RawMessage `json:"params"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		var result any
+		switch req.Method {
+		case "resources/list":
+			result = map[string]any{
+				"resources": []map[string]any{
+					{
+						"uri":         "file:///a.txt",
+						"name":        "a",
+						"description": "file a",
+						"mimeType":    "text/plain",
+					},
+					{
+						"uri":         "file:///b.txt",
+						"name":        "b",
+						"description": "file b",
+						"mimeType":    "text/plain",
+					},
+				},
+			}
+		case "resources/read":
+			var params struct {
+				URI string `json:"uri"`
+			}
+			_ = json.Unmarshal(req.Params, &params)
+			result = map[string]any{
+				"contents": []map[string]any{
+					{
+						"uri":      params.URI,
+						"mimeType": "text/plain",
+						"text":     "hello from " + params.URI,
+					},
+				},
+			}
+		default:
+			http.Error(w, "unknown method", http.StatusBadRequest)
+			return
+		}
+
+		resp := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  result,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+func TestHTTPConn_ListResources(t *testing.T) {
+	t.Parallel()
+
+	srv := newHTTPResourceServer(t)
+	defer srv.Close()
+
+	conn := mcp.NewHTTPConnForTest("test-server", srv.URL)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resources, err := conn.ListResources(ctx)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	if len(resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(resources))
+	}
+	if resources[0].URI != "file:///a.txt" || resources[0].Name != "a" {
+		t.Errorf("unexpected resource[0]: %+v", resources[0])
+	}
+	if resources[1].URI != "file:///b.txt" || resources[1].Name != "b" {
+		t.Errorf("unexpected resource[1]: %+v", resources[1])
+	}
+}
+
+func TestHTTPConn_ReadResource(t *testing.T) {
+	t.Parallel()
+
+	srv := newHTTPResourceServer(t)
+	defer srv.Close()
+
+	conn := mcp.NewHTTPConnForTest("test-server", srv.URL)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	content, err := conn.ReadResource(ctx, "file:///a.txt")
+	if err != nil {
+		t.Fatalf("ReadResource: %v", err)
+	}
+	want := fmt.Sprintf("hello from %s", "file:///a.txt")
+	if content != want {
+		t.Errorf("ReadResource content = %q, want %q", content, want)
+	}
+}

--- a/internal/provider/anthropic/stream_api_error_test.go
+++ b/internal/provider/anthropic/stream_api_error_test.go
@@ -1,0 +1,21 @@
+package anthropic
+
+import (
+	"testing"
+)
+
+// TestStreamAPIError_Error verifies the Error() string format for a
+// mid-stream SSE error sentinel.
+func TestStreamAPIError_Error(t *testing.T) {
+	err := &streamAPIError{
+		Message:    "overloaded",
+		StatusCode: 503,
+		Raw:        "raw-body",
+	}
+
+	got := err.Error()
+	want := "stream error: overloaded"
+	if got != want {
+		t.Errorf("streamAPIError.Error() = %q, want %q", got, want)
+	}
+}

--- a/internal/provider/openai/stream_api_error_test.go
+++ b/internal/provider/openai/stream_api_error_test.go
@@ -1,0 +1,21 @@
+package openai
+
+import (
+	"testing"
+)
+
+// TestStreamAPIError_Error verifies the Error() string format for a
+// mid-stream SSE error sentinel.
+func TestStreamAPIError_Error(t *testing.T) {
+	err := &streamAPIError{
+		Message:    "rate limit exceeded",
+		StatusCode: 429,
+		Raw:        "raw-body",
+	}
+
+	got := err.Error()
+	want := "stream error: rate limit exceeded"
+	if got != want {
+		t.Errorf("streamAPIError.Error() = %q, want %q", got, want)
+	}
+}

--- a/internal/server/http_relay_control_filter_test.go
+++ b/internal/server/http_relay_control_filter_test.go
@@ -1,0 +1,59 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"go-agent-harness/internal/relay"
+)
+
+// TestRelayControl_PolicyFilter hits POST /v1/relay/policy/filter and verifies
+// that the handler returns a filtered capability pack plus the policy result.
+func TestRelayControl_PolicyFilter(t *testing.T) {
+	h, _ := newRelayControlServer(t)
+
+	rec := doJSON(t, h, http.MethodPost, "/v1/relay/policy/filter", map[string]any{
+		"pack": map[string]any{
+			"run_id": "run-filter",
+			"tools": []map[string]any{
+				{"name": "read"},
+				{"name": "bash:destructive"},
+			},
+		},
+		"policy_context": map[string]any{
+			"TenantID":        "t1",
+			"WorkerTrustTier": "standard",
+			"IsLocalWorker":   true,
+		},
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var resp struct {
+		FilteredPack *relay.CapabilityPack `json:"filtered_pack"`
+		Result       *relay.PolicyResult   `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode policy filter response: %v", err)
+	}
+
+	if resp.Result == nil {
+		t.Fatal("expected a policy result")
+	}
+	if !resp.Result.Allowed {
+		t.Errorf("expected policy to be allowed for a standard local worker, got denied: %v", resp.Result.Denied)
+	}
+
+	if resp.FilteredPack == nil {
+		t.Fatal("expected a filtered pack")
+	}
+	if resp.FilteredPack.RunID != "run-filter" {
+		t.Errorf("filtered pack run_id = %q, want %q", resp.FilteredPack.RunID, "run-filter")
+	}
+	if len(resp.FilteredPack.Tools) != 2 {
+		t.Errorf("expected 2 tools in filtered pack, got %d: %+v", len(resp.FilteredPack.Tools), resp.FilteredPack.Tools)
+	}
+}


### PR DESCRIPTION
Makes the `test-regression` workflow green. It was failing not on a broken test or the 80% total
threshold (total is 84.3%) but on the coverage gate's **zero-tolerance rule for 0%-coverage
functions** — six functions had no test calling them:
`StartSSEBridgeFrom`, `httpConn.ListResources`/`ReadResource`, the anthropic and openai
`streamAPIError.Error()`, and `handleRelayPolicyFilter`.

Adds a focused unit test for each. **Test files only — no source changed.** Verified locally that all
six now report >0% coverage (100/100/100/57/53/50%).

Note: a minority of `test-regression` runs also fail intermittently on unrelated `-race` flakes
(separate follow-ups); this PR fixes the dominant, deterministic cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6