### PR TITLE
test: deflake three -race test failures (async cleanup, bcrypt cost, diagnostic)

### DIFF
--- a/internal/harness/workspace_selection_test.go
+++ b/internal/harness/workspace_selection_test.go
@@ -345,6 +345,7 @@ func TestRunRequest_WorkspaceType_ValidTypes(t *testing.T) {
 			},
 		},
 	)
+	t.Cleanup(func() { _ = runner.Shutdown(context.Background()) })
 
 	for _, wsType := range validTypes {
 		wsType := wsType
@@ -995,6 +996,16 @@ func TestWorktreeContainment_ToolCwdIsWorktree(t *testing.T) {
 			wsPath, _ = ev.Payload["workspace_path"].(string)
 			gotProvisioned = true
 		case EventToolCallCompleted:
+			// If the tool errored, surface the real error instead of running
+			// filesystem assertions that will fail with a misleading "no such file".
+			// The underlying intermittent tool error is a separate unresolved issue.
+			if errStr, ok := ev.Payload["error"].(string); ok && errStr != "" {
+				output, _ := ev.Payload["output"].(string)
+				if output != "" {
+					t.Fatalf("bash tool errored: %s; output: %s", errStr, output)
+				}
+				t.Fatalf("bash tool errored: %s", errStr)
+			}
 			// Run filesystem assertions while the worktree still exists.
 			if !gotToolDone {
 				gotToolDone = true

--- a/internal/server/http_conversations_cleanup_admin_test.go
+++ b/internal/server/http_conversations_cleanup_admin_test.go
@@ -31,6 +31,7 @@ func TestCleanupEndpoint_RequiresAdminScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateAPIKey(runs:write): %v", err)
 	}
+	writeKey = minCostRehash(t, writeToken, writeKey)
 	if err := ms.CreateAPIKey(context.Background(), writeKey); err != nil {
 		t.Fatalf("CreateAPIKey(runs:write): %v", err)
 	}
@@ -38,6 +39,7 @@ func TestCleanupEndpoint_RequiresAdminScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateAPIKey(admin): %v", err)
 	}
+	adminKey = minCostRehash(t, adminToken, adminKey)
 	if err := ms.CreateAPIKey(context.Background(), adminKey); err != nil {
 		t.Fatalf("CreateAPIKey(admin): %v", err)
 	}

--- a/internal/server/http_subagents_tenant_test.go
+++ b/internal/server/http_subagents_tenant_test.go
@@ -14,7 +14,23 @@ import (
 	"go-agent-harness/internal/harness"
 	"go-agent-harness/internal/store"
 	"go-agent-harness/internal/subagents"
+
+	"golang.org/x/crypto/bcrypt"
 )
+
+// minCostRehash replaces key.KeyHash with a MinCost bcrypt hash of rawToken so
+// that CompareHashAndPassword stays fast under -race. The production bcrypt cost
+// used by store.GenerateAPIKey is slow enough to blow the 30s handler timeout
+// under the race detector, which flakes these auth-heavy tests.
+func minCostRehash(t *testing.T, rawToken string, key store.APIKey) store.APIKey {
+	t.Helper()
+	h, err := bcrypt.GenerateFromPassword([]byte(rawToken), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("bcrypt MinCost: %v", err)
+	}
+	key.KeyHash = string(h)
+	return key
+}
 
 // tenantFakeSubagentManager is a minimal in-memory subagents.Manager double
 // that stores whatever TenantID the caller passes on Create and never applies
@@ -101,7 +117,7 @@ func newSubagentTenantAPIKey(t *testing.T, tenantID, name string) (string, store
 	if err != nil {
 		t.Fatalf("GenerateAPIKey(%s): %v", tenantID, err)
 	}
-	return rawToken, key
+	return rawToken, minCostRehash(t, rawToken, key)
 }
 
 func doSubagentRequest(t *testing.T, ts *httptest.Server, method, token, path string, body []byte) (int, string) {


### PR DESCRIPTION
Fixes three intermittent `-race` test failures identified during CI-health investigation. **Test
files only — no source changed. No assertion weakened.**

1. **`TestRunRequest_WorkspaceType_ValidTypes`** — `StartRun` provisions the workspace in a detached
goroutine, and the subtest never waited, so the outer test's `t.TempDir()` `RemoveAll` raced the
in-flight `git worktree add` (`directory not empty`). Added `runner.Shutdown` via `t.Cleanup` so
provisioning finishes before teardown.

2. **`TestSubagentsTenantIsolation_*` and `TestCleanupEndpoint_RequiresAdminScope`** — these hashed
their API keys at the **production bcrypt cost**, and `CompareHashAndPassword` at that cost blew the
30s handler timeout under `-race` (returning 503). Rehash the test keys at `bcrypt.MinCost` (a fast
helper already exists for exactly this). Now pass consistently.

3. **`TestWorktreeContainment_ToolCwdIsWorktree`** — the `tool.call.completed` event fires for both
success and error, so a tool error surfaced as a misleading `no such file`. Now surfaces the actual
`error` payload. This is a **diagnostic improvement** — the underlying intermittent tool error is a
separate open issue; this makes the next failure actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182aJaeQgukK1vkNjy95wt6