### PR TITLE
RSI eval: hard/brutal Go task tier + verified prompt improvement

### DIFF
--- a/benchmarks/terminal_bench/agent.py
+++ b/benchmarks/terminal_bench/agent.py
@@ -159,6 +159,11 @@ exit 1
             "HARNESS_MEMORY_MODE": self._memory_mode,
             "HARNESS_PROMPTS_DIR": f"{CONTAINER_REPO_ROOT}/prompts",
             "HARNESS_PRICING_CATALOG_PATH": self._pricing_catalog_path,
+            # Widen provider retry budget inside the container against rate-limited
+            # (e.g. free-tier) endpoints. Passed through from the host env; unset
+            # leaves the harness built-in defaults (3 attempts / 60s).
+            "HARNESS_RETRY_MAX_ATTEMPTS": os.getenv("HARNESS_RETRY_MAX_ATTEMPTS", ""),
+            "HARNESS_RETRY_MAX_TOTAL_SEC": os.getenv("HARNESS_RETRY_MAX_TOTAL_SEC", ""),
         }
         lines = ["# go-code Terminal-Bench harness environment"]
         for key, value in env_map.items():

--- a/benchmarks/terminal_bench/reference_solutions/brutal-csv-parser/csv.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-csv-parser/csv.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ParseCSV parses RFC-4180-style CSV text into rows of string fields.
+//
+// Contract:
+//   - Fields within a record are separated by commas; records are
+//     separated by a single '\n'.
+//   - A trailing '\n' at the very end of the input does not produce a
+//     spurious empty final record.
+//   - A field may be wrapped in double quotes ("like this"). A quoted
+//     field may contain commas and embedded literal newlines without
+//     those characters ending the field or the record.
+//   - Inside a quoted field, a doubled double-quote ("") is an escaped
+//     quote and collapses to a single literal '"' character in the
+//     field's value.
+//   - Unquoted fields are taken completely literally: no interior or
+//     surrounding whitespace is trimmed.
+//   - An empty input string ("") parses to zero rows.
+//   - An empty line parses to a single row containing one empty field:
+//     [""].
+//
+// Reference solution: hand-written state machine (no encoding/csv) that
+// tracks whether it is currently inside a quoted field so that commas,
+// newlines, and quote characters are only treated as delimiters when they
+// are NOT protected by an open quote.
+func ParseCSV(input string) ([][]string, error) {
+	if input == "" {
+		return [][]string{}, nil
+	}
+
+	var rows [][]string
+	var fields []string
+	var field strings.Builder
+	inQuotes := false
+
+	n := len(input)
+	for i := 0; i < n; i++ {
+		c := input[i]
+
+		if inQuotes {
+			if c == '"' {
+				if i+1 < n && input[i+1] == '"' {
+					// Escaped quote: "" -> literal ".
+					field.WriteByte('"')
+					i++
+					continue
+				}
+				// Closing quote.
+				inQuotes = false
+				continue
+			}
+			// Any other byte (including commas and newlines) inside a
+			// quoted field is part of the field's literal value.
+			field.WriteByte(c)
+			continue
+		}
+
+		switch c {
+		case '"':
+			inQuotes = true
+		case ',':
+			fields = append(fields, field.String())
+			field.Reset()
+		case '\n':
+			fields = append(fields, field.String())
+			field.Reset()
+			rows = append(rows, fields)
+			fields = nil
+		default:
+			field.WriteByte(c)
+		}
+	}
+
+	if inQuotes {
+		return nil, fmt.Errorf("csv: unterminated quoted field")
+	}
+
+	// A trailing newline already closed the final record above; do not
+	// append a spurious empty final record for it.
+	if input[n-1] == '\n' {
+		return rows, nil
+	}
+
+	fields = append(fields, field.String())
+	rows = append(rows, fields)
+	return rows, nil
+}

--- a/benchmarks/terminal_bench/reference_solutions/brutal-getorcompute/cache.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-getorcompute/cache.go
@@ -1,0 +1,51 @@
+package main
+
+import "sync"
+
+// entry holds the memoized result for a single key. sync.Once guarantees
+// that compute() runs at most once per entry, no matter how many goroutines
+// race to resolve it, and that every goroutine observes the value written
+// by the winning call (Once.Do establishes a happens-before edge between
+// the function it runs and every call to Do returning).
+type entry struct {
+	once  sync.Once
+	value int
+}
+
+// Cache is a thread-safe memoizing cache of string -> int.
+//
+// Reference solution: GetOrCompute never lets two callers "win" the race to
+// compute the same key. The map itself (which entries exist) is protected
+// by a plain mutex, but the map lock is held only long enough to get or
+// create the *entry for a key -- it is never held while compute() runs, so
+// unrelated keys are never serialized against each other. Per-key
+// single-flight is provided by that entry's sync.Once, which is safe to
+// call concurrently and runs compute() exactly once.
+type Cache struct {
+	mu    sync.Mutex
+	items map[string]*entry
+}
+
+// NewCache creates an empty Cache.
+func NewCache() *Cache {
+	return &Cache{items: make(map[string]*entry)}
+}
+
+// GetOrCompute returns the cached value for key, computing and storing it
+// via compute if it is not already present. compute is called at most once
+// per key even under concurrent callers.
+func (c *Cache) GetOrCompute(key string, compute func() int) int {
+	c.mu.Lock()
+	e, ok := c.items[key]
+	if !ok {
+		e = &entry{}
+		c.items[key] = e
+	}
+	c.mu.Unlock()
+
+	e.once.Do(func() {
+		e.value = compute()
+	})
+
+	return e.value
+}

--- a/benchmarks/terminal_bench/reference_solutions/brutal-ledger/ledger.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-ledger/ledger.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"sort"
+	"sync"
+)
+
+// Ledger is an in-memory account ledger, safe for concurrent use.
+type Ledger struct {
+	mu       sync.RWMutex
+	balances map[string]int64
+}
+
+// NewLedger creates an empty Ledger.
+func NewLedger() *Ledger {
+	return &Ledger{balances: make(map[string]int64)}
+}
+
+// Post records a signed amount to an account. Multiple posts to the same
+// account accumulate.
+func (l *Ledger) Post(account string, amount int64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.balances[account] += amount
+}
+
+// Balance returns the net balance for one account (0 if unknown).
+func (l *Ledger) Balance(account string) int64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.balances[account]
+}
+
+// Total returns the sum of every account's balance.
+func (l *Ledger) Total() int64 {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	var total int64
+	for _, v := range l.balances {
+		total += v
+	}
+	return total
+}
+
+// TopN returns up to n accounts with the highest balance, ties broken by
+// account name ascending. Never panics.
+func (l *Ledger) TopN(n int) []string {
+	if n <= 0 {
+		return []string{}
+	}
+
+	l.mu.RLock()
+	names := make([]string, 0, len(l.balances))
+	balances := make(map[string]int64, len(l.balances))
+	for k, v := range l.balances {
+		names = append(names, k)
+		balances[k] = v
+	}
+	l.mu.RUnlock()
+
+	sort.Slice(names, func(i, j int) bool {
+		bi, bj := balances[names[i]], balances[names[j]]
+		if bi != bj {
+			return bi > bj
+		}
+		return names[i] < names[j]
+	})
+
+	if n > len(names) {
+		n = len(names)
+	}
+	return names[:n]
+}

--- a/benchmarks/terminal_bench/reference_solutions/brutal-semver/semver.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-semver/semver.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Compare returns -1 if a has lower precedence than b, 0 if a and b have
+// equal precedence, and +1 if a has higher precedence than b, per the
+// Semantic Versioning 2.0.0 precedence rules (see
+// https://semver.org/#spec-item-11). See task.yaml for the full contract.
+func Compare(a, b string) int {
+	av, apre := splitVersion(a)
+	bv, bpre := splitVersion(b)
+
+	if c := compareCore(av, bv); c != 0 {
+		return c
+	}
+
+	// Same MAJOR.MINOR.PATCH. A version without a pre-release has higher
+	// precedence than the same version with one.
+	if apre == "" && bpre == "" {
+		return 0
+	}
+	if apre == "" {
+		return 1
+	}
+	if bpre == "" {
+		return -1
+	}
+
+	return comparePrerelease(apre, bpre)
+}
+
+// splitVersion strips build metadata (everything from the first '+'
+// onward, which is ignored entirely for precedence) and separates the core
+// MAJOR.MINOR.PATCH from the pre-release identifier string (without the
+// leading '-').
+func splitVersion(v string) (core [3]int, prerelease string) {
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+
+	rest := v
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		rest = v[:i]
+		prerelease = v[i+1:]
+	}
+
+	parts := strings.SplitN(rest, ".", 3)
+	for i := 0; i < 3 && i < len(parts); i++ {
+		n, _ := strconv.Atoi(parts[i])
+		core[i] = n
+	}
+	return core, prerelease
+}
+
+func compareCore(a, b [3]int) int {
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// comparePrerelease compares two pre-release identifier strings
+// (dot-separated), per semver.org rule 11.
+func comparePrerelease(a, b string) int {
+	aids := strings.Split(a, ".")
+	bids := strings.Split(b, ".")
+
+	n := len(aids)
+	if len(bids) < n {
+		n = len(bids)
+	}
+
+	for i := 0; i < n; i++ {
+		if c := compareIdentifier(aids[i], bids[i]); c != 0 {
+			return c
+		}
+	}
+
+	// All shared identifiers are equal; the pre-release with more
+	// identifiers has higher precedence.
+	if len(aids) < len(bids) {
+		return -1
+	}
+	if len(aids) > len(bids) {
+		return 1
+	}
+	return 0
+}
+
+// compareIdentifier compares a single pair of dot-separated pre-release
+// identifiers per semver.org rule 11.
+func compareIdentifier(a, b string) int {
+	an, aIsNum := numericIdentifier(a)
+	bn, bIsNum := numericIdentifier(b)
+
+	if aIsNum && bIsNum {
+		switch {
+		case an < bn:
+			return -1
+		case an > bn:
+			return 1
+		default:
+			return 0
+		}
+	}
+
+	// A numeric identifier always has lower precedence than a non-numeric
+	// identifier.
+	if aIsNum && !bIsNum {
+		return -1
+	}
+	if !aIsNum && bIsNum {
+		return 1
+	}
+
+	// Both non-numeric: compare lexically in ASCII order.
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// numericIdentifier reports whether s consists only of decimal digits and,
+// if so, its numeric value.
+func numericIdentifier(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/benchmarks/terminal_bench/reference_solutions/brutal-topo-sort/topo.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-topo-sort/topo.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"sort"
+)
+
+// TopoSort returns a topological order of nodes such that for every edge
+// {u, v} in edges, u must come before v in the returned slice.
+//
+// Contract:
+//   - Return a topological order: for every edge {u, v}, u appears before v.
+//   - Deterministic tie-break: whenever multiple nodes are ready (in-degree
+//     0) at the same time, the lexicographically SMALLEST ready node name is
+//     emitted next. This makes the output unique for a given input.
+//   - Every node in `nodes` must appear in the output, including nodes with
+//     no incident edges (disconnected nodes), ordered by the same
+//     lexicographic ready-set rule.
+//   - If the graph has a cycle, return a nil slice and a non-nil error.
+//   - Every endpoint that appears in edges is assumed to also appear in
+//     nodes.
+//
+// Reference solution: the node universe comes from `nodes` (so disconnected
+// nodes are included), the ready set is kept sorted so ties always resolve
+// to the lexicographically smallest name, and a cycle is detected by
+// comparing the number of emitted nodes against the full node universe.
+func TopoSort(nodes []string, edges [][2]string) ([]string, error) {
+	inDegree := make(map[string]int, len(nodes))
+	adj := make(map[string][]string, len(nodes))
+
+	for _, n := range nodes {
+		inDegree[n] = 0
+	}
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		adj[u] = append(adj[u], v)
+		inDegree[v]++
+	}
+
+	ready := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if inDegree[n] == 0 {
+			ready = append(ready, n)
+		}
+	}
+	sort.Strings(ready)
+
+	order := make([]string, 0, len(nodes))
+	for len(ready) > 0 {
+		u := ready[0]
+		ready = ready[1:]
+		order = append(order, u)
+
+		for _, v := range adj[u] {
+			inDegree[v]--
+			if inDegree[v] == 0 {
+				// Insert v keeping `ready` sorted so the next pick is
+				// always the lexicographically smallest ready node.
+				pos := sort.SearchStrings(ready, v)
+				ready = append(ready, "")
+				copy(ready[pos+1:], ready[pos:])
+				ready[pos] = v
+			}
+		}
+	}
+
+	if len(order) != len(nodes) {
+		return nil, errors.New("toposort: cycle detected")
+	}
+	return order, nil
+}

--- a/benchmarks/terminal_bench/reference_solutions/brutal-wordwrap/wrap.go
+++ b/benchmarks/terminal_bench/reference_solutions/brutal-wordwrap/wrap.go
@@ -1,0 +1,64 @@
+package main
+
+import "strings"
+
+// Wrap splits text into words (runs of spaces/tabs are treated as a single
+// separator; leading/trailing runs produce no empty words) and greedily
+// packs as many words as fit onto each line without exceeding width
+// characters, joining words with a single space.
+//
+// A '\n' byte always forces a hard line break. Wrap("", width) returns an
+// empty slice. If width <= 0, wrapping is disabled and each hard line
+// becomes exactly one (unwrapped) output line. A hard line with no words
+// becomes an empty string ("") line. See task.yaml for the full contract.
+func Wrap(text string, width int) []string {
+	if text == "" {
+		return []string{}
+	}
+
+	var lines []string
+	for _, hardLine := range strings.Split(text, "\n") {
+		words := splitWords(hardLine)
+		switch {
+		case len(words) == 0:
+			lines = append(lines, "")
+		case width <= 0:
+			lines = append(lines, strings.Join(words, " "))
+		default:
+			lines = append(lines, wrapWords(words, width)...)
+		}
+	}
+	return lines
+}
+
+// splitWords splits s into words on runs of spaces/tabs, discarding any
+// empty tokens produced by leading, trailing, or repeated separators.
+func splitWords(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return r == ' ' || r == '\t'
+	})
+}
+
+// wrapWords greedily packs words into lines no longer than width. A word
+// longer than width simply becomes its own line: it is assigned to an empty
+// current line, and the next word (if any) will not fit alongside it, so it
+// is flushed on its own without ever being split, truncated, or dropped.
+func wrapWords(words []string, width int) []string {
+	var lines []string
+	var current string
+	for _, w := range words {
+		switch {
+		case current == "":
+			current = w
+		case len(current)+1+len(w) <= width:
+			current += " " + w
+		default:
+			lines = append(lines, current)
+			current = w
+		}
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+	return lines
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-context-cancel/pool.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-context-cancel/pool.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"sync"
+)
+
+// Reference solution: honors context cancellation and does not leak goroutines.
+func Process(ctx context.Context, jobs []int, workers int, fn func(int) int) ([]int, error) {
+	results := make([]int, len(jobs))
+	idxCh := make(chan int)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case idx, ok := <-idxCh:
+					if !ok {
+						return
+					}
+					results[idx] = fn(jobs[idx])
+				}
+			}
+		}()
+	}
+
+produce:
+	for i := range jobs {
+		select {
+		case <-ctx.Done():
+			break produce
+		case idxCh <- i:
+		}
+	}
+	close(idxCh)
+	wg.Wait()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-errors-is/store.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-errors-is/store.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is the sentinel callers are expected to check for with
+// errors.Is when a lookup misses.
+var ErrNotFound = errors.New("not found")
+
+// NotFoundError carries the specific key that was missing.
+type NotFoundError struct {
+	Key string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("key %q: not found", e.Key)
+}
+
+// Unwrap makes *NotFoundError participate in the errors.Is chain: it
+// unwraps to the ErrNotFound sentinel, so errors.Is(err, ErrNotFound)
+// succeeds, while the error itself is still a *NotFoundError so
+// errors.As(err, &nfe) finds it and exposes Key.
+func (e *NotFoundError) Unwrap() error {
+	return ErrNotFound
+}
+
+// Store is a simple in-memory key/value store.
+type Store struct {
+	data map[string]string
+}
+
+// NewStore creates an empty Store.
+func NewStore() *Store {
+	return &Store{data: make(map[string]string)}
+}
+
+// Put sets key to value.
+func (s *Store) Put(key, value string) {
+	s.data[key] = value
+}
+
+// Get returns the value stored at key.
+//
+// Reference solution: NotFoundError.Unwrap() returns ErrNotFound, so the
+// error returned on a miss satisfies both errors.Is(err, ErrNotFound) and
+// errors.As(err, &nfe), with nfe.Key set to the missing key.
+func (s *Store) Get(key string) (string, error) {
+	v, ok := s.data[key]
+	if !ok {
+		return "", &NotFoundError{Key: key}
+	}
+	return v, nil
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-json-roundtrip/money.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-json-roundtrip/money.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Money represents a monetary amount as integer cents plus an ISO-4217-style
+// currency code. Cents is the single source of truth for the amount; there is
+// no separate "dollars" field.
+type Money struct {
+	Cents    int64
+	Currency string
+}
+
+// moneyWire is the on-the-wire JSON shape for Money. The amount is encoded as
+// an integer number of cents, never a float, so the exact value always
+// round-trips.
+type moneyWire struct {
+	Cents    int64  `json:"cents"`
+	Currency string `json:"currency"`
+}
+
+// MarshalJSON renders Money as {"cents":2999,"currency":"USD"}. Cents is
+// encoded as an integer — never routed through a float64 — so precision is
+// never lost.
+func (m Money) MarshalJSON() ([]byte, error) {
+	return json.Marshal(moneyWire{Cents: m.Cents, Currency: m.Currency})
+}
+
+// UnmarshalJSON parses the integer cents value back into Money, symmetric
+// with MarshalJSON.
+func (m *Money) UnmarshalJSON(data []byte) error {
+	var w moneyWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	m.Cents = w.Cents
+	m.Currency = w.Currency
+	return nil
+}
+
+// String renders Money for logging/debugging purposes.
+func (m Money) String() string {
+	return fmt.Sprintf("%d %s cents", m.Cents, m.Currency)
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-lock-ordering/account.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-lock-ordering/account.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"errors"
+	"sync"
+)
+
+// Account is a simple bank account protected by its own mutex.
+type Account struct {
+	ID      int
+	mu      sync.Mutex
+	balance int64
+}
+
+// NewAccount creates an account with the given id and starting balance.
+func NewAccount(id int, balance int64) *Account {
+	return &Account{ID: id, balance: balance}
+}
+
+// Balance safely reads the current balance.
+func (a *Account) Balance() int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.balance
+}
+
+// Transfer moves amount from `from` to `to`.
+//
+// Reference solution: acquires the two accounts' mutexes in a canonical
+// order (lower ID first) rather than always locking `from` first, so
+// concurrent transfers running in opposite directions between the same pair
+// of accounts can never deadlock.
+func Transfer(from, to *Account, amount int64) error {
+	if from == to {
+		// Transferring to yourself: nothing to move, and there is only one
+		// lock to take.
+		from.mu.Lock()
+		defer from.mu.Unlock()
+		if from.balance < amount {
+			return errors.New("insufficient funds")
+		}
+		return nil
+	}
+
+	first, second := from, to
+	if second.ID < first.ID {
+		first, second = second, first
+	}
+
+	first.mu.Lock()
+	defer first.mu.Unlock()
+	second.mu.Lock()
+	defer second.mu.Unlock()
+
+	if from.balance < amount {
+		return errors.New("insufficient funds")
+	}
+
+	from.balance -= amount
+	to.balance += amount
+	return nil
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-lru-eviction/lru.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-lru-eviction/lru.go
@@ -1,0 +1,63 @@
+package main
+
+import "container/list"
+
+// entry is the value stored in each list.Element.
+type entry struct {
+	key   int
+	value int
+}
+
+// LRU is a fixed-capacity int->int cache with least-recently-used eviction.
+type LRU struct {
+	capacity int
+	ll       *list.List
+	items    map[int]*list.Element
+}
+
+// NewLRU creates an LRU cache that holds at most capacity entries.
+func NewLRU(capacity int) *LRU {
+	return &LRU{
+		capacity: capacity,
+		ll:       list.New(),
+		items:    make(map[int]*list.Element),
+	}
+}
+
+// Put inserts or updates key with value, marking it most-recently-used. If
+// this would exceed capacity, the least-recently-used entry is evicted.
+func (c *LRU) Put(key, value int) {
+	if el, ok := c.items[key]; ok {
+		el.Value.(*entry).value = value
+		c.ll.MoveToFront(el)
+		return
+	}
+
+	el := c.ll.PushFront(&entry{key: key, value: value})
+	c.items[key] = el
+
+	if c.ll.Len() > c.capacity {
+		back := c.ll.Back()
+		if back != nil {
+			c.ll.Remove(back)
+			delete(c.items, back.Value.(*entry).key)
+		}
+	}
+}
+
+// Get returns the value for key and whether it was found. Reference fix: a
+// hit also marks the key as most-recently-used, same as Put does, so a key
+// that was just read is not the next eviction candidate.
+func (c *LRU) Get(key int) (int, bool) {
+	el, ok := c.items[key]
+	if !ok {
+		return 0, false
+	}
+	c.ll.MoveToFront(el)
+	return el.Value.(*entry).value, true
+}
+
+// Len returns the number of entries currently in the cache.
+func (c *LRU) Len() int {
+	return c.ll.Len()
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-nil-interface/validate.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-nil-interface/validate.go
@@ -1,0 +1,34 @@
+package main
+
+import "strings"
+
+type User struct {
+	Name string
+	Age  int
+}
+
+type ValidationError struct {
+	Problems []string
+}
+
+func (e *ValidationError) Error() string {
+	return strings.Join(e.Problems, "; ")
+}
+
+// Reference solution: only construct and return a *ValidationError when
+// there is at least one problem. Otherwise return a plain nil error, so
+// callers checking `err != nil` do not fall into the typed-nil-interface
+// trap.
+func Validate(u User) error {
+	e := &ValidationError{}
+	if u.Name == "" {
+		e.Problems = append(e.Problems, "name is empty")
+	}
+	if u.Age < 0 || u.Age > 150 {
+		e.Problems = append(e.Problems, "age out of range")
+	}
+	if len(e.Problems) == 0 {
+		return nil
+	}
+	return e
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-pagination/page.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-pagination/page.go
@@ -1,0 +1,25 @@
+package main
+
+// Paginate splits items into pages of size pageSize and returns the items on
+// the requested page (1-indexed) together with the total number of pages.
+//
+// Reference solution: computes totalPages as a ceiling division and clamps
+// the slice bounds so partial last pages and out-of-range pages never panic.
+func Paginate(items []string, pageSize, page int) (pageItems []string, totalPages int) {
+	if pageSize <= 0 || len(items) == 0 {
+		return []string{}, 0
+	}
+
+	totalPages = (len(items) + pageSize - 1) / pageSize
+
+	if page < 1 || page > totalPages {
+		return []string{}, totalPages
+	}
+
+	start := (page - 1) * pageSize
+	end := start + pageSize
+	if end > len(items) {
+		end = len(items)
+	}
+	return items[start:end], totalPages
+}

--- a/benchmarks/terminal_bench/reference_solutions/hard-slice-aliasing/window.go
+++ b/benchmarks/terminal_bench/reference_solutions/hard-slice-aliasing/window.go
@@ -1,0 +1,17 @@
+package main
+
+// Reference solution: each returned window is a freshly allocated, fully
+// independent copy of the corresponding slice of data, so mutating or
+// appending to a window can never affect data or any other window.
+func Windows(data []int, size int) [][]int {
+	if size <= 0 || size > len(data) {
+		return [][]int{}
+	}
+	out := make([][]int, 0, len(data)-size+1)
+	for i := 0; i+size <= len(data); i++ {
+		w := make([]int, size)
+		copy(w, data[i:i+size])
+		out = append(out, w)
+	}
+	return out
+}

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY csv.go /app/csv.go
+COPY csv_test.go /app/csv_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/csv.go
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/csv.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+)
+
+// ParseCSV parses RFC-4180-style CSV text into rows of string fields.
+//
+// Contract:
+//   - Fields within a record are separated by commas; records are
+//     separated by a single '\n'.
+//   - A trailing '\n' at the very end of the input does not produce a
+//     spurious empty final record.
+//   - A field may be wrapped in double quotes ("like this"). A quoted
+//     field may contain commas and embedded literal newlines without
+//     those characters ending the field or the record.
+//   - Inside a quoted field, a doubled double-quote ("") is an escaped
+//     quote and collapses to a single literal '"' character in the
+//     field's value.
+//   - Unquoted fields are taken completely literally: no interior or
+//     surrounding whitespace is trimmed.
+//   - An empty input string ("") parses to zero rows.
+//   - An empty line parses to a single row containing one empty field:
+//     [""].
+func ParseCSV(input string) ([][]string, error) {
+	if input == "" {
+		return [][]string{}, nil
+	}
+
+	lines := strings.Split(input, "\n")
+
+	rows := make([][]string, 0, len(lines))
+	for _, line := range lines {
+		rawFields := strings.Split(line, ",")
+		fields := make([]string, 0, len(rawFields))
+		for _, f := range rawFields {
+			if len(f) >= 2 && f[0] == '"' && f[len(f)-1] == '"' {
+				f = f[1 : len(f)-1]
+			}
+			fields = append(fields, f)
+		}
+		rows = append(rows, fields)
+	}
+
+	return rows, nil
+}

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/csv_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/csv_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Happy-path smoke test covering only a trivial comma-separated line. The
+// full grading suite (quoted fields with embedded commas, escaped quotes,
+// embedded newlines, and trailing-newline handling) is applied separately.
+func TestParseCSVSmoke(t *testing.T) {
+	got, err := ParseCSV("a,b,c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{"a", "b", "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %v, want %v", "a,b,c", got, want)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-csv-parser:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/go.mod
@@ -1,0 +1,3 @@
+module csvparser
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/main.go
@@ -1,0 +1,13 @@
+package main
+
+import "fmt"
+
+func main() {
+	input := "name,age\n\"Doe, Jane\",30\n"
+	rows, err := ParseCSV(input)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("rows:", rows)
+}

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/task.yaml
@@ -1,0 +1,30 @@
+instruction: |
+  `ParseCSV` in `csv.go` parses RFC-4180-style CSV text into rows of string
+  fields, but the current implementation has multiple independent bugs. Fix
+  `csv.go` so `ParseCSV` honors the following contract:
+    - Fields within a record are separated by commas; records are separated
+      by a single '\n'.
+    - A trailing '\n' at the very end of the input does not produce a
+      spurious empty final record. (`"a,b\n"` parses to exactly one record.)
+    - A field may be wrapped in double quotes ("like this"). A quoted field
+      may contain commas and embedded literal newlines without those
+      characters ending the field or the record.
+    - Inside a quoted field, a doubled double-quote ("") is an escaped quote
+      and collapses to a single literal `"` character in the field's value.
+    - Unquoted fields are taken completely literally: no interior or
+      surrounding whitespace is trimmed.
+    - An empty input string ("") parses to zero rows.
+    - An empty line (a record with no characters before the next '\n' or the
+      end of input) parses to a single row containing one empty field: [""].
+  You may change `csv.go` only. Do not use the `encoding/csv` package (or any
+  other CSV library) — implement the parser by hand. Do not change the
+  signature of `ParseCSV`. `go build ./...` must succeed and the code must be
+  free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-csv-parser/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-csv-parser/tests/test_task.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Bug 1: a comma inside a quoted field must not split the field.
+func TestOracleQuotedFieldWithComma(t *testing.T) {
+	input := `"a,b",c`
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{"a,b", "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+
+// Bug 2: a doubled double-quote ("") inside a quoted field must collapse to
+// a single literal quote character.
+func TestOracleEscapedQuote(t *testing.T) {
+	input := `"a""b",c`
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{`a"b`, "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+
+// Bug 3: a newline embedded inside a quoted field must not start a new
+// record.
+func TestOracleEmbeddedNewline(t *testing.T) {
+	input := "\"a\nb\",c"
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{"a\nb", "c"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+
+// Bug 4: a trailing newline at the end of the input must not create a
+// spurious empty final record.
+func TestOracleTrailingNewline(t *testing.T) {
+	input := "a,b\n"
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{"a", "b"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+
+// Plain multi-row, unquoted input with no trailing newline must still
+// parse correctly.
+func TestOracleHappyPathMultiRow(t *testing.T) {
+	input := "a,b,c\nd,e,f"
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := [][]string{{"a", "b", "c"}, {"d", "e", "f"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+
+// An empty input string parses to zero rows; an empty line parses to a
+// single row with one empty field.
+func TestOracleEmptyInputAndEmptyLine(t *testing.T) {
+	got, err := ParseCSV("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ParseCSV(\"\") = %#v, want zero rows", got)
+	}
+
+	got2, err := ParseCSV("\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want2 := [][]string{{""}}
+	if !reflect.DeepEqual(got2, want2) {
+		t.Fatalf("ParseCSV(\"\\n\") = %#v, want %#v", got2, want2)
+	}
+}
+
+// Integration case: quoted field containing both a comma and escaped
+// quotes, a separate quoted field containing an embedded newline, a plain
+// trailing row, and a trailing newline at the very end — all four
+// behaviors must work together, not just in isolation.
+func TestOracleIntegration(t *testing.T) {
+	input := "id,name,bio\n" +
+		"1,\"Doe, Jane\",\"Loves \"\"Go\"\" and\n" +
+		"simplicity\"\n" +
+		"2,Bob,plain\n"
+
+	got, err := ParseCSV(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := [][]string{
+		{"id", "name", "bio"},
+		{"1", "Doe, Jane", "Loves \"Go\" and\nsimplicity"},
+		{"2", "Bob", "plain"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseCSV(%q) = %#v, want %#v", input, got, want)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY cache.go /app/cache.go
+COPY cache_test.go /app/cache_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/cache.go
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/cache.go
@@ -1,0 +1,53 @@
+package main
+
+import "sync"
+
+// Cache is intended to be a thread-safe memoizing cache of string -> int.
+//
+// Contract:
+//   - GetOrCompute returns the cached value for key if it is already present.
+//   - Otherwise it calls compute() exactly once to produce the value, stores
+//     it, and returns it.
+//   - Under concurrent callers using the SAME key, compute() must be called
+//     AT MOST ONCE for that key, and every caller must observe the same
+//     resulting value.
+//   - The cache must be free of data races.
+//
+// BUG: the read in GetOrCompute is unsynchronized (no lock is held while
+// checking c.items), while the store below is guarded by c.mu. That looks
+// "thread-safe" at a glance -- the write is protected by a mutex -- but it
+// is not: the unlocked read races with concurrent locked writes, and, worse,
+// there is a check-then-act gap between the unlocked "is key present?"
+// check and the locked store. Multiple concurrent callers for the same
+// absent key can all observe "not present" before any of them has stored a
+// value, so each of them calls compute() and stores its own result. compute
+// can therefore run many times for a single key, and callers can observe
+// different values depending on scheduling -- exactly the single-flight
+// violation this cache must not have.
+type Cache struct {
+	mu    sync.Mutex
+	items map[string]int
+}
+
+// NewCache creates an empty Cache.
+func NewCache() *Cache {
+	return &Cache{items: make(map[string]int)}
+}
+
+// GetOrCompute returns the cached value for key, computing and storing it
+// via compute if it is not already present.
+func (c *Cache) GetOrCompute(key string, compute func() int) int {
+	if v, ok := c.items[key]; ok { // BUG: unsynchronized read of c.items
+		return v
+	}
+
+	// BUG: compute() runs with no lock held at all, so concurrent callers
+	// that all missed the check above race each other here too.
+	v := compute()
+
+	c.mu.Lock()
+	c.items[key] = v
+	c.mu.Unlock()
+
+	return v
+}

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/cache_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/cache_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test: a single goroutine calling GetOrCompute. This does
+// NOT exercise concurrent callers -- the full grading suite (including the
+// single-flight and data-race checks) is applied separately.
+func TestGetOrComputeHappyPath(t *testing.T) {
+	c := NewCache()
+
+	calls := 0
+	v := c.GetOrCompute("a", func() int {
+		calls++
+		return 7
+	})
+	if v != 7 {
+		t.Fatalf(`GetOrCompute("a") = %d, want 7`, v)
+	}
+	if calls != 1 {
+		t.Fatalf("compute called %d times, want 1", calls)
+	}
+
+	// A second call for the same key must return the cached value without
+	// invoking compute again.
+	v2 := c.GetOrCompute("a", func() int {
+		t.Fatalf("compute should not be called for an already-cached key")
+		return -1
+	})
+	if v2 != 7 {
+		t.Fatalf(`GetOrCompute("a") on second call = %d, want 7`, v2)
+	}
+
+	// A different key computes independently.
+	v3 := c.GetOrCompute("b", func() int { return 100 })
+	if v3 != 100 {
+		t.Fatalf(`GetOrCompute("b") = %d, want 100`, v3)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-getorcompute:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/go.mod
@@ -1,0 +1,3 @@
+module getorcompute
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/main.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+func main() {
+	c := NewCache()
+
+	v := c.GetOrCompute("answer", func() int {
+		fmt.Println("computing...")
+		return 42
+	})
+	fmt.Println("value:", v)
+
+	// Second call for the same key must not compute again.
+	v2 := c.GetOrCompute("answer", func() int {
+		fmt.Println("this should never print")
+		return -1
+	})
+	fmt.Println("value:", v2)
+}

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/task.yaml
@@ -1,0 +1,21 @@
+instruction: |
+  The cache in `cache.go` is not safely shareable across goroutines. Fix
+  `GetOrCompute` so it honors the following contract:
+    - It returns the cached value for `key` if already present.
+    - Otherwise it calls `compute()` to produce the value, stores it, and
+      returns it.
+    - Under concurrent callers using the SAME key, `compute()` must be
+      called AT MOST ONCE for that key, and every caller must observe the
+      same resulting value.
+    - The cache must be free of data races.
+  You may change `cache.go` only. Do not change the signatures of
+  `NewCache` or `GetOrCompute`.
+  `go build ./...` must succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-getorcompute/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-getorcompute/tests/test_task.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only -- the agent never sees it. It writes a fresh Go test
+# into /app and runs it, so the decisive checks cannot be inspected or
+# weakened by the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A single key hit by many concurrent callers: compute must run exactly
+// once for that key, and every caller must observe the same resulting
+// value. The buggy cache.go's unsynchronized check-then-act lets many
+// callers see "absent" before any of them stores a value, so compute runs
+// more than once.
+func TestOracleSingleFlight(t *testing.T) {
+	c := NewCache()
+
+	const n = 100
+	var calls int64
+	start := make(chan struct{})
+	results := make([]int, n)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i] = c.GetOrCompute("shared-key", func() int {
+				atomic.AddInt64(&calls, 1)
+				time.Sleep(5 * time.Millisecond)
+				return 42
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&calls); got != 1 {
+		t.Fatalf("compute was called %d times for one key, want exactly 1", got)
+	}
+	for i, v := range results {
+		if v != 42 {
+			t.Fatalf("results[%d] = %d, want 42", i, v)
+		}
+	}
+}
+
+// Distinct keys computed concurrently must each resolve to their own,
+// correct value.
+func TestOracleDistinctKeys(t *testing.T) {
+	c := NewCache()
+
+	const n = 50
+	start := make(chan struct{})
+	results := make([]int, n)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			key := fmt.Sprintf("key-%d", i)
+			results[i] = c.GetOrCompute(key, func() int {
+				return i * i
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, v := range results {
+		want := i * i
+		if v != want {
+			t.Fatalf("results[%d] = %d, want %d", i, v, want)
+		}
+	}
+}
+
+// Sequential calls: once a key is cached, a later call must not invoke
+// compute again.
+func TestOracleCachedSecondCall(t *testing.T) {
+	c := NewCache()
+
+	first := c.GetOrCompute("once", func() int { return 9 })
+	if first != 9 {
+		t.Fatalf("first GetOrCompute = %d, want 9", first)
+	}
+
+	second := c.GetOrCompute("once", func() int {
+		panic("compute must not be invoked for an already-cached key")
+	})
+	if second != 9 {
+		t.Fatalf("second GetOrCompute = %d, want 9", second)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY ledger.go /app/ledger.go
+COPY ledger_test.go /app/ledger_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-ledger:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/go.mod
@@ -1,0 +1,3 @@
+module ledger
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/ledger.go
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/ledger.go
@@ -1,0 +1,70 @@
+package main
+
+import "sort"
+
+// Ledger is an in-memory account ledger.
+//
+// Contract:
+//   - Post accumulates: multiple posts to the same account add up to a net
+//     balance.
+//   - Balance returns the net balance for one account (0 if unknown).
+//   - Total returns the sum of every account's balance.
+//   - TopN returns up to n account names ordered by balance DESCENDING, ties
+//     broken by account name ASCENDING. If n >= number of accounts, it
+//     returns all of them. If n <= 0, it returns an empty slice. TopN must
+//     never panic.
+//   - The Ledger must be safe for concurrent use: concurrent Post/Balance/
+//     Total calls from multiple goroutines must be free of data races.
+type Ledger struct {
+	balances map[string]int64
+}
+
+// NewLedger creates an empty Ledger.
+func NewLedger() *Ledger {
+	return &Ledger{balances: make(map[string]int64)}
+}
+
+// Post records a signed amount to an account.
+//
+// BUG: the underlying map is read and written with no synchronization at
+// all, so concurrent Post/Balance/Total calls race under `go test -race`
+// (and can even trigger a fatal "concurrent map writes" crash).
+func (l *Ledger) Post(account string, amount int64) {
+	l.balances[account] += amount
+}
+
+// Balance returns the net balance for one account (0 if unknown).
+func (l *Ledger) Balance(account string) int64 {
+	return l.balances[account]
+}
+
+// Total returns the sum of every account's balance.
+func (l *Ledger) Total() int64 {
+	var total int64
+	for _, v := range l.balances {
+		total += v
+	}
+	return total
+}
+
+// TopN returns up to n accounts with the highest balance, ties broken by
+// account name ascending.
+func (l *Ledger) TopN(n int) []string {
+	names := make([]string, 0, len(l.balances))
+	for k := range l.balances {
+		names = append(names, k)
+	}
+
+	// BUG: sorts ascending (lowest balance first) instead of descending, and
+	// the comparator only looks at balance, so accounts with equal balances
+	// come out in whatever order the map happened to yield them instead of
+	// being tie-broken by name.
+	sort.Slice(names, func(i, j int) bool {
+		return l.balances[names[i]] < l.balances[names[j]]
+	})
+
+	// BUG: no bounds checking on n — n greater than len(names) slices out of
+	// range and panics, and n <= 0 is not special-cased to return an empty
+	// slice (a negative n also panics here).
+	return names[:n]
+}

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/ledger_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/ledger_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including TopN ordering,
+// TopN bounds, and concurrency checks) is applied separately.
+func TestLedgerHappyPath(t *testing.T) {
+	l := NewLedger()
+	l.Post("alice", 100)
+	if got, want := l.Balance("alice"), int64(100); got != want {
+		t.Fatalf("Balance(\"alice\") = %d, want %d", got, want)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	l := NewLedger()
+	l.Post("alice", 100)
+	l.Post("bob", 50)
+	l.Post("alice", 25)
+
+	fmt.Println("alice balance:", l.Balance("alice"))
+	fmt.Println("bob balance:", l.Balance("bob"))
+	fmt.Println("total:", l.Total())
+	fmt.Println("top 2:", l.TopN(2))
+}

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/task.yaml
@@ -1,0 +1,29 @@
+instruction: |
+  `ledger.go` implements an in-memory account ledger, but it does not fully
+  honor its contract. Fix `ledger.go` so the following holds:
+    - `Post(account, amount)` accumulates: multiple posts to the same account
+      add up to a net balance.
+    - `Balance(account)` returns the net balance for that account, or 0 if the
+      account has never been posted to.
+    - `Total()` returns the sum of every account's balance.
+    - `TopN(n)` returns up to n account names ordered by balance DESCENDING,
+      with ties broken by account name ASCENDING. If n is greater than or
+      equal to the number of accounts, it returns all of them (in the same
+      order). If n <= 0, it returns an empty slice. TopN must never panic,
+      regardless of n.
+    - The Ledger must be safe for concurrent use: concurrent calls to
+      Post/Balance/Total from multiple goroutines must be free of data races.
+  The current implementation has more than one independent defect relative to
+  this contract — fixing the first thing you notice is not enough. Verify
+  every part of the contract above, including behavior under `-race`.
+  You may change `ledger.go` only. Do not change the signatures of `Ledger`,
+  `NewLedger`, `Post`, `Balance`, `Total`, or `TopN`. `go build ./...` must
+  succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-ledger/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-ledger/tests/test_task.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+// Post must accumulate, Balance must return the net per account (0 for an
+// unknown account), and Total must be the sum across all accounts.
+func TestOracleBalancesAndTotal(t *testing.T) {
+	l := NewLedger()
+	l.Post("alice", 100)
+	l.Post("alice", 50)
+	l.Post("bob", 200)
+	l.Post("bob", -75)
+	l.Post("carol", -30)
+	l.Post("dave", 0)
+
+	cases := []struct {
+		account string
+		want    int64
+	}{
+		{"alice", 150},
+		{"bob", 125},
+		{"carol", -30},
+		{"dave", 0},
+		{"unknown", 0},
+	}
+	for _, c := range cases {
+		if got := l.Balance(c.account); got != c.want {
+			t.Fatalf("Balance(%q) = %d, want %d", c.account, got, c.want)
+		}
+	}
+
+	wantTotal := int64(150 + 125 - 30 + 0)
+	if got := l.Total(); got != wantTotal {
+		t.Fatalf("Total() = %d, want %d", got, wantTotal)
+	}
+}
+
+// TopN must be ordered by balance descending, with ties broken by account
+// name ascending — not by whatever order the underlying map yields.
+func TestOracleTopNOrder(t *testing.T) {
+	l := NewLedger()
+	// "zeta" and "alpha" tie at 300; inserted in an order that would betray
+	// an implementation relying on map iteration order or insertion order.
+	l.Post("zeta", 300)
+	l.Post("alpha", 300)
+	l.Post("mid", 200)
+	l.Post("low", -50)
+
+	got := l.TopN(4)
+	want := []string{"alpha", "zeta", "mid", "low"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TopN(4) = %v, want %v", got, want)
+	}
+
+	got2 := l.TopN(2)
+	want2 := []string{"alpha", "zeta"}
+	if !reflect.DeepEqual(got2, want2) {
+		t.Fatalf("TopN(2) = %v, want %v", got2, want2)
+	}
+}
+
+// TopN must never panic, must return every account (in correct order) when n
+// is at least the number of accounts, and must return an empty slice for
+// n <= 0.
+func TestOracleTopNBounds(t *testing.T) {
+	l := NewLedger()
+	l.Post("a", 10)
+	l.Post("b", 20)
+	l.Post("c", 30)
+
+	runSafely := func(label string, fn func()) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("%s panicked: %v", label, r)
+			}
+		}()
+		fn()
+	}
+
+	runSafely("TopN(10)", func() {
+		got := l.TopN(10)
+		want := []string{"c", "b", "a"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("TopN(10) = %v, want %v", got, want)
+		}
+	})
+
+	runSafely("TopN(0)", func() {
+		got := l.TopN(0)
+		if len(got) != 0 {
+			t.Fatalf("TopN(0) = %v, want an empty slice", got)
+		}
+	})
+
+	runSafely("TopN(-1)", func() {
+		got := l.TopN(-1)
+		if len(got) != 0 {
+			t.Fatalf("TopN(-1) = %v, want an empty slice", got)
+		}
+	})
+}
+
+// Concurrent Post/Balance/Total from many goroutines must be data-race free
+// and must produce exactly the expected totals.
+func TestOracleConcurrentPost(t *testing.T) {
+	l := NewLedger()
+	const goroutines = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			l.Post("shared", 1)
+			l.Post("other", 2)
+		}()
+		go func() {
+			defer wg.Done()
+			_ = l.Balance("shared")
+			_ = l.Total()
+		}()
+	}
+	wg.Wait()
+
+	if got, want := l.Balance("shared"), int64(goroutines); got != want {
+		t.Fatalf("Balance(\"shared\") = %d, want %d", got, want)
+	}
+	if got, want := l.Balance("other"), int64(goroutines*2); got != want {
+		t.Fatalf("Balance(\"other\") = %d, want %d", got, want)
+	}
+	if got, want := l.Total(), int64(goroutines+goroutines*2); got != want {
+		t.Fatalf("Total() = %d, want %d", got, want)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-semver/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY semver.go /app/semver.go
+COPY semver_test.go /app/semver_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-semver/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-semver:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-semver/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/go.mod
@@ -1,0 +1,3 @@
+module semver
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-semver/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	a, b := "1.0.0-alpha", "1.0.0"
+	fmt.Printf("Compare(%q, %q) = %d\n", a, b, Compare(a, b))
+}

--- a/benchmarks/terminal_bench/tasks/brutal-semver/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-semver/semver.go
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/semver.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Compare returns -1 if a has lower precedence than b, 0 if a and b have
+// equal precedence, and +1 if a has higher precedence than b, per the
+// Semantic Versioning 2.0.0 precedence rules (see
+// https://semver.org/#spec-item-11). See task.yaml for the full contract.
+func Compare(a, b string) int {
+	av, apre := splitVersion(a)
+	bv, bpre := splitVersion(b)
+
+	if c := compareCore(av, bv); c != 0 {
+		return c
+	}
+
+	if apre == "" && bpre == "" {
+		return 0
+	}
+	// BUG: a version WITHOUT a pre-release must have HIGHER precedence than
+	// the same version WITH one (e.g. 1.0.0 > 1.0.0-alpha). This has the
+	// comparison backwards, so a pre-release release is treated as greater
+	// than (or, transitively, at least not lower than) the plain release.
+	if apre == "" {
+		return -1
+	}
+	if bpre == "" {
+		return 1
+	}
+
+	return comparePrerelease(apre, bpre)
+}
+
+// splitVersion separates the core MAJOR.MINOR.PATCH from the pre-release
+// identifier string (without the leading '-').
+//
+// BUG: build metadata (the part starting at the first '+') is never
+// stripped. When a pre-release is present it stays glued onto the
+// pre-release string; when there is no pre-release, the build metadata is
+// mistaken for one. Either way build metadata ends up influencing
+// precedence, even though it must be ignored entirely.
+func splitVersion(v string) (core [3]int, prerelease string) {
+	rest := v
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		rest = v[:i]
+		prerelease = v[i+1:]
+	} else if i := strings.IndexByte(v, '+'); i >= 0 {
+		rest = v[:i]
+		prerelease = v[i+1:]
+	}
+
+	parts := strings.SplitN(rest, ".", 3)
+	for i := 0; i < 3 && i < len(parts); i++ {
+		n, _ := strconv.Atoi(parts[i])
+		core[i] = n
+	}
+	return core, prerelease
+}
+
+func compareCore(a, b [3]int) int {
+	for i := 0; i < 3; i++ {
+		if a[i] != b[i] {
+			if a[i] < b[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// comparePrerelease compares two pre-release identifier strings
+// (dot-separated), per semver.org rule 11.
+func comparePrerelease(a, b string) int {
+	aids := strings.Split(a, ".")
+	bids := strings.Split(b, ".")
+
+	n := len(aids)
+	if len(bids) < n {
+		n = len(bids)
+	}
+
+	for i := 0; i < n; i++ {
+		// BUG: identifiers are compared purely as strings, even when both
+		// are numeric. This makes "2" sort after "11" (since "1" < "2" as
+		// the first byte) instead of comparing them numerically, and does
+		// not apply the "numeric identifiers always have lower precedence
+		// than non-numeric ones" rule.
+		if aids[i] != bids[i] {
+			if aids[i] < bids[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// All shared identifiers are equal; the pre-release with more
+	// identifiers has higher precedence.
+	if len(aids) < len(bids) {
+		return -1
+	}
+	if len(aids) > len(bids) {
+		return 1
+	}
+	return 0
+}

--- a/benchmarks/terminal_bench/tasks/brutal-semver/semver_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/semver_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including pre-release and
+// build-metadata precedence rules) is applied separately.
+func TestCompareHappyPath(t *testing.T) {
+	if got := Compare("1.0.0", "2.0.0"); got != -1 {
+		t.Fatalf("Compare(%q, %q) = %d, want -1", "1.0.0", "2.0.0", got)
+	}
+	if got := Compare("2.0.0", "1.0.0"); got != 1 {
+		t.Fatalf("Compare(%q, %q) = %d, want 1", "2.0.0", "1.0.0", got)
+	}
+	if got := Compare("1.0.0", "1.0.0"); got != 0 {
+		t.Fatalf("Compare(%q, %q) = %d, want 0", "1.0.0", "1.0.0", got)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-semver/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/task.yaml
@@ -1,0 +1,38 @@
+instruction: |
+  `Compare` in `semver.go` is supposed to implement Semantic Versioning 2.0.0
+  precedence (see https://semver.org/#spec-item-11) but the current
+  implementation violates the contract in more than one independent way.
+  Fix `semver.go` so `Compare(a, b string) int` honors the following
+  contract exactly for well-formed
+  `MAJOR.MINOR.PATCH[-prerelease][+build]` version strings:
+    - Returns -1 if a has lower precedence than b, 0 if a and b have equal
+      precedence, and +1 if a has higher precedence than b.
+    - MAJOR, MINOR, and PATCH are compared numerically, in that order.
+    - A version WITH a pre-release has LOWER precedence than the same
+      version WITHOUT one (e.g. `1.0.0-alpha` < `1.0.0`).
+    - When both versions have a pre-release and the same MAJOR.MINOR.PATCH,
+      compare their dot-separated pre-release identifiers left to right:
+        - Numeric identifiers (containing only digits) are compared
+          numerically, not lexically (e.g. `2` < `11`).
+        - Identifiers containing any letter or hyphen are compared lexically
+          in ASCII sort order.
+        - A numeric identifier always has LOWER precedence than a
+          non-numeric identifier.
+        - If all preceding identifiers are equal, the pre-release with MORE
+          identifiers has higher precedence.
+    - Build metadata (everything from the first `+` onward) is ignored
+      entirely for precedence purposes — two versions that differ only in
+      build metadata (including one with build metadata and one without)
+      have equal precedence.
+  You do not need to validate or return errors for malformed input; you may
+  assume every version string is well-formed. You may change `semver.go`
+  only. Do not change the signature of `Compare`. `go build ./...` must
+  succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-semver/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-semver/tests/test_task.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+#
+# semver.go ships with three independent bugs; each TestOracle* function
+# below is designed so at least one of its assertions fails against the
+# buggy starting code while all of them pass against a correct fix:
+#   1. TestOracleChainAscending        — pre-release identifiers are compared
+#                                          lexically instead of numerically
+#                                          (e.g. "2" vs "11").
+#   2. TestOraclePrereleaseLowerThanRelease / TestOracleChainAscending —
+#                                          a pre-release version is not
+#                                          treated as lower precedence than
+#                                          the same version without one.
+#   3. TestOracleBuildMetadataIgnored  — build metadata is not ignored for
+#                                          precedence.
+ORACLE_TEST = r'''
+package main
+
+import "testing"
+
+// The canonical ascending precedence chain from semver.org §11.
+var chain = []string{
+	"1.0.0-alpha",
+	"1.0.0-alpha.1",
+	"1.0.0-alpha.beta",
+	"1.0.0-beta",
+	"1.0.0-beta.2",
+	"1.0.0-beta.11",
+	"1.0.0-rc.1",
+	"1.0.0",
+}
+
+// Every version in the chain must compare equal to itself, and every
+// adjacent pair must compare strictly in ascending order (and strictly
+// descending in the reverse direction).
+func TestOracleChainAscending(t *testing.T) {
+	for _, x := range chain {
+		if got := Compare(x, x); got != 0 {
+			t.Fatalf("Compare(%q, %q) = %d, want 0", x, x, got)
+		}
+	}
+	for i := 0; i+1 < len(chain); i++ {
+		x, y := chain[i], chain[i+1]
+		if got := Compare(x, y); got != -1 {
+			t.Fatalf("Compare(%q, %q) = %d, want -1", x, y, got)
+		}
+		if got := Compare(y, x); got != 1 {
+			t.Fatalf("Compare(%q, %q) = %d, want 1", y, x, got)
+		}
+	}
+}
+
+// MAJOR and PATCH numeric comparisons, independent of any pre-release
+// handling.
+func TestOracleCoreNumeric(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "1.0.0", 1},
+		{"2.1.0", "2.1.1", -1},
+		{"2.1.1", "2.1.0", 1},
+	}
+	for _, c := range cases {
+		if got := Compare(c.a, c.b); got != c.want {
+			t.Fatalf("Compare(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// A pre-release version must have strictly lower precedence than the same
+// version without one, in both directions.
+func TestOraclePrereleaseLowerThanRelease(t *testing.T) {
+	if got := Compare("1.0.0-alpha", "1.0.0"); got != -1 {
+		t.Fatalf("Compare(%q, %q) = %d, want -1", "1.0.0-alpha", "1.0.0", got)
+	}
+	if got := Compare("1.0.0", "1.0.0-alpha"); got != 1 {
+		t.Fatalf("Compare(%q, %q) = %d, want 1", "1.0.0", "1.0.0-alpha", got)
+	}
+}
+
+// Build metadata (everything from the first '+' onward) must never affect
+// precedence.
+func TestOracleBuildMetadataIgnored(t *testing.T) {
+	cases := [][2]string{
+		{"1.0.0+build.1", "1.0.0"},
+		{"1.0.0+a", "1.0.0+b"},
+		{"1.0.0-alpha+x", "1.0.0-alpha+y"},
+	}
+	for _, c := range cases {
+		if got := Compare(c[0], c[1]); got != 0 {
+			t.Fatalf("Compare(%q, %q) = %d, want 0 (build metadata must be ignored)", c[0], c[1], got)
+		}
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY topo.go /app/topo.go
+COPY topo_test.go /app/topo_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-topo-sort:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/go.mod
@@ -1,0 +1,3 @@
+module toposort
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	nodes := []string{"a", "b", "c", "d", "e"}
+	edges := [][2]string{{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}, {"d", "e"}}
+
+	order, err := TopoSort(nodes, edges)
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("order:", order)
+}

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/task.yaml
@@ -1,0 +1,35 @@
+instruction: |
+  `TopoSort` in `topo.go` computes a topological order of a directed graph
+  but has multiple bugs. Fix it so it honors the following contract:
+
+    func TopoSort(nodes []string, edges [][2]string) ([]string, error)
+
+  Each edge {u, v} means u must come before v in the returned order.
+
+    - Return a topological order: for every edge {u, v}, u appears before v
+      in the output.
+    - Deterministic tie-break: whenever more than one node is ready
+      (in-degree 0) at the same time, emit the lexicographically SMALLEST
+      ready node name next (Kahn's algorithm with a sorted/priority ready
+      set). This makes the output unique for a given input, and it must be
+      identical across repeated calls with the same input.
+    - Every node in `nodes` must appear in the output, including nodes with
+      no incident edges at all (disconnected nodes). Disconnected nodes are
+      ready immediately and participate in the same lexicographic tie-break
+      as any other ready node.
+    - If the graph has a cycle, `TopoSort` must return a nil slice and a
+      non-nil error. It must not return a partial or incorrect order with a
+      nil error.
+    - You may assume every endpoint that appears in `edges` also appears in
+      `nodes`.
+
+  You may change `topo.go` only. Do not change the signature of `TopoSort`.
+  `go build ./...` must succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/tests/test_task.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The ready set must always break ties by choosing the lexicographically
+// smallest ready node, and the result must be identical across repeated
+// calls with the same input.
+func TestOracleDeterministicOrder(t *testing.T) {
+	nodes := []string{"a", "b", "c", "d", "e"}
+	edges := [][2]string{{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}, {"d", "e"}}
+	want := []string{"a", "b", "c", "d", "e"}
+
+	got1, err1 := TopoSort(nodes, edges)
+	if err1 != nil {
+		t.Fatalf("unexpected error: %v", err1)
+	}
+	if !reflect.DeepEqual(got1, want) {
+		t.Fatalf("TopoSort() = %v, want %v", got1, want)
+	}
+
+	got2, err2 := TopoSort(nodes, edges)
+	if err2 != nil {
+		t.Fatalf("unexpected error on second call: %v", err2)
+	}
+	if !reflect.DeepEqual(got2, want) {
+		t.Fatalf("second call TopoSort() = %v, want %v", got2, want)
+	}
+	if !reflect.DeepEqual(got1, got2) {
+		t.Fatalf("non-deterministic output: first call = %v, second call = %v", got1, got2)
+	}
+}
+
+// Disconnected nodes (no incident edges) must be included in the output and
+// must participate in the same lexicographic tie-break as any other ready
+// node.
+func TestOracleTieBreakAndDisconnected(t *testing.T) {
+	nodes := []string{"x", "m", "a", "z"}
+	edges := [][2]string{{"z", "m"}}
+	want := []string{"a", "x", "z", "m"}
+
+	got, err := TopoSort(nodes, edges)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TopoSort() = %v, want %v", got, want)
+	}
+}
+
+// A cyclic graph must be reported as an error with a nil result, not a
+// partial or incorrect order with a nil error.
+func TestOracleCycle(t *testing.T) {
+	nodes := []string{"a", "b", "c"}
+	edges := [][2]string{{"a", "b"}, {"b", "c"}, {"c", "a"}}
+
+	got, err := TopoSort(nodes, edges)
+	if err == nil {
+		t.Fatalf("expected a non-nil error for a cyclic graph, got nil (result=%v)", got)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected a nil/empty result for a cyclic graph, got %v", got)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/topo.go
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/topo.go
@@ -1,0 +1,67 @@
+package main
+
+// TopoSort returns a topological order of nodes such that for every edge
+// {u, v} in edges, u must come before v in the returned slice.
+//
+// Contract:
+//   - Return a topological order: for every edge {u, v}, u appears before v.
+//   - Deterministic tie-break: whenever multiple nodes are ready (in-degree
+//     0) at the same time, the lexicographically SMALLEST ready node name is
+//     emitted next. This makes the output unique for a given input.
+//   - Every node in `nodes` must appear in the output, including nodes with
+//     no incident edges (disconnected nodes), ordered by the same
+//     lexicographic ready-set rule.
+//   - If the graph has a cycle, return a nil slice and a non-nil error.
+//   - Every endpoint that appears in edges is assumed to also appear in
+//     nodes.
+//
+// BUG: this implementation has three independent defects (search "BUG:"
+// below). All three must be fixed.
+func TopoSort(nodes []string, edges [][2]string) ([]string, error) {
+	inDegree := make(map[string]int)
+	adj := make(map[string][]string)
+
+	// BUG: the node universe driving the algorithm is derived only from the
+	// edges below (inDegree only ever gets an entry for a node that shows up
+	// as an edge endpoint). A node listed in `nodes` with no incident edges
+	// never gets an inDegree entry, so it never becomes "ready" and is
+	// silently dropped from the output instead of being included.
+	for _, e := range edges {
+		u, v := e[0], e[1]
+		if _, ok := inDegree[u]; !ok {
+			inDegree[u] = 0
+		}
+		adj[u] = append(adj[u], v)
+		inDegree[v]++
+	}
+
+	// BUG: ready nodes are pushed onto a stack in discovery order and popped
+	// LIFO below, instead of always selecting the lexicographically smallest
+	// ready node. Whenever more than one node is ready at once, the emitted
+	// order is not the required deterministic lexicographic order.
+	var ready []string
+	for _, n := range nodes {
+		if deg, ok := inDegree[n]; ok && deg == 0 {
+			ready = append(ready, n)
+		}
+	}
+
+	var order []string
+	for len(ready) > 0 {
+		u := ready[len(ready)-1]
+		ready = ready[:len(ready)-1]
+		order = append(order, u)
+		for _, v := range adj[u] {
+			inDegree[v]--
+			if inDegree[v] == 0 {
+				ready = append(ready, v)
+			}
+		}
+	}
+
+	// BUG: no cycle detection. If the graph has a cycle, some nodes never
+	// reach in-degree 0 and `order` ends up shorter than the full node
+	// universe, but this always returns (order, nil) instead of noticing the
+	// shortfall and reporting an error.
+	return order, nil
+}

--- a/benchmarks/terminal_bench/tasks/brutal-topo-sort/topo_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-topo-sort/topo_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Happy-path smoke test: a trivial two-node chain with no ties, no
+// disconnected nodes, and no cycle. The full grading suite (deterministic
+// tie-break, disconnected-node inclusion, and cycle detection) is applied
+// separately.
+func TestTopoSortHappyPath(t *testing.T) {
+	nodes := []string{"a", "b"}
+	edges := [][2]string{{"a", "b"}}
+
+	got, err := TopoSort(nodes, edges)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TopoSort() = %v, want %v", got, want)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY wrap.go /app/wrap.go
+COPY wrap_test.go /app/wrap_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-brutal-wordwrap:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/go.mod
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/go.mod
@@ -1,0 +1,3 @@
+module wordwrap
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/main.go
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "fmt"
+
+func main() {
+	lines := Wrap("go is a small, fast, and fun language for building tools.", 20)
+	for _, l := range lines {
+		fmt.Println(l)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/task.yaml
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/task.yaml
@@ -1,0 +1,37 @@
+instruction: |
+  `Wrap` in `wrap.go` is supposed to greedily word-wrap `text` into lines of
+  at most `width` characters, but the current implementation violates the
+  contract in more than one independent way. Fix `Wrap` (and any helpers in
+  `wrap.go`) so it honors the following contract exactly:
+    - Words are separated by runs of spaces and/or tabs. Runs of separators
+      collapse to a single break, and leading/trailing separators produce no
+      empty words.
+    - Words are packed greedily: as many words as fit are placed on each
+      line, joined by a single space, and each line's length must be
+      `<= width` — EXCEPT a single word whose own length exceeds `width`,
+      which occupies a line by itself, unbroken. Such a word must never be
+      dropped, truncated, or cause a panic.
+    - A `'\n'` byte in `text` always forces a hard line break: it starts a
+      new output line, even if the words on either side of it would
+      otherwise fit together on one line.
+    - `Wrap("", width)` returns an empty `[]string` (length 0), for any
+      `width`.
+    - If `width <= 0`, wrapping is disabled: each hard line (the text
+      between consecutive `'\n'`s, or between the start/end of `text` and
+      the nearest `'\n'`) becomes exactly one output line, with its words
+      collapsed and joined by single spaces, left unwrapped regardless of
+      length.
+    - A hard line that contains no words (e.g. two consecutive `'\n'`s, or a
+      `'\n'` at the very start or end of `text`, or a hard line made up
+      entirely of spaces/tabs) becomes an empty string (`""`) output line,
+      regardless of whether `width` is positive or not.
+  You may change `wrap.go` only. Do not change the signature of
+  `Wrap(text string, width int) []string`. `go build ./...` must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/tests/test_task.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+#
+# wrap.go ships with four independent bugs; each TestOracle* function below
+# is designed so at least one of its assertions fails against the buggy
+# starting code while all of them pass against a correct fix:
+#   1. TestOracleOffByOneWidth      — off-by-one in the line-fit comparison.
+#   2. TestOracleLongWordOwnLine    — an over-width word is silently dropped.
+#   3. TestOracleWhitespaceCollapse — runs of spaces/tabs are not collapsed.
+#   4. TestOracleHardNewline        — '\n' is folded into ordinary whitespace
+#                                      instead of forcing a new line.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A line exactly at the width boundary must still be merged: "ab" + " " +
+// "cd" is exactly 5 characters wide, so it must stay on one line.
+func TestOracleOffByOneWidth(t *testing.T) {
+	got := Wrap("ab cd efg hi", 5)
+	want := []string{"ab cd", "efg", "hi"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 5) = %v, want %v", "ab cd efg hi", got, want)
+	}
+	for _, line := range got {
+		if len(line) > 5 {
+			t.Fatalf("line %q exceeds width 5", line)
+		}
+	}
+}
+
+// A word longer than width must occupy its own line, unbroken, and must not
+// be dropped or cause the words around it to be silently merged.
+func TestOracleLongWordOwnLine(t *testing.T) {
+	got := Wrap("hi supercalifragilisticexpialidocious bye", 10)
+	want := []string{"hi", "supercalifragilisticexpialidocious", "bye"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 10) = %v, want %v", "hi supercalifragilisticexpialidocious bye", got, want)
+	}
+}
+
+// Runs of spaces/tabs, and leading/trailing whitespace, must collapse to
+// single breaks and must never leak empty "words" into the output.
+func TestOracleWhitespaceCollapse(t *testing.T) {
+	got := Wrap("  a   bb    ccc  ", 80)
+	want := []string{"a bb ccc"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 80) = %v, want %v", "  a   bb    ccc  ", got, want)
+	}
+
+	got2 := Wrap("x\t\ty", 80)
+	want2 := []string{"x y"}
+	if !reflect.DeepEqual(got2, want2) {
+		t.Fatalf("Wrap(%q, 80) = %v, want %v", "x\t\ty", got2, want2)
+	}
+}
+
+// '\n' must force a hard line break, even when width is wide enough that
+// the surrounding words would otherwise fit on one line together.
+func TestOracleHardNewline(t *testing.T) {
+	got := Wrap("line one\nline two", 80)
+	want := []string{"line one", "line two"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 80) = %v, want %v", "line one\nline two", got, want)
+	}
+}
+
+// Edge cases from the contract: Wrap("", width) is always empty, and
+// width <= 0 disables wrapping per hard line (it must not collapse multiple
+// hard lines from '\n' into a single output line).
+func TestOracleEdgeCases(t *testing.T) {
+	if got := Wrap("", 10); len(got) != 0 {
+		t.Fatalf(`Wrap("", 10) = %v, want empty slice`, got)
+	}
+	if got := Wrap("", 0); len(got) != 0 {
+		t.Fatalf(`Wrap("", 0) = %v, want empty slice`, got)
+	}
+
+	got := Wrap("alpha beta\ngamma delta", 0)
+	want := []string{"alpha beta", "gamma delta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 0) = %v, want %v", "alpha beta\ngamma delta", got, want)
+	}
+
+	got2 := Wrap("a\n\nb", 10)
+	want2 := []string{"a", "", "b"}
+	if !reflect.DeepEqual(got2, want2) {
+		t.Fatalf("Wrap(%q, 10) = %v, want %v", "a\n\nb", got2, want2)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/wrap.go
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/wrap.go
@@ -1,0 +1,53 @@
+package main
+
+import "strings"
+
+// Wrap splits text into words and greedily packs as many of them as fit
+// onto each line without exceeding width characters. See task.yaml for the
+// full contract this function must satisfy.
+func Wrap(text string, width int) []string {
+	if text == "" {
+		return []string{}
+	}
+
+	// Newlines in the input mark hard line breaks and should never be
+	// merged with surrounding words.
+	flat := strings.ReplaceAll(text, "\n", " ")
+
+	words := splitWords(flat)
+	if width <= 0 {
+		return []string{strings.Join(words, " ")}
+	}
+	return wrapWords(words, width)
+}
+
+// splitWords splits s into words on space characters.
+func splitWords(s string) []string {
+	return strings.Split(s, " ")
+}
+
+// wrapWords greedily packs words into lines no longer than width.
+func wrapWords(words []string, width int) []string {
+	var lines []string
+	var current string
+	for _, w := range words {
+		if len(w) > width {
+			// A word that can never fit on its own line isn't useful to
+			// carry forward, so drop it rather than blow out the line.
+			continue
+		}
+		switch {
+		case current == "":
+			current = w
+		case len(current)+1+len(w) < width:
+			current += " " + w
+		default:
+			lines = append(lines, current)
+			current = w
+		}
+	}
+	if current != "" {
+		lines = append(lines, current)
+	}
+	return lines
+}

--- a/benchmarks/terminal_bench/tasks/brutal-wordwrap/wrap_test.go
+++ b/benchmarks/terminal_bench/tasks/brutal-wordwrap/wrap_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Happy-path smoke test. The full grading suite (including long words,
+// irregular whitespace, and embedded newlines) is applied separately.
+func TestWrapHappyPath(t *testing.T) {
+	got := Wrap("go is fun", 20)
+	want := []string{"go is fun"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Wrap(%q, 20) = %v, want %v", "go is fun", got, want)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY pool.go /app/pool.go
+COPY pool_test.go /app/pool_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-context-cancel:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/go.mod
@@ -1,0 +1,3 @@
+module ctxcancel
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func main() {
+	jobs := []int{1, 2, 3, 4, 5}
+	out, err := Process(context.Background(), jobs, 3, func(x int) int { return x * x })
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("results:", out)
+}

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/pool.go
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/pool.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"sync"
+)
+
+// Process runs fn over every job using `workers` goroutines and returns the
+// results in job order.
+//
+// Contract:
+//   - If ctx is cancelled while work is in flight, Process must stop promptly
+//     and return a nil result slice together with ctx.Err().
+//   - Process must not leave any worker goroutines running after it returns.
+//
+// BUG: this implementation ignores ctx entirely. It always drains every job
+// and returns a nil error, so a cancelled context is silently ignored.
+func Process(ctx context.Context, jobs []int, workers int, fn func(int) int) ([]int, error) {
+	results := make([]int, len(jobs))
+	idxCh := make(chan int)
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range idxCh {
+				results[idx] = fn(jobs[idx])
+			}
+		}()
+	}
+
+	for i := range jobs {
+		idxCh <- i
+	}
+	close(idxCh)
+	wg.Wait()
+
+	return results, nil
+}

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/pool_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/pool_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// Happy-path smoke test. The full grading suite (including cancellation and
+// goroutine-leak checks) is applied separately.
+func TestProcessHappyPath(t *testing.T) {
+	jobs := []int{1, 2, 3, 4, 5}
+	got, err := Process(context.Background(), jobs, 3, func(x int) int { return x * x })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []int{1, 4, 9, 16, 25}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("results[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/task.yaml
@@ -1,0 +1,18 @@
+instruction: |
+  The worker pool in `pool.go` ignores context cancellation. Fix `Process` so it
+  honors the following contract:
+    - If `ctx` is cancelled while work is in flight, `Process` must stop promptly
+      and return a nil results slice together with `ctx.Err()`.
+    - `Process` must not leave any worker goroutines running after it returns.
+    - When the context is not cancelled, it must still return correct results for
+      every job, in job order.
+  You may change `pool.go` only. Do not change the signature of `Process`.
+  `go build ./...` must succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-context-cancel/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-context-cancel/tests/test_task.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Process must return ctx.Err() promptly when the context is already cancelled,
+// instead of draining every (slow) job.
+func TestOracleCancelReturnsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	jobs := make([]int, 200)
+	for i := range jobs {
+		jobs[i] = i
+	}
+	slow := func(x int) int { time.Sleep(50 * time.Millisecond); return x * 2 }
+
+	type result struct {
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		_, err := Process(ctx, jobs, 4, slow)
+		done <- result{err: err}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Fatalf("Process returned nil error after cancellation; expected ctx.Err()")
+		}
+		if r.err != context.Canceled {
+			t.Fatalf("Process returned %v; expected context.Canceled", r.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("Process did not return within 3s after the context was cancelled " +
+			"(it appears to have ignored cancellation and drained every job)")
+	}
+}
+
+// After a cancelled Process returns, no worker goroutines should still be running.
+func TestOracleNoGoroutineLeak(t *testing.T) {
+	base := runtime.NumGoroutine()
+	for iter := 0; iter < 5; iter++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		jobs := make([]int, 200)
+		slow := func(x int) int { time.Sleep(20 * time.Millisecond); return x }
+		_, _ = Process(ctx, jobs, 8, slow)
+	}
+	// Give any (incorrectly) leaked goroutines a chance to surface.
+	time.Sleep(200 * time.Millisecond)
+	after := runtime.NumGoroutine()
+	if after > base+2 {
+		t.Fatalf("goroutine leak: started with %d, ended with %d after cancelled runs", base, after)
+	}
+}
+
+// With no cancellation, every job must be processed correctly, in order.
+func TestOracleHappyPath(t *testing.T) {
+	jobs := []int{2, 3, 4, 5, 6, 7, 8, 9}
+	got, err := Process(context.Background(), jobs, 3, func(x int) int { return x * x })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != len(jobs) {
+		t.Fatalf("len(results) = %d, want %d", len(got), len(jobs))
+	}
+	for i, j := range jobs {
+		if got[i] != j*j {
+			t.Fatalf("results[%d] = %d, want %d", i, got[i], j*j)
+		}
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY store.go /app/store.go
+COPY store_test.go /app/store_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-errors-is:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/go.mod
@@ -1,0 +1,3 @@
+module errorsis
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/main.go
@@ -1,0 +1,19 @@
+package main
+
+import "fmt"
+
+func main() {
+	s := NewStore()
+	s.Put("a", "1")
+
+	v, err := s.Get("a")
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("got:", v)
+
+	if _, err := s.Get("missing"); err != nil {
+		fmt.Println("error:", err)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/store.go
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/store.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrNotFound is the sentinel callers are expected to check for with
+// errors.Is when a lookup misses.
+var ErrNotFound = errors.New("not found")
+
+// NotFoundError carries the specific key that was missing.
+type NotFoundError struct {
+	Key string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("key %q: not found", e.Key)
+}
+
+// Store is a simple in-memory key/value store.
+type Store struct {
+	data map[string]string
+}
+
+// NewStore creates an empty Store.
+func NewStore() *Store {
+	return &Store{data: make(map[string]string)}
+}
+
+// Put sets key to value.
+func (s *Store) Put(key, value string) {
+	s.data[key] = value
+}
+
+// Get returns the value stored at key.
+//
+// Contract:
+//   - On a hit, Get returns the stored value and a nil error.
+//   - On a miss, the returned error must satisfy
+//     errors.Is(err, ErrNotFound) == true, AND must still be assertable to
+//     *NotFoundError via errors.As, exposing the missing Key.
+//
+// BUG: NotFoundError does not implement Unwrap(), and Get returns a bare
+// &NotFoundError{...} without ever wrapping ErrNotFound. errors.Is walks the
+// Unwrap() chain looking for a match, and there is none here, so
+// errors.Is(err, ErrNotFound) is FALSE for a missing-key error — any caller
+// that checks errors.Is(err, ErrNotFound) breaks even though the error text
+// says "not found".
+func (s *Store) Get(key string) (string, error) {
+	v, ok := s.data[key]
+	if !ok {
+		return "", &NotFoundError{Key: key}
+	}
+	return v, nil
+}

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/store_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/store_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including the errors.Is /
+// errors.As regression checks) is applied separately.
+func TestStoreHappyPath(t *testing.T) {
+	s := NewStore()
+	s.Put("a", "1")
+
+	got, err := s.Get("a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "1" {
+		t.Fatalf("got %q, want %q", got, "1")
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/task.yaml
@@ -1,0 +1,20 @@
+instruction: |
+  `Get` in `store.go` returns a `*NotFoundError` on a missing key, but that
+  error does not participate in the `errors.Is` / `errors.As` chain the way
+  callers expect. Fix `store.go` so it honors the following contract:
+    - For a missing key, the error returned by `Get` must satisfy
+      `errors.Is(err, ErrNotFound) == true`.
+    - That same error must still be assertable to `*NotFoundError` via
+      `errors.As`, exposing the `Key` that was missing.
+    - On a hit, `Get` returns the stored value and a nil error.
+  You may change `store.go` only. Do not change the signatures of
+  `NewStore`, `Put`, or `Get`, or the exported names `ErrNotFound` /
+  `NotFoundError`. `go build ./...` must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-errors-is/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-errors-is/tests/test_task.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// A missing key's error must satisfy errors.Is(err, ErrNotFound). The buggy
+// implementation returns a bare *NotFoundError with no Unwrap(), so
+// errors.Is(err, ErrNotFound) is false against it even though the error text
+// says "not found".
+func TestOracleIsNotFound(t *testing.T) {
+	s := NewStore()
+	_, err := s.Get("missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal("errors.Is(err, ErrNotFound) should be true")
+	}
+}
+
+// The same error must still be assertable to *NotFoundError via errors.As,
+// exposing the specific key that was missing.
+func TestOracleAsNotFound(t *testing.T) {
+	s := NewStore()
+	_, err := s.Get("ghost")
+	var nfe *NotFoundError
+	if !errors.As(err, &nfe) {
+		t.Fatal("errors.As should find *NotFoundError")
+	}
+	if nfe.Key != "ghost" {
+		t.Fatalf("Key=%q want ghost", nfe.Key)
+	}
+}
+
+// A hit must return the stored value and a nil error.
+func TestOracleHit(t *testing.T) {
+	s := NewStore()
+	s.Put("a", "1")
+	v, err := s.Get("a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "1" {
+		t.Fatalf("v=%q want %q", v, "1")
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY money.go /app/money.go
+COPY money_test.go /app/money_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-json-roundtrip:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/go.mod
@@ -1,0 +1,3 @@
+module jsonroundtrip
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func main() {
+	m := Money{Cents: 2999, Currency: "USD"}
+	b, err := json.Marshal(m)
+	if err != nil {
+		fmt.Println("marshal error:", err)
+		return
+	}
+	fmt.Println("json:", string(b))
+
+	var back Money
+	if err := json.Unmarshal(b, &back); err != nil {
+		fmt.Println("unmarshal error:", err)
+		return
+	}
+	fmt.Println("round-tripped:", back)
+}

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/money.go
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/money.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Money represents a monetary amount as integer cents plus an ISO-4217-style
+// currency code. Cents is the single source of truth for the amount; there is
+// no separate "dollars" field.
+type Money struct {
+	Cents    int64
+	Currency string
+}
+
+// moneyWire is the on-the-wire JSON shape for Money.
+type moneyWire struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency"`
+}
+
+// MarshalJSON renders Money as a human-readable decimal dollar amount, e.g.
+// {"amount":29.99,"currency":"USD"}.
+//
+// BUG: encoding the amount as a float64 dollar value loses precision for some
+// cent values. Multiplying back out in UnmarshalJSON does not always recover
+// the original integer number of cents, so
+// json.Unmarshal(json.Marshal(m)) does not always reproduce m.
+func (m Money) MarshalJSON() ([]byte, error) {
+	amount := float64(m.Cents) / 100.0
+	return json.Marshal(moneyWire{Amount: amount, Currency: m.Currency})
+}
+
+// UnmarshalJSON parses the decimal dollar amount back into integer cents.
+func (m *Money) UnmarshalJSON(data []byte) error {
+	var w moneyWire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	m.Cents = int64(w.Amount * 100)
+	m.Currency = w.Currency
+	return nil
+}
+
+// String renders Money for logging/debugging purposes.
+func (m Money) String() string {
+	return fmt.Sprintf("%d %s cents", m.Cents, m.Currency)
+}

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/money_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/money_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Happy-path smoke test. The full grading suite (including the round-trip
+// precision oracle) is applied separately.
+func TestMoneyMarshalUnmarshalSmoke(t *testing.T) {
+	m := Money{Cents: 500, Currency: "USD"}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var back Money
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if back.Currency != "USD" {
+		t.Fatalf("Currency = %q, want %q", back.Currency, "USD")
+	}
+	if back.Cents != 500 {
+		t.Fatalf("Cents = %d, want %d", back.Cents, 500)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/task.yaml
@@ -1,0 +1,29 @@
+instruction: |
+  `Money` in `money.go` has custom `MarshalJSON`/`UnmarshalJSON` methods that
+  round-trip a `Money` value through a floating-point dollar amount. This loses
+  precision for some cent values, so `json.Unmarshal(json.Marshal(m))` does not
+  always reproduce the original `m`.
+
+  Fix `money.go` so it honors the following contract:
+    - For every `Money` value, `json.Unmarshal(json.Marshal(m))` must reproduce
+      `m` exactly (identical `Cents` and `Currency`), including values like 1
+      cent, 29 cents, negative amounts, and large amounts. The exact integer
+      number of cents must never be routed through a `float64`.
+    - The JSON must remain human-meaningful (you may change the on-wire
+      representation — e.g. integer cents, or a string amount — as long as
+      the round trip is exact and `MarshalJSON`/`UnmarshalJSON` stay
+      symmetric with each other).
+    - `Currency` must continue to round-trip unchanged.
+
+  You may change `money.go` only. Keep the `Money` struct's fields
+  (`Cents int64`, `Currency string`) and the existing method receivers
+  (`MarshalJSON` on `Money`, `UnmarshalJSON` on `*Money`). `go build ./...`
+  must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-json-roundtrip/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-json-roundtrip/tests/test_task.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// Every Money value must survive a Marshal -> Unmarshal round trip exactly.
+// The buggy floating-point implementation fails this for values like 29
+// cents, where the dollar amount does not multiply back out to an exact
+// integer number of cents.
+func TestOracleRoundTrip(t *testing.T) {
+	cases := []Money{
+		{Cents: 0, Currency: "USD"},
+		{Cents: 1, Currency: "USD"},
+		{Cents: 29, Currency: "USD"},
+		{Cents: 99, Currency: "USD"},
+		{Cents: 100, Currency: "EUR"},
+		{Cents: -4237, Currency: "USD"},
+		{Cents: 123456789, Currency: "JPY"},
+	}
+
+	for _, m := range cases {
+		b, err := json.Marshal(m)
+		if err != nil {
+			t.Fatalf("Marshal(%+v) returned error: %v", m, err)
+		}
+
+		var back Money
+		if err := json.Unmarshal(b, &back); err != nil {
+			t.Fatalf("Unmarshal(%s) returned error: %v", b, err)
+		}
+
+		if !reflect.DeepEqual(m, back) {
+			t.Fatalf("round-trip changed %+v -> %+v (json=%s)", m, back, b)
+		}
+	}
+}
+
+// Currency must always survive the round trip unchanged.
+func TestOracleCurrencyPreserved(t *testing.T) {
+	m := Money{Cents: 500, Currency: "GBP"}
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal(%+v) returned error: %v", m, err)
+	}
+
+	var back Money
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("Unmarshal(%s) returned error: %v", b, err)
+	}
+
+	if back.Currency != "GBP" {
+		t.Fatalf("Currency = %q, want %q", back.Currency, "GBP")
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY account.go /app/account.go
+COPY account_test.go /app/account_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/account.go
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/account.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"sync"
+)
+
+// Account is a simple bank account protected by its own mutex.
+type Account struct {
+	ID      int
+	mu      sync.Mutex
+	balance int64
+}
+
+// NewAccount creates an account with the given id and starting balance.
+func NewAccount(id int, balance int64) *Account {
+	return &Account{ID: id, balance: balance}
+}
+
+// Balance safely reads the current balance.
+func (a *Account) Balance() int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.balance
+}
+
+// Transfer moves amount from `from` to `to`.
+//
+// Contract:
+//   - Transfer must be deadlock-free under concurrent transfers that run in
+//     both directions (e.g. Transfer(a, b, ...) and Transfer(b, a, ...) at the
+//     same time).
+//   - Transfer must move `amount` from `from` to `to` atomically and be free
+//     of data races.
+//   - If `from` has insufficient funds (balance < amount), Transfer must
+//     return a non-nil error and leave both balances unchanged.
+//
+// BUG: this implementation always locks `from` before `to`. Two goroutines
+// running Transfer(a, b, ...) and Transfer(b, a, ...) concurrently acquire
+// the locks in opposite orders, so they can each hold one lock while waiting
+// for the other, deadlocking forever.
+func Transfer(from, to *Account, amount int64) error {
+	from.mu.Lock()
+	defer from.mu.Unlock()
+
+	to.mu.Lock()
+	defer to.mu.Unlock()
+
+	if from.balance < amount {
+		return errors.New("insufficient funds")
+	}
+
+	from.balance -= amount
+	to.balance += amount
+	return nil
+}

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/account_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/account_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including concurrent
+// deadlock, race, and overdraft checks) is applied separately.
+func TestTransferHappyPath(t *testing.T) {
+	a := NewAccount(1, 1000)
+	b := NewAccount(2, 500)
+
+	if err := Transfer(a, b, 200); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, want := a.Balance(), int64(800); got != want {
+		t.Fatalf("a.Balance() = %d, want %d", got, want)
+	}
+	if got, want := b.Balance(), int64(700); got != want {
+		t.Fatalf("b.Balance() = %d, want %d", got, want)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-lock-ordering:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/go.mod
@@ -1,0 +1,3 @@
+module lockorder
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	a := NewAccount(1, 1000)
+	b := NewAccount(2, 500)
+
+	if err := Transfer(a, b, 200); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("a balance:", a.Balance())
+	fmt.Println("b balance:", b.Balance())
+}

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/task.yaml
@@ -1,0 +1,23 @@
+instruction: |
+  `Transfer` in `account.go` always locks `from` before `to`. Fix `Transfer` so it
+  honors the following contract:
+    - `Transfer` must be deadlock-free under concurrent transfers that run in both
+      directions (e.g. `Transfer(a, b, amount)` and `Transfer(b, a, amount)` firing
+      concurrently from many goroutines).
+    - `Transfer` must move `amount` from `from` to `to` atomically and be free of
+      data races.
+    - `Transfer` must return a non-nil error and make NO change to either balance if
+      `from` has insufficient funds (balance < amount).
+    - The total balance across all accounts must be conserved under concurrent
+      transfers.
+  You may change `account.go` only. Do not change the signatures of `Transfer`,
+  `NewAccount`, or `Balance`. `go build ./...` must succeed and the code must be
+  free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-lock-ordering/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-lock-ordering/tests/test_task.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+// runOracleSwarm assigns each goroutine a fixed ordered pair of accounts
+// (cycling through every ordered pair, shuffled) and has it repeatedly
+// Transfer along that direction, so that every account pair sees sustained
+// concurrent contention in both directions for the whole run rather than a
+// single one-shot attempt. A one-shot burst of random pairs did not reliably
+// deadlock the buggy implementation (the bad interleaving is probabilistic
+// and can be missed by chance); looping widens the race window enough to
+// make the deadlock dependable. It reports whether the swarm completed
+// within timeout.
+func runOracleSwarm(accounts []*Account, numGoroutines, itersPerGoroutine int, seed int64, timeout time.Duration) bool {
+	n := len(accounts)
+	pairs := make([][2]int, 0, n*(n-1))
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i != j {
+				pairs = append(pairs, [2]int{i, j})
+			}
+		}
+	}
+
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(pairs), func(i, j int) { pairs[i], pairs[j] = pairs[j], pairs[i] })
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		p := pairs[i%len(pairs)]
+		from, to := accounts[p[0]], accounts[p[1]]
+
+		wg.Add(1)
+		go func(from, to *Account) {
+			defer wg.Done()
+			<-start
+			for k := 0; k < itersPerGoroutine; k++ {
+				_ = Transfer(from, to, int64(k%50)+1)
+			}
+		}(from, to)
+	}
+
+	close(start)
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func newOracleAccounts(numAccounts int, initial int64) []*Account {
+	accounts := make([]*Account, numAccounts)
+	for i := range accounts {
+		accounts[i] = NewAccount(i, initial)
+	}
+	return accounts
+}
+
+// Transfers running concurrently in both directions (a->b and b->a) must not
+// deadlock. The buggy implementation always locks `from` before `to`, so
+// opposite-direction concurrent transfers between the same pair of accounts
+// can each hold one lock while waiting on the other, forever.
+func TestOracleNoDeadlock(t *testing.T) {
+	accounts := newOracleAccounts(6, 100000)
+	if !runOracleSwarm(accounts, 200, 20, 1, 5*time.Second) {
+		t.Fatal("deadlock: transfers did not complete within 5s (buggy lock ordering)")
+	}
+}
+
+// The total balance across all accounts must be conserved under concurrent
+// transfers, and the accounting must be race-free.
+func TestOracleConserved(t *testing.T) {
+	const numAccounts = 6
+	const initial int64 = 100000
+	accounts := newOracleAccounts(numAccounts, initial)
+	initialTotal := int64(numAccounts) * initial
+
+	if !runOracleSwarm(accounts, 200, 20, 2, 5*time.Second) {
+		t.Fatal("deadlock: transfers did not complete within 5s (buggy lock ordering)")
+	}
+
+	var total int64
+	for _, a := range accounts {
+		total += a.Balance()
+	}
+	if total != initialTotal {
+		t.Fatalf("balance not conserved: got total %d, want %d", total, initialTotal)
+	}
+}
+
+// Transfer must reject an overdraft and leave both balances untouched.
+func TestOracleRejectsOverdraft(t *testing.T) {
+	a := NewAccount(1, 50)
+	b := NewAccount(2, 0)
+
+	err := Transfer(a, b, 100)
+	if err == nil {
+		t.Fatal("Transfer with insufficient funds returned nil error")
+	}
+	if got, want := a.Balance(), int64(50); got != want {
+		t.Fatalf("a.Balance() = %d, want %d (overdrawn transfer must not change balances)", got, want)
+	}
+	if got, want := b.Balance(), int64(0); got != want {
+		t.Fatalf("b.Balance() = %d, want %d (overdrawn transfer must not change balances)", got, want)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY lru.go /app/lru.go
+COPY lru_test.go /app/lru_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-lru-eviction:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/go.mod
@@ -1,0 +1,3 @@
+module lrucache
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/lru.go
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/lru.go
@@ -1,0 +1,74 @@
+package main
+
+import "container/list"
+
+// entry is the value stored in each list.Element.
+type entry struct {
+	key   int
+	value int
+}
+
+// LRU is a fixed-capacity int->int cache with least-recently-used eviction.
+//
+// Contract:
+//   - Both Get (on a hit) and Put must mark the key as most-recently-used.
+//   - When Put would exceed capacity, evict exactly the least-recently-used
+//     key.
+//   - Get returns (value, true) on hit and (0, false) on miss; Put updates
+//     the value if the key already exists (no duplicate entry, no spurious
+//     eviction).
+//
+// BUG: Get looks up the map and returns the value WITHOUT moving the
+// element to the most-recently-used position. Put correctly moves/inserts
+// at the front and evicts from the back, but because Get never refreshes
+// recency, a key that was just read can still be evicted as if it were the
+// least-recently-used entry.
+type LRU struct {
+	capacity int
+	ll       *list.List
+	items    map[int]*list.Element
+}
+
+// NewLRU creates an LRU cache that holds at most capacity entries.
+func NewLRU(capacity int) *LRU {
+	return &LRU{
+		capacity: capacity,
+		ll:       list.New(),
+		items:    make(map[int]*list.Element),
+	}
+}
+
+// Put inserts or updates key with value, marking it most-recently-used. If
+// this would exceed capacity, the least-recently-used entry is evicted.
+func (c *LRU) Put(key, value int) {
+	if el, ok := c.items[key]; ok {
+		el.Value.(*entry).value = value
+		c.ll.MoveToFront(el)
+		return
+	}
+
+	el := c.ll.PushFront(&entry{key: key, value: value})
+	c.items[key] = el
+
+	if c.ll.Len() > c.capacity {
+		back := c.ll.Back()
+		if back != nil {
+			c.ll.Remove(back)
+			delete(c.items, back.Value.(*entry).key)
+		}
+	}
+}
+
+// Get returns the value for key and whether it was found.
+func (c *LRU) Get(key int) (int, bool) {
+	el, ok := c.items[key]
+	if !ok {
+		return 0, false
+	}
+	return el.Value.(*entry).value, true
+}
+
+// Len returns the number of entries currently in the cache.
+func (c *LRU) Len() int {
+	return c.ll.Len()
+}

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/lru_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/lru_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including recency-on-Get
+// and eviction-order checks) is applied separately.
+func TestLRUHappyPath(t *testing.T) {
+	c := NewLRU(2)
+	c.Put(1, 100)
+	c.Put(2, 200)
+
+	if v, ok := c.Get(1); !ok || v != 100 {
+		t.Fatalf("Get(1) = (%d, %v), want (100, true)", v, ok)
+	}
+	if c.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", c.Len())
+	}
+	if _, ok := c.Get(99); ok {
+		t.Fatalf("Get(99) = (_, true), want a miss")
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/main.go
@@ -1,0 +1,14 @@
+package main
+
+import "fmt"
+
+func main() {
+	c := NewLRU(2)
+	c.Put(1, 100)
+	c.Put(2, 200)
+	if v, ok := c.Get(1); ok {
+		fmt.Println("get 1:", v)
+	}
+	c.Put(3, 300)
+	fmt.Println("len:", c.Len())
+}

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/task.yaml
@@ -1,0 +1,20 @@
+instruction: |
+  The LRU cache in `lru.go` evicts the wrong entry because `Get` does not
+  update recency. Fix it so it honors the following contract:
+    - Both `Get` (on a hit) and `Put` must mark the key as most-recently-used.
+    - When `Put` would exceed capacity, evict exactly the least-recently-used
+      key.
+    - `Get` returns `(value, true)` on a hit and `(0, false)` on a miss;
+      `Put` updates the value if the key already exists (no duplicate entry,
+      no spurious eviction).
+  You may change `lru.go` only. Do not change the signatures of
+  `NewLRU`, `Put`, `Get`, or `Len`.
+  `go build ./...` must succeed and the code must be free of data races.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-lru-eviction/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-lru-eviction/tests/test_task.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"testing"
+)
+
+// Get must refresh recency on a hit: a key that was just read must not be
+// evicted as if it were the least-recently-used entry.
+func TestOracleGetUpdatesRecency(t *testing.T) {
+	c := NewLRU(2)
+	c.Put(1, 10)
+	c.Put(2, 20)
+
+	// Touch key 1 so key 2 becomes the least-recently-used entry.
+	if v, ok := c.Get(1); !ok || v != 10 {
+		t.Fatalf("Get(1) = (%d, %v), want (10, true)", v, ok)
+	}
+
+	// Inserting a third key must now evict key 2, not key 1.
+	c.Put(3, 30)
+
+	if v, ok := c.Get(1); !ok || v != 10 {
+		t.Fatalf("after eviction: Get(1) = (%d, %v), want (10, true) "+
+			"(key 1 was just read and must not have been evicted)", v, ok)
+	}
+	if v, ok := c.Get(3); !ok || v != 30 {
+		t.Fatalf("after eviction: Get(3) = (%d, %v), want (30, true)", v, ok)
+	}
+	if v, ok := c.Get(2); ok {
+		t.Fatalf("after eviction: Get(2) = (%d, true), want a miss "+
+			"(key 2 was least-recently-used and should have been evicted)", v)
+	}
+}
+
+// With no Gets in between, Put must evict strictly in insertion order.
+func TestOracleEvictsLRU(t *testing.T) {
+	c := NewLRU(2)
+	c.Put(1, 100)
+	c.Put(2, 200)
+	c.Put(3, 300)
+
+	if _, ok := c.Get(1); ok {
+		t.Fatalf("Get(1) = (_, true), want a miss (key 1 is least-recently-used)")
+	}
+	if v, ok := c.Get(2); !ok || v != 200 {
+		t.Fatalf("Get(2) = (%d, %v), want (200, true)", v, ok)
+	}
+	if v, ok := c.Get(3); !ok || v != 300 {
+		t.Fatalf("Get(3) = (%d, %v), want (300, true)", v, ok)
+	}
+}
+
+// Put on an existing key must update its value in place, not create a
+// duplicate entry or trigger a spurious eviction.
+func TestOracleUpdateExisting(t *testing.T) {
+	c := NewLRU(2)
+	c.Put(1, 10)
+	c.Put(1, 99)
+
+	if got := c.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+	if v, ok := c.Get(1); !ok || v != 99 {
+		t.Fatalf("Get(1) = (%d, %v), want (99, true)", v, ok)
+	}
+}
+
+// Get on a key that was never inserted must report a miss.
+func TestOracleMiss(t *testing.T) {
+	c := NewLRU(1)
+	if _, ok := c.Get(42); ok {
+		t.Fatalf("Get(42) = (_, true), want a miss on an empty cache")
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY validate.go /app/validate.go
+COPY validate_test.go /app/validate_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-nil-interface:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/go.mod
@@ -1,0 +1,3 @@
+module nilinterface
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	u := User{Name: "Ada", Age: 37}
+	if err := Validate(u); err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Println("valid user:", u.Name)
+}

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/task.yaml
@@ -1,0 +1,19 @@
+instruction: |
+  `Validate` in `validate.go` always returns a non-nil `*ValidationError`, even
+  when the user is valid. Fix `Validate` so it honors the following contract:
+    - `Validate` must return a nil `error` for a valid user (non-empty `Name`,
+      `0 <= Age <= 150`).
+    - `Validate` must return a non-nil `error` for an invalid user, and that
+      error must be assertable to `*ValidationError` via `errors.As`, exposing
+      the accumulated `Problems`.
+  You may change `validate.go` only. Do not change the signature of `Validate`
+  or the `ValidationError` type's fields or `Error` method.
+  `go build ./...` must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/tests/test_task.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// A valid user must produce a nil error. This is the classic typed-nil-
+// interface trap: the buggy implementation always returns a non-nil
+// *ValidationError wrapped in the error interface, so this fails against it
+// even though Problems is empty.
+func TestOracleValidReturnsNil(t *testing.T) {
+	err := Validate(User{Name: "Ada", Age: 37})
+	if err != nil {
+		t.Fatalf("valid user returned error: %v", err)
+	}
+}
+
+// An invalid user must produce a non-nil error that is assertable to
+// *ValidationError via errors.As, exposing the accumulated Problems.
+func TestOracleInvalidReturnsError(t *testing.T) {
+	err := Validate(User{Name: "", Age: 200})
+	if err == nil {
+		t.Fatalf("invalid user returned nil error")
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error is not assertable to *ValidationError: %v", err)
+	}
+	if len(ve.Problems) < 1 {
+		t.Fatalf("expected at least one problem, got %d", len(ve.Problems))
+	}
+}
+
+// Age boundaries (0 and 150) are valid and must return a nil error.
+func TestOracleBoundary(t *testing.T) {
+	if err := Validate(User{Name: "X", Age: 0}); err != nil {
+		t.Fatalf("age 0 should be valid, got error: %v", err)
+	}
+	if err := Validate(User{Name: "X", Age: 150}); err != nil {
+		t.Fatalf("age 150 should be valid, got error: %v", err)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/validate.go
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/validate.go
@@ -1,0 +1,42 @@
+package main
+
+import "strings"
+
+type User struct {
+	Name string
+	Age  int
+}
+
+type ValidationError struct {
+	Problems []string
+}
+
+func (e *ValidationError) Error() string {
+	return strings.Join(e.Problems, "; ")
+}
+
+// Validate checks u and reports problems via a *ValidationError.
+//
+// Contract:
+//   - Validate must return a nil error for a valid user (non-empty name,
+//     0 <= age <= 150).
+//   - Validate must return a non-nil error for an invalid user, and that
+//     error must be assertable to *ValidationError via errors.As, exposing
+//     the accumulated Problems.
+//
+// BUG: this implementation always constructs and returns a *ValidationError,
+// even when Problems is empty. Because the return type is the `error`
+// interface, a nil *ValidationError wrapped in `error` is NOT equal to a nil
+// error — the interface carries a non-nil type descriptor even though the
+// pointer value is nil. So `Validate(validUser) != nil` is true, and callers
+// that check `if err != nil` see an error for perfectly valid input.
+func Validate(u User) error {
+	e := &ValidationError{}
+	if u.Name == "" {
+		e.Problems = append(e.Problems, "name is empty")
+	}
+	if u.Age < 0 || u.Age > 150 {
+		e.Problems = append(e.Problems, "age out of range")
+	}
+	return e
+}

--- a/benchmarks/terminal_bench/tasks/hard-nil-interface/validate_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-nil-interface/validate_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+// Happy-path smoke test. The full grading suite (including the nil-interface
+// regression checks) is applied separately.
+func TestValidateHappyPath(t *testing.T) {
+	got := Validate(User{Name: "Grace", Age: 30})
+	if got != nil {
+		t.Fatalf("unexpected error: %v", got)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-pagination/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY page.go /app/page.go
+COPY page_test.go /app/page_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-pagination/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-pagination:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-pagination/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/go.mod
@@ -1,0 +1,3 @@
+module pagination
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-pagination/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	items := []string{"a", "b", "c", "d", "e"}
+	pageItems, totalPages := Paginate(items, 2, 1)
+	fmt.Println("page 1:", pageItems, "totalPages:", totalPages)
+}

--- a/benchmarks/terminal_bench/tasks/hard-pagination/page.go
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/page.go
@@ -1,0 +1,31 @@
+package main
+
+// Paginate splits items into pages of size pageSize and returns the items on
+// the requested page (1-indexed) together with the total number of pages.
+//
+// Contract:
+//   - Pages are 1-indexed. totalPages must be the ceiling of
+//     len(items)/pageSize (a partial last page still counts as a page).
+//   - For a valid page, return the correct sub-slice of items for that page;
+//     the last page may be a partial page (fewer than pageSize items) and
+//     must not panic.
+//   - For page < 1 or page > totalPages, return an empty slice (len 0) and
+//     the correct totalPages. Must not panic.
+//   - If pageSize <= 0, return an empty slice and totalPages == 0. Must not
+//     panic or divide by zero.
+//   - For empty items, totalPages == 0 and any page returns an empty slice.
+//
+// BUG: this implementation has two defects:
+//  1. totalPages is computed with plain integer division (len(items) /
+//     pageSize), so a partial last page is silently dropped from the count
+//     (e.g. 5 items at pageSize 2 reports 2 pages instead of 3).
+//  2. The slice bounds `items[start:end]` are never clamped to len(items),
+//     so requesting the last (partial) page, or any out-of-range page,
+//     slices past the end of the backing array and panics.
+func Paginate(items []string, pageSize, page int) (pageItems []string, totalPages int) {
+	totalPages = len(items) / pageSize
+
+	start := (page - 1) * pageSize
+	end := start + pageSize
+	return items[start:end], totalPages
+}

--- a/benchmarks/terminal_bench/tasks/hard-pagination/page_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/page_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Happy-path smoke test. The full grading suite (including boundary and
+// out-of-range checks) is applied separately.
+func TestPaginateHappyPath(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e", "f"}
+	got, totalPages := Paginate(items, 2, 1)
+	want := []string{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Paginate page 1 = %v, want %v", got, want)
+	}
+	if totalPages != 3 {
+		t.Fatalf("totalPages = %d, want 3", totalPages)
+	}
+}

--- a/benchmarks/terminal_bench/tasks/hard-pagination/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-pagination/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/task.yaml
@@ -1,0 +1,24 @@
+instruction: |
+  `Paginate` in `page.go` has two boundary bugs. Fix it so it honors the
+  following contract:
+    - Pages are 1-indexed. `totalPages` must equal the ceiling of
+      `len(items) / pageSize` (a partial last page still counts as a page).
+    - For a valid page, return the correct sub-slice of `items` for that
+      page. The last page may be a partial page (fewer than `pageSize`
+      items); this must return only the remaining items, not panic.
+    - For `page < 1` or `page > totalPages`, return an empty slice (length
+      0) and the correct `totalPages`. Must not panic.
+    - If `pageSize <= 0`, return an empty slice and `totalPages == 0`. Must
+      not panic or divide by zero.
+    - For empty `items`, `totalPages == 0` and any page returns an empty
+      slice.
+  You may change `page.go` only. Do not change the signature of `Paginate`.
+  `go build ./...` must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-pagination/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-pagination/tests/test_task.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// totalPages must be the ceiling of len(items)/pageSize, not plain integer
+// division. 5 items at pageSize 2 must report 3 pages, not 2.
+func TestOracleTotalPagesCeil(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	_, totalPages := Paginate(items, 2, 1)
+	if totalPages != 3 {
+		t.Fatalf("totalPages = %d, want 3", totalPages)
+	}
+}
+
+// The last (partial) page must return only the remaining items and must not
+// panic from slicing past the end of the backing array.
+func TestOraclePartialLastPageNoPanic(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	pageItems, totalPages := Paginate(items, 2, 3)
+	want := []string{"e"}
+	if !reflect.DeepEqual(pageItems, want) {
+		t.Fatalf("pageItems = %v, want %v", pageItems, want)
+	}
+	if totalPages != 3 {
+		t.Fatalf("totalPages = %d, want 3", totalPages)
+	}
+}
+
+// Requesting a page below 1 or above totalPages must return an empty slice
+// and the correct totalPages, without panicking.
+func TestOracleOutOfRange(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+
+	highItems, highTotal := Paginate(items, 2, 99)
+	if len(highItems) != 0 {
+		t.Fatalf("page=99: pageItems = %v, want empty", highItems)
+	}
+	if highTotal != 3 {
+		t.Fatalf("page=99: totalPages = %d, want 3", highTotal)
+	}
+
+	lowItems, lowTotal := Paginate(items, 2, 0)
+	if len(lowItems) != 0 {
+		t.Fatalf("page=0: pageItems = %v, want empty", lowItems)
+	}
+	if lowTotal != 3 {
+		t.Fatalf("page=0: totalPages = %d, want 3", lowTotal)
+	}
+}
+
+// When items divide evenly into pages, totalPages must not be off by one
+// and the last page must contain exactly the final pageSize items.
+func TestOracleExactMultiple(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+	_, totalPages := Paginate(items, 2, 1)
+	if totalPages != 2 {
+		t.Fatalf("totalPages = %d, want 2", totalPages)
+	}
+	pageItems, _ := Paginate(items, 2, 2)
+	want := []string{"c", "d"}
+	if !reflect.DeepEqual(pageItems, want) {
+		t.Fatalf("page 2 = %v, want %v", pageItems, want)
+	}
+}
+
+// Empty input and a non-positive pageSize must both be handled without
+// panicking (no divide-by-zero) and must report totalPages == 0.
+func TestOracleEmptyAndBadSize(t *testing.T) {
+	nilItems, nilTotal := Paginate(nil, 2, 1)
+	if len(nilItems) != 0 {
+		t.Fatalf("nil items: pageItems = %v, want empty", nilItems)
+	}
+	if nilTotal != 0 {
+		t.Fatalf("nil items: totalPages = %d, want 0", nilTotal)
+	}
+
+	items := []string{"a", "b", "c", "d", "e"}
+	zeroItems, zeroTotal := Paginate(items, 0, 1)
+	if len(zeroItems) != 0 {
+		t.Fatalf("pageSize=0: pageItems = %v, want empty", zeroItems)
+	}
+	if zeroTotal != 0 {
+		t.Fatalf("pageSize=0: totalPages = %d, want 0", zeroTotal)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/Dockerfile
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/Dockerfile
@@ -1,0 +1,9 @@
+FROM go-agent-harness-tb-base:latest
+
+COPY go.mod /app/go.mod
+COPY main.go /app/main.go
+COPY window.go /app/window.go
+COPY window_test.go /app/window_test.go
+COPY run-tests.sh /app/run-tests.sh
+
+RUN chmod +x /app/run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/docker-compose.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  client:
+    image: go-agent-harness-tb-hard-slice-aliasing:latest
+    container_name: ${T_BENCH_TASK_DOCKER_CLIENT_CONTAINER_NAME}
+    command: ["sh", "-c", "sleep infinity"]

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/go.mod
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/go.mod
@@ -1,0 +1,3 @@
+module slicealias
+
+go 1.22

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/main.go
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	data := []int{1, 2, 3, 4, 5}
+	windows := Windows(data, 3)
+	fmt.Println("windows:", windows)
+}

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/run-tests.sh
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/run-tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_ROOT="${TEST_DIR:-/tests}"
+python3 -m pytest -rA "${TEST_ROOT}"

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/task.yaml
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/task.yaml
@@ -1,0 +1,21 @@
+instruction: |
+  `Windows` in `window.go` returns all consecutive windows of length `size` over
+  `data`, but the returned windows are sub-slices of `data`'s own backing array,
+  so they are not independent of it or of each other. Fix `Windows` so it honors
+  the following contract:
+    - Each returned window has length `size` and contains the values
+      `data[i], data[i+1], ..., data[i+size-1]` for `i` in `0..len(data)-size`.
+    - The returned windows must be independent: mutating or appending to any
+      returned window must not change `data` or any other returned window.
+    - If `size <= 0` or `size > len(data)`, `Windows` must return an empty
+      `[][]int`.
+  You may change `window.go` only. Do not change the signature of `Windows`.
+  `go build ./...` must succeed.
+difficulty: hard
+category: bugfix
+parser_name: pytest
+max_agent_timeout_sec: 900
+max_test_timeout_sec: 180
+run_tests_in_same_shell: false
+test_scripts:
+  - run-tests.sh

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/tests/test_task.py
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/tests/test_task.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Hidden behavioral oracle. This test file is injected into the container at
+# grading time only — the agent never sees it. It writes a fresh Go test into
+# /app and runs it, so the decisive checks cannot be inspected or weakened by
+# the agent.
+ORACLE_TEST = r'''
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Windows must return the correct values for each window, in order.
+func TestOracleValues(t *testing.T) {
+	data := []int{1, 2, 3, 4, 5}
+	got := Windows(data, 3)
+	want := [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}}
+	if len(got) != len(want) {
+		t.Fatalf("Windows(%v, 3) returned %d windows %v, want %d windows %v",
+			data, len(got), got, len(want), want)
+	}
+	for i := range want {
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Fatalf("windows[%d] = %v, want %v (full result: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// Returned windows must be independent of the input slice and of each other:
+// neither an in-place write nor an append through one window may leak into
+// data or into a different window's backing array.
+func TestOracleIndependence(t *testing.T) {
+	data := []int{1, 2, 3, 4, 5}
+	windows := Windows(data, 3)
+	if len(windows) < 2 {
+		t.Fatalf("expected at least 2 windows for data=%v size=3, got %d: %v", data, len(windows), windows)
+	}
+
+	w0 := windows[0]
+	w0[0] = 999          // in-place write through the returned window
+	w1 := append(w0, 7)  // append through the returned window
+	_ = w1
+
+	wantData := []int{1, 2, 3, 4, 5}
+	if !reflect.DeepEqual(data, wantData) {
+		t.Fatalf("mutating windows[0] corrupted the input slice: data = %v, want %v "+
+			"(windows are aliasing data's backing array instead of being independent copies)",
+			data, wantData)
+	}
+
+	wantW1 := []int{2, 3, 4}
+	if !reflect.DeepEqual(windows[1], wantW1) {
+		t.Fatalf("mutating/appending windows[0] corrupted windows[1]: got %v, want %v "+
+			"(windows are aliasing each other's backing array instead of being independent copies)",
+			windows[1], wantW1)
+	}
+}
+
+// size <= 0 or size > len(data) must yield an empty result; size == len(data)
+// must yield exactly one window equal to the whole input.
+func TestOracleEdge(t *testing.T) {
+	data := []int{1, 2, 3, 4, 5}
+
+	if got := Windows(data, 0); len(got) != 0 {
+		t.Fatalf("Windows(data, 0) returned %d windows %v, want 0", len(got), got)
+	}
+	if got := Windows(data, 10); len(got) != 0 {
+		t.Fatalf("Windows(data, 10) returned %d windows %v, want 0 (size > len(data))", len(got), got)
+	}
+
+	got := Windows(data, len(data))
+	if len(got) != 1 {
+		t.Fatalf("Windows(data, len(data)) returned %d windows %v, want exactly 1", len(got), got)
+	}
+	want := []int{1, 2, 3, 4, 5}
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("Windows(data, len(data))[0] = %v, want %v", got[0], want)
+	}
+}
+'''
+
+
+def _write_oracle() -> None:
+    Path("/app/zz_oracle_test.go").write_text(ORACLE_TEST)
+
+
+def test_build_succeeds() -> None:
+    r = subprocess.run(
+        ["go", "build", "./..."], cwd="/app", capture_output=True, text=True, timeout=60
+    )
+    assert r.returncode == 0, f"go build failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+
+
+def test_behavioral_oracle() -> None:
+    _write_oracle()
+    r = subprocess.run(
+        ["go", "test", "-race", "-count=1", "-run", "TestOracle", "./..."],
+        cwd="/app",
+        capture_output=True,
+        text=True,
+        timeout=150,
+    )
+    assert r.returncode == 0, (
+        f"behavioral oracle failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/window.go
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/window.go
@@ -1,0 +1,27 @@
+package main
+
+// Windows returns all consecutive windows of length `size` over data, i.e.
+// data[i:i+size] for every i in 0..len(data)-size.
+//
+// Contract:
+//   - Each returned window has length `size` and contains the values
+//     data[i], data[i+1], ..., data[i+size-1].
+//   - The returned windows must be independent: mutating or appending to any
+//     returned window must not change data or any other returned window.
+//   - If size <= 0 or size > len(data), Windows returns an empty [][]int.
+//
+// BUG: this implementation returns data[i:i+size] directly. Every returned
+// window therefore aliases data's backing array (and, because it uses a
+// two-index slice expression, also shares leftover capacity with it). Writing
+// to or appending to one returned window can silently corrupt the input slice
+// and/or other windows.
+func Windows(data []int, size int) [][]int {
+	if size <= 0 || size > len(data) {
+		return [][]int{}
+	}
+	out := make([][]int, 0, len(data)-size+1)
+	for i := 0; i+size <= len(data); i++ {
+		out = append(out, data[i:i+size])
+	}
+	return out
+}

--- a/benchmarks/terminal_bench/tasks/hard-slice-aliasing/window_test.go
+++ b/benchmarks/terminal_bench/tasks/hard-slice-aliasing/window_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Happy-path smoke test. The full grading suite (including independence and
+// edge-case checks) is applied separately.
+func TestWindowsHappyPath(t *testing.T) {
+	data := []int{1, 2, 3, 4, 5}
+	got := Windows(data, 3)
+	want := [][]int{{1, 2, 3}, {2, 3, 4}, {3, 4, 5}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Windows(%v, 3) = %v, want %v", data, got, want)
+	}
+}

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"syscall"
@@ -24,15 +25,30 @@ type RetryConfig struct {
 	Jitter      bool
 }
 
-// DefaultRetryConfig returns the production retry settings.
+// DefaultRetryConfig returns the production retry settings. The attempt count
+// and total time budget can be widened via the HARNESS_RETRY_MAX_ATTEMPTS and
+// HARNESS_RETRY_MAX_TOTAL_SEC environment variables (useful against providers
+// with aggressive rate limiting, e.g. free tiers); unset or invalid values
+// leave the built-in defaults unchanged.
 func DefaultRetryConfig() RetryConfig {
-	return RetryConfig{
+	cfg := RetryConfig{
 		MaxAttempts: 3,
 		BaseDelay:   500 * time.Millisecond,
 		MaxDelay:    30 * time.Second,
 		MaxTotal:    60 * time.Second,
 		Jitter:      true,
 	}
+	if v := strings.TrimSpace(os.Getenv("HARNESS_RETRY_MAX_ATTEMPTS")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxAttempts = n
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("HARNESS_RETRY_MAX_TOTAL_SEC")); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxTotal = time.Duration(n) * time.Second
+		}
+	}
+	return cfg
 }
 
 func mergeRetryConfig(cfg *RetryConfig) RetryConfig {

--- a/prompts/base/main.md
+++ b/prompts/base/main.md
@@ -7,6 +7,14 @@ Many more specialized tools are available on demand — use the find_tool tool t
 Guidelines:
 - Prefer the dedicated tools over shell equivalents: use read to view files (not cat or sed), grep/glob to search, and edit or apply_patch for precise changes.
 - Make the smallest change that satisfies the request. On edits, match the exact existing text and keep the replaced region minimal and non-overlapping.
-- When you change code, verify it: run the relevant build or tests, or exercise the affected path, and fix what you broke before reporting the work done.
 - Work in the current repository. Use paths relative to the working directory, or absolute paths the user provides. Save downloads and generated files inside the workspace with descriptive names.
 - Be concise, and show file paths clearly when referring to files.
+
+How to approach a coding task:
+1. Reproduce first. Before changing anything, run the build and the tests to see the actual failure, and read the full error output — do not guess from the description alone.
+2. Understand before editing. Read the relevant file(s) completely and trace the logic that produces the failure. Read the task's stated contract carefully; the expected behavior is defined there, not only by the provided tests.
+3. Fix, then verify every time. After each change, re-run the build and the tests. Treat the work as unfinished until the build compiles cleanly and the tests pass.
+4. Don't stop at the first change. A task may contain more than one defect. After a fix, re-run and keep going until everything the contract requires is satisfied — a passing sample test is not proof the whole contract holds.
+5. Cover the hard cases. Actively consider edge cases (empty input, boundaries, off-by-one, large or negative values) and, for concurrent code, data races — run tests with the race detector when concurrency is involved, and reason about whether your fix is correct under all inputs the contract allows, not just the sampled ones.
+6. One change at a time. When a test still fails, form a specific hypothesis from the error, make one targeted change, and re-check — rather than changing many things at once.
+7. Stop when it's done. Once the build and tests pass and the contract is satisfied, stop; do not keep making unnecessary changes.

--- a/scripts/build-bench-images.sh
+++ b/scripts/build-bench-images.sh
@@ -27,6 +27,20 @@ TASKS=(
   "go-rename-refactor:go-agent-harness-tb-go-rename"
   "multi-report-pipeline:go-agent-harness-tb-multi-report"
   "go-interface-migration:go-agent-harness-tb-go-interface"
+  "hard-context-cancel:go-agent-harness-tb-hard-context-cancel"
+  "hard-lock-ordering:go-agent-harness-tb-hard-lock-ordering"
+  "hard-slice-aliasing:go-agent-harness-tb-hard-slice-aliasing"
+  "hard-nil-interface:go-agent-harness-tb-hard-nil-interface"
+  "hard-json-roundtrip:go-agent-harness-tb-hard-json-roundtrip"
+  "hard-lru-eviction:go-agent-harness-tb-hard-lru-eviction"
+  "hard-errors-is:go-agent-harness-tb-hard-errors-is"
+  "hard-pagination:go-agent-harness-tb-hard-pagination"
+  "brutal-wordwrap:go-agent-harness-tb-brutal-wordwrap"
+  "brutal-csv-parser:go-agent-harness-tb-brutal-csv-parser"
+  "brutal-getorcompute:go-agent-harness-tb-brutal-getorcompute"
+  "brutal-semver:go-agent-harness-tb-brutal-semver"
+  "brutal-ledger:go-agent-harness-tb-brutal-ledger"
+  "brutal-topo-sort:go-agent-harness-tb-brutal-topo-sort"
 )
 
 for entry in "${TASKS[@]}"; do

--- a/scripts/validate-hard-task.sh
+++ b/scripts/validate-hard-task.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# validate-hard-task.sh <task-name>
+# Faithful discrimination gate for an authored hard task, run inside the same
+# base image the grader uses. Verifies the hidden oracle:
+#   - FAILS against the buggy starting code (task ships a real bug)
+#   - PASSES against the reference solution (a correct fix is accepted)
+# A task is only sound if BOTH hold.
+set -uo pipefail
+
+TASK="${1:?usage: validate-hard-task.sh <task-name>}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/benchmarks/terminal_bench"
+TDIR="$ROOT/tasks/$TASK"
+REFDIR="$ROOT/reference_solutions/$TASK"
+BASE="go-agent-harness-tb-base:latest"
+
+[ -d "$TDIR" ] || { echo "no task dir: $TDIR"; exit 2; }
+[ -d "$REFDIR" ] || { echo "no reference dir: $REFDIR"; exit 2; }
+
+run_oracle () {  # $1=label  $2=overlay-dir(optional)
+  local label="$1" overlay="${2:-}"
+  local work; work="$(mktemp -d)"
+  cp "$TDIR"/*.go "$work"/ 2>/dev/null
+  cp "$TDIR"/go.mod "$work"/
+  [ -n "$overlay" ] && cp "$overlay"/*.go "$work"/
+  docker run --rm -v "$work":/app -v "$TDIR/tests":/tests:ro "$BASE" \
+    bash -lc 'cd /app && python3 -m pytest -rA -q /tests' >"$work/out.txt" 2>&1
+  local rc=$?
+  echo "----- [$label] pytest rc=$rc -----"
+  tail -n 8 "$work/out.txt"
+  rm -rf "$work"
+  return $rc
+}
+
+echo "### validating task: $TASK"
+run_oracle "BUGGY (expect FAIL)"; buggy_rc=$?
+run_oracle "REFERENCE (expect PASS)" "$REFDIR"; ref_rc=$?
+
+echo
+if [ "$buggy_rc" -ne 0 ] && [ "$ref_rc" -eq 0 ]; then
+  echo "RESULT: $TASK OK  (buggy fails, reference passes — task discriminates)"
+  exit 0
+else
+  echo "RESULT: $TASK BROKEN  (buggy_rc=$buggy_rc want!=0 ; ref_rc=$ref_rc want=0)"
+  exit 1
+fi


### PR DESCRIPTION
## What

An AIDE²-style recursive-self-improvement loop applied to this harness: a difficult external-oracle benchmark, plus a **verified base-prompt improvement** measured against it.

**Benchmark (14 new Go tasks).** 8 `hard-*` + 6 `brutal-*` (multi-bug word-wrap/CSV/ledger, a single-flight concurrency race, semver precedence, deterministic topological sort). Each ships a **hidden** pytest oracle (`tests/test_task.py`) that injects its Go test into the container at grade time — the solving agent never sees it, so it can't be gamed. Every task is validated to **fail on the planted bug and pass on a reference solution** (`benchmarks/terminal_bench/reference_solutions/`) via `scripts/validate-hard-task.sh` (runs in the base image).

**Verified prompt gain.** `prompts/base/main.md` gains a general working-method section (reproduce-first, verify-after-every-change, don't-stop-at-first-fix, cover edge-cases + use the race detector, stop-when-done). Measured on `gpt-4o-mini`: **+14 to +17 points** (51.6% → 68.8% clean), replicated across single-run and 3-attempt-averaged evaluations. No task-specific hints. Two further variants (self-test, scratchpad) were tested and correctly rejected as no-gain.

**Harness robustness.** `internal/provider/retry.go` makes the retry budget env-tunable (`HARNESS_RETRY_MAX_ATTEMPTS` / `HARNESS_RETRY_MAX_TOTAL_SEC`); production defaults unchanged (3 attempts / 60s). `agent.py` passes these into the container so benchmark runs can ride over rate-limited endpoints.

## Notes
- Model choice mattered more than task difficulty: a frontier free model solved even the brutal tasks, so the benchmark uses a small reliable model where prompt quality is measurable.
- Excludes unrelated in-tree changes (`internal/cron/*`, `icon-explorations/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)