### PR TITLE
feat(subagents): fix registration gaps, add messaging tools, fix orchestration reliability

### DIFF
--- a/catalog/models.json
+++ b/catalog/models.json
@@ -404,6 +404,32 @@
         "llama-70b": "llama-3.3-70b-versatile"
       }
     },
+    "cerebras": {
+      "display_name": "Cerebras",
+      "base_url": "https://api.cerebras.ai/v1",
+      "api_key_env": "CEREBRAS_API_KEY",
+      "protocol": "openai_compat",
+      "quirks": [
+        "speed_optimized"
+      ],
+      "models": {
+        "gpt-oss-120b": {
+          "display_name": "GPT-OSS 120B (Cerebras)",
+          "description": "OpenAI's open-weight gpt-oss-120b model served on Cerebras wafer-scale inference. Verified reachable via GET /v1/models on the Cerebras API.",
+          "context_window": 131072,
+          "modalities": [
+            "text"
+          ],
+          "tool_calling": true,
+          "streaming": true,
+          "strengths": [
+            "speed",
+            "open-source"
+          ],
+          "speed_tier": "ultra-fast"
+        }
+      }
+    },
     "xai": {
       "display_name": "xAI (Grok)",
       "base_url": "https://api.x.ai/v1",

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -714,11 +714,22 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	}
 	goalManager := goals.NewManager(goalStore)
 
+	// skillListerAdapter (assigned to skillLister above, when skills are
+	// enabled) already implements GetSkillFilePath/UpdateSkillVerification,
+	// so it satisfies htools.SkillVerifier as well as htools.SkillLister —
+	// it was just never asserted to the wider interface, so the verify_skill
+	// tool was never registered even though nothing new is needed to run it.
+	var skillVerifier htools.SkillVerifier
+	if sv, ok := skillLister.(htools.SkillVerifier); ok {
+		skillVerifier = sv
+	}
+
 	baseRegistryOptions := harness.DefaultRegistryOptions{
 		ApprovalMode:       approvalMode,
 		Policy:             nil,
 		AskUserBroker:      askUserBroker,
 		AskUserTimeout:     time.Duration(askUserTimeoutSeconds) * time.Second,
+		SkillVerifier:      skillVerifier,
 		MemoryManager:      memoryManager,
 		WorkingMemoryStore: workingMemoryStore,
 		SkillLister:        skillLister,
@@ -746,7 +757,6 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		TodosTool:         todosToolBuilder,
 		GoalManager:       goalManager,
 	}
-	tools := harness.NewDefaultRegistryWithOptions(workspace, baseRegistryOptions)
 	if rolloutDir != "" {
 		log.Printf("rollout recording enabled: %s", rolloutDir)
 	}
@@ -872,7 +882,6 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		addr:                 addr,
 		workspace:            workspace,
 		provider:             provider,
-		tools:                tools,
 		runnerCfg:            runnerCfg,
 		checkpointService:    checkpointService,
 		workflowDefinitions:  workflowDefinitions,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go-agent-harness/internal/checkpoints"
@@ -59,7 +60,6 @@ type httpRuntimeOptions struct {
 	addr                 string
 	workspace            string
 	provider             harness.Provider
-	tools                *harness.Registry
 	runnerCfg            harness.RunnerConfig
 	checkpointService    *checkpoints.Service
 	workflowDefinitions  []workflows.Definition
@@ -92,30 +92,89 @@ type httpRuntimeOptions struct {
 
 type httpRuntime struct {
 	runner          *harness.Runner
+	tools           *harness.Registry
 	subagentManager subagents.Manager
 	mcpServer       *mcpserver.Server
 	handler         http.Handler
 	httpServer      *http.Server
 }
 
-func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
-	runner := harness.NewRunner(opts.provider, opts.tools, opts.runnerCfg)
+// subagentRunnerHandoff implements subagents.RunEngine AND
+// htools.ConstrainedAgentRunner by forwarding to a *harness.Runner that is not
+// available yet at construction time. It exists to break an initialization
+// cycle in buildHTTPRuntime: the SubagentManager (and the plain "agent" tool)
+// must be resolvable before the tool registry is built, so that
+// internal/harness/tools_default.go's `if opts.SubagentManager != nil` and
+// `if opts.AgentRunner != nil` gates register the subagent-lifecycle tools
+// (start_subagent, get_subagent, wait_subagent, cancel_subagent, run_agent)
+// and the agent/spawn_agent tools onto the registry the top-level runner
+// uses — but both need a *harness.Runner, which in turn needs that same
+// registry. setRunner is called once, before buildHTTPRuntime returns and the
+// server starts accepting requests; the atomic pointer makes that handoff
+// race-safe under `go test -race`.
+type subagentRunnerHandoff struct {
+	runner atomic.Pointer[harness.Runner]
+}
 
-	workflowEngine := workflows.NewEngine(workflows.Options{
-		Definitions: opts.workflowDefinitions,
-		Runner:      runner,
-		Tools:       opts.tools,
-		Checkpoints: opts.checkpointService,
-		Store:       opts.workflowStore,
-		Now:         time.Now,
-	})
-	networkEngine := networks.NewEngine(networks.Options{
-		Definitions: opts.networkDefinitions,
-		Workflows:   workflowEngine,
-	})
+func (h *subagentRunnerHandoff) setRunner(r *harness.Runner) { h.runner.Store(r) }
+
+func (h *subagentRunnerHandoff) StartRun(req harness.RunRequest) (harness.Run, error) {
+	return h.runner.Load().StartRun(req)
+}
+
+func (h *subagentRunnerHandoff) GetRun(runID string) (harness.Run, bool) {
+	return h.runner.Load().GetRun(runID)
+}
+
+func (h *subagentRunnerHandoff) Subscribe(runID string) ([]harness.Event, <-chan harness.Event, func(), error) {
+	return h.runner.Load().Subscribe(runID)
+}
+
+func (h *subagentRunnerHandoff) CancelRun(runID string) error {
+	return h.runner.Load().CancelRun(runID)
+}
+
+func (h *subagentRunnerHandoff) RunPrompt(ctx context.Context, prompt string) (string, error) {
+	return h.runner.Load().RunPrompt(ctx, prompt)
+}
+
+func (h *subagentRunnerHandoff) RunPromptWithAllowedTools(ctx context.Context, prompt string, allowedTools []string) (string, error) {
+	return h.runner.Load().RunPromptWithAllowedTools(ctx, prompt, allowedTools)
+}
+
+// SteerRun implements htools.RunSteerer, backing message_subagent and
+// notify_parent (in each direction — the target run ID differs, the
+// mechanism is identical: *harness.Runner.SteerRun).
+func (h *subagentRunnerHandoff) SteerRun(runID, message string) error {
+	return h.runner.Load().SteerRun(runID, message)
+}
+
+// ParentRunID implements the other half of htools.RunSteerer, backing
+// notify_parent: it looks up runID's own Run record and reads the parent run
+// ID that BuildParentContextHandoffFromContext recorded on it at spawn time.
+func (h *subagentRunnerHandoff) ParentRunID(runID string) (string, bool) {
+	run, ok := h.runner.Load().GetRun(runID)
+	if !ok || run.ParentContextHandoff == nil {
+		return "", false
+	}
+	parentID := strings.TrimSpace(run.ParentContextHandoff.ParentRunID)
+	return parentID, parentID != ""
+}
+
+func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
+	handoff := &subagentRunnerHandoff{}
+
+	// registryOpts carries the subagent manager so the TOP-LEVEL registry
+	// (built below) registers start_subagent/get_subagent/wait_subagent/
+	// cancel_subagent/run_agent. The WorktreeRunnerFactory closure below
+	// deliberately keeps using the original opts.baseRegistryOptions (manager
+	// unset) so a worktree-isolated subagent cannot itself spawn subagents —
+	// only this top-level (and same-registry inline-subagent) path gains the
+	// tools this fix adds.
+	registryOpts := opts.baseRegistryOptions
 
 	subagentMgr, err := subagents.NewManager(subagents.Options{
-		InlineRunner:  runner,
+		InlineRunner:  handoff,
 		SkillResolver: opts.skillLister,
 		WorktreeRunnerFactory: func(workspaceRoot string) (subagents.RunEngine, error) {
 			childTools := harness.NewDefaultRegistryWithOptions(workspaceRoot, opts.baseRegistryOptions)
@@ -129,6 +188,38 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 	if err != nil {
 		return httpRuntime{}, fmt.Errorf("create subagent manager: %w", err)
 	}
+	// tools_default.go's deferred subagent tools (start_subagent, etc.) want
+	// the tools.SubagentManager shape (CreateAndWait/Start/Get/Wait/Cancel),
+	// not the subagents.Manager shape (Create/Get/List/Delete/Cancel) used by
+	// the HTTP /v1/subagents/* routes below. subagents.NewInlineManager
+	// already exists to bridge exactly this gap; it was simply never wired
+	// in anywhere.
+	registryOpts.SubagentManager = subagents.NewInlineManager(subagentMgr)
+	// Same circular-dependency fix, for the plain "agent"/"spawn_agent" tools:
+	// *harness.Runner already implements htools.ConstrainedAgentRunner, but it
+	// doesn't exist until after the registry does. handoff forwards to it once
+	// setRunner is called below.
+	registryOpts.AgentRunner = handoff
+	// Same handoff object also backs message_subagent/notify_parent — it
+	// already forwards to the runner once setRunner is called below.
+	registryOpts.RunSteerer = handoff
+
+	tools := harness.NewDefaultRegistryWithOptions(opts.workspace, registryOpts)
+	runner := harness.NewRunner(opts.provider, tools, opts.runnerCfg)
+	handoff.setRunner(runner)
+
+	workflowEngine := workflows.NewEngine(workflows.Options{
+		Definitions: opts.workflowDefinitions,
+		Runner:      runner,
+		Tools:       tools,
+		Checkpoints: opts.checkpointService,
+		Store:       opts.workflowStore,
+		Now:         time.Now,
+	})
+	networkEngine := networks.NewEngine(networks.Options{
+		Definitions: opts.networkDefinitions,
+		Workflows:   workflowEngine,
+	})
 
 	scriptEngine := scriptworkflow.NewEngine(scriptworkflow.EngineOptions{
 		Subagents: scriptSubagentAdapter{manager: subagentMgr},
@@ -184,7 +275,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		runStore:         opts.runStore,
 		relayWorkerStore: opts.relayWorkerStore,
 		relayControl:     opts.relayControl,
-		tools:            opts.tools,
+		tools:            tools,
 		todos:            opts.todos,
 		triggers:         opts.triggers,
 		rolloutDir:       opts.runnerCfg.RolloutDir,
@@ -208,6 +299,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 
 	return httpRuntime{
 		runner:          runner,
+		tools:           tools,
 		subagentManager: subagentMgr,
 		mcpServer:       mcpSrv,
 		handler:         topMux,

--- a/cmd/harnessd/runtime_container_test.go
+++ b/cmd/harnessd/runtime_container_test.go
@@ -48,7 +48,6 @@ func TestBuildHTTPRuntimeAssemblesRunnerSubagentsAndHTTPServer(t *testing.T) {
 		AskUserTimeout:    time.Minute,
 		MessageSummarizer: msgSummarizer,
 	}
-	tools := harness.NewDefaultRegistryWithOptions(workspace, baseRegistryOptions)
 	relayStore, err := relay.NewSQLiteWorkerStore(filepath.Join(t.TempDir(), "relay.db"))
 	if err != nil {
 		t.Fatalf("NewSQLiteWorkerStore: %v", err)
@@ -62,7 +61,6 @@ func TestBuildHTTPRuntimeAssemblesRunnerSubagentsAndHTTPServer(t *testing.T) {
 		addr:                "127.0.0.1:0",
 		workspace:           workspace,
 		provider:            &noopProvider{},
-		tools:               tools,
 		runnerCfg:           harness.RunnerConfig{DefaultModel: "gpt-4.1-mini"},
 		skillLister:         nil,
 		baseRegistryOptions: baseRegistryOptions,
@@ -86,6 +84,34 @@ func TestBuildHTTPRuntimeAssemblesRunnerSubagentsAndHTTPServer(t *testing.T) {
 	}
 	if runtime.subagentManager == nil {
 		t.Fatal("expected subagent manager")
+	}
+	if runtime.tools == nil {
+		t.Fatal("expected tool registry")
+	}
+	// Regression: the top-level registry must expose the subagent-lifecycle
+	// tools once a SubagentManager exists, so the main conversation can call
+	// start_subagent. Before this fix, opts.SubagentManager was never set on
+	// the registry options used to build the top-level registry (it was only
+	// known after the registry — and the runner built from it — already
+	// existed), so start_subagent was silently absent from every run.
+	wantSubagentTools := map[string]bool{
+		"start_subagent":   false,
+		"get_subagent":     false,
+		"wait_subagent":    false,
+		"cancel_subagent":  false,
+		"run_agent":        false,
+		"message_subagent": false,
+		"notify_parent":    false,
+	}
+	for _, def := range runtime.tools.DeferredDefinitions() {
+		if _, ok := wantSubagentTools[def.Name]; ok {
+			wantSubagentTools[def.Name] = true
+		}
+	}
+	for name, found := range wantSubagentTools {
+		if !found {
+			t.Errorf("expected tool %q to be registered on the top-level registry", name)
+		}
 	}
 	if runtime.handler == nil {
 		t.Fatal("expected http handler")

--- a/internal/harness/notify_parent_activation_test.go
+++ b/internal/harness/notify_parent_activation_test.go
@@ -1,0 +1,115 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// registerStubNotifyParentTool registers a minimal stand-in for the real
+// deferred.NotifyParentTool (name + Tier only matter for these tests — the
+// real tool lives in internal/harness/tools/deferred and can't be imported
+// here without an import cycle).
+func registerStubNotifyParentTool(t *testing.T, registry *Registry) {
+	t.Helper()
+	err := registry.RegisterWithOptions(
+		ToolDefinition{Name: "notify_parent", Description: "test stand-in"},
+		func(ctx context.Context, args json.RawMessage) (string, error) { return "{}", nil },
+		RegisterOptions{Tier: htools.TierDeferred},
+	)
+	if err != nil {
+		t.Fatalf("register stub notify_parent: %v", err)
+	}
+}
+
+// TestStartRun_AutoActivatesNotifyParentForSubagentRuns verifies that a run
+// started with a ParentContextHandoff (i.e. it is itself a subagent) has
+// notify_parent visible immediately — without the model needing to call
+// find_tool first. notify_parent is a key subagent-to-parent communication
+// primitive; requiring lazy discovery for it meant models frequently never
+// found it and hallucinated alternatives instead (observed in live testing).
+func TestStartRun_AutoActivatesNotifyParentForSubagentRuns(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	registerStubNotifyParentTool(t, registry)
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "child done"}}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "gpt-4.1-mini", MaxSteps: 1})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt: "child task",
+		ParentContextHandoff: &htools.ParentContextHandoff{
+			ParentRunID: "run_parent_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	defs := runner.filteredToolsForRun(run.ID)
+	if !hasToolNamed(defs, "notify_parent") {
+		t.Fatal("expected notify_parent to be auto-activated for a run with a recorded parent")
+	}
+}
+
+// TestStartRun_DoesNotAutoActivateNotifyParentForTopLevelRuns verifies a
+// top-level run (no ParentContextHandoff) does NOT get notify_parent
+// pre-activated — it has no parent to notify, so it should still require
+// find_tool like any other deferred tool (and will typically never need it).
+func TestStartRun_DoesNotAutoActivateNotifyParentForTopLevelRuns(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	registerStubNotifyParentTool(t, registry)
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "gpt-4.1-mini", MaxSteps: 1})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "top level task"})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	defs := runner.filteredToolsForRun(run.ID)
+	if hasToolNamed(defs, "notify_parent") {
+		t.Fatal("did not expect notify_parent to be auto-activated for a top-level run with no parent")
+	}
+}
+
+// TestStartRun_DoesNotAutoActivateNotifyParentWhenParentRunIDEmpty verifies a
+// ParentContextHandoff with every field blank (e.g. transcript-only handoff,
+// no real parent run) does not trigger activation either.
+func TestStartRun_DoesNotAutoActivateNotifyParentWhenParentRunIDEmpty(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	registerStubNotifyParentTool(t, registry)
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "done"}}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "gpt-4.1-mini", MaxSteps: 1})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:               "task",
+		ParentContextHandoff: &htools.ParentContextHandoff{}, // no ParentRunID
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	defs := runner.filteredToolsForRun(run.ID)
+	if hasToolNamed(defs, "notify_parent") {
+		t.Fatal("did not expect notify_parent to be auto-activated when ParentRunID is empty")
+	}
+}
+
+func hasToolNamed(defs []ToolDefinition, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -767,6 +767,21 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		}
 	}
 
+	// Subagents (runs with a recorded parent) default to the "subagent" agent
+	// intent — a headless-worker framing (no human present, execute the
+	// parent's instructions literally, call tools directly rather than
+	// improvising an alternative) — unless the caller already chose an
+	// explicit AgentIntent, or a full SystemPrompt override applies instead
+	// (e.g. a profile's own system_prompt, which always wins in
+	// resolveSystemPrompt regardless of AgentIntent). This targets the
+	// failure mode observed in live testing: subagents on the unrestricted
+	// "full" profile (empty SystemPrompt) inventing fake HTTP calls or
+	// writing source files instead of calling an available tool directly.
+	if req.ParentContextHandoff != nil && strings.TrimSpace(req.ParentContextHandoff.ParentRunID) != "" &&
+		strings.TrimSpace(req.AgentIntent) == "" && strings.TrimSpace(req.SystemPrompt) == "" {
+		req.AgentIntent = "subagent"
+	}
+
 	model := req.Model
 	if model == "" {
 		model = r.config.DefaultModel
@@ -805,6 +820,17 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 	run.ConversationID = strings.TrimSpace(req.ConversationID)
 	if run.ConversationID == "" {
 		run.ConversationID = run.ID
+	}
+
+	// notify_parent is a key subagent-to-parent communication primitive, not
+	// a rarely-used capability — requiring find_tool discovery for it meant
+	// models often never found it and hallucinated alternatives instead
+	// (observed in live testing). Any run with a recorded parent (i.e. it was
+	// spawned as a subagent, per ParentContextHandoff) gets it pre-activated
+	// so it's visible from turn one, without becoming visible to top-level
+	// runs that have no parent to notify.
+	if req.ParentContextHandoff != nil && strings.TrimSpace(req.ParentContextHandoff.ParentRunID) != "" {
+		r.activations.Activate(run.ID, "notify_parent")
 	}
 
 	// Validate caller-supplied ConversationID against tenant/agent ownership.

--- a/internal/harness/subagent_prompt_intent_test.go
+++ b/internal/harness/subagent_prompt_intent_test.go
@@ -1,0 +1,125 @@
+package harness
+
+import (
+	"testing"
+
+	htools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/systemprompt"
+)
+
+// TestStartRun_DefaultsSubagentIntentForParentedRuns verifies that a run with
+// a recorded parent (ParentContextHandoff.ParentRunID set) is resolved with
+// AgentIntent "subagent" when the caller didn't specify one. This targets the
+// failure mode observed in live testing: subagents on the unrestricted "full"
+// profile (empty SystemPrompt, no AgentIntent) improvised hallucinated
+// alternatives (fake HTTP calls, writing source files) instead of calling an
+// available tool directly.
+func TestStartRun_DefaultsSubagentIntentForParentedRuns(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "child done"}}}
+	engine := &promptEngineStub{resolved: systemprompt.ResolvedPrompt{StaticPrompt: "STATIC"}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+		PromptEngine: engine,
+	})
+
+	_, err := runner.StartRun(RunRequest{
+		Prompt:               "child task",
+		ParentContextHandoff: &htools.ParentContextHandoff{ParentRunID: "run_parent_123"},
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if len(engine.resolveReqs) != 1 {
+		t.Fatalf("expected exactly one Resolve call, got %d", len(engine.resolveReqs))
+	}
+	if got := engine.resolveReqs[0].AgentIntent; got != "subagent" {
+		t.Fatalf("expected AgentIntent %q, got %q", "subagent", got)
+	}
+}
+
+// TestStartRun_DoesNotDefaultSubagentIntentForTopLevelRuns verifies a
+// top-level run (no ParentContextHandoff) is unaffected — it keeps whatever
+// AgentIntent it already had (empty, in this case).
+func TestStartRun_DoesNotDefaultSubagentIntentForTopLevelRuns(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "done"}}}
+	engine := &promptEngineStub{resolved: systemprompt.ResolvedPrompt{StaticPrompt: "STATIC"}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+		PromptEngine: engine,
+	})
+
+	_, err := runner.StartRun(RunRequest{Prompt: "top level task"})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if len(engine.resolveReqs) != 1 {
+		t.Fatalf("expected exactly one Resolve call, got %d", len(engine.resolveReqs))
+	}
+	if got := engine.resolveReqs[0].AgentIntent; got != "" {
+		t.Fatalf("expected empty AgentIntent for a top-level run, got %q", got)
+	}
+}
+
+// TestStartRun_DoesNotOverrideExplicitAgentIntentForSubagents verifies that a
+// caller-supplied AgentIntent on a parented run is respected, not overwritten.
+func TestStartRun_DoesNotOverrideExplicitAgentIntentForSubagents(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "child done"}}}
+	engine := &promptEngineStub{resolved: systemprompt.ResolvedPrompt{StaticPrompt: "STATIC"}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+		PromptEngine: engine,
+	})
+
+	_, err := runner.StartRun(RunRequest{
+		Prompt:               "child task",
+		AgentIntent:          "code_review",
+		ParentContextHandoff: &htools.ParentContextHandoff{ParentRunID: "run_parent_123"},
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if got := engine.resolveReqs[0].AgentIntent; got != "code_review" {
+		t.Fatalf("expected explicit AgentIntent %q to be preserved, got %q", "code_review", got)
+	}
+}
+
+// TestStartRun_DoesNotSetSubagentIntentWhenSystemPromptOverrideIsSet verifies
+// that a parented run with an explicit SystemPrompt override never even calls
+// the prompt engine (SystemPrompt always wins), so no AgentIntent defaulting
+// is needed or applied.
+func TestStartRun_DoesNotSetSubagentIntentWhenSystemPromptOverrideIsSet(t *testing.T) {
+	t.Parallel()
+
+	provider := &stubProvider{turns: []CompletionResult{{Content: "child done"}}}
+	engine := &promptEngineStub{resolved: systemprompt.ResolvedPrompt{StaticPrompt: "SHOULD_NOT_USE"}}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{
+		DefaultModel: "gpt-4.1-mini",
+		MaxSteps:     1,
+		PromptEngine: engine,
+	})
+
+	_, err := runner.StartRun(RunRequest{
+		Prompt:               "child task",
+		SystemPrompt:         "PROFILE_SYSTEM_PROMPT",
+		ParentContextHandoff: &htools.ParentContextHandoff{ParentRunID: "run_parent_123"},
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	if engine.resolveCalls != 0 {
+		t.Fatalf("expected prompt engine not called when SystemPrompt override is set, got %d calls", engine.resolveCalls)
+	}
+}

--- a/internal/harness/tools/deferred/message_subagent.go
+++ b/internal/harness/tools/deferred/message_subagent.go
@@ -1,0 +1,140 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	tools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/descriptions"
+)
+
+// MessageSubagentTool returns a deferred tool that sends a follow-up message
+// to a running subagent by resolving its subagent ID to a run ID (via
+// manager.Get) and steering that run.
+func MessageSubagentTool(manager tools.SubagentManager, steerer tools.RunSteerer) tools.Tool {
+	def := tools.Definition{
+		Name:         "message_subagent",
+		Description:  descriptions.Load("message_subagent"),
+		Action:       tools.ActionExecute,
+		Mutating:     true,
+		ParallelSafe: false,
+		Tier:         tools.TierDeferred,
+		Tags:         []string{"agent", "subagent", "delegation", "lifecycle"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"id": map[string]any{
+					"type":        "string",
+					"description": "Subagent identifier returned from start_subagent.",
+				},
+				"message": map[string]any{
+					"type":        "string",
+					"description": "The message to send. Injected into the subagent's conversation before its next turn.",
+				},
+			},
+			"required": []string{"id", "message"},
+		},
+	}
+
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args struct {
+			ID      string `json:"id"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("parse message_subagent args: %w", err)
+		}
+		id := strings.TrimSpace(args.ID)
+		if id == "" {
+			return "", fmt.Errorf("message_subagent: id is required")
+		}
+		message := strings.TrimSpace(args.Message)
+		if message == "" {
+			return "", fmt.Errorf("message_subagent: message is required")
+		}
+		if manager == nil {
+			return "", fmt.Errorf("message_subagent: subagent manager is not configured")
+		}
+		if steerer == nil {
+			return "", fmt.Errorf("message_subagent: run steerer is not configured")
+		}
+
+		item, err := manager.Get(ctx, id)
+		if err != nil {
+			return "", fmt.Errorf("message_subagent: failed to look up subagent %q: %w", id, err)
+		}
+		if err := steerer.SteerRun(item.RunID, message); err != nil {
+			return "", fmt.Errorf("message_subagent: failed to send message to subagent %q: %w", id, err)
+		}
+
+		return tools.MarshalToolResult(map[string]any{
+			"id":     id,
+			"run_id": item.RunID,
+			"status": "sent",
+		})
+	}
+
+	return tools.Tool{Definition: def, Handler: handler}
+}
+
+// NotifyParentTool returns a deferred tool that sends a message back to the
+// run that spawned the current run as a subagent, looking up the parent run
+// ID recorded via ParentContextHandoff (see BuildParentContextHandoffFromContext).
+func NotifyParentTool(steerer tools.RunSteerer) tools.Tool {
+	def := tools.Definition{
+		Name:         "notify_parent",
+		Description:  descriptions.Load("notify_parent"),
+		Action:       tools.ActionExecute,
+		Mutating:     true,
+		ParallelSafe: false,
+		Tier:         tools.TierDeferred,
+		Tags:         []string{"agent", "subagent", "delegation", "lifecycle"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"message": map[string]any{
+					"type":        "string",
+					"description": "The message to send back to the parent agent that spawned this run.",
+				},
+			},
+			"required": []string{"message"},
+		},
+	}
+
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("parse notify_parent args: %w", err)
+		}
+		message := strings.TrimSpace(args.Message)
+		if message == "" {
+			return "", fmt.Errorf("notify_parent: message is required")
+		}
+		if steerer == nil {
+			return "", fmt.Errorf("notify_parent: run steerer is not configured")
+		}
+
+		runID := tools.RunIDFromContext(ctx)
+		if runID == "" {
+			return "", fmt.Errorf("notify_parent: no run context available")
+		}
+		parentRunID, ok := steerer.ParentRunID(runID)
+		if !ok || parentRunID == "" {
+			return "", fmt.Errorf("notify_parent: this run has no recorded parent to notify (it was not spawned as a subagent)")
+		}
+		if err := steerer.SteerRun(parentRunID, message); err != nil {
+			return "", fmt.Errorf("notify_parent: failed to send message to parent run %q: %w", parentRunID, err)
+		}
+
+		return tools.MarshalToolResult(map[string]any{
+			"parent_run_id": parentRunID,
+			"status":        "sent",
+		})
+	}
+
+	return tools.Tool{Definition: def, Handler: handler}
+}

--- a/internal/harness/tools/deferred/message_subagent_test.go
+++ b/internal/harness/tools/deferred/message_subagent_test.go
@@ -1,0 +1,135 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go-agent-harness/internal/harness/tools"
+)
+
+// mockRunSteerer is a fake tools.RunSteerer for testing message_subagent and
+// notify_parent without a real *harness.Runner.
+type mockRunSteerer struct {
+	parentByRunID map[string]string // runID -> parentRunID, absent means no parent recorded
+
+	steerErr error
+	steered  []steerCall
+}
+
+type steerCall struct {
+	runID   string
+	message string
+}
+
+func (m *mockRunSteerer) SteerRun(runID, message string) error {
+	m.steered = append(m.steered, steerCall{runID: runID, message: message})
+	return m.steerErr
+}
+
+func (m *mockRunSteerer) ParentRunID(runID string) (string, bool) {
+	id, ok := m.parentByRunID[runID]
+	return id, ok
+}
+
+func TestMessageSubagentTool_SendsMessageToTheSubagentsRun(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{ID: "subagent-1", RunID: "run-child-1", Status: "running"},
+	}
+	steerer := &mockRunSteerer{}
+	tool := MessageSubagentTool(manager, steerer)
+
+	raw, _ := json.Marshal(map[string]any{"id": "subagent-1", "message": "please prioritize the auth bug"})
+	got, err := tool.Handler(context.Background(), raw)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &payload))
+	assert.Equal(t, "subagent-1", payload["id"])
+	assert.Equal(t, "run-child-1", payload["run_id"])
+	assert.Equal(t, "sent", payload["status"])
+
+	require.Len(t, steerer.steered, 1)
+	assert.Equal(t, "run-child-1", steerer.steered[0].runID)
+	assert.Equal(t, "please prioritize the auth bug", steerer.steered[0].message)
+	assert.True(t, manager.getCalled)
+}
+
+func TestMessageSubagentTool_RequiresID(t *testing.T) {
+	tool := MessageSubagentTool(&mockSubagentManager{}, &mockRunSteerer{})
+	raw, _ := json.Marshal(map[string]any{"message": "hi"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err)
+}
+
+func TestMessageSubagentTool_RequiresMessage(t *testing.T) {
+	tool := MessageSubagentTool(&mockSubagentManager{}, &mockRunSteerer{})
+	raw, _ := json.Marshal(map[string]any{"id": "subagent-1"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err)
+}
+
+func TestMessageSubagentTool_PropagatesLookupError(t *testing.T) {
+	manager := &mockSubagentManager{err: assert.AnError}
+	tool := MessageSubagentTool(manager, &mockRunSteerer{})
+	raw, _ := json.Marshal(map[string]any{"id": "subagent-missing", "message": "hi"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err)
+}
+
+func TestMessageSubagentTool_PropagatesSteerError(t *testing.T) {
+	manager := &mockSubagentManager{result: tools.SubagentResult{ID: "subagent-1", RunID: "run-child-1"}}
+	steerer := &mockRunSteerer{steerErr: assert.AnError}
+	tool := MessageSubagentTool(manager, steerer)
+	raw, _ := json.Marshal(map[string]any{"id": "subagent-1", "message": "hi"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err)
+}
+
+func TestNotifyParentTool_SendsMessageToTheRecordedParent(t *testing.T) {
+	steerer := &mockRunSteerer{parentByRunID: map[string]string{"run-child-1": "run-parent-1"}}
+	tool := NotifyParentTool(steerer)
+
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{RunID: "run-child-1"})
+	raw, _ := json.Marshal(map[string]any{"message": "auth subtask done, tests green"})
+	got, err := tool.Handler(ctx, raw)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(got), &payload))
+	assert.Equal(t, "run-parent-1", payload["parent_run_id"])
+	assert.Equal(t, "sent", payload["status"])
+
+	require.Len(t, steerer.steered, 1)
+	assert.Equal(t, "run-parent-1", steerer.steered[0].runID)
+	assert.Equal(t, "auth subtask done, tests green", steerer.steered[0].message)
+}
+
+func TestNotifyParentTool_ErrorsWhenNoParentIsRecorded(t *testing.T) {
+	steerer := &mockRunSteerer{} // no parent recorded for any run
+	tool := NotifyParentTool(steerer)
+
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{RunID: "run-top-level"})
+	raw, _ := json.Marshal(map[string]any{"message": "hi"})
+	_, err := tool.Handler(ctx, raw)
+	require.Error(t, err)
+	assert.Empty(t, steerer.steered)
+}
+
+func TestNotifyParentTool_ErrorsWhenNoRunContext(t *testing.T) {
+	tool := NotifyParentTool(&mockRunSteerer{})
+	raw, _ := json.Marshal(map[string]any{"message": "hi"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.Error(t, err)
+}
+
+func TestNotifyParentTool_RequiresMessage(t *testing.T) {
+	steerer := &mockRunSteerer{parentByRunID: map[string]string{"run-child-1": "run-parent-1"}}
+	tool := NotifyParentTool(steerer)
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{RunID: "run-child-1"})
+	raw, _ := json.Marshal(map[string]any{})
+	_, err := tool.Handler(ctx, raw)
+	require.Error(t, err)
+}

--- a/internal/harness/tools/deferred/run_agent.go
+++ b/internal/harness/tools/deferred/run_agent.go
@@ -40,6 +40,11 @@ func RunAgentTool(manager tools.SubagentManager, profilesDir string) tools.Tool 
 					"type":        "integer",
 					"description": "Optional step override for this call. Overrides the profile's max_steps.",
 				},
+				"allowed_tools": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional list of tool names to restrict the subagent to (e.g. [\"notify_parent\", \"bash\"]). Defaults to the profile's own tool set (the \"full\" profile grants every tool) — set this to give the subagent only what it needs for its task.",
+				},
 			},
 			"required": []string{"task"},
 		},

--- a/internal/harness/tools/deferred/subagent_tool_test.go
+++ b/internal/harness/tools/deferred/subagent_tool_test.go
@@ -10,6 +10,29 @@ import (
 	"go-agent-harness/internal/harness/tools"
 )
 
+// mockActivationTracker is a fake tools.ActivationTrackerInterface for
+// testing that StartSubagentTool co-activates the rest of the
+// subagent-lifecycle tool family once it actually spawns a subagent.
+type mockActivationTracker struct {
+	activated map[string][]string // runID -> tool names activated for it
+}
+
+func (m *mockActivationTracker) Activate(runID string, toolNames ...string) {
+	if m.activated == nil {
+		m.activated = make(map[string][]string)
+	}
+	m.activated[runID] = append(m.activated[runID], toolNames...)
+}
+
+func (m *mockActivationTracker) IsActive(runID string, toolName string) bool {
+	for _, name := range m.activated[runID] {
+		if name == toolName {
+			return true
+		}
+	}
+	return false
+}
+
 func TestStartSubagentTool_CreatesAndReturnsSubagentID(t *testing.T) {
 	manager := &mockSubagentManager{
 		result: tools.SubagentResult{
@@ -18,7 +41,7 @@ func TestStartSubagentTool_CreatesAndReturnsSubagentID(t *testing.T) {
 			Status: "running",
 		},
 	}
-	tool := StartSubagentTool(manager, "")
+	tool := StartSubagentTool(manager, "", nil)
 
 	raw, _ := json.Marshal(map[string]any{
 		"task":      "Handle refactor",
@@ -36,6 +59,70 @@ func TestStartSubagentTool_CreatesAndReturnsSubagentID(t *testing.T) {
 	assert.Equal(t, "run-1", payload["run_id"])
 	assert.Equal(t, 12, manager.lastReq.MaxSteps)
 	assert.True(t, manager.startCalled)
+}
+
+func TestStartSubagentTool_SchemaAdvertisesAllowedTools(t *testing.T) {
+	tool := StartSubagentTool(&mockSubagentManager{}, "", nil)
+	props, ok := tool.Definition.Parameters["properties"].(map[string]any)
+	require.True(t, ok, "expected schema properties map")
+	_, ok = props["allowed_tools"]
+	assert.True(t, ok, "expected start_subagent schema to advertise allowed_tools so parents can restrict a subagent's tools")
+}
+
+func TestStartSubagentTool_ForwardsAllowedToolsToManager(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{ID: "subagent-1", RunID: "run-1", Status: "running"},
+	}
+	tool := StartSubagentTool(manager, "", nil)
+
+	raw, _ := json.Marshal(map[string]any{
+		"task":          "notify the parent only",
+		"allowed_tools": []string{"notify_parent"},
+	})
+	_, err := tool.Handler(context.Background(), raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"notify_parent"}, manager.lastReq.AllowedTools)
+}
+
+// TestStartSubagentTool_CoActivatesTheRestOfTheLifecycleFamily covers a real
+// failure observed in live testing: find_tool activated start_subagent (plus
+// unrelated tools that happened to share tags) but never wait_subagent or
+// get_subagent, so a parent that successfully spawned a subagent had no way
+// to check on it — it just kept calling start_subagent again, spawning
+// duplicate subagents until it ran out of steps, occasionally hallucinating
+// a fake `bash("wait ...")` command as a last resort. The moment
+// start_subagent actually succeeds, the rest of the family it depends on
+// (get_subagent, wait_subagent, cancel_subagent, message_subagent) must be
+// activated too, regardless of what find_tool's keyword ranking surfaced.
+func TestStartSubagentTool_CoActivatesTheRestOfTheLifecycleFamily(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{ID: "subagent-1", RunID: "run-1", Status: "queued"},
+	}
+	tracker := &mockActivationTracker{}
+	tool := StartSubagentTool(manager, "", tracker)
+
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{RunID: "run-parent-1"})
+	raw, _ := json.Marshal(map[string]any{"task": "do something"})
+	_, err := tool.Handler(ctx, raw)
+	require.NoError(t, err)
+
+	for _, name := range []string{"get_subagent", "wait_subagent", "cancel_subagent", "message_subagent"} {
+		assert.True(t, tracker.IsActive("run-parent-1", name), "expected %q to be co-activated for the parent run", name)
+	}
+}
+
+// TestStartSubagentTool_NilTrackerIsSafe verifies a nil tracker (e.g. a
+// registry built without one configured) doesn't panic — co-activation is a
+// best-effort improvement, not a hard dependency of start_subagent working.
+func TestStartSubagentTool_NilTrackerIsSafe(t *testing.T) {
+	manager := &mockSubagentManager{
+		result: tools.SubagentResult{ID: "subagent-1", RunID: "run-1", Status: "queued"},
+	}
+	tool := StartSubagentTool(manager, "", nil)
+
+	raw, _ := json.Marshal(map[string]any{"task": "do something"})
+	_, err := tool.Handler(context.Background(), raw)
+	require.NoError(t, err)
 }
 
 func TestGetSubagentTool_ReturnsSubagentStatus(t *testing.T) {

--- a/internal/harness/tools/deferred/subagent_tools.go
+++ b/internal/harness/tools/deferred/subagent_tools.go
@@ -12,8 +12,12 @@ import (
 )
 
 // StartSubagentTool returns a deferred tool that starts a profile-based subagent
-// and returns immediately with the subagent identifier.
-func StartSubagentTool(manager tools.SubagentManager, profilesDir string) tools.Tool {
+// and returns immediately with the subagent identifier. tracker may be nil;
+// when set, it is used to co-activate the rest of the subagent-lifecycle tool
+// family (get_subagent, wait_subagent, cancel_subagent, message_subagent) for
+// the calling run the moment a subagent is actually spawned — see the handler
+// below for why.
+func StartSubagentTool(manager tools.SubagentManager, profilesDir string, tracker tools.ActivationTrackerInterface) tools.Tool {
 	def := tools.Definition{
 		Name:         "start_subagent",
 		Description:  descriptions.Load("start_subagent"),
@@ -41,6 +45,11 @@ func StartSubagentTool(manager tools.SubagentManager, profilesDir string) tools.
 					"type":        "integer",
 					"description": "Optional step override for this call. Defaults to the profile's max_steps.",
 				},
+				"allowed_tools": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional list of tool names to restrict the subagent to (e.g. [\"notify_parent\", \"bash\"]). Defaults to the profile's own tool set (the \"full\" profile grants every tool) — set this to give the subagent only what it needs for its task.",
+				},
 			},
 			"required": []string{"task"},
 		},
@@ -58,6 +67,18 @@ func StartSubagentTool(manager tools.SubagentManager, profilesDir string) tools.
 		item, err := manager.Start(ctx, req)
 		if err != nil {
 			return "", fmt.Errorf("start_subagent: subagent failed to start: %w", err)
+		}
+
+		// A caller that can spawn a subagent needs the rest of the lifecycle
+		// family immediately, not whatever find_tool's keyword ranking
+		// happened to surface — observed live: a parent that found only
+		// start_subagent (missing wait_subagent/get_subagent) had no way to
+		// check on what it spawned, and just kept spawning duplicates until
+		// it ran out of steps.
+		if tracker != nil {
+			if runID := tools.RunIDFromContext(ctx); runID != "" {
+				tracker.Activate(runID, "get_subagent", "wait_subagent", "cancel_subagent", "message_subagent")
+			}
 		}
 
 		return tools.MarshalToolResult(map[string]any{

--- a/internal/harness/tools/descriptions/embed_test.go
+++ b/internal/harness/tools/descriptions/embed_test.go
@@ -226,6 +226,8 @@ func TestEmbeddedFSAndKnownListAreInSync(t *testing.T) {
 		"lsp_references":          true,
 		"lsp_restart":             true,
 		"manage_skill_packs":      true,
+		"message_subagent":        true,
+		"notify_parent":           true,
 		"observational_memory":    true,
 		"read":                    true,
 		"read_mcp_resource":       true,

--- a/internal/harness/tools/descriptions/message_subagent.md
+++ b/internal/harness/tools/descriptions/message_subagent.md
@@ -1,0 +1,11 @@
+Sends a follow-up message to a running subagent, injecting it into the
+subagent's own conversation before its next turn.
+
+Use this to redirect, correct, or add information for a subagent you already
+started with `start_subagent` — for example, to reprioritize its task, hand it
+new information, or tell it to wrap up early. The subagent must currently be
+running or waiting for input; sending a message to a subagent that has already
+finished returns an error.
+
+This does not wait for a reply. Use `get_subagent` or `wait_subagent` to check
+the subagent's status and output afterward.

--- a/internal/harness/tools/descriptions/notify_parent.md
+++ b/internal/harness/tools/descriptions/notify_parent.md
@@ -1,0 +1,16 @@
+Sends a message back to the agent that spawned this run as a subagent.
+
+Use this to report progress, ask a clarifying question, or hand back an
+intermediate result while you are still working — the parent does not need to
+call `wait_subagent` to hear from you. The message is injected into the
+parent's own conversation before its next turn.
+
+Call this directly whenever it's useful. It is a routine, expected part of
+working as a subagent — do not ask the user or the parent for permission
+before calling it, and do not confirm before sending; sending a status update
+is not a risky or destructive action.
+
+This tool only works when the current run was started as a subagent (for
+example, via `start_subagent`). A top-level run has no parent to notify, and
+calling this tool returns an error in that case. This does not end your own
+run or wait for a reply.

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -471,6 +471,23 @@ type SubagentManager interface {
 	Cancel(ctx context.Context, id string) error
 }
 
+// RunSteerer lets a tool inject a follow-up message into another live run's
+// conversation, or look up the parent run recorded (via ParentContextHandoff)
+// for a given run ID. It is implemented by an object that forwards to the
+// *harness.Runner owning both runs; it lives here (rather than importing
+// harness directly) to avoid the same import cycle SubagentManager avoids.
+type RunSteerer interface {
+	// SteerRun injects message into the conversation of the run identified by
+	// runID. The target run must be running or waiting for user input; the
+	// returned error surfaces the underlying reason otherwise (not found, not
+	// active, or steering buffer full).
+	SteerRun(runID, message string) error
+	// ParentRunID returns the parent run ID recorded for runID (populated
+	// from BuildParentContextHandoffFromContext when the run was spawned as a
+	// subagent), and whether one was recorded at all.
+	ParentRunID(runID string) (string, bool)
+}
+
 // SkillInfo holds read-only skill metadata for the tool layer.
 type SkillInfo struct {
 	Name         string   `json:"name"`

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -20,9 +20,9 @@ import (
 )
 
 type DefaultRegistryOptions struct {
-	ApprovalMode        ToolApprovalMode
-	Policy              ToolPolicy
-	SandboxScope        SandboxScope // controls filesystem/network restrictions
+	ApprovalMode ToolApprovalMode
+	Policy       ToolPolicy
+	SandboxScope SandboxScope // controls filesystem/network restrictions
 	// NetworkAllowlist is the operator-configured, explicit opt-in escape
 	// hatch for the outbound network guard (GAP-3): by default the
 	// fetch/download tools and the WebFetcher-backed tools (web_fetch,
@@ -43,8 +43,8 @@ type DefaultRegistryOptions struct {
 	// agent-supplied-destination surface — is always subject to the same
 	// dial-time SSRF guard as the fetch/download tools, regardless of what
 	// this implementation would otherwise have done for Fetch itself.
-	WebFetcher    htools.WebFetcher
-	AskUserBroker htools.AskUserQuestionBroker
+	WebFetcher          htools.WebFetcher
+	AskUserBroker       htools.AskUserQuestionBroker
 	AskUserTimeout      time.Duration
 	MemoryManager       om.Manager
 	WorkingMemoryStore  workingmemory.Store
@@ -68,6 +68,10 @@ type DefaultRegistryOptions struct {
 	MessageSummarizer   htools.MessageSummarizer   // optional: enables summarize/hybrid modes in compact_history
 	// SubagentManager enables the run_agent tool for profile-based subagent delegation.
 	SubagentManager htools.SubagentManager
+	// RunSteerer enables message_subagent (parent -> running subagent) and
+	// notify_parent (subagent -> spawning agent), both built on the same
+	// steer-a-live-run primitive in each direction.
+	RunSteerer htools.RunSteerer
 	// ProfilesDir is the directory to search for user-global profiles (.toml files).
 	// Defaults to ~/.harness/profiles/ if empty.
 	ProfilesDir string
@@ -380,13 +384,33 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 
 	// subagent lifecycle and run_agent tools: available when a SubagentManager is configured.
 	if opts.SubagentManager != nil {
+		// Pass opts.Activations only when non-nil: a nil *ActivationTracker
+		// wrapped directly into the htools.ActivationTrackerInterface
+		// parameter would produce a non-nil interface around a nil pointer,
+		// defeating StartSubagentTool's own nil check and panicking on use.
+		var activationTracker htools.ActivationTrackerInterface
+		if opts.Activations != nil {
+			activationTracker = opts.Activations
+		}
 		deferredTools = append(deferredTools,
-			deferred.StartSubagentTool(opts.SubagentManager, opts.ProfilesDir),
+			deferred.StartSubagentTool(opts.SubagentManager, opts.ProfilesDir, activationTracker),
 			deferred.GetSubagentTool(opts.SubagentManager),
 			deferred.WaitSubagentTool(opts.SubagentManager),
 			deferred.CancelSubagentTool(opts.SubagentManager),
 		)
 		deferredTools = append(deferredTools, deferred.RunAgentTool(opts.SubagentManager, opts.ProfilesDir))
+		// message_subagent needs both the manager (to resolve a subagent ID to
+		// a run ID) and a RunSteerer (to actually inject the message).
+		if opts.RunSteerer != nil {
+			deferredTools = append(deferredTools, deferred.MessageSubagentTool(opts.SubagentManager, opts.RunSteerer))
+		}
+	}
+
+	// notify_parent: the reverse direction of message_subagent (subagent ->
+	// spawning agent). It only needs a RunSteerer — the parent run ID is read
+	// from ParentContextHandoff on the current run, not looked up by ID.
+	if opts.RunSteerer != nil {
+		deferredTools = append(deferredTools, deferred.NotifyParentTool(opts.RunSteerer))
 	}
 
 	var registry *Registry

--- a/internal/subagents/manager.go
+++ b/internal/subagents/manager.go
@@ -358,7 +358,10 @@ func (m *manager) Delete(ctx context.Context, id string) error {
 		return err
 	}
 	m.mu.Lock()
-	delete(m.subagents, id)
+	// Delete by the resolved canonical ID, not the raw input id — id may be
+	// the RunID (see getManaged's fallback above), which is never a key in
+	// m.subagents and would make this a silent no-op.
+	delete(m.subagents, managed.ID)
 	m.mu.Unlock()
 	return nil
 }
@@ -543,11 +546,25 @@ func (m *manager) cleanupWorkspace(ctx context.Context, managed *managedSubagent
 func (m *manager) getManaged(id string) (*managedSubagent, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	managed, ok := m.subagents[id]
-	if !ok {
-		return nil, ErrNotFound
+	if managed, ok := m.subagents[id]; ok {
+		return managed, nil
 	}
-	return managed, nil
+	// start_subagent's response carries both `subagent_id` and `run_id` side
+	// by side (two similar-looking UUIDs), and models frequently pass the
+	// run_id here instead — observed live as a parent repeatedly re-spawning
+	// a new subagent after a "not found" error, rather than realizing it just
+	// used the wrong id. Fall back to a scan by RunID so every lookup path
+	// (get_subagent, wait_subagent, cancel_subagent, message_subagent)
+	// resolves correctly either way.
+	// ponytail: O(n) fallback scan, only on primary-key miss; upgrade to a
+	// secondary runID->id index if a single process ever tracks enough
+	// concurrent subagents for this to matter.
+	for _, managed := range m.subagents {
+		if managed.RunID == id {
+			return managed, nil
+		}
+	}
+	return nil, ErrNotFound
 }
 
 func (m *manager) snapshot(id string) (Subagent, error) {

--- a/internal/subagents/manager_test.go
+++ b/internal/subagents/manager_test.go
@@ -252,3 +252,87 @@ func TestManagerCancelActiveSubagent(t *testing.T) {
 		t.Fatalf("Status after Cancel = %q, want %q", updated.Status, harness.RunStatusCancelled)
 	}
 }
+
+// TestManagerGetResolvesByRunIDToo covers a real, repeatedly-observed model
+// confusion: start_subagent's response carries both `subagent_id` and
+// `run_id` (two similar-looking UUIDs), and models frequently pass the run_id
+// to get_subagent/wait_subagent/cancel_subagent/message_subagent instead of
+// the subagent_id. Before this fix, that returned ErrNotFound outright — live
+// testing showed a parent repeatedly re-spawning a new subagent instead of
+// realizing it just used the wrong id, looping until it ran out of steps.
+func TestManagerGetResolvesByRunIDToo(t *testing.T) {
+	t.Parallel()
+
+	inlineRunner := newTestRunner(t.TempDir(), "inline done")
+	mgr, err := NewManager(Options{InlineRunner: inlineRunner})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	item, err := mgr.Create(context.Background(), Request{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if item.RunID == "" || item.RunID == item.ID {
+		t.Fatalf("expected a distinct, non-empty RunID, got %q (ID=%q)", item.RunID, item.ID)
+	}
+
+	byRunID, err := mgr.Get(context.Background(), item.RunID)
+	if err != nil {
+		t.Fatalf("Get(RunID): %v", err)
+	}
+	if byRunID.ID != item.ID {
+		t.Fatalf("Get(RunID).ID = %q, want %q", byRunID.ID, item.ID)
+	}
+}
+
+func TestManagerCancelResolvesByRunIDToo(t *testing.T) {
+	t.Parallel()
+
+	engine := &statefulRunEngine{status: harness.RunStatusRunning}
+	mgr, err := NewManager(Options{InlineRunner: engine})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	item, err := mgr.Create(context.Background(), Request{Prompt: "cancel me"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := mgr.Cancel(context.Background(), item.RunID); err != nil {
+		t.Fatalf("Cancel(RunID): %v", err)
+	}
+	if engine.cancelCallCount != 1 {
+		t.Fatalf("CancelRun call count = %d, want 1", engine.cancelCallCount)
+	}
+}
+
+func TestManagerDeleteResolvesByRunIDTooAndFullyRemovesTheEntry(t *testing.T) {
+	t.Parallel()
+
+	inlineRunner := newTestRunner(t.TempDir(), "inline done")
+	mgr, err := NewManager(Options{InlineRunner: inlineRunner})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	item, err := mgr.Create(context.Background(), Request{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	waitForTerminal(t, mgr, item.ID)
+
+	if err := mgr.Delete(context.Background(), item.RunID); err != nil {
+		t.Fatalf("Delete(RunID): %v", err)
+	}
+	// The entry must be gone under BOTH keys — a delete keyed on the raw
+	// input (the run ID) rather than the resolved canonical subagent ID would
+	// silently no-op and leave it reachable by ID.
+	if _, err := mgr.Get(context.Background(), item.ID); err != ErrNotFound {
+		t.Fatalf("Get(ID) after Delete(RunID) error = %v, want ErrNotFound", err)
+	}
+	if _, err := mgr.Get(context.Background(), item.RunID); err != ErrNotFound {
+		t.Fatalf("Get(RunID) after Delete(RunID) error = %v, want ErrNotFound", err)
+	}
+}

--- a/prompts/base/main.md
+++ b/prompts/base/main.md
@@ -2,13 +2,14 @@ You are an expert coding assistant operating inside go-code, a coding agent harn
 
 Core tools: read, write, edit, apply_patch, bash (with job_output / job_kill for long-running jobs), ls, glob, grep, git_status, git_diff, fetch, download.
 
-Many more specialized tools are available on demand — use the find_tool tool to search for and activate them (LSP diagnostics, code search, MCP resources, skills, subagents, deployment, deep git history, and more) before falling back to bash. Do not assume a capability is missing; search for a tool first.
+Many more specialized tools are available on demand — use the find_tool tool to search for and activate them (LSP diagnostics, code search, MCP resources, skills, subagents, deployment, deep git history, and more) before falling back to bash. Do not assume a capability is missing; search for a tool first. Never invent an alternative — a fake HTTP call to an endpoint nobody gave you, a hand-written script that reimplements what a tool already does, a source file written just to simulate an action — when a real tool already exists for the job. If a task names an action you don't immediately recognize, search for the tool by name before assuming you have to build it yourself.
 
 Guidelines:
 - Prefer the dedicated tools over shell equivalents: use read to view files (not cat or sed), grep/glob to search, and edit or apply_patch for precise changes.
 - Make the smallest change that satisfies the request. On edits, match the exact existing text and keep the replaced region minimal and non-overlapping.
 - Work in the current repository. Use paths relative to the working directory, or absolute paths the user provides. Save downloads and generated files inside the workspace with descriptive names.
 - Be concise, and show file paths clearly when referring to files.
+- Before repeating a tool call, read its actual result first. If it already succeeded, do not call it again "to be safe" — for example, a second start_subagent call for a task you already delegated creates a duplicate, unwanted piece of work, not a retry. Delegating with start_subagent returns an id immediately; check on that same id with get_subagent or block on it with wait_subagent, rather than starting another one while you wait.
 
 How to approach a coding task:
 1. Reproduce first. Before changing anything, run the build and the tests to see the actual failure, and read the full error output — do not guess from the description alone.

--- a/prompts/catalog.yaml
+++ b/prompts/catalog.yaml
@@ -12,6 +12,10 @@ intents:
   general: intents/autonomous.md
   code_review: intents/code_review.md
   frontend_design: intents/frontend_design.md
+  # Default overlay for subagent runs (see Runner.StartRun) — headless,
+  # no-human-present framing distinct from "autonomous", which is
+  # benchmark/Docker-container-specific.
+  subagent: intents/subagent.md
 model_profiles:
   - name: deepseek
     match: deepseek-*

--- a/prompts/intents/subagent.md
+++ b/prompts/intents/subagent.md
@@ -1,0 +1,26 @@
+Headless subagent mode — you are a subagent, spawned by a parent agent to
+carry out one specific task. There is no human present in this conversation.
+
+- NEVER ask for confirmation or permission before acting (do not use
+  AskUserQuestion to ask "should I do X?" or "may I proceed?"). Reporting
+  progress is fine — asking permission for a routine, requested action is not.
+  Make the reasonable call yourself and proceed.
+- Your task came from the parent agent, not a human. Treat it as a literal,
+  specific instruction to execute with the tools you already have — not a
+  starting point for open-ended exploration or a different approach.
+- If your task says to call a specific tool, call that tool directly, by
+  name, with the arguments described. Do not write source files, shell
+  scripts, or ad-hoc HTTP requests to reimplement what a tool already does.
+  Before inventing a new way to do something, check whether a tool already
+  named for it exists (use `find_tool` if you are not sure it is already
+  visible to you) — never invent an HTTP endpoint, API, or internal service
+  that was not given to you.
+- You can send progress updates or ask the parent a question mid-task with
+  `notify_parent`, if that tool is available to you — you do not need to
+  wait until you are completely finished to communicate.
+- When you are done, state your result as your final plain-text message.
+  There is no further back-and-forth: the parent reads that message as your
+  output (via `get_subagent`/`wait_subagent`), not a reply you send it.
+- Stay inside the scope of the task you were given. Do not start unrelated
+  work, and do not ask the parent for clarification unless the task is
+  genuinely ambiguous in a way that would make any action you take wrong.


### PR DESCRIPTION
## Summary
- Wire `SubagentManager`/`AgentRunner`/`SkillVerifier` into the top-level tool registry — all three existed but were never actually reachable from the main conversation due to a circular-dependency ordering bug and a missed interface assertion.
- Add `message_subagent` (parent → running subagent) and `notify_parent` (subagent → spawning agent), both built on the existing `SteerRun` primitive. `start_subagent` now co-activates the rest of the subagent lifecycle family the moment it spawns something, rather than relying on `find_tool`'s keyword ranking.
- Fix the subagent manager only resolving lookups by `subagent_id` — models reliably confuse it with the look-alike `run_id` returned in the same response, and the mismatch failed outright instead of resolving. This was the root cause of a parent repeatedly re-spawning duplicate subagents instead of checking on the one it already had.
- Add a `subagent` prompt intent (headless framing) and strengthen the universal base prompt with the same anti-hallucination/anti-retry-loop principles for every run.
- Audited all 66 tool definitions for the same hidden-parameter bug class as the `allowed_tools` gap — no other instances found.
- Added a Cerebras provider entry to the model catalog.

## Test plan
- [x] `go build ./cmd/... ./internal/...`
- [x] `go test ./cmd/harnessd/... ./internal/subagents/... ./internal/harness/... ./internal/systemprompt/... -race -count=1` — all green
- [x] Live-verified against real daemons with real models (OpenAI, Cerebras): `message_subagent`, `notify_parent`, concurrent subagent fleets, and the duplicate-spawn fix (3/3 clean runs, exactly 1 subagent each, post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)