### PR TITLE
fix(harness): long-session reliability hardening, 15 TDD slices — epic #644

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,13 @@
 # Engineering Log
 
+## 2026-07-19 (Reliability Epic #644 Reconciliation)
+
+- Reconciled the 2026-06-24 15-slice long-session reliability plan against the supplied `origin/main` baseline. The code and deterministic regressions for T03–T15, plus the original T01/T02 behavior, were already present on the baseline (principally from prior harness/TUI integration work), so they were not duplicated or falsely represented as new failing-first commits.
+- Closed the two remaining plan-level correctness gaps with failing-first regressions:
+  - T01: completed run states are retained until their terminal event has actually persisted, preventing a transient store failure from silently dropping the only in-memory terminal history.
+  - T02: every event-store append now receives a five-second bounded context, preventing a wedged store from occupying a run goroutine indefinitely while preserving the existing lock-free terminal fanout path.
+- Validation: focused T01/T02 tests passed under `-race`; full `go test ./... -race`, `go vet ./...`, and `./scripts/test-regression.sh` passed (`coveragegate: PASS`, 84.4% total, zero zero-coverage functions).
+
 ## 2026-06-28 (Config-Driven Lifecycle Hooks — Epic #737)
 
 - Implemented epic #737 and all six child issues (#741, #744, #750, #755, #759, #763) in worktree branch `codex/config-hooks-epic-737`, one commit per slice, strict TDD throughout.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -91,7 +91,8 @@ type runState struct {
 	// run.failed) has been emitted. Any subsequent emit() call returns
 	// immediately to prevent post-terminal streaming callbacks from appending
 	// events after the forensic record is closed.
-	terminated bool
+	terminated             bool
+	terminalEventPersisted bool
 	// compactMu serializes auto-compact and manual CompactRun calls.
 	compactMu sync.RWMutex
 	// resetIndex increments each time the agent calls reset_context.
@@ -423,7 +424,7 @@ func (r *Runner) pruneCompletedRunsLocked() {
 	terminalCount := 0
 	candidates := make([]retainedRunCandidate, 0)
 	for runID, state := range r.runs {
-		if state == nil || !isTerminalRunStatus(state.run.Status) {
+		if state == nil || !isTerminalRunStatus(state.run.Status) || !state.terminalEventPersisted {
 			continue
 		}
 		terminalCount++
@@ -4994,6 +4995,14 @@ func (r *Runner) storeAppendEvent(ev Event, seq uint64) bool {
 		return false
 	}
 	return true
+}
+
+func (r *Runner) markTerminalEventPersisted(runID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if state := r.runs[runID]; state != nil {
+		state.terminalEventPersisted = true
+	}
 }
 
 // storeAppendNewMessages appends any messages in the current run state that

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -218,6 +218,8 @@ const recorderDrainTimeout = 30 * time.Second
 // the model returns 0 completion_tokens with empty content.
 const maxEmptyRetries = 3
 
+const terminalEventStoreTimeout = 5 * time.Second
+
 const (
 	defaultMaxCompletedRetention    = 32
 	defaultMaxConversationRetention = 256
@@ -4966,9 +4968,9 @@ func shouldPersistWorkflowRecap(status RunStatus) bool {
 // storeAppendEvent persists a single event to the store.
 // Called from emit() after the event is appended to state.events.
 // Executed outside the lock to avoid increasing lock hold time.
-func (r *Runner) storeAppendEvent(ev Event, seq uint64) {
+func (r *Runner) storeAppendEvent(ev Event, seq uint64) bool {
 	if r.config.Store == nil {
-		return
+		return true
 	}
 	payloadJSON, err := json.Marshal(ev.Payload)
 	if err != nil {
@@ -4982,12 +4984,16 @@ func (r *Runner) storeAppendEvent(ev Event, seq uint64) {
 		Payload:   string(payloadJSON),
 		Timestamp: ev.Timestamp,
 	}
-	if err := r.config.Store.AppendEvent(context.Background(), se); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), terminalEventStoreTimeout)
+	defer cancel()
+	if err := r.config.Store.AppendEvent(ctx, se); err != nil {
 		if r.config.Logger != nil {
 			r.config.Logger.Error("store: AppendEvent failed",
 				"run_id", ev.RunID, "event_type", string(ev.Type), "seq", seq, "error", err)
 		}
+		return false
 	}
+	return true
 }
 
 // storeAppendNewMessages appends any messages in the current run state that

--- a/internal/harness/runner_event_journal.go
+++ b/internal/harness/runner_event_journal.go
@@ -168,7 +168,9 @@ func (j *eventJournal) prepareLocked(state *runState, runID string, eventType Ev
 }
 
 func (j *eventJournal) publishTerminal(delivery eventDispatch) {
-	j.runner.storeAppendEvent(delivery.event, delivery.eventSeq)
+	if j.runner.storeAppendEvent(delivery.event, delivery.eventSeq) {
+		j.runner.markTerminalEventPersisted(delivery.runID)
+	}
 
 	for _, sub := range delivery.subscribers {
 		j.runner.sendTerminalSubscriberEvent(sub.ch, sub.event)

--- a/internal/harness/runner_prune_test.go
+++ b/internal/harness/runner_prune_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -35,6 +36,38 @@ func TestRunner_PruneCompletedRunsFromMemory(t *testing.T) {
 		defer runner.mu.RUnlock()
 		return len(runner.runs) <= 3
 	})
+}
+
+func TestRunner_PruneWaitsForTerminalEventPersistence(t *testing.T) {
+	runner := NewRunner(staticContentProvider{content: "done"}, NewRegistry(), RunnerConfig{
+		DefaultModel:          "test-model",
+		MaxSteps:              1,
+		MaxCompletedRetention: 1,
+		Store:                 &terminalAppendFailStore{Store: runstore.NewMemoryStore()},
+	})
+
+	for i := 0; i < 3; i++ {
+		run, err := runner.StartRun(RunRequest{Prompt: fmt.Sprintf("unpersisted %d", i)})
+		if err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
+		waitForStatus(t, runner, run.ID, RunStatusCompleted)
+	}
+
+	runner.mu.RLock()
+	defer runner.mu.RUnlock()
+	if got := len(runner.runs); got != 3 {
+		t.Fatalf("pruned terminal runs before terminal events persisted: got %d, want 3", got)
+	}
+}
+
+type terminalAppendFailStore struct{ runstore.Store }
+
+func (s *terminalAppendFailStore) AppendEvent(_ context.Context, event *runstore.Event) error {
+	if event.EventType == string(EventRunCompleted) {
+		return errors.New("terminal event store unavailable")
+	}
+	return s.Store.AppendEvent(context.Background(), event)
 }
 
 func TestRunner_PruneKeepsCompletedRunWithActiveSubscriber(t *testing.T) {

--- a/internal/harness/runner_terminal_store_test.go
+++ b/internal/harness/runner_terminal_store_test.go
@@ -74,6 +74,27 @@ func TestTerminalStoreAppendDoesNotBlockRunnerQueries(t *testing.T) {
 	waitForStatus(t, runner, holdRun.ID, RunStatusCompleted)
 }
 
+func TestTerminalStoreAppendUsesBoundedContext(t *testing.T) {
+	provider := staticContentProvider{content: "done"}
+	store := &deadlineRecordingStore{Store: runstore.NewMemoryStore(), deadline: make(chan time.Duration, 1)}
+	runner := NewRunner(provider, NewRegistry(), RunnerConfig{Store: store})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "bounded terminal append"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted)
+
+	select {
+	case remaining := <-store.deadline:
+		if remaining <= 0 || remaining > 6*time.Second {
+			t.Fatalf("terminal append deadline remaining = %s, want bounded deadline near 5s", remaining)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("terminal AppendEvent did not receive a deadline")
+	}
+}
+
 type promptGateProvider struct {
 	gates map[string]<-chan struct{}
 }
@@ -107,6 +128,23 @@ type blockingTerminalAppendStore struct {
 	once       sync.Once
 	started    chan struct{}
 	release    chan struct{}
+}
+
+type deadlineRecordingStore struct {
+	runstore.Store
+	deadline chan time.Duration
+}
+
+func (s *deadlineRecordingStore) AppendEvent(ctx context.Context, event *runstore.Event) error {
+	if event.EventType == string(EventRunCompleted) {
+		if deadline, ok := ctx.Deadline(); ok {
+			select {
+			case s.deadline <- time.Until(deadline):
+			default:
+			}
+		}
+	}
+	return s.Store.AppendEvent(ctx, event)
 }
 
 func (s *blockingTerminalAppendStore) setBlockRunID(runID string) {


### PR DESCRIPTION
## Summary

Reconciles the 2026-06-24 reliability epic against the supplied current `main` baseline. T03–T15 and the original T01/T02 implementations plus their deterministic regressions were already present on `origin/main`, so this PR deliberately does not duplicate or misrepresent them as new fixes.

This PR closes the two remaining plan-level gaps with failing-first regression tests:

- T01: do not prune terminal run state until its terminal event has successfully persisted.
- T02: bound event-store appends with a five-second context while keeping terminal persistence/fanout outside `Runner.mu`.

## Validation

- `go test ./internal/harness -run "TestTerminalStoreAppend(DoesNotBlockRunnerQueries|UsesBoundedContext)|TestRunner_Prune(CompletedRunsFromMemory|WaitsForTerminalEventPersistence)" -race -count=1`
- `go test ./... -race`
- `go vet ./...`
- `./scripts/test-regression.sh` — PASS (`coveragegate: PASS`, 84.4%, zero zero-coverage functions)

## Notes

`gofmt -l .` reports only pre-existing formatting drift outside this branch.

Closes #644
Closes #649
Closes #646
Closes #651
Closes #647
Closes #645
Closes #650
Closes #648
Closes #657
Closes #659
Closes #655
Closes #658
Closes #653
Closes #652
Closes #654
Closes #656