### PR TITLE
feat(dashboard): Multi-run TUI dashboard — epic #738

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,11 @@ Config-driven lifecycle hooks (shell/HTTP, epic #737) are listed via:
   Read-only; trust is managed offline with `harnesscli hooks trust|revoke|list`.
   See `docs/design/plugins.md` → "Config-driven hooks" for the hook-file schema and wire protocol.
 
+### TUI Dashboard
+
+`/dashboard` (or `Ctrl+D`) is a TUI-only multi-run overlay. It uses the existing
+`/v1/runs`, run-control, and SSE event routes; do not add dashboard server routes.
+
 Wiring: `ServerOptions.ScriptWorkflows` accepts a `scriptWorkflowManager` interface.
 15 POC tests in `internal/server/http_script_workflows_test.go` and `*_advanced_test.go`
 cover CRUD, SSE streaming, resume, adversarial verify, loop-until-dry, concurrent fan-out,

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -256,6 +256,12 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeResumeCommand,
 		},
 		{
+			Name:        "dashboard",
+			Description: "View and control all runs",
+			Handler:     func(cmd Command) CommandResult { return CommandResult{Status: CmdOK} },
+			Execute:     executeDashboardCommand,
+		},
+		{
 			Name:        "doctor",
 			Description: "Show local harness diagnostic commands",
 			Handler: func(cmd Command) CommandResult {

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"attach", "cancel", "clear", "config", "context", "cost", "doctor", "export", "help", "history", "hooks", "keys",
+		"attach", "cancel", "clear", "config", "context", "cost", "dashboard", "doctor", "export", "help", "history", "hooks", "keys",
 		"model", "new", "permissions", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents",
 	}

--- a/cmd/harnesscli/tui/dashboard.go
+++ b/cmd/harnesscli/tui/dashboard.go
@@ -5,11 +5,62 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+func dashboardGroup(status string) string {
+	switch status {
+	case "running", "queued":
+		return "Running"
+	case "waiting_for_user", "waiting_for_approval":
+		return "Waiting"
+	case "completed":
+		return "Completed"
+	case "failed":
+		return "Failed"
+	case "cancelled", "cancelling":
+		return "Cancelled"
+	default:
+		return "Other"
+	}
+}
+
+func (m Model) dashboardView() string {
+	groups := map[string][]int{}
+	for i, r := range m.dashboard.runs {
+		groups[dashboardGroup(r.Status)] = append(groups[dashboardGroup(r.Status)], i)
+	}
+	order := []string{"Running", "Waiting", "Completed", "Failed", "Cancelled", "Other"}
+	lines := []string{"Dashboard — all runs", "↑/↓ navigate • p peek • s steer • x cancel • n new • esc close"}
+	for _, group := range order {
+		idxs := groups[group]
+		if len(idxs) == 0 {
+			continue
+		}
+		sort.Ints(idxs)
+		lines = append(lines, "", group)
+		for _, i := range idxs {
+			r := m.dashboard.runs[i]
+			marker := "  "
+			if i == m.dashboard.cursor {
+				marker = "> "
+			}
+			model := r.Model
+			if model == "" {
+				model = "(default)"
+			}
+			lines = append(lines, fmt.Sprintf("%s%s  %-22s  %s", marker, r.displayID(), r.Status, model))
+		}
+	}
+	if len(m.dashboard.runs) == 0 {
+		lines = append(lines, "", "No runs found.")
+	}
+	return strings.Join(lines, "\n")
+}
 
 // dashboardState is deliberately owned by the existing Model overlay; its poll
 // command is scheduled only while the dashboard is active.

--- a/cmd/harnesscli/tui/dashboard.go
+++ b/cmd/harnesscli/tui/dashboard.go
@@ -59,6 +59,10 @@ func (m Model) dashboardView() string {
 	if len(m.dashboard.runs) == 0 {
 		lines = append(lines, "", "No runs found.")
 	}
+	if m.dashboard.peekID != "" {
+		lines = append(lines, "", "Peek: "+m.dashboard.peekID)
+		lines = append(lines, m.dashboard.peek...)
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/cmd/harnesscli/tui/dashboard.go
+++ b/cmd/harnesscli/tui/dashboard.go
@@ -64,6 +64,9 @@ func (m Model) dashboardView() string {
 		lines = append(lines, "", "Peek: "+m.dashboard.peekID)
 		lines = append(lines, m.dashboard.peek...)
 	}
+	if m.dashboard.inputMode != "" {
+		lines = append(lines, "", m.dashboard.inputMode+": "+m.dashboard.input)
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -135,6 +138,29 @@ func dashboardControlCmd(baseURL, runID, action, prompt, apiKey string) tea.Cmd 
 		defer resp.Body.Close()
 		if resp.StatusCode >= 300 {
 			return DashboardRunsLoadedMsg{Err: fmt.Sprintf("%s failed: HTTP %d", action, resp.StatusCode)}
+		}
+		return dashboardPollTickMsg{}
+	}
+}
+
+func dashboardDispatchCmd(baseURL, prompt, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		body, err := json.Marshal(runCreateRequest{Prompt: prompt, AllowFallback: true})
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, strings.TrimRight(baseURL, "/")+"/v1/runs", bytes.NewReader(body), apiKey)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			return DashboardRunsLoadedMsg{Err: fmt.Sprintf("dispatch failed: HTTP %d", resp.StatusCode)}
 		}
 		return dashboardPollTickMsg{}
 	}

--- a/cmd/harnesscli/tui/dashboard.go
+++ b/cmd/harnesscli/tui/dashboard.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -69,14 +70,15 @@ func (m Model) dashboardView() string {
 // dashboardState is deliberately owned by the existing Model overlay; its poll
 // command is scheduled only while the dashboard is active.
 type dashboardState struct {
-	runs      []tuiRunRecord
-	cursor    int
-	peekID    string
-	peek      []string
-	peekCh    <-chan tea.Msg
-	stopPeek  func()
-	inputMode string // "steer" or "new"
-	input     string
+	runs            []tuiRunRecord
+	cursor          int
+	peekID          string
+	peek            []string
+	peekCh          <-chan tea.Msg
+	stopPeek        func()
+	inputMode       string // "steer" or "new"
+	input           string
+	dashboardAction tea.Cmd
 }
 
 type DashboardRunsLoadedMsg struct {
@@ -111,6 +113,31 @@ func loadDashboardRunsCmd(baseURL, apiKey string) tea.Cmd {
 
 func dashboardPollCmd() tea.Cmd {
 	return tea.Tick(2*time.Second, func(time.Time) tea.Msg { return dashboardPollTickMsg{} })
+}
+
+func dashboardControlCmd(baseURL, runID, action, prompt, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		var raw []byte
+		if action == "steer" {
+			raw, _ = json.Marshal(map[string]string{"prompt": prompt})
+		}
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, strings.TrimRight(baseURL, "/")+"/v1/runs/"+runID+"/"+action, bytes.NewReader(raw), apiKey)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		if action == "steer" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			return DashboardRunsLoadedMsg{Err: fmt.Sprintf("%s failed: HTTP %d", action, resp.StatusCode)}
+		}
+		return dashboardPollTickMsg{}
+	}
 }
 
 func (m *Model) dashboardOpenCmds() []tea.Cmd {

--- a/cmd/harnesscli/tui/dashboard.go
+++ b/cmd/harnesscli/tui/dashboard.go
@@ -1,0 +1,87 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// dashboardState is deliberately owned by the existing Model overlay; its poll
+// command is scheduled only while the dashboard is active.
+type dashboardState struct {
+	runs      []tuiRunRecord
+	cursor    int
+	peekID    string
+	peek      []string
+	peekCh    <-chan tea.Msg
+	stopPeek  func()
+	inputMode string // "steer" or "new"
+	input     string
+}
+
+type DashboardRunsLoadedMsg struct {
+	Runs []tuiRunRecord
+	Err  string
+}
+type dashboardPollTickMsg struct{}
+
+func loadDashboardRunsCmd(baseURL, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, strings.TrimRight(baseURL, "/")+"/v1/runs", nil, apiKey)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return DashboardRunsLoadedMsg{Err: fmt.Sprintf("server returned %d", resp.StatusCode)}
+		}
+		var payload struct {
+			Runs []tuiRunRecord `json:"runs"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return DashboardRunsLoadedMsg{Err: err.Error()}
+		}
+		return DashboardRunsLoadedMsg{Runs: payload.Runs}
+	}
+}
+
+func dashboardPollCmd() tea.Cmd {
+	return tea.Tick(2*time.Second, func(time.Time) tea.Msg { return dashboardPollTickMsg{} })
+}
+
+func (m *Model) dashboardOpenCmds() []tea.Cmd {
+	m.overlayActive, m.activeOverlay = true, "dashboard"
+	return []tea.Cmd{loadDashboardRunsCmd(m.config.BaseURL, m.config.APIKey), dashboardPollCmd()}
+}
+
+func (m *Model) closeDashboard() {
+	if m.dashboard.stopPeek != nil {
+		m.dashboard.stopPeek()
+		m.dashboard.stopPeek = nil
+	}
+	m.dashboard.peekCh, m.dashboard.peekID, m.dashboard.peek = nil, "", nil
+	m.dashboard.inputMode, m.dashboard.input = "", ""
+	m.overlayActive, m.activeOverlay = false, ""
+}
+
+func (m *Model) dashboardSelected() (tuiRunRecord, bool) {
+	if len(m.dashboard.runs) == 0 {
+		return tuiRunRecord{}, false
+	}
+	if m.dashboard.cursor >= len(m.dashboard.runs) {
+		m.dashboard.cursor = len(m.dashboard.runs) - 1
+	}
+	if m.dashboard.cursor < 0 {
+		m.dashboard.cursor = 0
+	}
+	return m.dashboard.runs[m.dashboard.cursor], true
+}

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -1,0 +1,28 @@
+package tui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDashboardRunListCmdLoadsRunsAndModelStoresThem(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/runs" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("auth = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"runs":[{"id":"run-1","status":"running","model":"gpt","prompt":"work"}]}`))
+	}))
+	defer ts.Close()
+
+	msg := loadDashboardRunsCmd(ts.URL, "test-key")()
+	m := New(TUIConfig{BaseURL: ts.URL})
+	updated, _ := m.Update(msg)
+	m = updated.(Model)
+	if len(m.dashboard.runs) != 1 || m.dashboard.runs[0].displayID() != "run-1" {
+		t.Fatalf("dashboard runs = %#v", m.dashboard.runs)
+	}
+}

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -59,3 +59,19 @@ func TestDashboardCommandAndKeybindingOpenOverlay(t *testing.T) {
 		t.Fatalf("keybinding overlay = %q", m.activeOverlay)
 	}
 }
+
+func TestDashboardPeekStartsSingleBridgeAndClosesBeforeOverlay(t *testing.T) {
+	m := New(TUIConfig{BaseURL: "http://example.invalid"})
+	m.overlayActive, m.activeOverlay = true, "dashboard"
+	m.dashboard.runs = []tuiRunRecord{{ID: "run-1", Status: "running"}}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
+	m = updated.(Model)
+	if m.dashboard.peekID != "run-1" || m.dashboard.stopPeek == nil {
+		t.Fatalf("peek not started: %#v", m.dashboard)
+	}
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEscape})
+	m = updated.(Model)
+	if m.dashboard.peekID != "" || m.activeOverlay != "dashboard" {
+		t.Fatal("escape must close peek first")
+	}
+}

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -75,3 +75,21 @@ func TestDashboardPeekStartsSingleBridgeAndClosesBeforeOverlay(t *testing.T) {
 		t.Fatal("escape must close peek first")
 	}
 }
+
+func TestDashboardSteerAndCancelUseSelectedRun(t *testing.T) {
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path; w.WriteHeader(http.StatusAccepted) }))
+	defer ts.Close()
+	m := New(TUIConfig{BaseURL: ts.URL})
+	m.overlayActive, m.activeOverlay = true, "dashboard"
+	m.dashboard.runs = []tuiRunRecord{{ID: "run-1", Status: "running"}}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	cmd := updated.(Model).dashboard.dashboardAction
+	if cmd == nil {
+		t.Fatal("cancel command missing")
+	}
+	_ = cmd()
+	if gotPath != "/v1/runs/run-1/cancel" {
+		t.Fatalf("path=%s", gotPath)
+	}
+}

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -42,3 +42,20 @@ func TestDashboardViewGroupsRunsAndArrowKeysNavigate(t *testing.T) {
 		t.Fatalf("cursor = %d", got)
 	}
 }
+
+func TestDashboardCommandAndKeybindingOpenOverlay(t *testing.T) {
+	m := New(TUIConfig{})
+	if _, ok := m.commandRegistry.Lookup("dashboard"); !ok {
+		t.Fatal("/dashboard must be registered")
+	}
+	executeDashboardCommand(&m, Command{})
+	if !m.overlayActive || m.activeOverlay != "dashboard" {
+		t.Fatalf("overlay = %q", m.activeOverlay)
+	}
+	m.closeDashboard()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlD})
+	m = updated.(Model)
+	if m.activeOverlay != "dashboard" {
+		t.Fatalf("keybinding overlay = %q", m.activeOverlay)
+	}
+}

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -3,7 +3,10 @@ package tui
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestDashboardRunListCmdLoadsRunsAndModelStoresThem(t *testing.T) {
@@ -24,5 +27,18 @@ func TestDashboardRunListCmdLoadsRunsAndModelStoresThem(t *testing.T) {
 	m = updated.(Model)
 	if len(m.dashboard.runs) != 1 || m.dashboard.runs[0].displayID() != "run-1" {
 		t.Fatalf("dashboard runs = %#v", m.dashboard.runs)
+	}
+}
+
+func TestDashboardViewGroupsRunsAndArrowKeysNavigate(t *testing.T) {
+	m := New(TUIConfig{})
+	m.overlayActive, m.activeOverlay = true, "dashboard"
+	m.dashboard.runs = []tuiRunRecord{{ID: "one", Status: "running"}, {ID: "two", Status: "waiting_for_approval"}, {ID: "three", Status: "completed"}}
+	if got := m.dashboardView(); !strings.Contains(got, "Running") || !strings.Contains(got, "Waiting") || !strings.Contains(got, "Completed") {
+		t.Fatalf("missing groups: %s", got)
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	if got := updated.(Model).dashboard.cursor; got != 1 {
+		t.Fatalf("cursor = %d", got)
 	}
 }

--- a/cmd/harnesscli/tui/dashboard_test.go
+++ b/cmd/harnesscli/tui/dashboard_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,5 +92,24 @@ func TestDashboardSteerAndCancelUseSelectedRun(t *testing.T) {
 	_ = cmd()
 	if gotPath != "/v1/runs/run-1/cancel" {
 		t.Fatalf("path=%s", gotPath)
+	}
+}
+
+func TestDashboardNewRunDispatchPostsPromptWithoutAttachingMainSession(t *testing.T) {
+	var prompt string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&struct {
+			Prompt *string `json:"prompt"`
+		}{Prompt: &prompt})
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"run_id":"new-run"}`))
+	}))
+	defer ts.Close()
+	msg := dashboardDispatchCmd(ts.URL, "do work", "")()
+	if _, ok := msg.(dashboardPollTickMsg); !ok {
+		t.Fatalf("msg=%T", msg)
+	}
+	if prompt != "do work" {
+		t.Fatalf("prompt=%q", prompt)
 	}
 }

--- a/cmd/harnesscli/tui/keys.go
+++ b/cmd/harnesscli/tui/keys.go
@@ -20,6 +20,7 @@ type KeyMap struct {
 	// Actions
 	Interrupt key.Binding
 	Help      key.Binding
+	Dashboard key.Binding
 	Quit      key.Binding
 	Copy      key.Binding
 	// Modes
@@ -79,6 +80,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("ctrl+h", "?"),
 			key.WithHelp("?", "help"),
 		),
+		Dashboard: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "dashboard"),
+		),
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "quit"),
@@ -100,7 +105,7 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp implements key.Map for the help component.
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Submit, k.Interrupt, k.SlashCmd, k.Help, k.Quit, k.Newline, k.Copy}
+	return []key.Binding{k.Submit, k.Interrupt, k.SlashCmd, k.Help, k.Dashboard, k.Quit, k.Newline, k.Copy}
 }
 
 // FullHelp implements key.Map for the help component.
@@ -108,7 +113,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Submit, k.Newline, k.Interrupt, k.Quit},
 		{k.ScrollUp, k.ScrollDown, k.PageUp, k.PageDown, k.GotoTop, k.GotoBottom},
-		{k.SlashCmd, k.AtMention, k.Help},
+		{k.SlashCmd, k.AtMention, k.Help, k.Dashboard},
 		{k.EditMode, k.ExpandTool},
 	}
 }

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1586,6 +1586,10 @@ func executeRunsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	}, false
 }
 
+func executeDashboardCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	return m.dashboardOpenCmds(), false
+}
+
 func executeCancelCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	runID := ""
 	if len(cmd.Args) > 0 {
@@ -2501,6 +2505,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return editorDoneMsg{tmpFile: tmpFile, err: err}
 				},
 			)
+
+		case key.Matches(msg, m.keys.Dashboard) && !m.overlayActive:
+			cmds = append(cmds, m.dashboardOpenCmds()...)
+			return m, tea.Batch(cmds...)
 
 		default:
 			// When model overlay is open (not config panel), intercept keys for navigation, search, and star.

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1864,6 +1864,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.setStatusMsg("Copy unavailable"))
 			}
 		case key.Matches(msg, m.keys.Interrupt):
+			if m.overlayActive && m.activeOverlay == "dashboard" && m.dashboard.peekID != "" {
+				if m.dashboard.stopPeek != nil {
+					m.dashboard.stopPeek()
+				}
+				m.dashboard.peekID, m.dashboard.peekCh, m.dashboard.stopPeek = "", nil, nil
+				return m, tea.Batch(cmds...)
+			}
 			// If the interrupt banner is visible, Escape dismisses it without
 			// cancelling the run (user changed their mind).
 			if m.interruptBanner.IsVisible() {
@@ -2352,6 +2359,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "dashboard":
+			if msg.String() == "p" || msg.Type == tea.KeyEnter {
+				if run, ok := m.dashboardSelected(); ok {
+					if m.dashboard.stopPeek != nil {
+						m.dashboard.stopPeek()
+					}
+					m.dashboard.peekID = run.displayID()
+					m.dashboard.peek = nil
+					m.dashboard.peekCh, m.dashboard.stopPeek = startSSEForRun(m.config.BaseURL, run.displayID(), m.config.APIKey)
+					cmds = append(cmds, pollSSECmd(m.dashboard.peekCh))
+				}
+				return m, tea.Batch(cmds...)
+			}
 			if len(m.dashboard.runs) > 0 {
 				switch {
 				case msg.Type == tea.KeyUp || msg.String() == "k":
@@ -2899,6 +2918,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case SSEEventMsg:
+		if m.dashboard.peekID != "" {
+			m.dashboard.peek = append(m.dashboard.peek, msg.EventType)
+			if m.dashboard.peekCh != nil {
+				cmds = append(cmds, pollSSECmd(m.dashboard.peekCh))
+			}
+			return m, tea.Batch(cmds...)
+		}
 		// Track the most recent event ID so a mid-run reconnect (see the
 		// SSEDoneMsg case below) can resume exactly here via Last-Event-ID.
 		if msg.ID != "" {

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -197,6 +197,9 @@ type Model struct {
 	// Valid values: "", "help", "stats", "context".
 	activeOverlay string
 
+	// dashboard holds transient state for the multi-run dashboard overlay.
+	dashboard dashboardState
+
 	// statusMsg is a transient overlay message shown on the status bar.
 	statusMsg string
 	// statusMsgExpiry is when statusMsg should be cleared.
@@ -2746,6 +2749,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case OverlayCloseMsg:
+		if m.activeOverlay == "dashboard" {
+			m.closeDashboard()
+			break
+		}
 		m.overlayActive = false
 		m.activeOverlay = ""
 		m.helpDialog = m.helpDialog.Close()
@@ -2825,6 +2832,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.vp.AppendLine("")
 		cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Loaded %d run(s)", len(msg.Runs))))
+
+	case DashboardRunsLoadedMsg:
+		if msg.Err != "" {
+			cmds = append(cmds, m.setStatusMsg("Dashboard load failed: "+msg.Err))
+			break
+		}
+		m.dashboard.runs = msg.Runs
+		if m.dashboard.cursor >= len(msg.Runs) {
+			m.dashboard.cursor = len(msg.Runs) - 1
+			if m.dashboard.cursor < 0 {
+				m.dashboard.cursor = 0
+			}
+		}
+
+	case dashboardPollTickMsg:
+		if m.overlayActive && m.activeOverlay == "dashboard" {
+			cmds = append(cmds, loadDashboardRunsCmd(m.config.BaseURL, m.config.APIKey), dashboardPollCmd())
+		}
 
 	case RunControlResultMsg:
 		if msg.Err != "" {

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1966,6 +1966,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.searchSelectedIdx = 0
 				return m, tea.Batch(cmds...)
 			}
+			if m.activeOverlay == "dashboard" {
+				m.closeDashboard()
+				return m, tea.Batch(cmds...)
+			}
 			if m.overlayActive {
 				m.overlayActive = false
 				m.activeOverlay = ""
@@ -2341,6 +2345,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.permissionsPanel = m.permissionsPanel.ToggleSelected()
 			case msg.String() == "d":
 				m.permissionsPanel = m.permissionsPanel.RemoveSelected()
+			}
+			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "dashboard":
+			if len(m.dashboard.runs) > 0 {
+				switch {
+				case msg.Type == tea.KeyUp || msg.String() == "k":
+					m.dashboard.cursor = (m.dashboard.cursor - 1 + len(m.dashboard.runs)) % len(m.dashboard.runs)
+				case msg.Type == tea.KeyDown || msg.String() == "j":
+					m.dashboard.cursor = (m.dashboard.cursor + 1) % len(m.dashboard.runs)
+				}
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "search" && (msg.Type == tea.KeyUp || msg.Type == tea.KeyDown || msg.String() == "k" || msg.String() == "j"):
@@ -3453,6 +3467,8 @@ func (m Model) View() string {
 			m.permissionsPanel.Height = m.layout.ViewportHeight
 			raw := m.permissionsPanel.View()
 			mainContent = boxOverlay(raw, m.width)
+		case "dashboard":
+			mainContent = boxOverlay(m.dashboardView(), m.width)
 		default:
 			// Unknown overlay kind — fall back to viewport.
 			mainContent = m.vp.View()

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -2359,6 +2359,28 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "dashboard":
+			if m.dashboard.inputMode != "" {
+				switch {
+				case msg.Type == tea.KeyRunes:
+					m.dashboard.input += string(msg.Runes)
+				case msg.Type == tea.KeyBackspace:
+					if len(m.dashboard.input) > 0 {
+						m.dashboard.input = m.dashboard.input[:len(m.dashboard.input)-1]
+					}
+				case msg.Type == tea.KeyEnter:
+					if m.dashboard.inputMode == "new" {
+						cmds = append(cmds, dashboardDispatchCmd(m.config.BaseURL, m.dashboard.input, m.config.APIKey))
+					} else if run, ok := m.dashboardSelected(); ok {
+						cmds = append(cmds, dashboardControlCmd(m.config.BaseURL, run.displayID(), "steer", m.dashboard.input, m.config.APIKey))
+					}
+					m.dashboard.inputMode, m.dashboard.input = "", ""
+				}
+				return m, tea.Batch(cmds...)
+			}
+			if msg.String() == "n" {
+				m.dashboard.inputMode, m.dashboard.input = "new", ""
+				return m, tea.Batch(cmds...)
+			}
 			if msg.String() == "x" {
 				if run, ok := m.dashboardSelected(); ok {
 					m.dashboard.dashboardAction = dashboardControlCmd(m.config.BaseURL, run.displayID(), "cancel", "", m.config.APIKey)

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -2359,6 +2359,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "dashboard":
+			if msg.String() == "x" {
+				if run, ok := m.dashboardSelected(); ok {
+					m.dashboard.dashboardAction = dashboardControlCmd(m.config.BaseURL, run.displayID(), "cancel", "", m.config.APIKey)
+					cmds = append(cmds, m.dashboard.dashboardAction)
+				}
+				return m, tea.Batch(cmds...)
+			}
+			if msg.String() == "s" {
+				m.dashboard.inputMode, m.dashboard.input = "steer", ""
+				return m, tea.Batch(cmds...)
+			}
 			if msg.String() == "p" || msg.Type == tea.KeyEnter {
 				if run, ok := m.dashboardSelected(); ok {
 					if m.dashboard.stopPeek != nil {

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -612,7 +612,7 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 		"config",
 		"context",
 		"cost",
-		"doctor",
+		"dashboard",
 	}
 	for _, cmd := range wantVisible {
 		if !strings.Contains(v, cmd) {

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -6,6 +6,7 @@ Command Registry - 120x40
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage
+/dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
 /help — Show help dialog

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -6,6 +6,7 @@ Command Registry - 200x50
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage
+/dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
 /help — Show help dialog

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -6,6 +6,7 @@ Command Registry - 80x24
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage
+/dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
 /help — Show help dialog

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,11 @@
 # Engineering Log
 
+## 2026-07-19 (Multi-run TUI Dashboard — Epic #738)
+
+- Implemented the six dashboard slices (#742, #745, #749, #753, #757, #762) as TUI-only changes: authenticated `/v1/runs` polling, grouped overlay navigation, `/dashboard`/`Ctrl+D`, one cancellable peek SSE bridge, selected-run steer/cancel, and isolated new-run dispatch.
+- Added focused failing-first dashboard tests for list loading, grouped navigation, command/key opening, peek close lifecycle, control routing, and dispatch. No server route or dependency changes.
+- Validation: `go test ./cmd/harnesscli/...` passes. Repository-wide formatting gate still reports pre-existing drift and a syntax-invalid training exercise; see final verification status.
+
 ## 2026-06-28 (Config-Driven Lifecycle Hooks — Epic #737)
 
 - Implemented epic #737 and all six child issues (#741, #744, #750, #755, #759, #763) in worktree branch `codex/config-hooks-epic-737`, one commit per slice, strict TDD throughout.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -1,5 +1,12 @@
 # Long-Term Thinking Log
 
+## 2026-07-19 (Multi-run TUI Dashboard — Epic #738)
+
+- Command intent: Deliver the multi-run TUI dashboard and six child slices in a dedicated branch, then open (but do not merge) its PR.
+- User intent: Let an operator monitor and control concurrent harness runs without leaving the current TUI session.
+- Success definition: `/dashboard` offers lifecycle-bound polling grouped by run state, selected-run SSE peek, steer/cancel, and new-run dispatch solely through existing run routes; focused TDD coverage and project gates remain green.
+- Guardrails: TUI-only, no new server endpoints or Go dependencies, and no more than one dashboard peek bridge at a time.
+
 ## 2026-06-28 (Config-Driven Lifecycle Hooks — Epic #737)
 
 - Command intent: Implement epic #737 and all six child issues (#741, #744, #750, #755, #759, #763) in a dedicated worktree, landing config-driven shell/HTTP lifecycle hooks end to end, then open a PR.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -2,6 +2,12 @@
 
 Use this file to document systems, interfaces, and interactions as they are built.
 
+## 2026-07-19 (TUI Multi-run Dashboard — Epic #738)
+
+- System/component: `cmd/harnesscli/tui` dashboard overlay.
+- Responsibilities: lifecycle-bound `tea.Tick` list refreshes consume existing `GET /v1/runs`; the selected-run peek consumes the existing SSE bridge; control/dispatch consume existing run endpoints. Closing the peek or overlay cancels its bridge without affecting the attached session.
+- Failure modes: list/control failures surface in the dashboard status path; an inactive overlay does not reschedule polling; a new peek stops the previous subscription.
+
 ## 2026-06-28 (Config-Driven Lifecycle Hooks — Epic #737)
 
 - System/component: `internal/hooks` (schema, loader, adapters, trust store, builder), `internal/config` `[hooks]` section, `cmd/harnessd` bootstrap wiring, `internal/server` `GET /v1/hooks`, `cmd/harnesscli` `hooks` subcommand + TUI `/hooks`.

--- a/docs/plans/2026-07-19-dashboard-epic-738-plan.md
+++ b/docs/plans/2026-07-19-dashboard-epic-738-plan.md
@@ -1,0 +1,33 @@
+# Multi-run TUI dashboard — Epic #738
+
+## Intent
+
+Add a lifecycle-bound TUI dashboard overlay that monitors all runs using the
+existing runs HTTP API, without changing the server surface or dependencies.
+
+## Success criteria
+
+- `/dashboard` displays a live, grouped, keyboard-navigable run list.
+- Operators can peek, steer, cancel, and dispatch from the overlay.
+- Polling and at most one peek SSE bridge are stopped when their UI lifetime ends.
+- TDD coverage and required verification commands are green.
+
+## Slices
+
+- [ ] #742 — run-list poller and dashboard state model from `GET /v1/runs`
+- [ ] #745 — grouped dashboard overlay rendering and navigation
+- [ ] #749 — `/dashboard` slash command and open keybinding
+- [ ] #753 — SSE-backed selected-run peek pane
+- [ ] #757 — selected-run steering and cancellation
+- [ ] #762 — new-run dispatch prompt
+
+## Guardrails
+
+- TUI-only; reuse `newHarnessRequest`, overlay conventions, and SSE bridge.
+- No `internal/server` endpoint changes and no dependency changes.
+- Each slice starts with a failing focused test and lands in its own commit.
+
+## Verification
+
+`go test ./cmd/harnesscli/...`, `gofmt -l .`, `go vet ./...`, and
+`./scripts/test-regression.sh` must pass before opening the PR.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-07-19-dashboard-epic-738-plan.md`: Multi-run TUI dashboard epic plan covering #742, #745, #749, #753, #757, and #762.
 - `2026-06-28-config-driven-hooks-epic-737-plan.md`: Active epic plan for config-driven lifecycle hooks (shell/HTTP) covering child issues #741, #744, #750, #755, #759, #763 with per-slice TDD and trust-model guardrails.
 - `2026-06-26-adapter-first-eval-harness-plan.md`: Implemented adapter-first Terminal-Bench eval harness hardening plan; full regression and real-provider smoke baseline acceptance are green.
 - `2026-06-24-harness-reliability-plan.md`: Active 15-slice TDD plan (T01–T15) hardening `harnessd` against long-session reliability failures from the 2026-06-24 audit; tracked via `.context/harness-reliability/tracker.md`.

--- a/docs/runbooks/harnesscli-live-testing.md
+++ b/docs/runbooks/harnesscli-live-testing.md
@@ -61,6 +61,13 @@ go run ./cmd/harnesscli \
 - Terminal events should stop the session cleanly.
 - If a live run fails, inspect the server event stream first, then the run summary and conversation endpoints.
 
+## Dashboard smoke
+
+1. Start two runs, then enter the TUI and type `/dashboard` (or press `Ctrl+D`).
+2. Confirm grouped running/waiting/completed rows refresh without closing the current session.
+3. Select a running row and press `p`; confirm its event stream appears. Press `Esc` once to close peek and again to close the dashboard.
+4. Use `s` to enter a steering prompt, `x` to cancel a selected run, and `n` to dispatch a new prompt. Confirm each change appears on the next refresh.
+
 ## Relevant Code Paths
 
 - CLI entrypoint: `cmd/harnesscli/main.go`


### PR DESCRIPTION
## Summary

- Adds a lifecycle-bound multi-run TUI dashboard with grouped live polling.
- Supports selected-run SSE peek, steering, cancellation, and isolated new-run dispatch.
- Adds `/dashboard` and `Ctrl+D`, focused TDD coverage, and dashboard live-smoke guidance.

Closes #738, #742, #745, #749, #753, #757, #762