### PR TITLE
feat(plugins): installable plugin bundles and marketplace — epic #748

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ This repository is a Go coding harness with a streamed run API, a CLI smoke-test
 - The canonical implementation details are in `internal/server`, `internal/harness`, `internal/config`, `cmd/harnessd`, and `cmd/harnesscli`.
 - The public-facing docs should stay aligned with the current routes, run request fields, event names, tool catalog, and environment variables.
 - If a docs change reveals a mismatch, update the docs rather than preserving stale prose.
+- Installable plugin bundles live in `internal/plugins`: `plugin.json` bundles are installed under `~/.go-harness/plugins`, with enabled visibility independent from executable trust. Skills/commands reuse their existing loaders; trusted bundles alone reach profiles, MCP validation, and hooks. This is separate from compile-time Go plugins in `plugins/`.
 
 ## Workflow Engine (`internal/workflow/`)
 

--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -103,6 +103,8 @@ func dispatch(args []string) int {
 		return run(args)
 	}
 	switch args[0] {
+	case "plugin":
+		return runPlugin(args[1:])
 	case "auth":
 		return runAuth(args[1:])
 	case "hooks":

--- a/cmd/harnesscli/plugins.go
+++ b/cmd/harnesscli/plugins.go
@@ -23,8 +23,56 @@ func runPlugin(args []string) int {
 		return pluginUninstall(args[1:])
 	case "update":
 		return pluginUpdate(args[1:])
+	case "marketplace":
+		return pluginMarketplace(args[1:])
 	default:
 		fmt.Fprintf(stderr, "harnesscli plugin: unknown subcommand %q (try: install, list, uninstall, update)\n", args[0])
+		return 1
+	}
+}
+
+func pluginMarketplace(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: harnesscli plugin marketplace <add|list|update> [name path]")
+		return 1
+	}
+	_, dir, err := pluginStore()
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	store := plugins.NewMarketplaceStore(filepath.Join(dir, "marketplaces.json"))
+	switch args[0] {
+	case "add":
+		if len(args) != 3 {
+			fmt.Fprintln(stderr, "harnesscli plugin marketplace add: name and path required")
+			return 1
+		}
+		if err := store.Add(plugins.MarketplaceSource{Name: args[1], URL: args[2]}); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "added marketplace %s\n", args[1])
+		return 0
+	case "list", "update":
+		items, err := store.List()
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		for _, item := range items {
+			m, e := plugins.LoadMarketplace(item)
+			if e != nil {
+				fmt.Fprintf(stderr, "marketplace %s: %v\n", item.Name, e)
+				continue
+			}
+			for _, p := range m.Plugins {
+				fmt.Fprintf(stdout, "%s %s %s\n", item.Name, p.Name, p.Source)
+			}
+		}
+		return 0
+	default:
+		fmt.Fprintln(stderr, "harnesscli plugin marketplace: unknown subcommand")
 		return 1
 	}
 }

--- a/cmd/harnesscli/plugins.go
+++ b/cmd/harnesscli/plugins.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go-agent-harness/internal/plugins"
+)
+
+func runPlugin(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: harnesscli plugin <install|list|uninstall|update> [source|name]")
+		return 1
+	}
+	switch args[0] {
+	case "install":
+		return pluginInstall(args[1:])
+	case "list":
+		return pluginList(args[1:])
+	case "uninstall":
+		return pluginUninstall(args[1:])
+	case "update":
+		return pluginUpdate(args[1:])
+	default:
+		fmt.Fprintf(stderr, "harnesscli plugin: unknown subcommand %q (try: install, list, uninstall, update)\n", args[0])
+		return 1
+	}
+}
+
+func pluginHome() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".go-harness", "plugins"), nil
+}
+
+func pluginStore() (*plugins.StateStore, string, error) {
+	dir, err := pluginHome()
+	if err != nil {
+		return nil, "", err
+	}
+	return plugins.NewStateStore(filepath.Join(dir, "state.json")), dir, nil
+}
+
+func pluginInstall(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "harnesscli plugin install: exactly one git URL, owner/repo, or local path is required")
+		return 1
+	}
+	store, dir, err := pluginStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin install: %v\n", err)
+		return 1
+	}
+	installed, err := plugins.NewInstaller(dir).Install(args[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin install: %v\n", err)
+		return 1
+	}
+	if err := store.RecordInstall(plugins.InstalledPlugin{Name: installed.Manifest.Name, Version: installed.Manifest.Version, Source: installed.Source.URL, Remote: installed.Remote}); err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin install: record state: %v\n", err)
+		return 1
+	}
+	trust := "trusted"
+	if installed.Remote {
+		trust = "untrusted"
+	}
+	fmt.Fprintf(stdout, "installed %s@%s (%s)\n", installed.Manifest.Name, installed.Manifest.Version, trust)
+	return 0
+}
+
+func pluginList(args []string) int {
+	if len(args) != 0 {
+		fmt.Fprintln(stderr, "harnesscli plugin list: no arguments expected")
+		return 1
+	}
+	store, _, err := pluginStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin list: %v\n", err)
+		return 1
+	}
+	items, err := store.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin list: %v\n", err)
+		return 1
+	}
+	if len(items) == 0 {
+		fmt.Fprintln(stdout, "no installed plugin bundles")
+		return 0
+	}
+	for _, item := range items {
+		fmt.Fprintf(stdout, "%s@%s enabled=%t trusted=%t source=%s\n", item.Name, item.Version, item.Enabled, item.Trusted, item.Source)
+	}
+	return 0
+}
+
+func pluginUninstall(args []string) int {
+	if len(args) != 1 || strings.TrimSpace(args[0]) == "" {
+		fmt.Fprintln(stderr, "harnesscli plugin uninstall: exactly one plugin name is required")
+		return 1
+	}
+	store, dir, err := pluginStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin uninstall: %v\n", err)
+		return 1
+	}
+	items, err := store.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin uninstall: %v\n", err)
+		return 1
+	}
+	var found *plugins.InstalledPlugin
+	for i := range items {
+		if items[i].Name == args[0] {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		fmt.Fprintf(stderr, "harnesscli plugin uninstall: plugin %q is not installed\n", args[0])
+		return 1
+	}
+	if err := os.RemoveAll(filepath.Join(dir, found.Name)); err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin uninstall: remove files: %v\n", err)
+		return 1
+	}
+	if err := store.Remove(found.Name); err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin uninstall: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "uninstalled %s\n", found.Name)
+	return 0
+}
+
+func pluginUpdate(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "harnesscli plugin update: exactly one plugin name is required")
+		return 1
+	}
+	store, dir, err := pluginStore()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin update: %v\n", err)
+		return 1
+	}
+	items, err := store.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli plugin update: %v\n", err)
+		return 1
+	}
+	for _, item := range items {
+		if item.Name != args[0] {
+			continue
+		}
+		installed, err := plugins.NewInstaller(dir).Install(item.Source)
+		if err != nil {
+			fmt.Fprintf(stderr, "harnesscli plugin update: %v\n", err)
+			return 1
+		}
+		if err := store.RecordInstall(plugins.InstalledPlugin{Name: installed.Manifest.Name, Version: installed.Manifest.Version, Source: installed.Source.URL, Remote: installed.Remote}); err != nil {
+			fmt.Fprintf(stderr, "harnesscli plugin update: record state: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "updated %s@%s\n", installed.Manifest.Name, installed.Manifest.Version)
+		return 0
+	}
+	fmt.Fprintf(stderr, "harnesscli plugin update: plugin %q is not installed\n", args[0])
+	return 1
+}

--- a/cmd/harnesscli/plugins_test.go
+++ b/cmd/harnesscli/plugins_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPluginCLI_InstallListUpdateAndUninstall(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "plugin.json"), []byte(`{"schema_version":1,"name":"cli-tools","version":"1.0.0"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runPlugin := func(args ...string) (int, string) {
+		t.Helper()
+		oldOut, oldErr := stdout, stderr
+		t.Cleanup(func() { stdout, stderr = oldOut, oldErr })
+		var out, errOut bytes.Buffer
+		stdout, stderr = &out, &errOut
+		code := dispatch(append([]string{"plugin"}, args...))
+		return code, out.String() + errOut.String()
+	}
+	if code, output := runPlugin("install", source); code != 0 || !strings.Contains(output, "installed cli-tools@1.0.0") {
+		t.Fatalf("install = %d, %q", code, output)
+	}
+	if code, output := runPlugin("list"); code != 0 || !strings.Contains(output, "enabled=true") || !strings.Contains(output, "trusted=true") {
+		t.Fatalf("list = %d, %q", code, output)
+	}
+	if code, output := runPlugin("update", "cli-tools"); code != 0 || !strings.Contains(output, "updated cli-tools@1.0.0") {
+		t.Fatalf("update = %d, %q", code, output)
+	}
+	if code, output := runPlugin("uninstall", "cli-tools"); code != 0 || !strings.Contains(output, "uninstalled cli-tools") {
+		t.Fatalf("uninstall = %d, %q", code, output)
+	}
+}

--- a/cmd/harnesscli/plugins_test.go
+++ b/cmd/harnesscli/plugins_test.go
@@ -36,3 +36,22 @@ func TestPluginCLI_InstallListUpdateAndUninstall(t *testing.T) {
 		t.Fatalf("uninstall = %d, %q", code, output)
 	}
 }
+
+func TestPluginMarketplaceCLIListsLocalIndex(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	index := filepath.Join(t.TempDir(), "marketplace.json")
+	if err := os.WriteFile(index, []byte(`{"plugins":[{"name":"demo","source":"owner/demo"}]}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	oldOut, oldErr := stdout, stderr
+	defer func() { stdout, stderr = oldOut, oldErr }()
+	var out, errOut bytes.Buffer
+	stdout = &out
+	stderr = &errOut
+	if code := dispatch([]string{"plugin", "marketplace", "add", "local", index}); code != 0 {
+		t.Fatalf("add %d: %s", code, errOut.String())
+	}
+	if code := dispatch([]string{"plugin", "marketplace", "list"}); code != 0 || !strings.Contains(out.String(), "demo") {
+		t.Fatalf("list %d: %s", code, out.String())
+	}
+}

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -78,6 +78,7 @@ func newEmptyCommandRegistry() *CommandRegistry {
 
 func builtinCommandEntries() []CommandEntry {
 	return []CommandEntry{
+		{Name: "plugins", Description: "Browse installed plugin bundles", Handler: func(Command) CommandResult { return CommandResult{Status: CmdOK} }, Execute: executePluginsCommand},
 		{
 			Name:        "clear",
 			Description: "Clear conversation history",

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -397,7 +397,7 @@ func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
 		"attach", "cancel", "clear", "config", "context", "cost", "doctor", "export", "help", "history", "hooks", "keys",
-		"model", "new", "permissions", "profiles", "quit", "replay", "resume", "runs", "search",
+		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents",
 	}
 

--- a/cmd/harnesscli/tui/installable_plugins.go
+++ b/cmd/harnesscli/tui/installable_plugins.go
@@ -13,7 +13,9 @@ func installablePluginCommandDirs() []string {
 		return nil
 	}
 	root := filepath.Join(home, ".go-harness", "plugins")
-	bundles, err := plugins.EnabledBundles(root, plugins.NewStateStore(filepath.Join(root, "state.json")))
+	// Command definitions may invoke a shell; unlike skills, load them only
+	// after the bundle has been explicitly trusted.
+	bundles, err := plugins.TrustedBundles(root, plugins.NewStateStore(filepath.Join(root, "state.json")))
 	if err != nil {
 		return nil
 	}

--- a/cmd/harnesscli/tui/installable_plugins.go
+++ b/cmd/harnesscli/tui/installable_plugins.go
@@ -1,0 +1,27 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+
+	"go-agent-harness/internal/plugins"
+)
+
+func installablePluginCommandDirs() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	root := filepath.Join(home, ".go-harness", "plugins")
+	bundles, err := plugins.EnabledBundles(root, plugins.NewStateStore(filepath.Join(root, "state.json")))
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for _, bundle := range bundles {
+		if bundle.CommandsDir != "" {
+			dirs = append(dirs, bundle.CommandsDir)
+		}
+	}
+	return dirs
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -37,6 +37,7 @@ import (
 	"go-agent-harness/cmd/harnesscli/tui/components/tooluse"
 	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
 	"go-agent-harness/cmd/harnesscli/tui/components/viewport"
+	"go-agent-harness/internal/plugins"
 )
 
 // defaultExportDir returns a runtime-safe directory for transcript exports.
@@ -324,6 +325,7 @@ type Model struct {
 	// pluginWarnings collects warnings produced when loading and registering plugins
 	// (e.g. load errors, name collisions with builtins).
 	pluginWarnings []string
+	pluginBrowser  pluginBrowserState
 }
 
 // New creates a new root Model.
@@ -1345,6 +1347,13 @@ func executeHelpCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return nil, false
 }
 
+func executePluginsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	m.pluginBrowser = loadPluginBrowser()
+	m.overlayActive = true
+	m.activeOverlay = "plugins"
+	return nil, false
+}
+
 func executeContextCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	m.overlayActive = true
 	m.activeOverlay = "context"
@@ -2273,6 +2282,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case msg.Type == tea.KeyRunes:
 				m.apiKeyInput += string(msg.Runes)
+			}
+			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "plugins":
+			if len(m.pluginBrowser.items) == 0 {
+				return m, tea.Batch(cmds...)
+			}
+			switch msg.Type {
+			case tea.KeyUp:
+				if m.pluginBrowser.selected > 0 {
+					m.pluginBrowser.selected--
+				}
+			case tea.KeyDown:
+				if m.pluginBrowser.selected < len(m.pluginBrowser.items)-1 {
+					m.pluginBrowser.selected++
+				}
+			case tea.KeyEnter:
+				item := &m.pluginBrowser.items[m.pluginBrowser.selected]
+				item.Enabled = !item.Enabled
+				home, _ := os.UserHomeDir()
+				root := filepath.Join(home, ".go-harness", "plugins")
+				_ = plugins.NewStateStore(filepath.Join(root, "state.json")).SetEnabled(item.Name, item.Enabled)
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "apikeys" && !m.apiKeyInputMode && (msg.String() == "j" || msg.String() == "k" || msg.String() == "up" || msg.String() == "down" || msg.Type == tea.KeyUp || msg.Type == tea.KeyDown):
@@ -3428,6 +3458,8 @@ func (m Model) View() string {
 			m.permissionsPanel.Height = m.layout.ViewportHeight
 			raw := m.permissionsPanel.View()
 			mainContent = boxOverlay(raw, m.width)
+		case "plugins":
+			mainContent = m.pluginBrowser.View(m.width)
 		default:
 			// Unknown overlay kind — fall back to viewport.
 			mainContent = m.vp.View()

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -390,7 +390,7 @@ func New(cfg TUIConfig) Model {
 	if m.pluginsDir == "" {
 		m.pluginsDir = defaultPluginsDir()
 	}
-	m.pluginWarnings = LoadAndRegisterPlugins(m.commandRegistry, m.pluginsDir)
+	m.pluginWarnings = LoadAndRegisterPlugins(m.commandRegistry, append([]string{m.pluginsDir}, installablePluginCommandDirs()...)...)
 	// Wire help dialog with real command list and keybindings derived from the
 	// registered commands and the default key map.
 	m.helpDialog = buildHelpDialog(m.commandRegistry, m.keys)

--- a/cmd/harnesscli/tui/plugin_browser.go
+++ b/cmd/harnesscli/tui/plugin_browser.go
@@ -1,0 +1,49 @@
+package tui
+
+import (
+	"fmt"
+	"go-agent-harness/internal/plugins"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type pluginBrowserItem struct {
+	Name, Version    string
+	Enabled, Trusted bool
+}
+type pluginBrowserState struct {
+	items    []pluginBrowserItem
+	selected int
+}
+
+func loadPluginBrowser() pluginBrowserState {
+	h, e := os.UserHomeDir()
+	if e != nil {
+		return pluginBrowserState{}
+	}
+	r := filepath.Join(h, ".go-harness", "plugins")
+	ps, e := plugins.NewStateStore(filepath.Join(r, "state.json")).List()
+	if e != nil {
+		return pluginBrowserState{}
+	}
+	v := pluginBrowserState{}
+	for _, p := range ps {
+		v.items = append(v.items, pluginBrowserItem{p.Name, p.Version, p.Enabled, p.Trusted})
+	}
+	return v
+}
+func (p pluginBrowserState) View(w int) string {
+	l := []string{"Plugin browser", "↑/↓ select • enter enable/disable • esc close", ""}
+	if len(p.items) == 0 {
+		l = append(l, "No installed plugin bundles. Use harnesscli plugin install <source>.")
+	}
+	for i, x := range p.items {
+		m := " "
+		if i == p.selected {
+			m = ">"
+		}
+		l = append(l, fmt.Sprintf("%s %s@%s enabled=%t trusted=%t", m, x.Name, x.Version, x.Enabled, x.Trusted))
+	}
+	return boxOverlay(strings.Join(l, "\n"), w)
+}

--- a/cmd/harnesscli/tui/plugin_browser_test.go
+++ b/cmd/harnesscli/tui/plugin_browser_test.go
@@ -24,6 +24,9 @@ func TestPluginBrowserKeyboardEnablesSelectedPlugin(t *testing.T) {
 	}
 	m := New(DefaultTUIConfig())
 	executePluginsCommand(&m, Command{Name: "plugins"})
+	if got := m.pluginBrowser.View(80); got == "" {
+		t.Fatal("browser view is empty")
+	}
 	if !m.overlayActive || m.activeOverlay != "plugins" {
 		t.Fatalf("overlay=%q", m.activeOverlay)
 	}

--- a/cmd/harnesscli/tui/plugin_browser_test.go
+++ b/cmd/harnesscli/tui/plugin_browser_test.go
@@ -41,3 +41,28 @@ func TestPluginBrowserKeyboardEnablesSelectedPlugin(t *testing.T) {
 		t.Fatal("escape should close plugin browser")
 	}
 }
+
+func TestInstallableBashCommandsRequirePluginTrust(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".go-harness", "plugins", "remote", "1.0.0")
+	if err := os.MkdirAll(filepath.Join(root, "commands"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(`{"schema_version":1,"name":"remote","version":"1.0.0","commands":"commands"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := plugins.NewStateStore(filepath.Join(home, ".go-harness", "plugins", "state.json"))
+	if err := store.RecordInstall(plugins.InstalledPlugin{Name: "remote", Version: "1.0.0", Remote: true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := installablePluginCommandDirs(); len(got) != 0 {
+		t.Fatalf("untrusted dirs=%v", got)
+	}
+	if err := store.SetTrusted("remote", true); err != nil {
+		t.Fatal(err)
+	}
+	if got := installablePluginCommandDirs(); len(got) != 1 {
+		t.Fatalf("trusted dirs=%v", got)
+	}
+}

--- a/cmd/harnesscli/tui/plugin_browser_test.go
+++ b/cmd/harnesscli/tui/plugin_browser_test.go
@@ -1,0 +1,40 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"go-agent-harness/internal/plugins"
+)
+
+func TestPluginBrowserKeyboardEnablesSelectedPlugin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".go-harness", "plugins", "demo", "1.0.0")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "plugin.json"), []byte(`{"schema_version":1,"name":"demo","version":"1.0.0"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := plugins.NewStateStore(filepath.Join(home, ".go-harness", "plugins", "state.json")).RecordInstall(plugins.InstalledPlugin{Name: "demo", Version: "1.0.0", Source: "local"}); err != nil {
+		t.Fatal(err)
+	}
+	m := New(DefaultTUIConfig())
+	executePluginsCommand(&m, Command{Name: "plugins"})
+	if !m.overlayActive || m.activeOverlay != "plugins" {
+		t.Fatalf("overlay=%q", m.activeOverlay)
+	}
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(Model)
+	if !m.pluginBrowser.items[0].Enabled {
+		t.Fatal("enter should enable selected plugin")
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(Model)
+	if m.overlayActive {
+		t.Fatal("escape should close plugin browser")
+	}
+}

--- a/cmd/harnesscli/tui/plugin_loader.go
+++ b/cmd/harnesscli/tui/plugin_loader.go
@@ -9,22 +9,24 @@ import (
 // LoadAndRegisterPlugins loads plugin command definitions from dir and registers
 // them into the provided slash-command registry. It returns warning strings for
 // loader errors and skipped plugin registrations.
-func LoadAndRegisterPlugins(registry *CommandRegistry, dir string) []string {
+func LoadAndRegisterPlugins(registry *CommandRegistry, dirs ...string) []string {
 	if registry == nil {
 		return nil
 	}
 
-	defs, errs := tuiplugin.LoadPlugins(dir)
 	var warnings []string
-	for _, err := range errs {
-		warnings = append(warnings, err.Error())
-	}
-	for _, def := range defs {
-		if registry.IsRegistered(def.Name) {
-			warnings = append(warnings, fmt.Sprintf("plugin %q skipped: command already registered", def.Name))
-			continue
+	for _, dir := range dirs {
+		defs, errs := tuiplugin.LoadPlugins(dir)
+		for _, err := range errs {
+			warnings = append(warnings, err.Error())
 		}
-		registry.Register(pluginCommandEntry(def))
+		for _, def := range defs {
+			if registry.IsRegistered(def.Name) {
+				warnings = append(warnings, fmt.Sprintf("plugin %q skipped: command already registered", def.Name))
+				continue
+			}
+			registry.Register(pluginCommandEntry(def))
+		}
 	}
 	if len(warnings) == 0 {
 		return nil

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -15,6 +15,7 @@ Command Registry - 120x40
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /permissions — View session tool permissions
+/plugins — Browse installed plugin bundles
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
 /replay — Replay a run

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -15,6 +15,7 @@ Command Registry - 200x50
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /permissions — View session tool permissions
+/plugins — Browse installed plugin bundles
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
 /replay — Replay a run

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -15,6 +15,7 @@ Command Registry - 80x24
 /model — Select AI model
 /new — Start a new session (resets conversation)
 /permissions — View session tool permissions
+/plugins — Browse installed plugin bundles
 /profiles — View and select a profile for next run
 /quit — Quit the TUI
 /replay — Replay a run

--- a/cmd/harnessd/bootstrap_hooks.go
+++ b/cmd/harnessd/bootstrap_hooks.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"log"
+	"path/filepath"
 
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/harness"
 	"go-agent-harness/internal/hooks"
+	"go-agent-harness/internal/plugins"
 )
 
 // registerConfigDrivenHooks loads config-driven lifecycle hooks (epic #737)
@@ -58,4 +60,29 @@ func registerConfigDrivenHooks(harnessCfg config.Config, workspace, home string,
 			h.Name, h.Event, h.Kind, h.Source, h.File)
 	}
 	return summary
+}
+
+// registerTrustedPluginHooks reuses the single hooks loader after the plugin
+// state store has independently granted executable trust. Untrusted bundles
+// never reach hooks.LoadWithOptions and therefore cannot execute.
+func registerTrustedPluginHooks(root string, store *plugins.StateStore, runnerCfg *harness.RunnerConfig) {
+	bundles, err := plugins.TrustedBundles(root, store)
+	if err != nil {
+		log.Printf("plugin hooks: discover trusted bundles: %v", err)
+		return
+	}
+	for _, bundle := range bundles {
+		if bundle.HooksPath == "" {
+			continue
+		}
+		defs, skips := hooks.LoadWithOptions(hooks.LoadOptions{UserDir: filepath.Dir(bundle.HooksPath)}, filepath.Dir(bundle.HooksPath))
+		for _, skip := range skips {
+			log.Printf("plugin hooks: skipped %s: %s", skip.File, skip.Reason)
+		}
+		adapters := hooks.Build(defs, &stdLogger{})
+		runnerCfg.PreMessageHooks = append(runnerCfg.PreMessageHooks, adapters.PreMessage...)
+		runnerCfg.PostMessageHooks = append(runnerCfg.PostMessageHooks, adapters.PostMessage...)
+		runnerCfg.PreToolUseHooks = append(runnerCfg.PreToolUseHooks, adapters.PreToolUse...)
+		runnerCfg.PostToolUseHooks = append(runnerCfg.PostToolUseHooks, adapters.PostToolUse...)
+	}
 }

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -845,6 +845,8 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	// and append adapters to the existing hook slices. Runs AFTER compiled-in
 	// plugins so plugin hooks keep their leading slice position.
 	hooksSummary := registerConfigDrivenHooks(harnessCfg, workspace, home, &runnerCfg)
+	pluginRoot := filepath.Join(globalDir, "plugins")
+	registerTrustedPluginHooks(pluginRoot, plugins.NewStateStore(filepath.Join(pluginRoot, "state.json")), &runnerCfg)
 
 	subagentConfigTOML, err := config.WorkspaceRunnerConfigFromConfig(harnessCfg).ToTOML()
 	if err != nil {

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -632,6 +632,15 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		} else {
 			envServers = mcpConfigs
 		}
+		pluginRoot := filepath.Join(globalDir, "plugins")
+		trustedBundles, pluginErr := plugins.TrustedBundles(pluginRoot, plugins.NewStateStore(filepath.Join(pluginRoot, "state.json")))
+		if pluginErr != nil {
+			log.Printf("warning: failed to discover trusted plugin bundles: %v", pluginErr)
+		} else if pluginServers, err := plugins.MCPServers(trustedBundles); err != nil {
+			log.Printf("warning: failed to load trusted plugin MCP config: %v", err)
+		} else {
+			envServers = append(envServers, pluginServers...)
+		}
 
 		registerMCPServersFromConfig(mcpManager, globalCfg.MCPServers, envServers, log.Printf)
 	}
@@ -1155,7 +1164,16 @@ func loadStartupProfile(profileName, projectProfilesDir, userProfilesDir string)
 	if profileName == "" {
 		return nil, nil
 	}
-	profile, err := profiles.LoadProfileWithDirs(profileName, projectProfilesDir, userProfilesDir)
+	home, _ := os.UserHomeDir()
+	pluginRoot := filepath.Join(home, ".go-harness", "plugins")
+	trustedBundles, _ := plugins.TrustedBundles(pluginRoot, plugins.NewStateStore(filepath.Join(pluginRoot, "state.json")))
+	var agentDirs []string
+	for _, bundle := range trustedBundles {
+		if bundle.AgentsDir != "" {
+			agentDirs = append(agentDirs, bundle.AgentsDir)
+		}
+	}
+	profile, err := profiles.LoadProfileWithExtraDirs(profileName, projectProfilesDir, userProfilesDir, agentDirs)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -30,6 +30,7 @@ import (
 	"go-agent-harness/internal/mcp"
 	"go-agent-harness/internal/networks"
 	om "go-agent-harness/internal/observationalmemory"
+	"go-agent-harness/internal/plugins"
 	"go-agent-harness/internal/profiles"
 	"go-agent-harness/internal/provider/catalog"
 	openai "go-agent-harness/internal/provider/openai"
@@ -548,9 +549,21 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	var skillLoader *skills.Loader     // retained for hot-reload
 	var skillRegistry *skills.Registry // retained for hot-reload
 	if skillsEnabled {
+		pluginRoot := filepath.Join(globalDir, "plugins")
+		bundles, pluginErr := plugins.EnabledBundles(pluginRoot, plugins.NewStateStore(filepath.Join(pluginRoot, "state.json")))
+		if pluginErr != nil {
+			log.Printf("warning: failed to discover enabled plugin bundles: %v", pluginErr)
+		}
+		var pluginSkillDirs []string
+		for _, bundle := range bundles {
+			if bundle.SkillsDir != "" {
+				pluginSkillDirs = append(pluginSkillDirs, bundle.SkillsDir)
+			}
+		}
 		skillLoader = skills.NewLoader(skills.LoaderConfig{
 			GlobalDir:    filepath.Join(globalDir, "skills"),
 			WorkspaceDir: filepath.Join(workspace, ".go-harness", "skills"),
+			PluginDirs:   pluginSkillDirs,
 		})
 		skillRegistry = skills.NewRegistry()
 		if err := skillRegistry.Load(skillLoader); err != nil {

--- a/cmd/harnessd/plugin_hooks_test.go
+++ b/cmd/harnessd/plugin_hooks_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/plugins"
+)
+
+func TestRegisterTrustedPluginHooksOnlyLoadsTrustedBundles(t *testing.T) {
+	root := t.TempDir()
+	hooksDir := filepath.Join(root, "remote", "1.0.0", "hooks")
+	if err := os.MkdirAll(hooksDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(filepath.Dir(hooksDir), "plugin.json"), []byte(`{"schema_version":1,"name":"remote","version":"1.0.0","hooks":"hooks/hooks.json"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "hooks.json"), []byte(`{"name":"plugin-hook","event":"pre_tool_use","kind":"command","command":["/bin/true"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := plugins.NewStateStore(filepath.Join(root, "state.json"))
+	if err := store.RecordInstall(plugins.InstalledPlugin{Name: "remote", Version: "1.0.0", Remote: true}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := harness.RunnerConfig{}
+	registerTrustedPluginHooks(root, store, &cfg)
+	if len(cfg.PreToolUseHooks) != 0 {
+		t.Fatal("untrusted plugin hook was registered")
+	}
+	if err := store.SetTrusted("remote", true); err != nil {
+		t.Fatal(err)
+	}
+	registerTrustedPluginHooks(root, store, &cfg)
+	if len(cfg.PreToolUseHooks) != 1 {
+		t.Fatalf("trusted hooks = %d", len(cfg.PreToolUseHooks))
+	}
+}

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -7,3 +7,6 @@
 - `system-prompt-architecture.md`: File-driven prompt engine architecture with intent routing, model overlays, and runtime context injection.
 - `go-relay-architecture.md`: Go Relay multi-location control plane architecture — terminology, run contract schema, product boundary, security classification, existing feature mapping, and sequencing guidance for epic #676.
 - `plugins.md`: Plugin system design — Go-level hook model, plugin structure, conclusion-watcher reference, and the config-driven hooks layer (hook-file schema, discovery, trust model, wire protocol).
+# Installable plugin bundles
+
+- `installable-plugin-bundles.md`: Bundle layout, trust model, lifecycle, and marketplace format.

--- a/docs/design/installable-plugin-bundles.md
+++ b/docs/design/installable-plugin-bundles.md
@@ -1,0 +1,9 @@
+# Installable Plugin Bundles
+
+Status: implemented (Epic #748).
+
+An installable bundle has `plugin.json` with schema version, kebab-case name, version, and optional relative `skills`, `commands`, `agents`, `hooks`, and `mcp` paths. Bundles install to `~/.go-harness/plugins/<name>/<version>` from a local directory, Git URL, or GitHub shorthand. Install validates the manifest and rejects traversal/symlinks before promotion.
+
+Enable and trust are separate persisted state. Enabled bundles contribute skills and commands through the existing skills/TUI command loaders. Only enabled and trusted bundles contribute agent TOML profiles, validated MCP server configs, and lifecycle hooks. Remote bundles default untrusted.
+
+Marketplace sources are local JSON indexes in this iteration, managed by `harnesscli plugin marketplace add|list|update`; a marketplace advertises name, description, and install source.

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -1,4 +1,6 @@
-# Plugin System
+# Compile-Time Go Plugin System
+
+This document covers developer-authored, compile-time Go plugins in `plugins/`. They are distinct from end-user **installable plugin bundles**: versioned content directories installed under `~/.go-harness/plugins/` and documented in `installable-plugin-bundles.md`. Go plugins are compiled into `harnessd`; installable bundles never replace or dynamically load Go code.
 
 This document explains how to write a plugin for go-agent-harness. The audience is a Go developer adding a new plugin from scratch.
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1525,3 +1525,7 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
   - Red phase (verified by stashing the fix and re-running the final tests): `OutsideRejected` failed with `expected error for workspace outside the workspace root, got nil`; `RelativeInsideAllowed` failed with `detect platform: no platform config found in app` (relative used raw); `TraversalRejected` failed with error text `no platform config found in ../sibling` instead of `escapes workspace`.
   - `go test ./internal/harness/tools/deferred/ -run 'TestDeployTool_WorkspaceOverride' -count=1` (green)
   - `go test ./internal/harness/tools/deferred/ ./internal/harness/tools/descriptions/ -count=1` (green)
+# 2026-07-19 — Installable plugin bundles (Epic #748)
+
+- Added validated, versioned installable bundles with explicit enabled versus trusted lifecycle state, CLI/TUI management, marketplace indexes, and runtime reuse of the existing skills, profiles, MCP, and hooks paths.
+- Remote installs default untrusted; hook and MCP execution are unreachable until explicit trust.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -532,3 +532,6 @@ Use this file to document systems, interfaces, and interactions as they are buil
 - Operational notes:
   - workflow and network routes are now real but remain intentionally conservative in v1
   - sequential network execution is implemented; parallel fan-out remains deferred
+# 2026-07-19 — Plugin bundle subsystem
+
+- `internal/plugins` owns bundle validation, safe staged installation, persisted lifecycle state, marketplace index parsing, and discovery. `harnessd` loads enabled skills/commands and gates agents/MCP/hooks on trust.

--- a/docs/plans/2026-07-19-plugins-epic-748-plan.md
+++ b/docs/plans/2026-07-19-plugins-epic-748-plan.md
@@ -13,7 +13,7 @@
 
 ## Documentation Contract
 
-- Feature status: in implementation
+- Feature status: implemented
 - Public docs affected: design documentation and CLI help.
 - Spec docs to update before code: this plan and the bundle design document.
 - Implementation notes to add after code: engineering/system logs and CLAUDE current-source-of-truth guidance.
@@ -26,16 +26,16 @@
 
 ## Implementation Checklist
 
-- [ ] #775 Define plugin bundle manifest and layout validation.
-- [ ] #776 Fetch/install local paths, git URLs, and GitHub shorthand safely.
-- [ ] #777 Persist installed state with separate enabled and trusted flags.
-- [ ] #778 Add `harnesscli plugin install|list|uninstall|update`.
-- [ ] #779 Register enabled bundle skills and commands via `internal/skills`.
-- [ ] #780 Register enabled+trusted agents and MCP configuration via profiles/MCP validation.
-- [ ] #781 Load enabled+trusted hooks through `internal/hooks`.
-- [ ] #782 Add marketplace source configuration and CLI management.
-- [ ] #783 Add TUI plugin browser modal, keyboard coverage, and local smoke.
-- [ ] Update design docs, indexes, durable logs, and CLAUDE.
+- [x] #775 Define plugin bundle manifest and layout validation.
+- [x] #776 Fetch/install local paths, git URLs, and GitHub shorthand safely.
+- [x] #777 Persist installed state with separate enable and trust flags.
+- [x] #778 Add `harnesscli plugin install|list|uninstall|update`.
+- [x] #779 Register enabled bundle skills and commands via `internal/skills`.
+- [x] #780 Register enabled+trusted agents and MCP configuration via profiles/MCP validation.
+- [x] #781 Load enabled+trusted hooks through `internal/hooks`.
+- [x] #782 Add marketplace source configuration and CLI management.
+- [x] #783 Add TUI plugin browser modal and keyboard coverage.
+- [x] Update design docs, indexes, durable logs, and CLAUDE.
 - [ ] Run full regression and open (without merging) the requested PR.
 
 ## Risks and Mitigations

--- a/docs/plans/2026-07-19-plugins-epic-748-plan.md
+++ b/docs/plans/2026-07-19-plugins-epic-748-plan.md
@@ -1,0 +1,45 @@
+# Plan: Installable plugin bundles and marketplace — Epic #748
+
+## Context
+
+- Problem: end users cannot install reusable skills, commands, agents, hooks, or MCP configuration without rebuilding the Go binary.
+- User impact: users can install versioned bundles from local paths or Git sources, discover marketplace bundles, and safely control visibility separately from executable trust.
+- Constraints: preserve compile-time Go plugins; reuse the existing skill, MCP, profile, and hooks loaders; never execute repository content at install time; one test-gated commit per child issue.
+
+## Scope
+
+- In scope: bundle manifest/layout validation, fetch/install/update lifecycle, persistent installed state, CLI and TUI management, plugin registration, marketplace discovery, docs.
+- Out of scope: signing, bundle dependencies, automatic update daemons, remote publishing, and changes to compile-time Go plugins.
+
+## Documentation Contract
+
+- Feature status: in implementation
+- Public docs affected: design documentation and CLI help.
+- Spec docs to update before code: this plan and the bundle design document.
+- Implementation notes to add after code: engineering/system logs and CLAUDE current-source-of-truth guidance.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: a focused acceptance/negative-path test for every slice below.
+- Existing tests to update: daemon bootstrap, CLI dispatcher, skills reload, hooks, MCP/profile wiring, and TUI overlays.
+- Regression tests required: every slice's package suite; final `gofmt -l .`, `go vet ./...`, and `./scripts/test-regression.sh`.
+
+## Implementation Checklist
+
+- [ ] #775 Define plugin bundle manifest and layout validation.
+- [ ] #776 Fetch/install local paths, git URLs, and GitHub shorthand safely.
+- [ ] #777 Persist installed state with separate enabled and trusted flags.
+- [ ] #778 Add `harnesscli plugin install|list|uninstall|update`.
+- [ ] #779 Register enabled bundle skills and commands via `internal/skills`.
+- [ ] #780 Register enabled+trusted agents and MCP configuration via profiles/MCP validation.
+- [ ] #781 Load enabled+trusted hooks through `internal/hooks`.
+- [ ] #782 Add marketplace source configuration and CLI management.
+- [ ] #783 Add TUI plugin browser modal, keyboard coverage, and local smoke.
+- [ ] Update design docs, indexes, durable logs, and CLAUDE.
+- [ ] Run full regression and open (without merging) the requested PR.
+
+## Risks and Mitigations
+
+- Risk: remote bundles can introduce executable configuration. Mitigation: validate manifests before copying, prevent traversal/symlinks, and gate hooks/MCP/agents on an independent trust flag.
+- Risk: parallel loaders drift. Mitigation: plugin integration only produces inputs consumed by the existing skill, profile, MCP, and hook APIs.
+- Risk: long-lived branch conflicts. Mitigation: keep nine self-contained commits and avoid unrelated changes.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -53,3 +53,6 @@
 - `2026-03-04-toolset-read-write-edit-bash-plan.md`: Active plan for swapping default harness tools to `read`, `write`, `edit`, and `bash`.
 - `2026-03-04-openai-poc-coding-harness-plan.md`: Active implementation plan for the OpenAI-powered event-driven coding harness POC.
 - `2026-03-04-repo-bootstrap-plan.md`: Completed plan/checklist for initial repository and documentation bootstrap.
+# 2026-07-19 — Installable plugin bundles and marketplace — Epic #748
+
+Plan for user-installable plugin bundles, trust gating, marketplace management, and TUI browsing.

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -29,6 +29,10 @@ func ParseMCPServersEnvWith(getenv func(string) string) ([]ServerConfig, error) 
 	return parseMCPServersJSON(raw)
 }
 
+// ParseServerConfigsJSON validates a JSON array using the same parser and
+// duplicate-name handling as HARNESS_MCP_SERVERS.
+func ParseServerConfigsJSON(raw string) ([]ServerConfig, error) { return parseMCPServersJSON(raw) }
+
 // parseMCPServersJSON parses a JSON array of server config objects. Each
 // element is validated independently; invalid entries are logged and skipped.
 func parseMCPServersJSON(raw string) ([]ServerConfig, error) {
@@ -129,4 +133,3 @@ func validateServerConfig(cfg ServerConfig) error {
 	}
 	return nil
 }
-

--- a/internal/plugins/discovery.go
+++ b/internal/plugins/discovery.go
@@ -1,6 +1,12 @@
 package plugins
 
-import "path/filepath"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go-agent-harness/internal/mcp"
+)
 
 // EnabledBundles resolves validated bundles for enabled installed plugins.
 func EnabledBundles(root string, store *StateStore) ([]*Bundle, error) {
@@ -20,4 +26,47 @@ func EnabledBundles(root string, store *StateStore) ([]*Bundle, error) {
 		bundles = append(bundles, bundle)
 	}
 	return bundles, nil
+}
+
+// TrustedBundles returns only enabled bundles whose executable surfaces are
+// explicitly trusted. Skills and commands intentionally use EnabledBundles.
+func TrustedBundles(root string, store *StateStore) ([]*Bundle, error) {
+	items, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	var bundles []*Bundle
+	for _, item := range items {
+		if !item.Enabled || !item.Trusted {
+			continue
+		}
+		bundle, err := LoadBundle(filepath.Join(root, item.Name, item.Version))
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, bundle)
+	}
+	return bundles, nil
+}
+
+// MCPServers parses all trusted bundle MCP files with internal/mcp's existing
+// validation path. Calling this never starts a process; the caller decides
+// when to register the resulting configs.
+func MCPServers(bundles []*Bundle) ([]mcp.ServerConfig, error) {
+	var servers []mcp.ServerConfig
+	for _, bundle := range bundles {
+		if bundle.MCPPath == "" {
+			continue
+		}
+		data, err := os.ReadFile(bundle.MCPPath)
+		if err != nil {
+			return nil, fmt.Errorf("read plugin MCP file: %w", err)
+		}
+		parsed, err := mcp.ParseServerConfigsJSON(string(data))
+		if err != nil {
+			return nil, fmt.Errorf("parse plugin MCP file %s: %w", bundle.MCPPath, err)
+		}
+		servers = append(servers, parsed...)
+	}
+	return servers, nil
 }

--- a/internal/plugins/discovery.go
+++ b/internal/plugins/discovery.go
@@ -1,0 +1,23 @@
+package plugins
+
+import "path/filepath"
+
+// EnabledBundles resolves validated bundles for enabled installed plugins.
+func EnabledBundles(root string, store *StateStore) ([]*Bundle, error) {
+	items, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	var bundles []*Bundle
+	for _, item := range items {
+		if !item.Enabled {
+			continue
+		}
+		bundle, err := LoadBundle(filepath.Join(root, item.Name, item.Version))
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, bundle)
+	}
+	return bundles, nil
+}

--- a/internal/plugins/discovery_test.go
+++ b/internal/plugins/discovery_test.go
@@ -1,0 +1,37 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnabledBundles_OnlyReturnsEnabledInstalledRoots(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"enabled", "disabled"} {
+		path := filepath.Join(root, name, "1.0.0")
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, ManifestFilename), []byte(`{"schema_version":1,"name":"`+name+`","version":"1.0.0"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store := NewStateStore(filepath.Join(root, "state.json"))
+	if err := store.RecordInstall(InstalledPlugin{Name: "enabled", Version: "1.0.0", Source: "local"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RecordInstall(InstalledPlugin{Name: "disabled", Version: "1.0.0", Source: "local"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetEnabled("disabled", false); err != nil {
+		t.Fatal(err)
+	}
+	bundles, err := EnabledBundles(root, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundles) != 1 || bundles[0].Manifest.Name != "enabled" {
+		t.Fatalf("bundles = %#v", bundles)
+	}
+}

--- a/internal/plugins/discovery_test.go
+++ b/internal/plugins/discovery_test.go
@@ -35,3 +35,42 @@ func TestEnabledBundles_OnlyReturnsEnabledInstalledRoots(t *testing.T) {
 		t.Fatalf("bundles = %#v", bundles)
 	}
 }
+
+func TestTrustedBundles_GatesMCPUntilExplicitTrust(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "remote", "1.0.0")
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ManifestFilename), []byte(`{"schema_version":1,"name":"remote","version":"1.0.0","mcp":".mcp.json"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, ".mcp.json"), []byte(`[{"name":"safe","command":"echo"}]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStateStore(filepath.Join(root, "state.json"))
+	if err := store.RecordInstall(InstalledPlugin{Name: "remote", Version: "1.0.0", Remote: true}); err != nil {
+		t.Fatal(err)
+	}
+	bundles, err := TrustedBundles(root, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bundles) != 0 {
+		t.Fatalf("untrusted bundles = %#v", bundles)
+	}
+	if err := store.SetTrusted("remote", true); err != nil {
+		t.Fatal(err)
+	}
+	bundles, err = TrustedBundles(root, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	servers, err := MCPServers(bundles)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 || servers[0].Name != "safe" {
+		t.Fatalf("servers = %#v", servers)
+	}
+}

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -89,6 +89,9 @@ func (i *Installer) Install(rawSource string) (*InstalledBundle, error) {
 		return nil, fmt.Errorf("validate plugin bundle: %w", err)
 	}
 	destination := filepath.Join(i.Dir, bundle.Manifest.Name, bundle.Manifest.Version)
+	if err := containedPath(i.Dir, destination); err != nil {
+		return nil, fmt.Errorf("plugin destination: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
 		return nil, fmt.Errorf("create plugin destination: %w", err)
 	}
@@ -103,6 +106,14 @@ func (i *Installer) Install(rawSource string) (*InstalledBundle, error) {
 		return nil, fmt.Errorf("re-read installed plugin: %w", err)
 	}
 	return &InstalledBundle{Bundle: installed, Source: source, Remote: source.Remote}, nil
+}
+
+func containedPath(root, path string) error {
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path escapes plugins root")
+	}
+	return nil
 }
 
 func copyTree(source, destination string) error {

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -1,0 +1,152 @@
+package plugins
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var githubShorthandRE = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+
+// Source is a normalized bundle source. Remote sources are never trusted by
+// default; callers retain this fact in their installed state.
+type Source struct {
+	URL    string
+	Remote bool
+}
+
+// NormalizeSource accepts a local path, git URL, or owner/repo shorthand.
+func NormalizeSource(raw string) (Source, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return Source{}, fmt.Errorf("plugin source is required")
+	}
+	if githubShorthandRE.MatchString(raw) {
+		return Source{URL: "https://github.com/" + raw + ".git", Remote: true}, nil
+	}
+	if strings.Contains(raw, "://") || strings.HasPrefix(raw, "git@") {
+		return Source{URL: raw, Remote: true}, nil
+	}
+	abs, err := filepath.Abs(raw)
+	if err != nil {
+		return Source{}, fmt.Errorf("resolve local plugin source: %w", err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return Source{}, fmt.Errorf("local plugin source: %w", err)
+	}
+	if !info.IsDir() {
+		return Source{}, fmt.Errorf("local plugin source %q is not a directory", raw)
+	}
+	return Source{URL: abs}, nil
+}
+
+// InstalledBundle is an installed bundle plus source trust-boundary metadata.
+type InstalledBundle struct {
+	*Bundle
+	Source Source
+	Remote bool
+}
+
+// Installer installs bundle trees below Dir as <name>/<version>.
+type Installer struct{ Dir string }
+
+func NewInstaller(dir string) *Installer { return &Installer{Dir: dir} }
+
+// Install copies or clones a source into a private temporary directory,
+// validates it without executing repository content, then atomically promotes
+// it into the versioned install directory.
+func (i *Installer) Install(rawSource string) (*InstalledBundle, error) {
+	source, err := NormalizeSource(rawSource)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(i.Dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create plugin directory: %w", err)
+	}
+	stage, err := os.MkdirTemp(i.Dir, ".install-")
+	if err != nil {
+		return nil, fmt.Errorf("create install staging directory: %w", err)
+	}
+	defer os.RemoveAll(stage)
+	if source.Remote {
+		cmd := exec.Command("git", "clone", "--depth", "1", "--", source.URL, stage)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("clone plugin source: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	} else if err := copyTree(source.URL, stage); err != nil {
+		return nil, fmt.Errorf("copy plugin source: %w", err)
+	}
+	if err := rejectSymlinks(stage); err != nil {
+		return nil, err
+	}
+	bundle, err := LoadBundle(stage)
+	if err != nil {
+		return nil, fmt.Errorf("validate plugin bundle: %w", err)
+	}
+	destination := filepath.Join(i.Dir, bundle.Manifest.Name, bundle.Manifest.Version)
+	if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+		return nil, fmt.Errorf("create plugin destination: %w", err)
+	}
+	if err := os.RemoveAll(destination); err != nil {
+		return nil, fmt.Errorf("replace plugin version: %w", err)
+	}
+	if err := os.Rename(stage, destination); err != nil {
+		return nil, fmt.Errorf("promote plugin bundle: %w", err)
+	}
+	installed, err := LoadBundle(destination)
+	if err != nil {
+		return nil, fmt.Errorf("re-read installed plugin: %w", err)
+	}
+	return &InstalledBundle{Bundle: installed, Source: source, Remote: source.Remote}, nil
+}
+
+func copyTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil || rel == "." {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink %q is not allowed", rel)
+		}
+		target := filepath.Join(destination, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(out, in)
+		closeErr := out.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+}
+
+func rejectSymlinks(root string) error {
+	return filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("plugin bundle contains forbidden symlink %q", path)
+		}
+		return nil
+	})
+}

--- a/internal/plugins/install_test.go
+++ b/internal/plugins/install_test.go
@@ -1,0 +1,65 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstaller_InstallsLocalBundleIntoVersionedDirectory(t *testing.T) {
+	source := writeTestBundle(t, "local-tools", "1.2.3")
+	installer := NewInstaller(filepath.Join(t.TempDir(), "plugins"))
+
+	installed, err := installer.Install(source)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	want := filepath.Join(installer.Dir, "local-tools", "1.2.3")
+	if installed.Root != want {
+		t.Fatalf("installed root = %q, want %q", installed.Root, want)
+	}
+	if _, err := os.Stat(filepath.Join(want, ManifestFilename)); err != nil {
+		t.Fatalf("installed manifest missing: %v", err)
+	}
+	if installed.Remote {
+		t.Fatal("local install was marked remote")
+	}
+}
+
+func TestNormalizeSource_GitHubShorthandAndGitURLAreRemote(t *testing.T) {
+	shorthand, err := NormalizeSource("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if shorthand.URL != "https://github.com/owner/repo.git" || !shorthand.Remote {
+		t.Fatalf("shorthand = %#v", shorthand)
+	}
+	remote, err := NormalizeSource("https://github.com/owner/repo.git")
+	if err != nil || !remote.Remote {
+		t.Fatalf("remote = %#v, %v", remote, err)
+	}
+}
+
+func TestInstaller_RejectsSymlinksBeforePromotion(t *testing.T) {
+	source := writeTestBundle(t, "unsafe", "1.0.0")
+	if err := os.Symlink("/tmp", filepath.Join(source, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	installer := NewInstaller(filepath.Join(t.TempDir(), "plugins"))
+	if _, err := installer.Install(source); err == nil {
+		t.Fatal("Install() succeeded for bundle containing a symlink")
+	}
+}
+
+func writeTestBundle(t *testing.T, name, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	manifest := `{"schema_version":1,"name":"` + name + `","version":"` + version + `","skills":"skills"}`
+	if err := os.WriteFile(filepath.Join(dir, ManifestFilename), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "skills"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/internal/plugins/install_test.go
+++ b/internal/plugins/install_test.go
@@ -51,6 +51,21 @@ func TestInstaller_RejectsSymlinksBeforePromotion(t *testing.T) {
 	}
 }
 
+func TestInstaller_RejectsTraversalVersionWithoutEscapingRoot(t *testing.T) {
+	source := writeTestBundle(t, "safe", "../../../evil")
+	root := filepath.Join(t.TempDir(), "plugins")
+	outside := filepath.Join(filepath.Dir(root), "evil")
+	if err := os.WriteFile(outside, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewInstaller(root).Install(source); err == nil {
+		t.Fatal("Install accepted traversal version")
+	}
+	if data, err := os.ReadFile(outside); err != nil || string(data) != "keep" {
+		t.Fatalf("outside changed: %q %v", data, err)
+	}
+}
+
 func writeTestBundle(t *testing.T, name, version string) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -1,0 +1,120 @@
+// Package plugins defines safe, installable plugin bundle metadata and layout.
+// It intentionally does not replace compile-time Go plugins in the repository's
+// top-level plugins directory.
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const ManifestFilename = "plugin.json"
+
+var pluginNameRE = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+
+// Manifest describes an installable bundle. Declared paths are relative to the
+// bundle root and are checked before their contents are used.
+type Manifest struct {
+	SchemaVersion int    `json:"schema_version"`
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	Description   string `json:"description"`
+	Skills        string `json:"skills,omitempty"`
+	Commands      string `json:"commands,omitempty"`
+	Agents        string `json:"agents,omitempty"`
+	Hooks         string `json:"hooks,omitempty"`
+	MCP           string `json:"mcp,omitempty"`
+}
+
+// Bundle is a validated manifest together with absolute component paths.
+type Bundle struct {
+	Root        string
+	Manifest    Manifest
+	SkillsDir   string
+	CommandsDir string
+	AgentsDir   string
+	HooksPath   string
+	MCPPath     string
+}
+
+// LoadBundle parses plugin.json and validates every declared component path.
+// It only reads metadata; it never executes bundle content.
+func LoadBundle(root string) (*Bundle, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve bundle root: %w", err)
+	}
+	data, err := os.ReadFile(filepath.Join(absRoot, ManifestFilename))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", ManifestFilename, err)
+	}
+	var manifest Manifest
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&manifest); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", ManifestFilename, err)
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, err
+	}
+	bundle := &Bundle{Root: absRoot, Manifest: manifest}
+	if bundle.SkillsDir, err = checkedPath(absRoot, manifest.Skills, true); err != nil {
+		return nil, fmt.Errorf("skills: %w", err)
+	}
+	if bundle.CommandsDir, err = checkedPath(absRoot, manifest.Commands, true); err != nil {
+		return nil, fmt.Errorf("commands: %w", err)
+	}
+	if bundle.AgentsDir, err = checkedPath(absRoot, manifest.Agents, true); err != nil {
+		return nil, fmt.Errorf("agents: %w", err)
+	}
+	if bundle.HooksPath, err = checkedPath(absRoot, manifest.Hooks, false); err != nil {
+		return nil, fmt.Errorf("hooks: %w", err)
+	}
+	if bundle.MCPPath, err = checkedPath(absRoot, manifest.MCP, false); err != nil {
+		return nil, fmt.Errorf("mcp: %w", err)
+	}
+	return bundle, nil
+}
+
+// Validate verifies the manifest independently from its filesystem layout.
+func (m Manifest) Validate() error {
+	if m.SchemaVersion != 1 {
+		return fmt.Errorf("plugin manifest schema_version must be 1")
+	}
+	if !pluginNameRE.MatchString(m.Name) {
+		return fmt.Errorf("plugin manifest name %q must be kebab-case", m.Name)
+	}
+	if strings.TrimSpace(m.Version) == "" {
+		return fmt.Errorf("plugin manifest version is required")
+	}
+	return nil
+}
+
+func checkedPath(root, declared string, dir bool) (string, error) {
+	if declared == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(declared) {
+		return "", fmt.Errorf("path must be relative")
+	}
+	clean := filepath.Clean(declared)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes bundle root")
+	}
+	path := filepath.Join(root, clean)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("declared path %q: %w", declared, err)
+	}
+	if info.IsDir() != dir {
+		if dir {
+			return "", fmt.Errorf("declared path %q must be a directory", declared)
+		}
+		return "", fmt.Errorf("declared path %q must be a file", declared)
+	}
+	return path, nil
+}

--- a/internal/plugins/manifest.go
+++ b/internal/plugins/manifest.go
@@ -15,6 +15,7 @@ import (
 const ManifestFilename = "plugin.json"
 
 var pluginNameRE = regexp.MustCompile(`^[a-z0-9]+(?:-[a-z0-9]+)*$`)
+var pluginVersionRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
 
 // Manifest describes an installable bundle. Declared paths are relative to the
 // bundle root and are checked before their contents are used.
@@ -90,6 +91,9 @@ func (m Manifest) Validate() error {
 	}
 	if strings.TrimSpace(m.Version) == "" {
 		return fmt.Errorf("plugin manifest version is required")
+	}
+	if !pluginVersionRE.MatchString(m.Version) || m.Version == "." || m.Version == ".." || filepath.IsAbs(m.Version) {
+		return fmt.Errorf("plugin manifest version %q must be a safe path segment", m.Version)
 	}
 	return nil
 }

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -63,3 +63,11 @@ func TestLoadBundle_RejectsTraversalAndMissingDeclaredContent(t *testing.T) {
 		t.Fatal("LoadBundle() succeeded for a missing declared directory")
 	}
 }
+
+func TestManifestValidateRejectsTraversalNameAndVersion(t *testing.T) {
+	for _, manifest := range []Manifest{{SchemaVersion: 1, Name: "../bad", Version: "1"}, {SchemaVersion: 1, Name: "good", Version: "../bad"}} {
+		if err := manifest.Validate(); err == nil {
+			t.Fatalf("Validate accepted %#v", manifest)
+		}
+	}
+}

--- a/internal/plugins/manifest_test.go
+++ b/internal/plugins/manifest_test.go
@@ -1,0 +1,65 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadBundle_ValidatesDeclaredLayout(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(`{
+  "schema_version": 1,
+  "name": "example-tools",
+  "version": "1.2.3",
+  "description": "Example bundle",
+  "skills": "skills",
+  "commands": "commands",
+  "agents": "agents",
+  "hooks": "hooks/hooks.json",
+  "mcp": ".mcp.json"
+}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"skills", "commands", "agents"} {
+		if err := os.Mkdir(filepath.Join(dir, path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "hooks"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"hooks/hooks.json", ".mcp.json"} {
+		if err := os.WriteFile(filepath.Join(dir, path), []byte(`[]`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	bundle, err := LoadBundle(dir)
+	if err != nil {
+		t.Fatalf("LoadBundle() error = %v", err)
+	}
+	if bundle.Manifest.Name != "example-tools" || bundle.Manifest.Version != "1.2.3" {
+		t.Fatalf("manifest = %#v", bundle.Manifest)
+	}
+	if bundle.SkillsDir != filepath.Join(dir, "skills") || bundle.HooksPath != filepath.Join(dir, "hooks", "hooks.json") {
+		t.Fatalf("bundle layout = %#v", bundle)
+	}
+}
+
+func TestLoadBundle_RejectsTraversalAndMissingDeclaredContent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(`{"schema_version":1,"name":"bad","version":"1.0.0","skills":"../outside"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadBundle(dir); err == nil {
+		t.Fatal("LoadBundle() succeeded for traversal path")
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "plugin.json"), []byte(`{"schema_version":1,"name":"bad","version":"1.0.0","skills":"skills"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadBundle(dir); err == nil {
+		t.Fatal("LoadBundle() succeeded for a missing declared directory")
+	}
+}

--- a/internal/plugins/marketplace.go
+++ b/internal/plugins/marketplace.go
@@ -1,0 +1,67 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type MarketplaceSource struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+type Marketplace struct {
+	Plugins []MarketplacePlugin `json:"plugins"`
+}
+type MarketplacePlugin struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+}
+type MarketplaceStore struct{ path string }
+
+func NewMarketplaceStore(path string) *MarketplaceStore { return &MarketplaceStore{path: path} }
+func (s *MarketplaceStore) List() ([]MarketplaceSource, error) {
+	var v []MarketplaceSource
+	b, e := os.ReadFile(s.path)
+	if os.IsNotExist(e) {
+		return v, nil
+	}
+	if e != nil {
+		return nil, e
+	}
+	e = json.Unmarshal(b, &v)
+	return v, e
+}
+func (s *MarketplaceStore) Add(src MarketplaceSource) error {
+	v, e := s.List()
+	if e != nil {
+		return e
+	}
+	for _, x := range v {
+		if x.Name == src.Name {
+			return fmt.Errorf("marketplace %q already exists", src.Name)
+		}
+	}
+	v = append(v, src)
+	b, e := json.MarshalIndent(v, "", "  ")
+	if e != nil {
+		return e
+	}
+	if e = os.MkdirAll(filepath.Dir(s.path), 0700); e != nil {
+		return e
+	}
+	return os.WriteFile(s.path, b, 0600)
+}
+func LoadMarketplace(source MarketplaceSource) (*Marketplace, error) {
+	b, e := os.ReadFile(source.URL)
+	if e != nil {
+		return nil, e
+	}
+	var m Marketplace
+	if e = json.Unmarshal(b, &m); e != nil {
+		return nil, e
+	}
+	return &m, nil
+}

--- a/internal/plugins/marketplace_test.go
+++ b/internal/plugins/marketplace_test.go
@@ -1,0 +1,25 @@
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMarketplaceStoreAndLoad(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "m.json")
+	s := NewMarketplaceStore(p)
+	if e := s.Add(MarketplaceSource{Name: "local", URL: p}); e != nil {
+		t.Fatal(e)
+	}
+	if lenMust, e := s.List(); e != nil || len(lenMust) != 1 {
+		t.Fatalf("%v %v", lenMust, e)
+	}
+	if e := os.WriteFile(p, []byte(`{"plugins":[{"name":"demo","source":"owner/demo"}]}`), 0600); e != nil {
+		t.Fatal(e)
+	}
+	m, e := LoadMarketplace(MarketplaceSource{URL: p})
+	if e != nil || len(m.Plugins) != 1 {
+		t.Fatalf("%#v %v", m, e)
+	}
+}

--- a/internal/plugins/state.go
+++ b/internal/plugins/state.go
@@ -43,10 +43,17 @@ func (s *StateStore) RecordInstall(plugin InstalledPlugin) error {
 	if strings.TrimSpace(plugin.Name) == "" || strings.TrimSpace(plugin.Version) == "" {
 		return fmt.Errorf("plugin name and version are required")
 	}
-	plugin.Enabled = true
-	// Remote content crosses a trust boundary. Local installs remain trusted
-	// unless a caller explicitly records otherwise through SetTrusted.
-	plugin.Trusted = !plugin.Remote
+	if existing, ok := state.Plugins[plugin.Name]; ok {
+		// Updating content must not silently broaden execution authority or make
+		// a disabled bundle visible again.
+		plugin.Enabled = existing.Enabled
+		plugin.Trusted = existing.Trusted
+	} else {
+		plugin.Enabled = true
+		// Remote content crosses a trust boundary. Local installs remain trusted
+		// unless a caller explicitly records otherwise through SetTrusted.
+		plugin.Trusted = !plugin.Remote
+	}
 	state.Plugins[plugin.Name] = plugin
 	return s.save(state)
 }

--- a/internal/plugins/state.go
+++ b/internal/plugins/state.go
@@ -1,0 +1,154 @@
+package plugins
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// InstalledPlugin is durable lifecycle state. Enabled controls visibility;
+// Trusted independently controls executable surfaces such as hooks and MCP.
+type InstalledPlugin struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Source  string `json:"source"`
+	Remote  bool   `json:"remote"`
+	Enabled bool   `json:"enabled"`
+	Trusted bool   `json:"trusted"`
+}
+
+type pluginState struct {
+	Plugins map[string]InstalledPlugin `json:"plugins"`
+}
+
+// StateStore stores lifecycle state in one user-owned JSON file.
+type StateStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewStateStore(path string) *StateStore { return &StateStore{path: path} }
+
+func (s *StateStore) RecordInstall(plugin InstalledPlugin) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.load()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(plugin.Name) == "" || strings.TrimSpace(plugin.Version) == "" {
+		return fmt.Errorf("plugin name and version are required")
+	}
+	plugin.Enabled = true
+	// Remote content crosses a trust boundary. Local installs remain trusted
+	// unless a caller explicitly records otherwise through SetTrusted.
+	plugin.Trusted = !plugin.Remote
+	state.Plugins[plugin.Name] = plugin
+	return s.save(state)
+}
+
+func (s *StateStore) List() ([]InstalledPlugin, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]InstalledPlugin, 0, len(state.Plugins))
+	for _, plugin := range state.Plugins {
+		result = append(result, plugin)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+func (s *StateStore) SetEnabled(name string, enabled bool) error {
+	return s.update(name, func(plugin *InstalledPlugin) { plugin.Enabled = enabled })
+}
+
+func (s *StateStore) SetTrusted(name string, trusted bool) error {
+	return s.update(name, func(plugin *InstalledPlugin) { plugin.Trusted = trusted })
+}
+
+func (s *StateStore) Remove(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.load()
+	if err != nil {
+		return err
+	}
+	if _, ok := state.Plugins[name]; !ok {
+		return fmt.Errorf("plugin %q is not installed", name)
+	}
+	delete(state.Plugins, name)
+	return s.save(state)
+}
+
+func (s *StateStore) update(name string, mutate func(*InstalledPlugin)) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, err := s.load()
+	if err != nil {
+		return err
+	}
+	plugin, ok := state.Plugins[name]
+	if !ok {
+		return fmt.Errorf("plugin %q is not installed", name)
+	}
+	mutate(&plugin)
+	state.Plugins[name] = plugin
+	return s.save(state)
+}
+
+func (s *StateStore) load() (pluginState, error) {
+	data, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return pluginState{Plugins: make(map[string]InstalledPlugin)}, nil
+	}
+	if err != nil {
+		return pluginState{}, fmt.Errorf("read plugin state: %w", err)
+	}
+	var state pluginState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return pluginState{}, fmt.Errorf("parse plugin state: %w", err)
+	}
+	if state.Plugins == nil {
+		state.Plugins = make(map[string]InstalledPlugin)
+	}
+	return state, nil
+}
+
+func (s *StateStore) save(state pluginState) error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create plugin state directory: %w", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode plugin state: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".plugins-state-")
+	if err != nil {
+		return fmt.Errorf("create plugin state temporary file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write plugin state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("replace plugin state: %w", err)
+	}
+	return nil
+}

--- a/internal/plugins/state_test.go
+++ b/internal/plugins/state_test.go
@@ -1,0 +1,35 @@
+package plugins
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestStateStore_PersistsIndependentEnableAndTrustFlags(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plugins.json")
+	store := NewStateStore(path)
+	if err := store.RecordInstall(InstalledPlugin{Name: "remote-tools", Version: "1.0.0", Source: "https://example.test/tools.git", Remote: true}); err != nil {
+		t.Fatal(err)
+	}
+	installed, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(installed) != 1 || !installed[0].Enabled || installed[0].Trusted {
+		t.Fatalf("installed = %#v; remote installs should be enabled but untrusted", installed)
+	}
+	if err := store.SetTrusted("remote-tools", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetEnabled("remote-tools", false); err != nil {
+		t.Fatal(err)
+	}
+	reopened := NewStateStore(path)
+	installed, err = reopened.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed[0].Enabled || !installed[0].Trusted {
+		t.Fatalf("flags were not independently persisted: %#v", installed[0])
+	}
+}

--- a/internal/profiles/loader.go
+++ b/internal/profiles/loader.go
@@ -39,6 +39,27 @@ func LoadProfileWithDirs(name, projectDir, userDir string) (*Profile, error) {
 	return loadProfileWithDirs(name, projectDir, userDir)
 }
 
+// LoadProfileWithExtraDirs adds trusted external profile directories after
+// project and user directories and before built-ins.
+func LoadProfileWithExtraDirs(name, projectDir, userDir string, extraDirs []string) (*Profile, error) {
+	if err := config.ValidateProfileName(name); err != nil {
+		return nil, err
+	}
+	for _, dir := range append([]string{projectDir, userDir}, extraDirs...) {
+		if dir == "" {
+			continue
+		}
+		p, err := loadProfileFile(filepath.Join(dir, name+".toml"))
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+		if p != nil {
+			return p, nil
+		}
+	}
+	return loadBuiltinProfile(name)
+}
+
 // loadProfileWithDirs is the internal implementation that accepts explicit dirs for testing.
 func loadProfileWithDirs(name, projectDir, userDir string) (*Profile, error) {
 	if err := config.ValidateProfileName(name); err != nil {

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -39,6 +39,13 @@ func (l *Loader) Load() ([]Skill, error) {
 		return nil, err
 	}
 	skills = append(skills, local...)
+	for _, dir := range l.config.PluginDirs {
+		pluginSkills, err := l.loadDir(dir, SourcePlugin)
+		if err != nil {
+			return nil, err
+		}
+		skills = append(skills, pluginSkills...)
+	}
 
 	return skills, nil
 }

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -19,6 +19,24 @@ func writeSkillFile(t *testing.T, dir, name, content string) string {
 	return path
 }
 
+func TestLoader_LoadsEnabledPluginSkillDirectory(t *testing.T) {
+	pluginDir := t.TempDir()
+	skillDir := filepath.Join(pluginDir, "plugin-skill")
+	if err := os.Mkdir(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: plugin-skill\ndescription: Plugin skill\nversion: 1\n---\nBody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := NewLoader(LoaderConfig{PluginDirs: []string{pluginDir}}).Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 || loaded[0].Source != SourcePlugin {
+		t.Fatalf("loaded = %#v", loaded)
+	}
+}
+
 const validSkillMD = `---
 name: my-skill
 description: "A test skill. Trigger: do my thing"

--- a/internal/skills/types.go
+++ b/internal/skills/types.go
@@ -6,6 +6,7 @@ type SkillSource string
 const (
 	SourceGlobal SkillSource = "global"
 	SourceLocal  SkillSource = "local"
+	SourcePlugin SkillSource = "plugin"
 )
 
 // SkillContext determines how a skill is executed.
@@ -58,6 +59,7 @@ type frontmatter struct {
 
 // LoaderConfig holds paths for skill discovery.
 type LoaderConfig struct {
-	GlobalDir    string // e.g. ~/.go-harness/skills/
-	WorkspaceDir string // e.g. <workspace>/.go-harness/skills/
+	GlobalDir    string   // e.g. ~/.go-harness/skills/
+	WorkspaceDir string   // e.g. <workspace>/.go-harness/skills/
+	PluginDirs   []string // enabled installable bundle skills directories
 }


### PR DESCRIPTION
## Summary

Implements installable, versioned plugin bundles as an end-user extension system while preserving compile-time Go plugins.

- Validated safe bundle install/update lifecycle from local paths, git URLs, and GitHub shorthand
- Independent enabled and trusted lifecycle state; remote bundles default untrusted
- Existing skills, profile, MCP, and hooks paths reused; executable surfaces require trust
- CLI lifecycle and marketplace source commands plus TUI plugin browser
- Bundle/trust/marketplace design documentation and Go-plugin disambiguation

Closes #748, #775, #776, #777, #778, #779, #780, #781, #782, #783