### PR TITLE
feat(plan-mode): enforced plan-mode gating and approval — epic #740

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,15 @@ Wiring: `ServerOptions.ScriptWorkflows` accepts a `scriptWorkflowManager` interf
 cover CRUD, SSE streaming, resume, adversarial verify, loop-until-dry, concurrent fan-out,
 and error recovery chains.
 
+### Enforced Plan Mode
+
+`harnesscli --plan-mode` and the TUI `Ctrl+O` toggle send `plan_mode` in the
+normal run request. The runner injects live per-run state into the central
+`ApplyPolicy` wrapper: while active, mutations fail closed unless the
+permission-rule matcher accepts the designated `.harness/plan.md` plan file.
+Plan exit uses the existing approval broker and `/v1/runs/{id}/approve|deny`;
+the SQLite conversation store persists the latest plan content per conversation.
+
 ## Provider Note
 
 - OpenAI is the primary provider path.

--- a/cmd/harnesscli/main.go
+++ b/cmd/harnesscli/main.go
@@ -87,6 +87,7 @@ type runCreateRequest struct {
 	PromptProfile    string                   `json:"prompt_profile,omitempty"`
 	PromptExtensions *runCreatePromptSettings `json:"prompt_extensions,omitempty"`
 	WorkspacePath    string                   `json:"workspace_path,omitempty"`
+	PlanMode         bool                     `json:"plan_mode,omitempty"`
 }
 
 type runCreatePromptSettings struct {
@@ -149,6 +150,7 @@ func run(args []string) int {
 	promptProfile := flags.String("prompt-profile", "", "prompt profile override for model routing")
 	promptCustom := flags.String("prompt-custom", "", "custom prompt extension text")
 	workspace := flags.String("workspace", "", "workspace directory for this run (defaults to current working directory)")
+	planMode := flags.Bool("plan-mode", false, "start the run in enforced read-only plan mode")
 	enableTUI := flags.Bool("tui", false, "launch interactive BubbleTea TUI (experimental)")
 	resume := flags.String("resume", "", "resume an existing conversation by ID in the TUI (implies --tui)")
 	listProfiles := flags.Bool("list-profiles", false, "list available profiles and exit")
@@ -202,6 +204,7 @@ func run(args []string) int {
 		PromptProfile:    *promptProfile,
 		PromptExtensions: extensions,
 		WorkspacePath:    workspacePath,
+		PlanMode:         *planMode,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "harnesscli: start run: %v\n", err)

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -60,6 +60,7 @@ type runCreateRequest struct {
 	// requested model's provider can't be resolved, instead of hard-failing
 	// the run. Always true from the TUI.
 	AllowFallback bool `json:"allow_fallback,omitempty"`
+	PlanMode      bool `json:"plan_mode,omitempty"`
 }
 
 type runCreateResponse struct {
@@ -111,7 +112,8 @@ type RemoteSubagent struct {
 // profile is the name of the capability profile to use (may be empty); it is
 // sent as the "profile" field so the server applies the profile's tool
 // restrictions and isolation.
-func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace, apiKey string) tea.Cmd {
+func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace, apiKey string, planMode ...bool) tea.Cmd {
+	enabled := len(planMode) > 0 && planMode[0]
 	return func() tea.Msg {
 		body, _ := json.Marshal(runCreateRequest{
 			Prompt:          prompt,
@@ -122,6 +124,7 @@ func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffo
 			ProfileName:     profile,
 			WorkspacePath:   workspace,
 			AllowFallback:   true,
+			PlanMode:        enabled,
 		})
 		url := strings.TrimRight(baseURL, "/") + "/v1/runs"
 		req, err := newHarnessRequest(context.Background(), http.MethodPost, url, bytes.NewReader(body), apiKey)

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -2760,7 +2760,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.appendMessageBubble(messagebubble.RoleUser, msg.Value)
 		// Fire off the run against the harness API with the expanded prompt.
 		effModel, effProvider := m.effectiveModelAndProvider()
-		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey))
+		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey, m.planMode))
 
 	case AssistantDeltaMsg:
 		m.lastAssistantText += msg.Delta

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -317,6 +317,7 @@ type Model struct {
 	// toolApproval holds the state for an in-progress tool-approval decision.
 	// toolApproval.active is true when the overlay is shown.
 	toolApproval toolApprovalState
+	planApproval planApprovalState
 
 	// planMode tracks whether plan mode is toggled on (ctrl+o when idle).
 	planMode bool
@@ -1849,6 +1850,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		}
+		if m.planApproval.active {
+			newState, cmd := m.handlePlanApprovalKey(msg)
+			m.planApproval = newState
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return m, tea.Batch(cmds...)
+		}
 		switch {
 		case key.Matches(msg, m.keys.Quit):
 			// Two-stage Ctrl+C interrupt when a run is active.
@@ -3086,6 +3095,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// The decision has already been recorded server-side (e.g. from
 			// another client); make sure the overlay does not linger.
 			m.toolApproval = toolApprovalState{}
+		case "plan.approval_required":
+			var p struct {
+				Plan string `json:"plan"`
+			}
+			if err := json.Unmarshal(msg.Raw, &p); err == nil {
+				m.planApproval = planApprovalState{active: true, runID: m.RunID, content: p.Plan}
+			}
+		case "plan.approval_granted", "plan.approval_denied":
+			m.planApproval = planApprovalState{}
 		case "usage.delta":
 			var p struct {
 				CumulativeUsage struct {
@@ -3534,6 +3552,9 @@ func (m Model) View() string {
 		} else {
 			mainContent = m.vp.View()
 		}
+	} else if m.planApproval.active {
+		overlayLines := m.renderPlanApprovalOverlay()
+		mainContent = m.vp.View() + "\n" + strings.Join(overlayLines, "\n")
 	} else if m.overlayActive {
 		switch m.activeOverlay {
 		case "help":

--- a/cmd/harnesscli/tui/plan_approval.go
+++ b/cmd/harnesscli/tui/plan_approval.go
@@ -1,0 +1,52 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type planApprovalState struct {
+	active         bool
+	runID, content string
+	offset         int
+}
+
+func (m Model) handlePlanApprovalKey(msg tea.KeyMsg) (planApprovalState, tea.Cmd) {
+	st := m.planApproval
+	switch msg.String() {
+	case "a", "A", "y", "Y", "enter":
+		return planApprovalState{}, approveToolCmd(m.config.BaseURL, st.runID, m.config.APIKey)
+	case "d", "D", "n", "N":
+		return planApprovalState{}, denyToolCmd(m.config.BaseURL, st.runID, m.config.APIKey)
+	case "down", "j":
+		st.offset++
+	case "up", "k":
+		if st.offset > 0 {
+			st.offset--
+		}
+	}
+	return st, nil
+}
+
+func (m Model) renderPlanApprovalOverlay() []string {
+	if !m.planApproval.active {
+		return nil
+	}
+	lines := strings.Split(m.planApproval.content, "\n")
+	const page = 10
+	if m.planApproval.offset > len(lines)-1 {
+		m.planApproval.offset = len(lines) - 1
+	}
+	end := m.planApproval.offset + page
+	if end > len(lines) {
+		end = len(lines)
+	}
+	out := []string{"", "┌─ Plan Approval Required ─────────────────────────", "│  Review the proposed plan:"}
+	for _, line := range lines[m.planApproval.offset:end] {
+		out = append(out, "│  "+line)
+	}
+	out = append(out, fmt.Sprintf("│  [%d/%d]  ↑/↓ scroll", m.planApproval.offset+1, len(lines)), "│", "│  [a]pprove  [d] request changes", "└────────────────────────────────────────", "")
+	return out
+}

--- a/cmd/harnesscli/tui/plan_approval_test.go
+++ b/cmd/harnesscli/tui/plan_approval_test.go
@@ -1,0 +1,21 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestPlanApprovalOverlayScrollsAndRendersChoices(t *testing.T) {
+	m := New(TUIConfig{})
+	m.planApproval = planApprovalState{active: true, runID: "r", content: strings.Repeat("line\n", 15)}
+	view := strings.Join(m.renderPlanApprovalOverlay(), "\n")
+	if !strings.Contains(view, "Plan Approval Required") || !strings.Contains(view, "request changes") {
+		t.Fatalf("view=%s", view)
+	}
+	st, _ := m.handlePlanApprovalKey(tea.KeyMsg{Type: tea.KeyDown})
+	if st.offset != 1 {
+		t.Fatalf("offset=%d", st.offset)
+	}
+}

--- a/cmd/harnesscli/tui/planmode_api_test.go
+++ b/cmd/harnesscli/tui/planmode_api_test.go
@@ -1,0 +1,25 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStartRunCmdSendsPlanMode(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body runCreateRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if !body.PlanMode {
+			t.Fatal("plan_mode was not sent")
+		}
+		_, _ = w.Write([]byte(`{"run_id":"r"}`))
+	}))
+	defer ts.Close()
+	if _, ok := startRunCmd(ts.URL, "p", "", "", "", "", "", "", "", true)().(RunStartedMsg); !ok {
+		t.Fatal("run not started")
+	}
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,9 @@
 # Engineering Log
 
+## 2026-07-19 (Enforced Plan Mode — Epic #740)
+
+- Added per-run plan state, central policy-wrapper gating, broker-backed plan-exit approval, SQLite plan persistence, CLI/TUI request plumbing, and a scrollable TUI approval preview. Mutations with absent or non-matching paths fail closed while planning.
+
 ## 2026-07-19 (Session Rewind — Epic #739)
 
 - Added SQLite pre-image points, non-fatal runner capture, hash-checked restore/truncation, HTTP list/restore routes, and explicit TUI confirmation. Oversized files are skipped rather than stored.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -1,5 +1,12 @@
 # Long-Term Thinking Log
 
+## 2026-07-19 (Plan Mode — Epic #740)
+
+- Command intent: Implement all six plan-mode slices in this worktree, verify, push, and open a PR without merging it.
+- User intent: Make planning genuinely read-only except for a single designated plan artifact, and require the operator's approval before implementation edits can proceed.
+- Success definition: `RunRequest.PlanMode` reaches live runner state; real policy-wrapped tool dispatch rejects non-plan mutations; plan exit pauses through the existing broker/routes; plan content persists with its conversation; both CLI surfaces render and submit the state.
+- Guardrails: reuse `ApplyPolicy`, permission-rule matching, `ApprovalBroker`, and SQLite migrations; do not touch #567; six test-first commits plus a merge commit.
+
 ## 2026-07-19 (Session Rewind — Epic #739)
 
 - Command intent: Implement all six rewind slices in this worktree, push the branch, and open (without merging) a PR.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -1,5 +1,9 @@
 # System Log
 
+## 2026-07-19 (Enforced Plan Mode — Epic #740)
+
+- `RunRequest.PlanMode` initializes `Active`; the step engine places a runner-owned gate in real tool contexts, and `ApplyPolicy` returns `plan_mode_denied` before normal approval handling for non-plan mutations. A terminal plan response transitions to `ExitPending`, emits plan approval events, uses the configured `ApprovalBroker`, and returns to `Active` on deny or `Inactive` on approve. `conversation_plans` is run/conversation scoped.
+
 ## 2026-07-19 (Session Rewind — Epic #739)
 
 - `SQLiteConversationStore` owns cascade-deleted rewind snapshots; restore writes/deletes captured paths after hash safety checks, then truncates messages.

--- a/docs/plans/2026-07-19-plan-mode-epic-740-plan.md
+++ b/docs/plans/2026-07-19-plan-mode-epic-740-plan.md
@@ -1,0 +1,47 @@
+# Plan: enforced plan mode — Epic #740
+
+## Context
+
+- Problem: the TUI plan toggle is cosmetic and edits are not constrained.
+- User impact: operators need an auditable read-only planning phase before implementation.
+- Constraints: reuse the existing tool policy, permission-rule matcher, approval broker, and conversation store.
+
+## Scope
+
+- In scope: #764 state/request plumbing; #765 policy gate; #766 broker approval; #767 SQLite persistence; #768 CLI/TUI request plumbing; #769 TUI approval preview.
+- Out of scope: #567 and any workspace-boundary redesign.
+
+## Documentation Contract
+
+- Feature status: in implementation
+- Public docs affected: operator runbook and CLAUDE.md policy notes.
+- Spec docs to update before code: this plan and plan index.
+- Implementation notes to add after code: engineering and system logs.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: request/state lifecycle, real wrapped-tool denial, broker HTTP approve/deny, SQLite restart persistence, CLI/TUI serialization, and overlay key/scroll behavior.
+- Existing tests to update: TUI plan-mode and command/API snapshots.
+- Regression tests required: non-plan policy and normal run HTTP paths.
+
+## Cross-Surface Impact Map
+
+- Config: None; plan mode is a per-run request.
+- Server API: `RunRequest.PlanMode` is accepted by the existing run endpoint; existing approval routes are reused.
+- TUI state: ctrl+o is serialized with the next run and plan approval events use the existing decision transport.
+- Regression tests: harness tools, runner, SQLite, server HTTP, CLI, and TUI coverage.
+
+## Implementation Checklist
+
+- [ ] #764 state machine and request plumbing
+- [ ] #765 central edit gate
+- [ ] #766 approval transition
+- [ ] #767 plan persistence
+- [ ] #768 CLI/TUI start plumbing
+- [ ] #769 TUI approval view
+- [ ] Docs, full regression, merge origin/main, push and PR
+
+## Risks and Mitigations
+
+- Risk: static registry wrappers cannot see per-run state. Mitigation: inject live run plan state into the real tool execution context.
+- Risk: a mutation has no path. Mitigation: fail closed while plan mode is active.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.
+- `2026-07-19-plan-mode-epic-740-plan.md`: Enforced plan-mode epic plan covering #764–#769.
 - `2026-07-19-dashboard-epic-738-plan.md`: Multi-run TUI dashboard epic plan covering #742, #745, #749, #753, #757, and #762.
 - `2026-06-28-config-driven-hooks-epic-737-plan.md`: Active epic plan for config-driven lifecycle hooks (shell/HTTP) covering child issues #741, #744, #750, #755, #759, #763 with per-slice TDD and trust-model guardrails.
 - `2026-06-26-adapter-first-eval-harness-plan.md`: Implemented adapter-first Terminal-Bench eval harness hardening plan; full regression and real-provider smoke baseline acceptance are green.

--- a/internal/harness/conversation_plan_test.go
+++ b/internal/harness/conversation_plan_test.go
@@ -1,0 +1,39 @@
+package harness
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestSQLiteConversationStorePlanContentSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "plans.db")
+	s, err := NewSQLiteConversationStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SavePlanContent(context.Background(), "conv", "run", "# plan"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = NewSQLiteConversationStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	if err := s.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.LoadPlanContent(context.Background(), "conv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "# plan" {
+		t.Fatalf("plan=%q", got)
+	}
+}

--- a/internal/harness/conversation_store.go
+++ b/internal/harness/conversation_store.go
@@ -85,3 +85,10 @@ type ConversationStore interface {
 	// Returns an error if the conversation does not exist or keepFromStep < 0.
 	CompactConversation(ctx context.Context, convID string, keepFromStep int, summary Message) error
 }
+
+// PlanContentStore is an optional run-scoped extension implemented by the
+// SQLite conversation store. Keeping it separate preserves other stores.
+type PlanContentStore interface {
+	SavePlanContent(ctx context.Context, conversationID, runID, content string) error
+	LoadPlanContent(ctx context.Context, conversationID string) (string, error)
+}

--- a/internal/harness/conversation_store_sqlite.go
+++ b/internal/harness/conversation_store_sqlite.go
@@ -65,6 +65,13 @@ CREATE TABLE IF NOT EXISTS rewind_file_snapshots (
 );
 CREATE INDEX IF NOT EXISTS idx_rewind_points_conversation ON rewind_points(conversation_id, step DESC);
 
+CREATE TABLE IF NOT EXISTS conversation_plans (
+    conversation_id TEXT PRIMARY KEY REFERENCES conversations(id) ON DELETE CASCADE,
+    run_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
 -- FTS5 virtual table for full-text search on message content.
 CREATE VIRTUAL TABLE IF NOT EXISTS conversation_messages_fts
 USING fts5(conversation_id UNINDEXED, role UNINDEXED, content, content='conversation_messages', content_rowid='id');
@@ -73,6 +80,33 @@ USING fts5(conversation_id UNINDEXED, role UNINDEXED, content, content='conversa
 // SQLiteConversationStore implements ConversationStore using SQLite.
 type SQLiteConversationStore struct {
 	db *sql.DB
+}
+
+func (s *SQLiteConversationStore) SavePlanContent(ctx context.Context, conversationID, runID, content string) error {
+	if strings.TrimSpace(conversationID) == "" {
+		return fmt.Errorf("conversation id is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO conversations (id, created_at, updated_at) VALUES (?, ?, ?) ON CONFLICT(id) DO NOTHING`, conversationID, time.Now().UTC().Format(time.RFC3339Nano), time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("create plan conversation: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO conversation_plans (conversation_id, run_id, content, updated_at) VALUES (?, ?, ?, ?) ON CONFLICT(conversation_id) DO UPDATE SET run_id=excluded.run_id, content=excluded.content, updated_at=excluded.updated_at`, conversationID, runID, content, time.Now().UTC().Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("save plan content: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteConversationStore) LoadPlanContent(ctx context.Context, conversationID string) (string, error) {
+	var content string
+	err := s.db.QueryRowContext(ctx, `SELECT content FROM conversation_plans WHERE conversation_id=?`, conversationID).Scan(&content)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("load plan content: %w", err)
+	}
+	return content, nil
 }
 
 // NewSQLiteConversationStore creates a new SQLite-backed conversation store.

--- a/internal/harness/events.go
+++ b/internal/harness/events.go
@@ -16,11 +16,11 @@ type EventType string
 
 // Run lifecycle events.
 const (
-	EventRunStarted         EventType = "run.started"
-	EventRunCompleted       EventType = "run.completed"
-	EventRunFailed          EventType = "run.failed"
-	EventRunWaitingForUser  EventType = "run.waiting_for_user"
-	EventRunResumed         EventType = "run.resumed"
+	EventRunStarted        EventType = "run.started"
+	EventRunCompleted      EventType = "run.completed"
+	EventRunFailed         EventType = "run.failed"
+	EventRunWaitingForUser EventType = "run.waiting_for_user"
+	EventRunResumed        EventType = "run.resumed"
 	// EventRunCostLimitReached is emitted when the cumulative cost of a run
 	// reaches or exceeds the max_cost_usd ceiling specified in the RunRequest.
 	// The run is then terminated with EventRunCompleted (not EventRunFailed).
@@ -42,8 +42,8 @@ const (
 
 // LLM turn events.
 const (
-	EventLLMTurnRequested      EventType = "llm.turn.requested"
-	EventLLMTurnCompleted      EventType = "llm.turn.completed"
+	EventLLMTurnRequested       EventType = "llm.turn.requested"
+	EventLLMTurnCompleted       EventType = "llm.turn.completed"
 	EventAssistantMessageDelta  EventType = "assistant.message.delta"
 	EventAssistantThinkingDelta EventType = "assistant.thinking.delta"
 	// EventReasoningComplete is emitted after each LLM turn when
@@ -77,7 +77,10 @@ const (
 	// tool call. A permission_denied error is returned to the LLM and the run
 	// continues to the next step.
 	// Payload fields: call_id (string), tool (string).
-	EventToolApprovalDenied EventType = "tool.approval_denied"
+	EventToolApprovalDenied   EventType = "tool.approval_denied"
+	EventPlanApprovalRequired EventType = "plan.approval_required"
+	EventPlanApprovalGranted  EventType = "plan.approval_granted"
+	EventPlanApprovalDenied   EventType = "plan.approval_denied"
 )
 
 // Assistant completion events.
@@ -588,11 +591,11 @@ func ParseToolOutputDeltaPayload(payload map[string]any) (ToolOutputDeltaPayload
 // ContextWindowSnapshotBreakdown is the breakdown sub-object in a context
 // window snapshot payload.
 type ContextWindowSnapshotBreakdown struct {
-	SystemPromptTokens int  `json:"system_prompt_tokens"`
-	ConversationTokens int  `json:"conversation_tokens"`
-	ToolResultTokens   int  `json:"tool_result_tokens"`
+	SystemPromptTokens int `json:"system_prompt_tokens"`
+	ConversationTokens int `json:"conversation_tokens"`
+	ToolResultTokens   int `json:"tool_result_tokens"`
 	// Estimated is always true — all counts use the rune-count heuristic.
-	Estimated          bool `json:"estimated"`
+	Estimated bool `json:"estimated"`
 }
 
 // ContextWindowSnapshotPayload is the typed payload for EventContextWindowSnapshot.
@@ -611,7 +614,7 @@ type ContextWindowSnapshotPayload struct {
 	// UsageRatio is the fraction of the context window in use (0.0–1.0+).
 	UsageRatio float64 `json:"usage_ratio"`
 	// HeadroomTokens is the estimated remaining capacity. May be negative on overrun.
-	HeadroomTokens int `json:"headroom_tokens"`
+	HeadroomTokens int                            `json:"headroom_tokens"`
 	Breakdown      ContextWindowSnapshotBreakdown `json:"breakdown"`
 }
 

--- a/internal/harness/plan_mode.go
+++ b/internal/harness/plan_mode.go
@@ -1,12 +1,50 @@
 package harness
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	htools "go-agent-harness/internal/harness/tools"
 )
+
+func (r *Runner) awaitPlanApproval(ctx context.Context, runID, content string) (bool, error) {
+	r.mu.Lock()
+	st := r.runs[runID]
+	if st == nil || st.planMode != PlanModeActive {
+		r.mu.Unlock()
+		return true, nil
+	}
+	st.planMode = PlanModeExitPending
+	r.mu.Unlock()
+	if r.config.ApprovalBroker == nil {
+		return false, fmt.Errorf("plan mode requires an approval broker")
+	}
+	r.setStatus(runID, RunStatusWaitingForApproval, "", "")
+	r.emit(runID, EventPlanApprovalRequired, map[string]any{"tool": "plan_exit", "plan": content})
+	approved, err := r.config.ApprovalBroker.Ask(ctx, ApprovalRequest{RunID: runID, CallID: "plan_exit", Tool: "plan_exit", Args: content, Timeout: r.config.AskUserTimeout})
+	if err != nil {
+		return false, err
+	}
+	r.mu.Lock()
+	st = r.runs[runID]
+	if st != nil {
+		if approved {
+			st.planMode = PlanModeInactive
+		} else {
+			st.planMode = PlanModeActive
+		}
+	}
+	r.mu.Unlock()
+	r.setStatus(runID, RunStatusRunning, "", "")
+	if approved {
+		r.emit(runID, EventPlanApprovalGranted, map[string]any{"plan": content})
+	} else {
+		r.emit(runID, EventPlanApprovalDenied, map[string]any{"plan": content})
+	}
+	return approved, nil
+}
 
 // PlanModeState is the per-run lifecycle for an enforced planning phase.
 type PlanModeState string

--- a/internal/harness/plan_mode.go
+++ b/internal/harness/plan_mode.go
@@ -1,6 +1,12 @@
 package harness
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
 
 // PlanModeState is the per-run lifecycle for an enforced planning phase.
 type PlanModeState string
@@ -25,4 +31,32 @@ func normalizedPlanFile(path string) string {
 		return defaultPlanFile
 	}
 	return path
+}
+
+type runPlanModeGate struct {
+	runner *Runner
+	runID  string
+}
+
+func (g runPlanModeGate) Active() bool {
+	g.runner.mu.RLock()
+	defer g.runner.mu.RUnlock()
+	st := g.runner.runs[g.runID]
+	return st != nil && st.planMode == PlanModeActive
+}
+func (g runPlanModeGate) AllowMutation(def htools.Definition, args json.RawMessage) bool {
+	if !isPathPermissionTool(def.Name) {
+		return false
+	}
+	g.runner.mu.RLock()
+	st := g.runner.runs[g.runID]
+	if st == nil {
+		g.runner.mu.RUnlock()
+		return false
+	}
+	planFile, workspace := st.planFile, st.permissionWorkspaceRoot
+	g.runner.mu.RUnlock()
+	rules := []PermissionRule{{Pattern: fmt.Sprintf("%s(**)", def.Name), Effect: PermissionEffectDeny}, {Pattern: fmt.Sprintf("%s(%s)", def.Name, planFile), Effect: PermissionEffectAllow}}
+	effect, err := EvaluatePermissionRules(rules, def.Name, args, workspace)
+	return err == nil && effect == PermissionEffectAllow
 }

--- a/internal/harness/plan_mode.go
+++ b/internal/harness/plan_mode.go
@@ -1,0 +1,28 @@
+package harness
+
+import "strings"
+
+// PlanModeState is the per-run lifecycle for an enforced planning phase.
+type PlanModeState string
+
+const (
+	PlanModeInactive    PlanModeState = "inactive"
+	PlanModeActive      PlanModeState = "active"
+	PlanModeExitPending PlanModeState = "exit_pending"
+)
+
+const defaultPlanFile = ".harness/plan.md"
+
+func initialPlanModeState(enabled bool) PlanModeState {
+	if enabled {
+		return PlanModeActive
+	}
+	return PlanModeInactive
+}
+
+func normalizedPlanFile(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return defaultPlanFile
+	}
+	return path
+}

--- a/internal/harness/plan_mode.go
+++ b/internal/harness/plan_mode.go
@@ -88,6 +88,19 @@ type runPlanModeGate struct {
 	runID  string
 }
 
+// PlanModeState returns the live plan-mode state for a run. It is primarily
+// useful to transports and integration tests which must observe approval
+// transitions without reaching into runner internals.
+func (r *Runner) PlanModeState(runID string) (PlanModeState, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	st, ok := r.runs[runID]
+	if !ok {
+		return "", false
+	}
+	return st.planMode, true
+}
+
 func (g runPlanModeGate) Active() bool {
 	g.runner.mu.RLock()
 	defer g.runner.mu.RUnlock()

--- a/internal/harness/plan_mode.go
+++ b/internal/harness/plan_mode.go
@@ -22,6 +22,18 @@ func (r *Runner) awaitPlanApproval(ctx context.Context, runID, content string) (
 		return false, fmt.Errorf("plan mode requires an approval broker")
 	}
 	r.setStatus(runID, RunStatusWaitingForApproval, "", "")
+	if plans, ok := r.config.ConversationStore.(PlanContentStore); ok {
+		r.mu.RLock()
+		st := r.runs[runID]
+		var convID string
+		if st != nil {
+			convID = st.run.ConversationID
+		}
+		r.mu.RUnlock()
+		if err := plans.SavePlanContent(ctx, convID, runID, content); err != nil {
+			return false, err
+		}
+	}
 	r.emit(runID, EventPlanApprovalRequired, map[string]any{"tool": "plan_exit", "plan": content})
 	approved, err := r.config.ApprovalBroker.Ask(ctx, ApprovalRequest{RunID: runID, CallID: "plan_exit", Tool: "plan_exit", Args: content, Timeout: r.config.AskUserTimeout})
 	if err != nil {

--- a/internal/harness/plan_mode_test.go
+++ b/internal/harness/plan_mode_test.go
@@ -1,6 +1,13 @@
 package harness
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
 
 func TestStartRunInitializesPlanModeState(t *testing.T) {
 	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{})
@@ -16,5 +23,24 @@ func TestStartRunInitializesPlanModeState(t *testing.T) {
 	}
 	if state.planFile != defaultPlanFile {
 		t.Fatalf("plan file = %q", state.planFile)
+	}
+}
+
+func TestPlanModeRealPolicyWrapperDeniesEditOutsidePlanFile(t *testing.T) {
+	called := false
+	wrapped := htools.ApplyPolicy(htools.Definition{Name: "write", Action: htools.ActionWrite, Mutating: true}, htools.ApprovalModeFullAuto, nil,
+		func(_ context.Context, _ json.RawMessage) (string, error) { called = true; return "ok", nil })
+	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{})
+	run, err := runner.StartRun(RunRequest{Prompt: "plan", PlanMode: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.WithValue(context.Background(), htools.ContextKeyPlanModeGate, runPlanModeGate{runner: runner, runID: run.ID})
+	out, err := wrapped(ctx, json.RawMessage(`{"path":"main.go","content":"bad"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if called || !strings.Contains(out, "plan_mode_denied") {
+		t.Fatalf("real policy wrapper result=%s called=%v", out, called)
 	}
 }

--- a/internal/harness/plan_mode_test.go
+++ b/internal/harness/plan_mode_test.go
@@ -1,0 +1,20 @@
+package harness
+
+import "testing"
+
+func TestStartRunInitializesPlanModeState(t *testing.T) {
+	runner := NewRunner(&stubProvider{}, NewRegistry(), RunnerConfig{})
+	run, err := runner.StartRun(RunRequest{Prompt: "plan this", PlanMode: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner.mu.RLock()
+	state := runner.runs[run.ID]
+	runner.mu.RUnlock()
+	if state.planMode != PlanModeActive {
+		t.Fatalf("plan state = %q, want active", state.planMode)
+	}
+	if state.planFile != defaultPlanFile {
+		t.Fatalf("plan file = %q", state.planFile)
+	}
+}

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -34,6 +34,8 @@ import (
 
 type runState struct {
 	run                Run
+	planMode           PlanModeState
+	planFile           string
 	staticSystemPrompt string
 	promptResolved     *systemprompt.ResolvedPrompt
 	usageTotals        usageTotalsAccumulator
@@ -889,6 +891,8 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 
 	state := &runState{
 		run:                     run,
+		planMode:                initialPlanModeState(req.PlanMode),
+		planFile:                normalizedPlanFile(req.PlanFile),
 		staticSystemPrompt:      systemPrompt,
 		promptResolved:          resolvedPrompt,
 		usageTotals:             usageTotalsAccumulator{},

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -964,6 +964,7 @@ func (se *stepEngine) run() {
 
 			meta := r.runMetadata(runID)
 			toolCtx := context.WithValue(ctx, htools.ContextKeyRunID, runID)
+			toolCtx = context.WithValue(toolCtx, htools.ContextKeyPlanModeGate, runPlanModeGate{runner: r, runID: runID})
 			toolCtx = context.WithValue(toolCtx, htools.ContextKeyToolCallID, call.ID)
 			toolCtx = context.WithValue(toolCtx, htools.ContextKeyRunMetadata, meta)
 			toolCtx = htools.WithSandboxScope(toolCtx, effectiveSandboxScope)

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -590,6 +590,16 @@ func (se *stepEngine) run() {
 				"duration_ms": time.Since(stepStartTime).Milliseconds(),
 			})
 			emitCausalGraph(step)
+			approved, approvalErr := r.awaitPlanApproval(ctx, runID, result.Content)
+			if approvalErr != nil {
+				r.failRun(runID, approvalErr)
+				return
+			}
+			if !approved {
+				messages = append(messages, Message{Role: "user", Content: "The operator requested changes to the plan. Revise the designated plan file and present the updated plan."})
+				r.stepSetMessages(runID, messages)
+				continue
+			}
 			r.completeRun(runID, result.Content)
 			return
 		}
@@ -661,6 +671,16 @@ func (se *stepEngine) run() {
 				"duration_ms": time.Since(stepStartTime).Milliseconds(),
 			})
 			emitCausalGraph(step)
+			approved, approvalErr := r.awaitPlanApproval(ctx, runID, result.Content)
+			if approvalErr != nil {
+				r.failRun(runID, approvalErr)
+				return
+			}
+			if !approved {
+				messages = append(messages, Message{Role: "user", Content: "The operator requested changes to the plan. Revise the designated plan file and present the updated plan."})
+				r.stepSetMessages(runID, messages)
+				continue
+			}
 			r.completeRun(runID, result.Content)
 			return
 		}

--- a/internal/harness/tools/policy.go
+++ b/internal/harness/tools/policy.go
@@ -22,6 +22,12 @@ func applyPolicy(def Definition, mode ApprovalMode, policy Policy, handler Handl
 		mode = ApprovalModeFullAuto
 	}
 	return func(ctx context.Context, args json.RawMessage) (string, error) {
+		if gate, ok := PlanModeGateFromContext(ctx); ok && gate.Active() && def.Mutating && !gate.AllowMutation(def, args) {
+			return MarshalToolResult(map[string]any{"error": map[string]any{
+				"code": "plan_mode_denied", "tool": def.Name, "action": def.Action,
+				"reason": "plan mode only permits edits to the designated plan file", "allowed": false,
+			}})
+		}
 		if mode == ApprovalModeFullAuto {
 			return handler(ctx, args)
 		}

--- a/internal/harness/tools/policy_planmode_test.go
+++ b/internal/harness/tools/policy_planmode_test.go
@@ -1,0 +1,36 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type inactivePlanGate struct{}
+
+func (inactivePlanGate) Active() bool                                   { return false }
+func (inactivePlanGate) AllowMutation(Definition, json.RawMessage) bool { return false }
+
+func TestApplyPolicyWithoutActivePlanGatePreservesApprovalBehavior(t *testing.T) {
+	def := Definition{Name: "write", Action: ActionWrite, Mutating: true}
+	for _, tc := range []struct {
+		name   string
+		policy Policy
+	}{{"allowed", allowPolicy{}}, {"denied", denyPolicy{reason: "blocked"}}} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := func(context.Context, json.RawMessage) (string, error) { return "handler", nil }
+			baseline, err := ApplyPolicy(def, ApprovalModePermissions, tc.policy, h)(context.Background(), json.RawMessage(`{"path":"x"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.WithValue(context.Background(), ContextKeyPlanModeGate, inactivePlanGate{})
+			got, err := ApplyPolicy(def, ApprovalModePermissions, tc.policy, h)(ctx, json.RawMessage(`{"path":"x"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != baseline {
+				t.Fatalf("inactive gate changed policy output: got %q want %q", got, baseline)
+			}
+		})
+	}
+}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -60,6 +60,11 @@ type Policy interface {
 	Allow(ctx context.Context, in PolicyInput) (PolicyDecision, error)
 }
 
+type PlanModeGate interface {
+	Active() bool
+	AllowMutation(def Definition, args json.RawMessage) bool
+}
+
 // ToolTier classifies a tool as core (always visible) or deferred (hidden until activated).
 type ToolTier string
 
@@ -557,6 +562,7 @@ const ContextKeyTranscriptReader contextKey = "transcript_reader"
 const ContextKeyOutputStreamer contextKey = "output_streamer"
 const ContextKeyMessageReplacer contextKey = "message_replacer"
 const ContextKeySandboxScope contextKey = "sandbox_scope"
+const ContextKeyPlanModeGate contextKey = "plan_mode_gate"
 const contextKeyForkDepth contextKey = "fork_depth"
 
 // DefaultMaxForkDepth is the maximum recursion depth for spawned subagents.
@@ -639,6 +645,14 @@ func RunIDFromContext(ctx context.Context) string {
 	}
 	v, _ := ctx.Value(ContextKeyRunID).(string)
 	return v
+}
+
+func PlanModeGateFromContext(ctx context.Context) (PlanModeGate, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	v, ok := ctx.Value(ContextKeyPlanModeGate).(PlanModeGate)
+	return v, ok
 }
 
 func ToolCallIDFromContext(ctx context.Context) string {

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -379,7 +379,13 @@ type WorkspaceProvisionOptions struct {
 
 type RunRequest struct {
 	Prompt string `json:"prompt"`
-	Model  string `json:"model,omitempty"`
+	// PlanMode starts the run in the read-only planning state. While active,
+	// mutation is limited to PlanFile until the operator approves the plan.
+	PlanMode bool `json:"plan_mode,omitempty"`
+	// PlanFile is the workspace-relative plan artifact allowed during PlanMode.
+	// Empty uses the stable default `.harness/plan.md`.
+	PlanFile string `json:"plan_file,omitempty"`
+	Model    string `json:"model,omitempty"`
 	// WorkspaceType selects the workspace backend for this run.
 	// When set, the runner provisions an isolated workspace and cleans it up
 	// on run completion (success, failure, or cancellation).

--- a/internal/server/http_plan_mode_test.go
+++ b/internal/server/http_plan_mode_test.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+func startPlanModeHTTPRun(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(`{"prompt":"plan", "plan_mode":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("start status=%d body=%s", resp.StatusCode, b)
+	}
+	var body struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	return body.RunID
+}
+func waitPending(t *testing.T, b *harness.InMemoryApprovalBroker, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ok := b.Pending(runID); ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for broker pending")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestHTTPPlanModeRealDispatchDeniesOutsidePlanFile(t *testing.T) {
+	provider := &scriptedProvider{turns: []harness.CompletionResult{{ToolCalls: []harness.ToolCall{{ID: "write-outside", Name: "write", Arguments: `{"path":"outside.go","content":"no"}`}}}, {Content: "plan complete"}}}
+	reg := harness.NewDefaultRegistryWithOptions(t.TempDir(), harness.DefaultRegistryOptions{})
+	runner := harness.NewRunner(provider, reg, harness.RunnerConfig{DefaultModel: "test", ApprovalBroker: harness.NewInMemoryApprovalBroker()})
+	ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, AuthDisabled: true}))
+	defer ts.Close()
+	runID := startPlanModeHTTPRun(t, ts)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		msgs := runner.GetRunMessages(runID)
+		for _, m := range msgs {
+			if m.Role == "tool" && strings.Contains(m.Content, "plan_mode_denied") {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("real HTTP run never surfaced plan_mode_denied: %#v", msgs)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestHTTPPlanExitApprovalRoutesTransitionState(t *testing.T) {
+	for _, tc := range []struct {
+		name, path string
+		want       harness.PlanModeState
+		wantRevise bool
+	}{{"approve", "approve", harness.PlanModeInactive, false}, {"deny", "deny", harness.PlanModeActive, true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			broker := harness.NewInMemoryApprovalBroker()
+			provider := &scriptedProvider{turns: []harness.CompletionResult{{Content: "# proposed plan"}}}
+			runner := harness.NewRunner(provider, harness.NewRegistry(), harness.RunnerConfig{DefaultModel: "test", ApprovalBroker: broker})
+			ts := httptest.NewServer(NewWithOptions(ServerOptions{Runner: runner, AuthDisabled: true}))
+			defer ts.Close()
+			runID := startPlanModeHTTPRun(t, ts)
+			waitPending(t, broker, runID)
+			resp, err := http.Post(ts.URL+"/v1/runs/"+runID+"/"+tc.path, "application/json", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("route status=%d", resp.StatusCode)
+			}
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				state, ok := runner.PlanModeState(runID)
+				if ok && state == tc.want {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("state=%q ok=%v want=%q", state, ok, tc.want)
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if tc.wantRevise {
+				deadline = time.Now().Add(5 * time.Second)
+				for {
+					found := false
+					for _, m := range runner.GetRunMessages(runID) {
+						found = found || strings.Contains(m.Content, "requested changes")
+					}
+					if found {
+						break
+					}
+					if time.Now().After(deadline) {
+						t.Fatal("deny did not send revise message")
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Wire the plan-mode request through runner, CLI, and TUI state.
- Enforce the designated plan-file mutation gate in the central tool policy wrapper.
- Reuse the approval broker/routes for plan exit, persist plan content, and render a scrollable TUI review overlay.

## Validation

- `go test ./cmd/harnesscli/tui ./internal/harness ./internal/server -count=1`
- `./scripts/test-regression.sh`

Closes #740
Closes #764
Closes #765
Closes #766
Closes #767
Closes #768
Closes #769