### PR TITLE
test(rewind): fix zero-coverage-gate regression from epic #739

### DIFF
--- a/cmd/harnesscli/tui/rewind_api_test.go
+++ b/cmd/harnesscli/tui/rewind_api_test.go
@@ -1,0 +1,238 @@
+package tui
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestFetchRewindPointsCmd_Success verifies fetchRewindPointsCmd hits
+// GET /v1/conversations/{id}/rewind-points and decodes the point list.
+func TestFetchRewindPointsCmd_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"points":[{"id":"p1","step":2,"tool":"write"}]}`))
+	}))
+	defer ts.Close()
+
+	msg := fetchRewindPointsCmd(ts.URL, "conv-1", "")()
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method: want GET, got %q", gotMethod)
+	}
+	if gotPath != "/v1/conversations/conv-1/rewind-points" {
+		t.Errorf("path: want /v1/conversations/conv-1/rewind-points, got %q", gotPath)
+	}
+
+	got, ok := msg.(RewindPointsLoadedMsg)
+	if !ok {
+		t.Fatalf("expected RewindPointsLoadedMsg, got %T", msg)
+	}
+	if len(got.Points) != 1 || got.Points[0].ID != "p1" || got.Points[0].Tool != "write" {
+		t.Fatalf("Points = %+v", got.Points)
+	}
+}
+
+// TestFetchRewindPointsCmd_ErrorStatus verifies a non-200 response yields
+// RewindResultMsg.Err instead of a decode panic.
+func TestFetchRewindPointsCmd_ErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	msg := fetchRewindPointsCmd(ts.URL, "conv-missing", "")()
+	got, ok := msg.(RewindResultMsg)
+	if !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+	if got.Err == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// TestFetchRewindPointsCmd_NetworkError verifies an unreachable server yields
+// RewindResultMsg.Err.
+func TestFetchRewindPointsCmd_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	msg := fetchRewindPointsCmd("http://127.0.0.1:1", "conv-err", "")()
+	got, ok := msg.(RewindResultMsg)
+	if !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+	if got.Err == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// TestRestoreRewindCmd_Success verifies restoreRewindCmd POSTs the point id
+// to /v1/conversations/{id}/rewind and decodes the restore result.
+func TestRestoreRewindCmd_Success(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath, gotBody string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"FilesRestored":2,"MessagesTruncated":3}`))
+	}))
+	defer ts.Close()
+
+	msg := restoreRewindCmd(ts.URL, "conv-2", "point-9", "")()
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: want POST, got %q", gotMethod)
+	}
+	if gotPath != "/v1/conversations/conv-2/rewind" {
+		t.Errorf("path: want /v1/conversations/conv-2/rewind, got %q", gotPath)
+	}
+	if !strings.Contains(gotBody, `"point_id":"point-9"`) {
+		t.Errorf("body missing point_id: %q", gotBody)
+	}
+
+	got, ok := msg.(RewindResultMsg)
+	if !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+	if got.FilesRestored != 2 || got.MessagesTruncated != 3 {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+// TestRestoreRewindCmd_ErrorStatus verifies a non-200 response (e.g. the
+// server refusing an externally-modified file) surfaces as RewindResultMsg.Err.
+func TestRestoreRewindCmd_ErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rewind refused", http.StatusConflict)
+	}))
+	defer ts.Close()
+
+	msg := restoreRewindCmd(ts.URL, "conv-3", "point-1", "")()
+	got, ok := msg.(RewindResultMsg)
+	if !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+	if got.Err == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// TestRestoreRewindCmd_NetworkError verifies an unreachable server yields
+// RewindResultMsg.Err rather than a panic.
+func TestRestoreRewindCmd_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	msg := restoreRewindCmd("http://127.0.0.1:1", "conv-4", "point-1", "")()
+	got, ok := msg.(RewindResultMsg)
+	if !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+	if got.Err == "" {
+		t.Error("expected a non-empty error message")
+	}
+}
+
+// TestExecuteRewindCommand_NoArgsFetchesPoints verifies /rewind with no
+// arguments lists points rather than restoring anything.
+func TestExecuteRewindCommand_NoArgsFetchesPoints(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"points":[]}`))
+	}))
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	cmds, quit := executeRewindCommand(&m, Command{Name: "rewind"})
+	if quit {
+		t.Fatal("/rewind must not quit")
+	}
+	if len(cmds) != 1 || cmds[0] == nil {
+		t.Fatalf("expected exactly one command, got %d", len(cmds))
+	}
+	if _, ok := cmds[0]().(RewindPointsLoadedMsg); !ok {
+		t.Fatalf("expected RewindPointsLoadedMsg from the returned command")
+	}
+	wantPath := "/v1/conversations/" + m.conversationID + "/rewind-points"
+	if gotPath != wantPath {
+		t.Errorf("path: want %q, got %q", wantPath, gotPath)
+	}
+}
+
+// TestExecuteRewindCommand_RequiresConfirmToken verifies that a point id
+// without the literal "confirm" token never issues a restore request.
+func TestExecuteRewindCommand_RequiresConfirmToken(t *testing.T) {
+	t.Parallel()
+
+	requested := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = true
+	}))
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	cmds, quit := executeRewindCommand(&m, Command{Name: "rewind", Args: []string{"point-1"}})
+	if quit {
+		t.Fatal("/rewind must not quit")
+	}
+	if len(cmds) != 1 || cmds[0] == nil {
+		t.Fatalf("expected exactly one status command, got %d", len(cmds))
+	}
+	cmds[0]()
+	if requested {
+		t.Fatal("executeRewindCommand issued an HTTP request without the confirm token")
+	}
+}
+
+// TestExecuteRewindCommand_ConfirmRestores verifies /rewind <point-id> confirm
+// issues the destructive restore request.
+func TestExecuteRewindCommand_ConfirmRestores(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"FilesRestored":1,"MessagesTruncated":1}`))
+	}))
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	cmds, quit := executeRewindCommand(&m, Command{Name: "rewind", Args: []string{"point-1", "confirm"}})
+	if quit {
+		t.Fatal("/rewind must not quit")
+	}
+	if len(cmds) != 1 || cmds[0] == nil {
+		t.Fatalf("expected exactly one command, got %d", len(cmds))
+	}
+	msg := cmds[0]()
+	if gotMethod != http.MethodPost {
+		t.Errorf("method: want POST, got %q", gotMethod)
+	}
+	wantPath := "/v1/conversations/" + m.conversationID + "/rewind"
+	if gotPath != wantPath {
+		t.Errorf("path: want %q, got %q", wantPath, gotPath)
+	}
+	if _, ok := msg.(RewindResultMsg); !ok {
+		t.Fatalf("expected RewindResultMsg, got %T", msg)
+	}
+}

--- a/internal/server/http_rewind_test.go
+++ b/internal/server/http_rewind_test.go
@@ -1,10 +1,14 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"go-agent-harness/internal/harness"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -22,5 +26,133 @@ func TestRewindPointsEndpointListsPoints(t *testing.T) {
 	New(runner).ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRestoreRewindEndpointRestoresFileAndTruncatesMessages verifies
+// POST /v1/conversations/{id}/rewind writes the pre-image back to disk and
+// truncates messages after the rewind point, through the real HTTP handler.
+func TestRestoreRewindEndpointRestoresFileAndTruncatesMessages(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "notes.txt")
+	if err := os.WriteFile(path, []byte("after"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	convID := "rewind-restore-http"
+	if err := store.SaveConversation(ctx, convID, []harness.Message{
+		{Role: "user", Content: "keep"},
+		{Role: "assistant", Content: "drop"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateConversationMeta(ctx, convID, workspace, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveRewindPoint(ctx, harness.RewindPoint{
+		ID:             "restore-point",
+		ConversationID: convID,
+		Step:           0,
+		Tool:           "write",
+		Files: []harness.RewindFileSnapshot{{
+			Path:         "notes.txt",
+			Content:      []byte("before"),
+			Exists:       true,
+			ExpectedHash: harness.RewindContentHash([]byte("after")),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := harness.NewRunner(&staticProvider{result: harness.CompletionResult{Content: "ok"}}, harness.NewRegistry(), harness.RunnerConfig{ConversationStore: store})
+
+	body, _ := json.Marshal(map[string]any{"point_id": "restore-point"})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/conversations/"+convID+"/rewind", bytes.NewReader(body))
+	New(runner).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var result harness.RewindRestoreResult
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+	}
+	if result.FilesRestored != 1 {
+		t.Errorf("FilesRestored = %d, want 1", result.FilesRestored)
+	}
+	if result.MessagesTruncated != 1 {
+		t.Errorf("MessagesTruncated = %d, want 1", result.MessagesTruncated)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != "before" {
+		t.Fatalf("file content = %q, err=%v, want %q", got, err, "before")
+	}
+}
+
+// TestRestoreRewindEndpointRequiresPointID verifies a missing point_id is
+// rejected as a client error rather than reaching the store.
+func TestRestoreRewindEndpointRequiresPointID(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	runner := harness.NewRunner(&staticProvider{result: harness.CompletionResult{Content: "ok"}}, harness.NewRegistry(), harness.RunnerConfig{ConversationStore: store})
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/conversations/rewind-missing-point/rewind", bytes.NewReader([]byte(`{}`)))
+	New(runner).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%s, want 400", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRestoreRewindEndpointRefusesExternalModificationWithoutForce verifies
+// the HTTP handler surfaces the store's refusal as a 409 without a force flag,
+// and that force:true proceeds anyway.
+func TestRestoreRewindEndpointRefusesExternalModificationWithoutForce(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "notes.txt")
+	if err := os.WriteFile(path, []byte("outside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	convID := "rewind-refuse-http"
+	if err := store.SaveConversation(ctx, convID, []harness.Message{{Role: "user", Content: "keep"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateConversationMeta(ctx, convID, workspace, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveRewindPoint(ctx, harness.RewindPoint{
+		ID:             "refuse-point",
+		ConversationID: convID,
+		Files: []harness.RewindFileSnapshot{{
+			Path:         "notes.txt",
+			Content:      []byte("before"),
+			Exists:       true,
+			ExpectedHash: harness.RewindContentHash([]byte("agent")),
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := harness.NewRunner(&staticProvider{result: harness.CompletionResult{Content: "ok"}}, harness.NewRegistry(), harness.RunnerConfig{ConversationStore: store})
+
+	body, _ := json.Marshal(map[string]any{"point_id": "refuse-point"})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/conversations/"+convID+"/rewind", bytes.NewReader(body))
+	New(runner).ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status=%d body=%s, want 409", rr.Code, rr.Body.String())
+	}
+
+	forceBody, _ := json.Marshal(map[string]any{"point_id": "refuse-point", "force": true})
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/conversations/"+convID+"/rewind", bytes.NewReader(forceBody))
+	New(runner).ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("force restore status=%d body=%s, want 200", rr2.Code, rr2.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

The rewind epic (#739, merged in #800) shipped four functions with zero test coverage: `fetchRewindPointsCmd` and `restoreRewindCmd` (`cmd/harnesscli/tui/api.go`), `executeRewindCommand` (`cmd/harnesscli/tui/model.go`), and `handleRestoreRewind` (`internal/server/http_conversations.go`). This tripped the zero-coverage-function gate in `scripts/test-regression.sh` on `main`. It wasn't caught before merge because that gate only runs on push-to-main/schedule, not as a per-PR check — so it silently regressed while several other epics merged in parallel.

This is not one of the 7 roadmap epics; it's a small hygiene follow-up to restore the coverage-gate invariant.

## What changed

- `cmd/harnesscli/tui/rewind_api_test.go` (new): direct `tea.Cmd`-level tests for `fetchRewindPointsCmd` and `restoreRewindCmd` (success, HTTP error, network error), and for `executeRewindCommand`'s three branches (no-args lists points, missing "confirm" token never restores, confirmed restores) — following the existing `conversation_history_api_test.go` / `run_control_command_test.go` patterns.
- `internal/server/http_rewind_test.go`: added real HTTP-handler tests for `POST /v1/conversations/{id}/rewind` — success (restores file content, truncates messages), missing `point_id` (400), and external-modification refusal without `force` (409) followed by a successful `force:true` restore (200).

## Verification

- `go test ./cmd/harnesscli/tui/... ./internal/server/... -run "Rewind"` — all new tests pass.
- `gofmt -l` / `go vet` — clean on touched files.
- `bash scripts/test-regression.sh` — full suite green: `coveragegate: PASS (total=84.0%, min=80.0%, zero-functions=0)`.