### PR TITLE
docs(cli): specify headless exit-code contract for runs and goals

### DIFF
--- a/docs/plans/823-exit-codes.md
+++ b/docs/plans/823-exit-codes.md
@@ -1,0 +1,46 @@
+# Plan: headless exit-code contract — epic #823, Slice 1 (docs)
+
+## Context
+
+- Problem: `harnesscli -prompt ...` exits 0 for every terminal run state (including `run.failed` and `run.cancelled`), so shell scripts and CI cannot branch on run outcomes without parsing stdout.
+- User impact: headless automation (CI, wrapper scripts) gets no reliable success/failure signal.
+- Constraints: Slice 1 is docs-only — ratify and document the exit-code table; no behavior changes (Slices 2–4 implement). Worktree-only flow; no merge to main from this branch.
+
+## Scope
+
+- In scope:
+  - New `website/docs/reference/exit-codes.md`: full exit-code table (run terminal events, waiting/blocked states, client errors, interrupt), kimi-code 0/3/6 alignment rationale, reserved goal-status mapping, `max_turns.exhausted` and `run.cost_limit_reached` semantics, precise blocked signals, current-vs-contracted table.
+  - Cross-links from `website/docs/cli/harnesscli.md` and `website/docs/reference/events-catalog.md`.
+  - `docs/plans/INDEX.md` entry for this plan.
+- Out of scope: implementing the mapping (Slice 2), blocked detection (Slice 3), e2e assertions and per-command doc updates (Slice 4). No Go code changes.
+
+## Documentation Contract
+
+- Feature status: `planned` (contract ratified by this slice; implementation in later slices — the page states this explicitly per `docs/runbooks/documentation-maintenance.md` "public docs describe implemented behavior only", so the page clearly separates current behavior from contracted behavior).
+- Public docs affected: `website/docs/reference/exit-codes.md` (new), `website/docs/cli/harnesscli.md`, `website/docs/reference/events-catalog.md`.
+- Spec docs to update before code: this plan.
+- Implementation notes to add after code: none for Slice 1 (docs-only).
+
+## Test Plan (TDD)
+
+- New failing tests to add first: none — epic designates Slice 1 as docs-only ("no behavior tests apply; reviewer validates the table against the event constants in `internal/harness/events.go`").
+- Existing tests to update: none.
+- Regression tests required: none for this slice. Validation = website build (Docusaurus broken-link check) + manual trace of every documented code to an event constant, run status, or current CLI behavior.
+
+## Cross-Surface Impact Map
+
+- None — docs-only slice; no provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing touched.
+
+## Implementation Checklist
+
+- [x] Verify every epic citation against the source (event constants, run statuses, CLI return paths, wrapper propagation).
+- [x] Write `website/docs/reference/exit-codes.md`.
+- [x] Cross-link from `website/docs/cli/harnesscli.md` and `website/docs/reference/events-catalog.md`.
+- [x] Update `docs/plans/INDEX.md`.
+- [x] Build the website to validate links (`npm run build` green with `onBrokenLinks: 'throw'`); no Go packages touched, so no Go tests apply.
+- [ ] Commit, push `epic/823-exit-codes`, open PR against the repo (no merge).
+
+## Risks and Mitigations
+
+- Risk: contract page drifts from code reality (documents behavior that does not exist yet).
+- Mitigation: explicit "current vs. contracted behavior" table and a traceability table mapping every code to its source constant/status/CLI path; page is labeled as the contract target for Slices 2–4.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,5 +1,6 @@
 # Plans Index
 
+- `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.

--- a/website/docs/cli/harnesscli.md
+++ b/website/docs/cli/harnesscli.md
@@ -42,6 +42,8 @@ When you invoke `harnesscli` with no recognized subcommand — typically just `-
 
 Terminal events are `run.completed`, `run.failed`, and `run.cancelled`. Every non-terminal event is printed as a single line: `<event_type> <full_event_json>`.
 
+The process exit code reports the run's outcome for scripts and CI — see [Exit Codes](/docs/reference/exit-codes) for the headless exit-code contract (which terminal event maps to which code, plus blocked and interrupted runs).
+
 ### Flags
 
 | Flag | Default | Description |
@@ -177,7 +179,7 @@ The continuation prompt is everything after the run ID, joined with spaces.
 | `-base-url` | `http://localhost:8080` | Harness API base URL |
 | `-no-stream` | `false` | Print only `run_id=<id>` and exit without streaming events |
 
-When `-no-stream` is false (the default), the new run's events are streamed and `terminal_event=<type>` is printed on completion. When `-no-stream` is true, only `run_id=<id>` is printed.
+When `-no-stream` is false (the default), the new run's events are streamed and `terminal_event=<type>` is printed on completion; the same [exit-code contract](/docs/reference/exit-codes) as the one-shot mode applies. When `-no-stream` is true, only `run_id=<id>` is printed and the exit code stays `0`/`1` (no terminal event is observed).
 
 ---
 
@@ -453,6 +455,7 @@ harnesscli auth login -server http://myserver:9090 -tenant myteam
 ## Next steps
 
 - **Server setup** — See [harnessd Reference](/docs/server/harnessd) to learn how to configure and start the server `harnesscli` connects to.
+- **Exit codes** — See [Exit Codes](/docs/reference/exit-codes) for the headless exit-code contract used when scripting runs from shell or CI.
 - **Event reference** — See [Events](/docs/concepts/events) for the full list of SSE event types and their payloads.
 - **Rollout & replay** — See [Rollout & Replay](/docs/operations/rollout-replay-forensics) for the underlying replay, fork, and drift-detection semantics.
 - **Configuration** — See [Environment Variables](/docs/reference/environment-variables) for `HARNESS_PROVIDER`, `HARNESS_FAKE_TURNS`, and the full `HARNESS_*` env var reference.

--- a/website/docs/reference/events-catalog.md
+++ b/website/docs/reference/events-catalog.md
@@ -66,6 +66,8 @@ Three events signal the end of the stream. Clients MUST stop reading after recei
 
 `IsTerminalEvent(et EventType) bool` returns `true` for exactly these three types (source: `internal/harness/events.go:466–468`).
 
+In headless mode (`harnesscli -prompt ...` or streaming `harnesscli continue`) the terminal event also determines the process exit code — see [Exit Codes](/docs/reference/exit-codes) for the mapping.
+
 ---
 
 ## Run lifecycle

--- a/website/docs/reference/exit-codes.md
+++ b/website/docs/reference/exit-codes.md
@@ -1,0 +1,156 @@
+---
+title: "Exit Codes"
+sidebar_label: "Exit Codes"
+sidebar_position: 9
+---
+
+import { Callout } from '@site/src/components/ui';
+
+This page is the **exit-code contract for headless `harnesscli` usage** — the one-shot streaming mode (`harnesscli -prompt ...`) and the streaming `continue` subcommand. It exists so shell scripts and CI pipelines can branch on a run's outcome via `$?` instead of parsing stdout.
+
+<Callout type="warning">
+**Contract status.** This page ratifies the target contract (tracking issue: epic #823, part of the kimi-code parity program #803). The implementation lands in later slices of that epic — see the [current vs. contracted behavior](#current-vs-contracted-behavior) table below for exactly which process outcomes change and which are already in effect. Until the implementation slices merge, treat the **Current** column as ground truth.
+</Callout>
+
+The contract adopts [kimi-code](https://github.com/MoonshotAI/kimi-code)'s headless codes where semantics align: kimi's `kimi -p` exits `0` when a goal completes, `3` when it blocks, `6` when it pauses, and non-zero on turn failure. Aligning on the same numbers means scripts written against one CLI keep working against the other.
+
+---
+
+## The contract
+
+Applies to: `harnesscli -prompt ...` (default streaming run mode) and `harnesscli continue <run-id> <prompt>` (streaming). For everything else, see [command coverage](#command-coverage).
+
+| Exit code | Meaning | Trigger |
+|---|---|---|
+| `0` | Success | Terminal event `run.completed` — the run finished. |
+| `1` | Client-side error | Bad flags, missing prompt, connection/HTTP failure, stream transport error. Also the defensive default for an unknown or empty terminal event type, so a scripting caller never mistakes an unrecognized outcome for success. |
+| `2` | Run failed | Terminal event `run.failed` — a turn failed server-side (satisfies kimi's "non-zero on turn failure"). |
+| `3` | Blocked | The run cannot proceed without input it will never get headlessly: `run.waiting_for_user`, `tool.approval_required`, or `plan.approval_required` observed while stdin is **not** a terminal. See [blocked runs](#blocked-runs-exit-3). |
+| `6` | Paused / cancelled | Terminal event `run.cancelled`. Work is interrupted but resumable via `harnesscli continue <run-id> <prompt>`. |
+| `130` | Interrupted | SIGINT/SIGTERM while streaming (`128 + SIGINT`, the conventional shell code). The CLI best-effort cancels the still-executing server-side run before exiting. |
+
+### kimi-code alignment rationale
+
+- `0` for a completed run/goal is identical in both CLIs.
+- `3` (blocked) and `6` (paused) reuse kimi's exact codes for the same semantics: a headless caller can distinguish "needs a human" (`3`) from "stopped but resumable" (`6`) without reading any output.
+- `2` for `run.failed` satisfies kimi's "non-zero on turn failure" guarantee while staying distinct from `1` (the failure is server-side, not a client usage or transport problem), so `if [ $? -eq 1 ]` retry-the-invocation logic keeps its current meaning.
+- `1` and `130` are go-code's current behavior and are unchanged; `130` is the standard shell convention both CLIs follow.
+
+---
+
+## Run terminal events
+
+The terminal event set is exactly three event types — `run.completed`, `run.failed`, `run.cancelled` — as defined by `IsTerminalEvent` (`internal/harness/events.go:472`). After a terminal event the SSE stream ends; the exit code is derived from which terminal event arrived:
+
+| Terminal event | Source constant | Exit code |
+|---|---|---|
+| `run.completed` | `EventRunCompleted` (`internal/harness/events.go:20`) | `0` |
+| `run.failed` | `EventRunFailed` (`internal/harness/events.go:21`) | `2` |
+| `run.cancelled` | `EventRunCancelled` (`internal/harness/events.go:34`) | `6` |
+
+Two non-terminal events deserve explicit call-outs because they change how a script should interpret the terminal event that follows:
+
+<Callout type="info">
+**`max_turns.exhausted` is not terminal.** `EventMaxTurnsExhausted` (`internal/harness/events.go:384`) is emitted when an agent exhausts its turn budget, and the run then terminates with `run.failed` (`reason=max_turns_exhausted`). It carries no exit code of its own — it surfaces through the subsequent terminal event's code, which is `2`.
+</Callout>
+
+<Callout type="info">
+**Cost-limit runs exit `0`.** `run.cost_limit_reached` (`EventRunCostLimitReached`, `internal/harness/events.go:27`) terminates the run with `run.completed` — **not** `run.failed` — when the `max_cost_usd` ceiling is hit. The process therefore exits `0` even though the run stopped early. Scripts that treat "hit the cost ceiling" as a failure must watch for the `run.cost_limit_reached` event line on stdout; the exit code alone does not distinguish it from an ordinary completion.
+</Callout>
+
+---
+
+## Blocked runs (exit 3)
+
+A run is **blocked** when it cannot make progress without input a headless caller will never provide. Two families of signals indicate this:
+
+| Signal | Source constant | Run status while blocked | Kind |
+|---|---|---|---|
+| `run.waiting_for_user` | `EventRunWaitingForUser` (`internal/harness/events.go:22`) | `waiting_for_user` (`RunStatusWaitingForUser`, `internal/harness/types.go:337`) | Question-blocked: the run invoked `ask_user_question`. |
+| `tool.approval_required` | `EventToolApprovalRequired` (`internal/harness/events.go:69`) | `waiting_for_approval` (`RunStatusWaitingForApproval`, `internal/harness/types.go:338`) | Approval-blocked: a tool call needs operator approval. |
+| `plan.approval_required` | `EventPlanApprovalRequired` (`internal/harness/events.go:83`) | `waiting_for_approval` (`internal/harness/types.go:338`) | Approval-blocked: a plan needs operator approval. |
+
+There is no dedicated "waiting-for-approval" run event — the approval-required events are the signal, and the run status transitions to `waiting_for_approval`.
+
+Contracted behavior when a blocked signal is observed in one-shot or streaming `continue` mode:
+
+- **stdin is not a terminal** (piped/redirected, the CI case): the CLI prints the blocked reason and run ID to **stderr**, stops streaming, and exits `3`. The server-side run is left intact — no auto-cancel — so an operator can resume it later with `harnesscli continue <run-id> <prompt>` or by answering via `POST /v1/runs/{id}/input` (questions) or `/approve` / `/deny` (approvals).
+- **stdin is a terminal**: behavior is unchanged — the stream stays open and no exit-3 shortcut is taken. Interactive answer wiring in the streaming loop is a separate epic's scope; that epic must preserve exit `3` for non-interactive stdin.
+
+The terminal check uses the same `term.IsTerminal` test the `--tui` path already uses (`cmd/harnesscli/main.go:517`).
+
+---
+
+## Command coverage
+
+| Command | Covered by this contract? | Exit codes |
+|---|---|---|
+| `harnesscli -prompt ...` (streaming run mode) | **Yes** | `0`, `1`, `2`, `3`, `6`, `130` per the table above. |
+| `harnesscli continue <run-id> <prompt>` (streaming, the default) | **Yes** | Same mapping as the one-shot path. |
+| `harnesscli continue -no-stream ...` | No (never observes events) | Prints `run_id=<id>` and exits `0`; `1` on client error. |
+| `list`, `status` / `show`, `cancel`, `replay`, `search` | No (non-streaming) | Unchanged: `0` on success, `1` on error. This contract documents but does not change them. |
+| `--tui` | No | Interactive TUI exit behavior is out of scope; the contract covers headless/streaming mode only. |
+
+---
+
+## Goal statuses (reserved codes)
+
+Goals (`internal/goals/goals.go:25-30`) have their own lifecycle statuses: `pending`, `running`, `verifying`, `completed`, `failed`, `cancelled`. The contract maps them onto the same codes so a future goal-scoped headless surface inherits the semantics without renumbering:
+
+| Goal status | Exit code | Notes |
+|---|---|---|
+| `completed` | `0` | Goal verified complete. |
+| `failed` | `2` | Goal verification or execution failed. |
+| `cancelled` | `6` | Goal cancelled; resumable. |
+| (blocked — future) | `3` | **Reserved.** No blocked goal status exists today; a goal waiting on user input maps here when one is added. |
+| (paused — future) | `6` | **Reserved.** Paused goals share the cancelled/resumable code, matching kimi's pause semantics. |
+
+<Callout type="warning">
+This goal mapping is **documentation-only in this epic**. There is no goal-scoped headless surface to implement it against today: no `/v1/goals` HTTP route and no goal CLI subcommand exist — `internal/goals` is reachable only through the in-run `goals` tool. A future goal epic must add the runtime mapping and its tests when it introduces that surface; until then no runtime goal exit codes are guaranteed.
+</Callout>
+
+---
+
+## Current vs. contracted behavior
+
+This table is the reviewer-facing diff of process outcomes. Rows marked **unchanged** are already in effect; rows marked **changes** land with the implementation slices of epic #823.
+
+| Outcome | Current exit code | Contracted exit code | Status |
+|---|---|---|---|
+| `run.completed` (success) | `0` | `0` | Unchanged |
+| Client/usage/transport error | `1` | `1` | Unchanged |
+| SIGINT/SIGTERM interrupt | `130` | `130` | Unchanged |
+| `run.failed` | `0` | `2` | **Changes** — today every terminal event exits `0` (`cmd/harnesscli/main.go:219-220`, `cmd/harnesscli/runctl.go:324-330`) |
+| `run.cancelled` | `0` | `6` | **Changes** — same unconditional-`0` paths |
+| Blocked, stdin non-interactive | (streams forever) | `3` | **Changes** — today the CLI waits on the SSE stream indefinitely |
+
+### stdout contract is unchanged
+
+Only the process exit code changes. The existing stdout lines — `run_id=<id>` when the run is created and `terminal_event=<event_type>` at the end of the stream — are preserved exactly, so existing log parsers keep working. Exit-code assertions and stdout parsing compose: a script may still read `terminal_event=run.failed` while also getting `2` from `$?`.
+
+### Wrapper propagation
+
+The `go-code` wrapper script needs no changes and propagates the code unchanged: in `scripts/go-code.sh` the `harnesscli` invocation is the last command of `main` for both `prompt` and `cli` modes (`scripts/go-code.sh:393`, `:399`), and `main "$@"` is the script's final line (`:404`), so the `harnesscli` exit status becomes the wrapper's own exit status (the `stop_server` EXIT trap does not override it). `go-code prompt "..." ; echo $?` therefore yields the same code as calling `harnesscli` directly.
+
+---
+
+## Traceability
+
+Every code in the contract traces to an existing event constant, run status, or current CLI behavior:
+
+| Exit code | Traces to |
+|---|---|
+| `0` | `EventRunCompleted` (`internal/harness/events.go:20`); current `run()` return at `cmd/harnesscli/main.go:220` |
+| `1` | Current usage/transport error returns (`cmd/harnesscli/main.go:164`, `:176`, `:183`, `:211`, `:236`; `cmd/harnesscli/runctl.go`) |
+| `2` | `EventRunFailed` (`internal/harness/events.go:21`) |
+| `3` | `EventRunWaitingForUser` (`internal/harness/events.go:22`), `EventToolApprovalRequired` (`internal/harness/events.go:69`), `EventPlanApprovalRequired` (`internal/harness/events.go:83`); statuses `RunStatusWaitingForUser` / `RunStatusWaitingForApproval` (`internal/harness/types.go:337-338`) |
+| `6` | `EventRunCancelled` (`internal/harness/events.go:34`) |
+| `130` | Current `handleStreamError` interrupt path (`cmd/harnesscli/main.go:233`) |
+
+---
+
+## Next steps
+
+- **CLI commands** — See the [harnesscli Reference](/docs/cli/harnesscli) for the streaming run mode and subcommand details.
+- **Events** — See the [Event Catalog](/docs/reference/events-catalog) for every SSE event type and payload, including the terminal events this contract maps.
+- **Flags** — See the [CLI Flag Reference](/docs/reference/cli-flags) for `-prompt`, `-no-stream`, and the rest of the flag surface.


### PR DESCRIPTION
Parent epic: #823. Part of #803.

## What

Docs-only Slice 1 of #823: ratifies the headless `harnesscli` exit-code contract before any behavior changes (Slices 2–4 implement it). No code changes.

- **New `website/docs/reference/exit-codes.md`**: the full exit-code table (`0` completed, `1` client error, `2` `run.failed`, `3` blocked with non-interactive stdin, `6` `run.cancelled`, `130` SIGINT/SIGTERM), the kimi-code 0/3/6 alignment rationale, precise blocked signals (`run.waiting_for_user`, `tool.approval_required`, `plan.approval_required`), `max_turns.exhausted` (non-terminal, surfaces via subsequent `run.failed` → 2) and `run.cost_limit_reached` (terminates with `run.completed` → 0) call-outs, the reserved goal-status mapping (documentation-only; no goal headless surface exists), a **current vs. contracted behavior** table (failed 0→2, cancelled 0→6, blocked infinite-stream→3; success 0, client error 1, interrupt 130 unchanged), stdout-contract preservation (`run_id=`/`terminal_event=`), wrapper propagation, and a traceability table mapping every code to its event constant / run status / current CLI path.
- **Cross-links** from `website/docs/cli/harnesscli.md` (streaming run mode, `continue`, next-steps) and `website/docs/reference/events-catalog.md` (terminal-events section).
- **Plan file** `docs/plans/823-exit-codes.md` + `docs/plans/INDEX.md` entry.

## Validation

- Docs-only slice per the epic (no behavior tests apply). Every documented code verified against source in-worktree: `internal/harness/events.go` constants (`:20-22`, `:27`, `:34`, `:69`, `:83`, `:384`, `IsTerminalEvent` `:472`), `internal/harness/types.go:337-338`, `internal/goals/goals.go:25-30`, CLI return paths `cmd/harnesscli/main.go:164,176,183,211,219-220,233,236,517`, `cmd/harnesscli/runctl.go:324-330`, wrapper `scripts/go-code.sh:393,399,404`.
- `cd website && npm ci && npm run build` → `[SUCCESS] Generated static files` with `onBrokenLinks: 'throw'` (link validation green; sidebar picks the page up via autogeneration, no `sidebars.ts` change needed).
- No Go packages touched → no `go test` runs apply; regression suite not run (no code changed).