### PR TITLE
feat(cli): add harnesscli service install/uninstall with launchd + systemd generators

### DIFF
--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -109,6 +109,8 @@ func dispatch(args []string) int {
 		return runAuth(args[1:])
 	case "hooks":
 		return runHooks(args[1:])
+	case "service":
+		return runService(args[1:])
 	case "list":
 		return runList(args[1:])
 	case "runs":

--- a/cmd/harnesscli/service.go
+++ b/cmd/harnesscli/service.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"go-agent-harness/internal/config"
+)
+
+// This file implements "harnesscli service install|uninstall" — user-level OS
+// service management for harnessd (launchd on macOS, systemd --user on Linux).
+// The generated unit runs harnessd with the same address resolution the daemon
+// itself uses (internal/config: default :8080, HARNESS_ADDR override), passed
+// through the unit's environment. Lifecycle subcommands (start/stop/status)
+// land in the next slice; here they are recognized stubs.
+
+const (
+	// serviceLabel is the launchd job label and the reverse-DNS stem of the
+	// plist filename.
+	serviceLabel = "com.gocode.harnessd"
+	// serviceLaunchdFileName is the plist filename under ~/Library/LaunchAgents.
+	serviceLaunchdFileName = "com.gocode.harnessd.plist"
+	// serviceSystemdUnitName is the systemd --user unit name (and filename
+	// under ~/.config/systemd/user).
+	serviceSystemdUnitName = "harnessd.service"
+)
+
+// servicePlatform selects the service manager backend. It is a var (not
+// runtime.GOOS inline) so tests can exercise the Linux path on macOS and vice
+// versa.
+var servicePlatform = runtime.GOOS
+
+// serviceRunLifecycle executes a lifecycle tool (launchctl/systemctl). It is a
+// var so tests can substitute a recording fake — unit tests must never exec
+// real service managers.
+var serviceRunLifecycle = func(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = stderr
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+// serviceOptions carries the resolved values embedded in a generated unit
+// file. All fields must be absolute (or address) values — the renderers are
+// pure functions with no I/O.
+type serviceOptions struct {
+	// BinaryPath is the absolute path to the harnessd executable.
+	BinaryPath string
+	// Addr is the harnessd listen address (e.g. ":8080"), exported to the
+	// daemon via HARNESS_ADDR in the unit environment.
+	Addr string
+	// LogDir is the directory that receives stdout/stderr log files.
+	LogDir string
+}
+
+// stdoutLogPath returns the service's stdout log file path.
+func (o serviceOptions) stdoutLogPath() string {
+	return filepath.Join(o.LogDir, "harnessd.stdout.log")
+}
+
+// stderrLogPath returns the service's stderr log file path.
+func (o serviceOptions) stderrLogPath() string {
+	return filepath.Join(o.LogDir, "harnessd.stderr.log")
+}
+
+// runService dispatches "harnesscli service <subcommand>", following the
+// runAuth nested-subcommand pattern.
+func runService(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "harnesscli service: subcommand required")
+		fmt.Fprintln(stderr, "usage: harnesscli service <install|uninstall> [--flags]")
+		return 1
+	}
+	switch args[0] {
+	case "install":
+		return runServiceInstall(args[1:])
+	case "uninstall":
+		return runServiceUninstall(args[1:])
+	case "start", "stop", "status":
+		fmt.Fprintf(stderr, "harnesscli service %s: not yet implemented (install and uninstall are available; lifecycle commands land in the next slice)\n", args[0])
+		return 1
+	default:
+		fmt.Fprintf(stderr, "harnesscli service: unknown subcommand %q (try: install, uninstall)\n", args[0])
+		return 1
+	}
+}
+
+// serviceUnitPath returns the unit file path for the given platform and home
+// directory, or an error for platforms without a supported backend.
+func serviceUnitPath(platform, home string) (string, error) {
+	switch platform {
+	case "darwin":
+		return filepath.Join(home, "Library", "LaunchAgents", serviceLaunchdFileName), nil
+	case "linux":
+		return filepath.Join(home, ".config", "systemd", "user", serviceSystemdUnitName), nil
+	default:
+		return "", fmt.Errorf("unsupported platform %q (user services are supported on macOS via launchd and Linux via systemd --user)", platform)
+	}
+}
+
+// renderServiceUnit renders the unit file for the given platform.
+func renderServiceUnit(platform string, opts serviceOptions) ([]byte, error) {
+	switch platform {
+	case "darwin":
+		return renderLaunchdPlist(opts), nil
+	case "linux":
+		return renderSystemdUnit(opts), nil
+	default:
+		return nil, fmt.Errorf("unsupported platform %q (user services are supported on macOS via launchd and Linux via systemd --user)", platform)
+	}
+}
+
+// xmlEscape escapes a string for embedding in plist XML text/attribute
+// content.
+func xmlEscape(s string) string {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		// EscapeText only errors on invalid UTF-8; fall back to the raw
+		// string rather than failing unit generation.
+		return s
+	}
+	return buf.String()
+}
+
+// renderLaunchdPlist renders a user-level launchd agent plist. Pure function.
+func renderLaunchdPlist(opts serviceOptions) []byte {
+	var b strings.Builder
+	b.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+	b.WriteString("<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n")
+	b.WriteString("<plist version=\"1.0\">\n<dict>\n")
+	fmt.Fprintf(&b, "\t<key>Label</key>\n\t<string>%s</string>\n", serviceLabel)
+	b.WriteString("\t<key>ProgramArguments</key>\n\t<array>\n")
+	fmt.Fprintf(&b, "\t\t<string>%s</string>\n", xmlEscape(opts.BinaryPath))
+	b.WriteString("\t</array>\n")
+	b.WriteString("\t<key>EnvironmentVariables</key>\n\t<dict>\n")
+	b.WriteString("\t\t<key>HARNESS_ADDR</key>\n")
+	fmt.Fprintf(&b, "\t\t<string>%s</string>\n", xmlEscape(opts.Addr))
+	b.WriteString("\t</dict>\n")
+	b.WriteString("\t<key>RunAtLoad</key>\n\t<true/>\n")
+	b.WriteString("\t<key>KeepAlive</key>\n\t<true/>\n")
+	b.WriteString("\t<key>StandardOutPath</key>\n")
+	fmt.Fprintf(&b, "\t<string>%s</string>\n", xmlEscape(opts.stdoutLogPath()))
+	b.WriteString("\t<key>StandardErrorPath</key>\n")
+	fmt.Fprintf(&b, "\t<string>%s</string>\n", xmlEscape(opts.stderrLogPath()))
+	b.WriteString("</dict>\n</plist>\n")
+	return []byte(b.String())
+}
+
+// renderSystemdUnit renders a systemd --user service unit. Pure function.
+func renderSystemdUnit(opts serviceOptions) []byte {
+	var b strings.Builder
+	b.WriteString("[Unit]\n")
+	b.WriteString("Description=go-code harnessd (user service)\n")
+	b.WriteString("After=network-online.target\n")
+	b.WriteString("Wants=network-online.target\n")
+	b.WriteString("\n[Service]\n")
+	b.WriteString("Type=simple\n")
+	fmt.Fprintf(&b, "ExecStart=%s\n", opts.BinaryPath)
+	fmt.Fprintf(&b, "Environment=HARNESS_ADDR=%s\n", opts.Addr)
+	b.WriteString("Restart=on-failure\n")
+	b.WriteString("RestartSec=5\n")
+	fmt.Fprintf(&b, "StandardOutput=append:%s\n", opts.stdoutLogPath())
+	fmt.Fprintf(&b, "StandardError=append:%s\n", opts.stderrLogPath())
+	b.WriteString("\n[Install]\n")
+	b.WriteString("WantedBy=default.target\n")
+	return []byte(b.String())
+}
+
+// resolveServiceBinary resolves the harnessd executable: an explicit --binary
+// flag wins, otherwise harnessd is looked up on PATH.
+func resolveServiceBinary(flagValue string) (string, error) {
+	if strings.TrimSpace(flagValue) != "" {
+		abs, err := filepath.Abs(flagValue)
+		if err != nil {
+			return "", fmt.Errorf("resolve --binary path: %w", err)
+		}
+		return abs, nil
+	}
+	path, err := exec.LookPath("harnessd")
+	if err != nil {
+		return "", fmt.Errorf("harnessd binary not found on PATH; install go-code first or pass --binary /path/to/harnessd")
+	}
+	return path, nil
+}
+
+// resolveServiceAddr resolves the listen address the generated unit exports as
+// HARNESS_ADDR: an explicit --addr flag wins, otherwise the internal/config
+// stack (defaults → ~/.harness/config.toml → HARNESS_ADDR env) decides — the
+// same resolution harnessd applies to itself. The project-config layer is
+// deliberately skipped: an installed user service has no meaningful working
+// directory, so only user-global config and env apply.
+func resolveServiceAddr(flagValue, home string) (string, error) {
+	if strings.TrimSpace(flagValue) != "" {
+		return flagValue, nil
+	}
+	cfg, err := config.Load(config.LoadOptions{
+		UserConfigPath: filepath.Join(home, ".harness", "config.toml"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve addr from config: %w", err)
+	}
+	return cfg.Addr, nil
+}
+
+// runServiceInstall implements "harnesscli service install".
+func runServiceInstall(args []string) int {
+	fs := flag.NewFlagSet("service install", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	binary := fs.String("binary", "", "path to the harnessd binary (default: look up harnessd on PATH)")
+	addr := fs.String("addr", "", "listen address for harnessd (default: resolve like harnessd — HARNESS_ADDR env or :8080)")
+	logDir := fs.String("log-dir", "", "directory for service logs (default ~/.harness/logs)")
+	dryRun := fs.Bool("dry-run", false, "print the rendered unit file and target path without writing anything")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: resolve home directory: %v\n", err)
+		return 1
+	}
+
+	unitPath, err := serviceUnitPath(servicePlatform, home)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: %v\n", err)
+		return 1
+	}
+
+	binaryPath, err := resolveServiceBinary(*binary)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: %v\n", err)
+		return 1
+	}
+
+	resolvedAddr, err := resolveServiceAddr(*addr, home)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: %v\n", err)
+		return 1
+	}
+
+	resolvedLogDir := *logDir
+	if strings.TrimSpace(resolvedLogDir) == "" {
+		resolvedLogDir = filepath.Join(home, ".harness", "logs")
+	}
+
+	content, err := renderServiceUnit(servicePlatform, serviceOptions{
+		BinaryPath: binaryPath,
+		Addr:       resolvedAddr,
+		LogDir:     resolvedLogDir,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: %v\n", err)
+		return 1
+	}
+
+	if *dryRun {
+		fmt.Fprintf(stdout, "target: %s\n\n%s", unitPath, content)
+		fmt.Fprintln(stdout, "(dry run: nothing written)")
+		return 0
+	}
+
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: create unit dir: %v\n", err)
+		return 1
+	}
+	// launchd/systemd do not create the log directory; do it here so the
+	// service can open its log files on first start.
+	if err := os.MkdirAll(resolvedLogDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: create log dir: %v\n", err)
+		return 1
+	}
+	if err := os.WriteFile(unitPath, content, 0o644); err != nil {
+		fmt.Fprintf(stderr, "harnesscli service install: write unit file: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "installed %s user service unit at %s\n", servicePlatformName(servicePlatform), unitPath)
+	fmt.Fprintf(stdout, "logs: %s\n", resolvedLogDir)
+	return 0
+}
+
+// runServiceUninstall implements "harnesscli service uninstall": best-effort
+// unload/disable of the running service, then removal of the unit file.
+func runServiceUninstall(args []string) int {
+	fs := flag.NewFlagSet("service uninstall", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: resolve home directory: %v\n", err)
+		return 1
+	}
+
+	unitPath, err := serviceUnitPath(servicePlatform, home)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: %v\n", err)
+		return 1
+	}
+
+	if _, err := os.Stat(unitPath); os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: service not installed (no unit file at %s)\n", unitPath)
+		return 1
+	} else if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: stat unit file: %v\n", err)
+		return 1
+	}
+
+	unloadServiceBestEffort(servicePlatform)
+
+	if err := os.Remove(unitPath); err != nil {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: remove unit file: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "removed %s\n", unitPath)
+	return 0
+}
+
+// unloadServiceBestEffort asks the platform service manager to stop and
+// disable the unit. Failures are warnings, not errors: the unit may simply
+// not be loaded, and the file removal must still proceed.
+func unloadServiceBestEffort(platform string) {
+	var name string
+	var args []string
+	switch platform {
+	case "darwin":
+		name = "launchctl"
+		args = []string{"bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), serviceLabel)}
+	case "linux":
+		name = "systemctl"
+		args = []string{"--user", "disable", "--now", serviceSystemdUnitName}
+	default:
+		return
+	}
+	if err := serviceRunLifecycle(name, args...); err != nil {
+		fmt.Fprintf(stderr, "harnesscli service uninstall: warning: %s %s failed: %v (continuing)\n",
+			name, strings.Join(args, " "), err)
+	}
+}
+
+// servicePlatformName returns a human label for the service backend.
+func servicePlatformName(platform string) string {
+	switch platform {
+	case "darwin":
+		return "launchd"
+	case "linux":
+		return "systemd"
+	default:
+		return platform
+	}
+}

--- a/cmd/harnesscli/service_test.go
+++ b/cmd/harnesscli/service_test.go
@@ -1,0 +1,406 @@
+package main
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordedCommand captures one lifecycle-tool invocation (launchctl/systemctl).
+type recordedCommand struct {
+	name string
+	args []string
+}
+
+// setupServiceTest isolates the service command surface: stdout/stderr are
+// captured, the platform is forced, and the lifecycle runner is replaced with
+// a recording fake so tests never exec real launchctl/systemctl.
+func setupServiceTest(t *testing.T, platform string) (outBuf, errBuf *bytes.Buffer, calls *[]recordedCommand) {
+	t.Helper()
+	origOut, origErr := stdout, stderr
+	origPlatform := servicePlatform
+	origRunner := serviceRunLifecycle
+
+	outBuf, errBuf = &bytes.Buffer{}, &bytes.Buffer{}
+	stdout, stderr = outBuf, errBuf
+	servicePlatform = platform
+	calls = &[]recordedCommand{}
+	serviceRunLifecycle = func(name string, args ...string) error {
+		*calls = append(*calls, recordedCommand{name: name, args: append([]string(nil), args...)})
+		return nil
+	}
+
+	t.Cleanup(func() {
+		stdout, stderr = origOut, origErr
+		servicePlatform = origPlatform
+		serviceRunLifecycle = origRunner
+	})
+	return outBuf, errBuf, calls
+}
+
+func writeFakeHarnessd(t *testing.T) (binDir, binPath string) {
+	t.Helper()
+	binDir = t.TempDir()
+	binPath = filepath.Join(binDir, "harnessd")
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return binDir, binPath
+}
+
+func TestServiceRenderLaunchdPlist(t *testing.T) {
+	content := renderLaunchdPlist(serviceOptions{
+		BinaryPath: "/usr/local/bin/harnessd",
+		Addr:       ":8080",
+		LogDir:     "/Users/test/.harness/logs",
+	})
+	plist := string(content)
+
+	// Well-formed XML (plutil-level validity is checked separately on macOS).
+	var doc struct {
+		XMLName xml.Name `xml:"plist"`
+	}
+	if err := xml.Unmarshal(content, &doc); err != nil {
+		t.Fatalf("rendered plist is not well-formed XML: %v\n%s", err, plist)
+	}
+
+	for _, want := range []string{
+		"<string>com.gocode.harnessd</string>",
+		"<key>ProgramArguments</key>",
+		"<string>/usr/local/bin/harnessd</string>",
+		"<key>KeepAlive</key>",
+		"<key>RunAtLoad</key>",
+		"<key>StandardOutPath</key>",
+		"<string>/Users/test/.harness/logs/harnessd.stdout.log</string>",
+		"<key>StandardErrorPath</key>",
+		"<string>/Users/test/.harness/logs/harnessd.stderr.log</string>",
+		"<key>HARNESS_ADDR</key>",
+		"<string>:8080</string>",
+	} {
+		if !strings.Contains(plist, want) {
+			t.Errorf("rendered plist missing %q\n%s", want, plist)
+		}
+	}
+
+	// The binary must be the first program argument.
+	paIdx := strings.Index(plist, "<key>ProgramArguments</key>")
+	binIdx := strings.Index(plist, "<string>/usr/local/bin/harnessd</string>")
+	if paIdx < 0 || binIdx < 0 || binIdx < paIdx {
+		t.Errorf("ProgramArguments[0] must be the resolved harnessd path\n%s", plist)
+	}
+}
+
+func TestServiceRenderSystemdUnit(t *testing.T) {
+	unit := string(renderSystemdUnit(serviceOptions{
+		BinaryPath: "/usr/local/bin/harnessd",
+		Addr:       ":9090",
+		LogDir:     "/home/test/.harness/logs",
+	}))
+
+	for _, want := range []string{
+		"[Unit]",
+		"[Service]",
+		"ExecStart=/usr/local/bin/harnessd",
+		"Environment=HARNESS_ADDR=:9090",
+		"Restart=on-failure",
+		"StandardOutput=append:/home/test/.harness/logs/harnessd.stdout.log",
+		"StandardError=append:/home/test/.harness/logs/harnessd.stderr.log",
+		"[Install]",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(unit, want) {
+			t.Errorf("rendered unit missing %q\n%s", want, unit)
+		}
+	}
+}
+
+func TestServiceInstallLaunchdWritesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	out, _, calls := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+	data, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("expected plist at %s: %v", unitPath, err)
+	}
+	if !strings.Contains(string(data), "/fake/harnessd") {
+		t.Errorf("plist should reference the resolved binary path\n%s", data)
+	}
+	if !strings.Contains(out.String(), unitPath) {
+		t.Errorf("install output %q should name the written path", out.String())
+	}
+	// The log directory must exist so launchd can open the log files.
+	if info, err := os.Stat(filepath.Join(home, ".harness", "logs")); err != nil || !info.IsDir() {
+		t.Errorf("expected log dir ~/.harness/logs to be created: %v", err)
+	}
+	// Slice 1 install writes the unit only; it must not bootstrap/start anything.
+	if len(*calls) != 0 {
+		t.Errorf("install must not invoke lifecycle tools, got %v", *calls)
+	}
+}
+
+func TestServiceInstallSystemdWritesFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	setupServiceTest(t, "linux")
+
+	code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "harnessd.service")
+	data, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatalf("expected unit at %s: %v", unitPath, err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "ExecStart=/fake/harnessd") {
+		t.Errorf("unit should reference the resolved binary path\n%s", text)
+	}
+	if !strings.Contains(text, "WantedBy=default.target") {
+		t.Errorf("unit must install into default.target\n%s", text)
+	}
+}
+
+func TestServiceInstallDryRunWritesNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	out, _, calls := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install", "--dry-run", "--binary", "/fake/harnessd"})
+	if code != 0 {
+		t.Fatalf("dry-run exit code: got %d", code)
+	}
+
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not write %s", unitPath)
+	}
+	if !strings.Contains(out.String(), unitPath) {
+		t.Errorf("dry-run output %q should name the target path", out.String())
+	}
+	if !strings.Contains(out.String(), "<plist") || !strings.Contains(out.String(), "/fake/harnessd") {
+		t.Errorf("dry-run output should print the rendered plist")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("dry-run must not invoke lifecycle tools, got %v", *calls)
+	}
+}
+
+func TestServiceInstallBinaryFlagWinsOverPATH(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir, _ := writeFakeHarnessd(t)
+	t.Setenv("PATH", binDir)
+	setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install", "--binary", "/explicit/harnessd"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	data, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "/explicit/harnessd") {
+		t.Errorf("--binary flag must win over PATH lookup\n%s", data)
+	}
+}
+
+func TestServiceInstallBinaryFromPATH(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir, binPath := writeFakeHarnessd(t)
+	t.Setenv("PATH", binDir)
+	setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	data, err := os.ReadFile(filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), binPath) {
+		t.Errorf("install should resolve harnessd from PATH as %q\n%s", binPath, data)
+	}
+}
+
+func TestServiceInstallMissingBinaryFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir()) // empty dir: no harnessd on PATH
+	_, errOut, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install"})
+	if code == 0 {
+		t.Fatal("install without --binary and without harnessd on PATH must fail")
+	}
+	if !strings.Contains(errOut.String(), "harnessd") || !strings.Contains(errOut.String(), "--binary") {
+		t.Errorf("error %q should name the missing binary and the --binary escape hatch", errOut.String())
+	}
+}
+
+func TestServiceInstallAddrFromEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HARNESS_ADDR", ":9999")
+	out, _, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install", "--dry-run", "--binary", "/fake/harnessd"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	if !strings.Contains(out.String(), ":9999") {
+		t.Errorf("rendered unit should honor HARNESS_ADDR\n%s", out.String())
+	}
+}
+
+func TestServiceInstallAddrFlagOverridesEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("HARNESS_ADDR", ":9999")
+	out, _, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "install", "--dry-run", "--binary", "/fake/harnessd", "--addr", ":7777"})
+	if code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	if !strings.Contains(out.String(), ":7777") {
+		t.Errorf("--addr flag must override HARNESS_ADDR\n%s", out.String())
+	}
+	if strings.Contains(out.String(), ":9999") {
+		t.Errorf("env addr should not appear when --addr is given\n%s", out.String())
+	}
+}
+
+func TestServiceUninstallNotInstalledFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, errOut, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "uninstall"})
+	if code == 0 {
+		t.Fatal("uninstall of a non-installed service must fail")
+	}
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+	if !strings.Contains(errOut.String(), "not installed") || !strings.Contains(errOut.String(), unitPath) {
+		t.Errorf("error %q should say not installed and name the unit path", errOut.String())
+	}
+}
+
+func TestServiceUninstallRemovesFileAndBootsOut(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, _, calls := setupServiceTest(t, "darwin")
+
+	if code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"}); code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+
+	code := dispatch([]string{"service", "uninstall"})
+	if code != 0 {
+		t.Fatalf("uninstall exit code: got %d", code)
+	}
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Errorf("uninstall must remove %s", unitPath)
+	}
+
+	// Best-effort launchctl bootout of the user agent before removal.
+	want := recordedCommand{
+		name: "launchctl",
+		args: []string{"bootout", fmt.Sprintf("gui/%d/com.gocode.harnessd", os.Getuid())},
+	}
+	if len(*calls) != 1 || (*calls)[0].name != want.name || strings.Join((*calls)[0].args, " ") != strings.Join(want.args, " ") {
+		t.Errorf("expected exactly %v, got %v", want, *calls)
+	}
+}
+
+func TestServiceUninstallSystemdDisableNow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, _, calls := setupServiceTest(t, "linux")
+
+	if code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"}); code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "harnessd.service")
+
+	code := dispatch([]string{"service", "uninstall"})
+	if code != 0 {
+		t.Fatalf("uninstall exit code: got %d", code)
+	}
+	if _, err := os.Stat(unitPath); !os.IsNotExist(err) {
+		t.Errorf("uninstall must remove %s", unitPath)
+	}
+
+	want := recordedCommand{name: "systemctl", args: []string{"--user", "disable", "--now", "harnessd.service"}}
+	if len(*calls) != 1 || (*calls)[0].name != want.name || strings.Join((*calls)[0].args, " ") != strings.Join(want.args, " ") {
+		t.Errorf("expected exactly %v, got %v", want, *calls)
+	}
+}
+
+func TestServiceLifecycleStubsNotImplemented(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	setupServiceTest(t, "darwin")
+
+	for _, sub := range []string{"start", "stop", "status"} {
+		_, errOut, _ := setupServiceTest(t, "darwin")
+		code := dispatch([]string{"service", sub})
+		if code == 0 {
+			t.Errorf("service %s must exit non-zero until implemented", sub)
+		}
+		if !strings.Contains(errOut.String(), "not yet implemented") {
+			t.Errorf("service %s error %q should say not yet implemented", sub, errOut.String())
+		}
+	}
+}
+
+func TestServiceUnknownSubcommandFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "explode"})
+	if code == 0 {
+		t.Fatal("unknown subcommand must fail")
+	}
+	if !strings.Contains(errOut.String(), "unknown subcommand") {
+		t.Errorf("error %q should report unknown subcommand", errOut.String())
+	}
+}
+
+func TestServiceNoSubcommandPrintsUsage(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service"})
+	if code == 0 {
+		t.Fatal("bare 'service' must print usage and fail")
+	}
+	if !strings.Contains(errOut.String(), "install") || !strings.Contains(errOut.String(), "uninstall") {
+		t.Errorf("usage %q should name subcommands", errOut.String())
+	}
+}
+
+func TestServiceInstallUnsupportedPlatformFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, _ := setupServiceTest(t, "windows")
+
+	code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"})
+	if code == 0 {
+		t.Fatal("install on an unsupported platform must fail")
+	}
+	if !strings.Contains(errOut.String(), "unsupported platform") {
+		t.Errorf("error %q should report the unsupported platform", errOut.String())
+	}
+}

--- a/docs/plans/807-service-install.md
+++ b/docs/plans/807-service-install.md
@@ -1,0 +1,80 @@
+# Plan: harnesscli service install/uninstall (epic #807, slice 1)
+
+## Context
+
+- Problem: end users can only keep `harnessd` alive via detached tmux; there is
+  no OS-service install. Epic #807 adds `harnesscli service
+  install|uninstall|start|stop|status` matching kimi-code's `kimi server
+  install`.
+- User impact: one-command persistent install of `harnessd` as a user-level
+  launchd agent (macOS) or systemd `--user` unit (Linux), with log capture and
+  crash restart.
+- Constraints: stdlib only (no plist/systemd libs); user-level services only
+  (no root/system units); tmux remains the dev-agent rule; this slice covers
+  ONLY install/uninstall + generators — start/stop/status are stubs for
+  slice 2.
+
+## Scope
+
+- In scope:
+  - `cmd/harnesscli/service.go`: `runService` nested dispatch (install,
+    uninstall; start/stop/status stubbed as not-yet-implemented)
+  - `case "service":` in `dispatch()` (`cmd/harnesscli/auth.go`)
+  - Pure generators `renderLaunchdPlist(opts)` / `renderSystemdUnit(opts)`
+  - Resolution: `--binary` or `exec.LookPath("harnessd")`; `--addr` or
+    `internal/config` resolution (defaults `:8080`, `HARNESS_ADDR`);
+    `--log-dir` default `~/.harness/logs`
+  - `--dry-run` prints target path + rendered unit, writes nothing
+  - `uninstall` removes unit file + best-effort `launchctl bootout` /
+    `systemctl --user disable --now`
+- Out of scope: start/stop/status (slice 2), docs (slice 3), Windows,
+  system-wide units, daemon changes.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none in this slice (slice 3 owns
+  `docs/runbooks/distribution.md` + `README.md`)
+- Spec docs to update before code: none
+- Implementation notes to add after code: none (slice 3)
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`cmd/harnesscli/service_test.go`):
+  - Golden-content: plist contains resolved binary path in ProgramArguments,
+    `KeepAlive`/`RunAtLoad` true, log paths, `HARNESS_ADDR`; unit contains
+    `ExecStart`, `Restart=on-failure`, `WantedBy=default.target`, env addr
+  - `--dry-run` writes nothing, prints target path + contents
+  - install writes plist (darwin) and unit (linux, injected platform) under
+    the temp-HOME paths
+  - binary resolution: `--binary` wins; missing harnessd on PATH errors
+  - addr resolution: `HARNESS_ADDR` env honored; `--addr` overrides env
+  - uninstall when not installed: non-zero + clear message; install→uninstall
+    removes file and invokes best-effort bootout/disable via injected runner
+  - stubs: start/stop/status report not-yet-implemented, non-zero exit
+- Existing tests to update: none
+- Regression tests required: none beyond the above (new feature)
+
+## Cross-Surface Impact Map
+
+- Not a provider/model flow change — not required.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first; watch them fail (compile error: runService undefined).
+- [x] Implement minimal code changes.
+- [x] `go test ./cmd/harnesscli/ -run Service` green (17 tests).
+- [x] `go test ./cmd/harnesscli/...` full package green; gofmt + go vet clean.
+- [x] macOS acceptance: `--dry-run` prints plist; real install into temp HOME
+      passes `plutil -lint` (OK); ProgramArguments[0] = resolved harnessd path.
+- [ ] Commit, push `epic/807-service-install`, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: platform-specific code paths untestable on darwin dev machine.
+  Mitigation: injectable `servicePlatform` var + pure renderers; linux paths
+  fully exercised in unit tests.
+- Risk: unit tests invoking real launchctl/systemctl.
+  Mitigation: injectable `serviceRunCommand` runner var; tests substitute a
+  recording fake.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
+- `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.


### PR DESCRIPTION
Parent epic: #807. Part of #803.

## Slice 1 of #807: install/uninstall + unit generators

- `harnesscli service install` writes a user-level launchd plist (macOS, `~/Library/LaunchAgents/com.gocode.harnessd.plist`) or systemd `--user` unit (Linux, `~/.config/systemd/user/harnessd.service`); `uninstall` removes it with best-effort `launchctl bootout` / `systemctl --user disable --now`.
- Pure, fully unit-tested generators: `renderLaunchdPlist(opts)` / `renderSystemdUnit(opts)` — KeepAlive + RunAtLoad + log paths (launchd); `ExecStart`, `Restart=on-failure`, `WantedBy=default.target` (systemd); addr exported as `HARNESS_ADDR`.
- Resolution: `--binary` (default `exec.LookPath("harnessd")`), `--addr` (default from `internal/config` stack: `:8080` / `HARNESS_ADDR`), `--log-dir` (default `~/.harness/logs`).
- `--dry-run` prints the rendered unit + target path and writes nothing.
- `start`/`stop`/`status` are recognized stubs (slice 2); docs land in slice 3.

## TDD + verification

- 17 tests written first (watched fail), now green: `go test ./cmd/harnesscli/ -run Service -count=1` ✅; full package `go test ./cmd/harnesscli/... -count=1` ✅; `go vet` clean; new files gofmt-clean.
- macOS acceptance verified manually: `install --dry-run` prints plist with `ProgramArguments[0]` = resolved harnessd path; real install into a temp HOME passes `plutil -lint` (OK); `uninstall` removes the file and boots out gracefully.

Do not merge — sibling slices of #807 follow.