### PR TITLE
feat(server): serve embedded /viz static shell from harnessd behind Bearer auth

### DIFF
--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -1,0 +1,59 @@
+# Plan: Session Visualizer — Slice 1: embedded /viz static shell behind Bearer auth
+
+Epic: #812 (parent #803). This plan covers **Slice 1 only**.
+
+## Context
+
+- Problem: harnessd exposes runs/events/summary over HTTP but has no UI; inspecting a run requires `harnesscli` or raw `curl`.
+- User impact: users cannot open a browser to inspect runs.
+- Constraints: embedded static assets only (`go:embed`), no build step, no CDN, no new auth mechanism, no mutating endpoints, read-only under existing Bearer auth + `runs:read` scope.
+
+## Scope
+
+- In scope:
+  - New `internal/server/viz` package: `//go:embed static`, handler serving the shell.
+  - `internal/server/http.go` `buildMux()`: register `/viz` and `/viz/` wrapped in `auth(read(...))`.
+  - Static shell: `index.html` + `app.js` + `style.css`; token via landing form or `?token=`, stored in `sessionStorage`, `fetch("/v1/runs?limit=1")` with Bearer header to prove connectivity; hash-based placeholders for list/detail views (no client routing yet).
+- Out of scope: slices 2–6 (harnesscli subcommand, real list/detail views, timeline, search, docs); any new endpoint, event type, or persistence.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none this slice (docs land in slice 6).
+- Spec docs to update before code: none.
+- Implementation notes to add after code: none this slice.
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`internal/server/http_viz_test.go`):
+  - `GET /viz/` without token → 401.
+  - `GET /viz` without token → 401 (registered behind middleware, no unauthenticated redirect leak).
+  - `GET /viz/` with a key holding no scopes → 403 `insufficient_scope` / `required: runs:read`.
+  - `GET /viz/` with `runs:write`-only key → 200 (documented superscope rule: `runs:write` satisfies `runs:read`, consistent with every other read route — the issue text says 403 here but the codebase rule wins; flagging in PR).
+  - `GET /viz/` with `runs:read` → 200, `text/html`, contains shell markup.
+  - `GET /viz/app.js` → 200 + JavaScript content type; `GET /viz/style.css` → 200 + CSS content type.
+  - `GET /viz` with `runs:read` → redirect to `/viz/`.
+  - Path traversal (`/viz/../`, `%2e%2e`) does not serve embedded content.
+  - Regression: `/healthz` still 200 unauthenticated.
+- Existing tests to update: none.
+- Regression tests required: `go test ./internal/server/... -count=1`.
+
+## Cross-Surface Impact Map
+
+- Not a provider/model flow change: Config — None; Server API — two new mux registrations only; TUI state — None; Regression tests — existing `internal/server` suite must stay green.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first; watch them fail (404).
+- [x] Implement `internal/server/viz` (embed + handler) and mux registration.
+- [x] Static shell files.
+- [x] Tests green; gofmt/go vet clean.
+- [x] Update `docs/plans/INDEX.md`.
+- [x] Run touched-package tests.
+- [ ] Commit, push `epic/812-session-visualizer`, open PR against repo.
+
+## Risks and Mitigations
+
+- Risk: issue text says runs:write-only key → 403, but `hasScope` grants runs:write → runs:read (superscope, tested in `auth_scope_test.go`).
+- Mitigation: assert 200 for runs:write and 403 for a scope-less key; document the deviation in the PR body.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -8,6 +8,7 @@
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
 - `809-mcp-oauth.md` — Epic #809 slice 1: static HTTP headers and typed auth errors for the MCP HTTP transport (in implementation).
+- `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -21,6 +21,7 @@ import (
 	linearadapter "go-agent-harness/internal/linear"
 	"go-agent-harness/internal/provider/catalog"
 	"go-agent-harness/internal/relay"
+	"go-agent-harness/internal/server/viz"
 	slackadapter "go-agent-harness/internal/slack"
 	"go-agent-harness/internal/store"
 	"go-agent-harness/internal/subagents"
@@ -366,6 +367,16 @@ func (s *Server) buildMux() http.Handler {
 
 	// GET /v1/hooks — config-driven hook listing (epic #737); read scope.
 	mux.Handle("/v1/hooks", auth(read(http.HandlerFunc(s.handleHooks))))
+
+	// /viz — embedded read-only session visualizer shell (epic #812).
+	// Static assets only; served behind the same Bearer auth + runs:read
+	// scope as every other read route. /viz redirects to /viz/ only after
+	// auth and scope checks pass, so unauthenticated requests get 401 (and
+	// scope-less keys 403) instead of an unauthenticated redirect.
+	mux.Handle("/viz", auth(read(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/viz/", http.StatusMovedPermanently)
+	}))))
+	mux.Handle("/viz/", auth(read(viz.Handler())))
 
 	return s.hardenHandler(mux)
 }

--- a/internal/server/http_viz_test.go
+++ b/internal/server/http_viz_test.go
@@ -1,0 +1,200 @@
+package server_test
+
+// http_viz_test.go — tests for the embedded session visualizer shell served
+// under /viz (epic #812, slice 1).
+//
+// Behavior under test:
+//   - /viz and /viz/ require Bearer auth, like every other route except /healthz.
+//   - /viz/ requires the runs:read scope (runs:write satisfies it via the
+//     documented superscope rule in auth.go).
+//   - With proper auth the embedded shell (index.html, app.js, style.css) is
+//     served with correct content types.
+//   - Path traversal attempts do not escape the embedded filesystem.
+//   - /healthz remains unauthenticated (regression).
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// vizTestServer builds an auth-enabled test server with three keys:
+// a runs:read key, a runs:write-only key, and a key with no scopes.
+func vizTestServer(t *testing.T) (h http.Handler, tokens map[string]string) {
+	t.Helper()
+
+	ms := store.NewMemoryStore()
+	tokens = make(map[string]string)
+
+	for _, tc := range []struct {
+		name   string
+		scopes []string
+	}{
+		{"read", []string{store.ScopeRunsRead}},
+		{"write_only", []string{store.ScopeRunsWrite}},
+		{"no_scopes", []string{}},
+	} {
+		raw, key := generateFastAPIKey(t, "tenant-viz-test", tc.name, tc.scopes)
+		if err := ms.CreateAPIKey(context.Background(), key); err != nil {
+			t.Fatalf("CreateAPIKey(%s): %v", tc.name, err)
+		}
+		tokens[tc.name] = raw
+	}
+
+	h = server.NewWithOptions(server.ServerOptions{Store: ms})
+	return h, tokens
+}
+
+func vizGet(t *testing.T, h http.Handler, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestVizRequiresAuth(t *testing.T) {
+	t.Parallel()
+	h, _ := vizTestServer(t)
+
+	for _, path := range []string{"/viz", "/viz/", "/viz/app.js", "/viz/style.css"} {
+		rec := vizGet(t, h, path, "")
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("GET %s without token: status = %d, want %d", path, rec.Code, http.StatusUnauthorized)
+		}
+	}
+}
+
+func TestVizRequiresRunsReadScope(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	// A key with no scopes must be rejected with the structured 403 body.
+	rec := vizGet(t, h, "/viz/", tokens["no_scopes"])
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("GET /viz/ with scope-less key: status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	var errResp struct {
+		Error    string `json:"error"`
+		Required string `json:"required"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&errResp); err != nil {
+		t.Fatalf("403 body is not valid JSON: %v; body=%q", err, rec.Body.String())
+	}
+	if errResp.Error != "insufficient_scope" {
+		t.Errorf("403 error = %q, want %q", errResp.Error, "insufficient_scope")
+	}
+	if errResp.Required != store.ScopeRunsRead {
+		t.Errorf("403 required = %q, want %q", errResp.Required, store.ScopeRunsRead)
+	}
+
+	// runs:write satisfies runs:read per the documented superscope rule
+	// (internal/server/auth.go hasScope), consistent with every other read route.
+	rec = vizGet(t, h, "/viz/", tokens["write_only"])
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /viz/ with runs:write-only key: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestVizServesShellWithReadScope(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	rec := vizGet(t, h, "/viz/", tokens["read"])
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /viz/: status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Errorf("GET /viz/: Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"<html", "app.js", "style.css"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("GET /viz/: body missing %q", want)
+		}
+	}
+}
+
+func TestVizServesStaticAssets(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	cases := []struct {
+		path        string
+		contentType string
+	}{
+		{"/viz/app.js", "javascript"},
+		{"/viz/style.css", "text/css"},
+	}
+	for _, tc := range cases {
+		rec := vizGet(t, h, tc.path, tokens["read"])
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET %s: status = %d, want %d", tc.path, rec.Code, http.StatusOK)
+			continue
+		}
+		if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, tc.contentType) {
+			t.Errorf("GET %s: Content-Type = %q, want it to contain %q", tc.path, ct, tc.contentType)
+		}
+		if rec.Body.Len() == 0 {
+			t.Errorf("GET %s: empty body", tc.path)
+		}
+	}
+}
+
+func TestVizRootRedirectsToSlash(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	rec := vizGet(t, h, "/viz", tokens["read"])
+	if rec.Code != http.StatusMovedPermanently && rec.Code != http.StatusTemporaryRedirect {
+		t.Fatalf("GET /viz: status = %d, want a redirect", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/viz/" {
+		t.Errorf("GET /viz: Location = %q, want %q", loc, "/viz/")
+	}
+}
+
+func TestVizPathTraversalRejected(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	for _, path := range []string{"/viz/../v1/runs", "/viz/%2e%2e/v1/runs", "/viz/../../etc/passwd"} {
+		rec := vizGet(t, h, path, tokens["read"])
+		if rec.Code == http.StatusOK {
+			body, _ := io.ReadAll(rec.Body)
+			if strings.Contains(string(body), "<html") {
+				t.Errorf("GET %s: traversal served embedded shell content", path)
+			}
+		}
+	}
+}
+
+func TestVizMissingAssetReturns404(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	rec := vizGet(t, h, "/viz/does-not-exist.js", tokens["read"])
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("GET /viz/does-not-exist.js: status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestVizDoesNotAffectHealthz(t *testing.T) {
+	t.Parallel()
+	h, _ := vizTestServer(t)
+
+	rec := vizGet(t, h, "/healthz", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("GET /healthz without token: status = %d, want %d (must stay unauthenticated)", rec.Code, http.StatusOK)
+	}
+}

--- a/internal/server/viz/static/app.js
+++ b/internal/server/viz/static/app.js
@@ -1,0 +1,147 @@
+/* harnessd session visualizer — slice 1 shell.
+ *
+ * Token story: the API key arrives via the landing form or a ?token= query
+ * param on first load, is kept in sessionStorage, and is sent only as an
+ * Authorization: Bearer header on fetch() calls to the existing /v1 API.
+ * The server never accepts tokens via query string; ?token= is consumed
+ * client-side and immediately scrubbed from the address bar.
+ *
+ * This slice proves connectivity against GET /v1/runs and renders hash-based
+ * placeholders. Real list/detail/timeline views land in later slices.
+ */
+(function () {
+  "use strict";
+
+  var TOKEN_KEY = "harness-viz-token";
+
+  var statusEl = document.getElementById("status");
+  var tokenPanel = document.getElementById("token-panel");
+  var tokenForm = document.getElementById("token-form");
+  var tokenInput = document.getElementById("token-input");
+  var tokenError = document.getElementById("token-error");
+  var viewPanel = document.getElementById("view-panel");
+  var viewEl = document.getElementById("view");
+
+  function setStatus(state, label) {
+    statusEl.textContent = label;
+    statusEl.className = "badge badge-" + state;
+  }
+
+  function currentToken() {
+    return sessionStorage.getItem(TOKEN_KEY) || "";
+  }
+
+  function scrubTokenFromURL() {
+    var params = new URLSearchParams(window.location.search);
+    if (!params.has("token")) {
+      return;
+    }
+    var token = params.get("token");
+    if (token) {
+      sessionStorage.setItem(TOKEN_KEY, token);
+    }
+    params.delete("token");
+    var search = params.toString();
+    var url = window.location.pathname + (search ? "?" + search : "") + window.location.hash;
+    window.history.replaceState(null, "", url);
+  }
+
+  function showTokenForm(message) {
+    tokenPanel.hidden = false;
+    viewPanel.hidden = true;
+    setStatus("idle", "disconnected");
+    if (message) {
+      tokenError.textContent = message;
+      tokenError.hidden = false;
+    } else {
+      tokenError.hidden = true;
+    }
+  }
+
+  function showView() {
+    tokenPanel.hidden = true;
+    viewPanel.hidden = false;
+    renderRoute();
+  }
+
+  function renderRoute() {
+    var hash = window.location.hash || "#/runs";
+    var match = hash.match(/^#\/runs\/(.+)$/);
+    if (match) {
+      viewEl.innerHTML =
+        "<h2>Run detail</h2><p class='muted'>Placeholder for run <code>" +
+        escapeHTML(match[1]) +
+        "</code> — metadata, summary, and the event timeline arrive in later slices.</p>";
+      return;
+    }
+    viewEl.innerHTML =
+      "<h2>Runs</h2><p class='muted'>Placeholder — the runs list arrives in a later slice. " +
+      "Connectivity check passed: the API accepted this key.</p>";
+  }
+
+  function escapeHTML(s) {
+    return s.replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function connect() {
+    var token = currentToken();
+    if (!token) {
+      showTokenForm("");
+      return;
+    }
+    setStatus("idle", "connecting…");
+    fetch("/v1/runs?limit=1", {
+      headers: { Authorization: "Bearer " + token }
+    })
+      .then(function (res) {
+        if (res.status === 401) {
+          sessionStorage.removeItem(TOKEN_KEY);
+          showTokenForm("Unauthorized — check the API key.");
+          return null;
+        }
+        if (res.status === 403) {
+          sessionStorage.removeItem(TOKEN_KEY);
+          showTokenForm("This key lacks the runs:read scope.");
+          return null;
+        }
+        if (!res.ok) {
+          throw new Error("GET /v1/runs failed: HTTP " + res.status);
+        }
+        return res.json();
+      })
+      .then(function (body) {
+        if (body === null) {
+          return;
+        }
+        setStatus("ok", "connected — read-only");
+        showView();
+      })
+      .catch(function (err) {
+        setStatus("err", "connection failed");
+        showTokenForm(String(err && err.message ? err.message : err));
+      });
+  }
+
+  tokenForm.addEventListener("submit", function (ev) {
+    ev.preventDefault();
+    var token = tokenInput.value.trim();
+    if (!token) {
+      showTokenForm("Enter an API key first.");
+      return;
+    }
+    sessionStorage.setItem(TOKEN_KEY, token);
+    tokenInput.value = "";
+    connect();
+  });
+
+  window.addEventListener("hashchange", function () {
+    if (!viewPanel.hidden) {
+      renderRoute();
+    }
+  });
+
+  scrubTokenFromURL();
+  connect();
+})();

--- a/internal/server/viz/static/index.html
+++ b/internal/server/viz/static/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>harnessd session visualizer</title>
+<link rel="stylesheet" href="/viz/style.css">
+</head>
+<body>
+<header class="topbar">
+  <h1>harnessd <span class="muted">session visualizer</span></h1>
+  <span id="status" class="badge badge-idle">disconnected</span>
+</header>
+
+<main>
+  <section id="token-panel" class="panel">
+    <p>
+      Enter an API key with <code>runs:read</code> scope to connect. The key is
+      kept in <code>sessionStorage</code> only and sent as an
+      <code>Authorization: Bearer</code> header on API requests — never in URLs,
+      cookies, or server logs beyond the existing header path.
+    </p>
+    <form id="token-form">
+      <input id="token-input" type="password" autocomplete="off"
+             placeholder="harness_sk_…" aria-label="API key">
+      <button type="submit">Connect</button>
+    </form>
+    <p id="token-error" class="error" hidden></p>
+  </section>
+
+  <section id="view-panel" class="panel" hidden>
+    <nav class="crumbs">
+      <a href="#/runs">#/runs</a>
+      <span class="muted">· read-only · list, detail, and timeline views arrive in later slices</span>
+    </nav>
+    <div id="view"></div>
+  </section>
+</main>
+
+<footer class="footer muted">
+  Served by harnessd from embedded assets. All data comes from the existing
+  <code>/v1</code> API over GET requests only.
+</footer>
+
+<script src="/viz/app.js"></script>
+</body>
+</html>

--- a/internal/server/viz/static/style.css
+++ b/internal/server/viz/static/style.css
@@ -1,0 +1,140 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f1115;
+  --panel: #171a21;
+  --border: #2a2f3a;
+  --text: #e6e8ec;
+  --muted: #8b919e;
+  --accent: #5aa9ff;
+  --ok: #4cc38a;
+  --err: #f16a6a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+code {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 0.92em;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar h1 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.muted {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.badge {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 12px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.badge-idle {
+  color: var(--muted);
+}
+
+.badge-ok {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.badge-err {
+  color: var(--err);
+  border-color: var(--err);
+}
+
+main {
+  max-width: 880px;
+  margin: 24px auto;
+  padding: 0 20px;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+
+#token-form {
+  display: flex;
+  gap: 8px;
+}
+
+#token-input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+#token-input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+button {
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #0b0d10;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 8px 16px;
+}
+
+.error {
+  color: var(--err);
+}
+
+.crumbs {
+  border-bottom: 1px solid var(--border);
+  margin: -4px 0 12px;
+  padding-bottom: 10px;
+  font-size: 13px;
+}
+
+.crumbs a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.footer {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 20px 24px;
+  font-size: 13px;
+}

--- a/internal/server/viz/viz.go
+++ b/internal/server/viz/viz.go
@@ -1,0 +1,33 @@
+// Package viz serves the embedded session visualizer: a read-only,
+// browser-based inspector for harnessd runs (epic #812).
+//
+// The visualizer is a static shell (plain HTML/JS/CSS, no build step, no
+// external assets) embedded into the harnessd binary via go:embed,
+// following the precedent in internal/harness/tools/descriptions. It is
+// mounted under /viz by internal/server and inherits the standard Bearer
+// auth + runs:read scope enforcement applied to every other read route —
+// the package itself performs no authentication.
+package viz
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+//go:embed static
+var staticFS embed.FS
+
+// Handler returns an http.Handler that serves the embedded visualizer
+// assets. It must be mounted on the "/viz/" subtree pattern; the returned
+// handler strips the "/viz/" prefix before delegating to a file server
+// over the embedded filesystem. Directory requests serve index.html.
+func Handler() http.Handler {
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		// Unreachable: the go:embed directive above guarantees "static"
+		// exists at build time.
+		panic("viz: embedded static filesystem unavailable: " + err.Error())
+	}
+	return http.StripPrefix("/viz/", http.FileServer(http.FS(sub)))
+}


### PR DESCRIPTION
Parent epic: #812. Part of #803.

## What

Slice 1 of #812: harnessd serves a minimal embedded, read-only session-visualizer shell at `/viz`, behind the existing Bearer auth + `runs:read` scope — no new endpoints, persistence, auth mechanism, build step, or external assets.

- **`internal/server/viz`** (new): `//go:embed static` (precedent: `internal/harness/tools/descriptions/embed.go`) exposing `Handler()` mounted on the `/viz/` subtree.
- **`internal/server/http.go` `buildMux()`**: registers `/viz` and `/viz/` wrapped in `auth(read(...))`; `/viz` redirects to `/viz/` only after auth + scope pass, so unauthenticated requests get 401 (not an unauthenticated redirect).
- **Static shell** (`index.html`/`app.js`/`style.css`): API key via landing form or `?token=` (consumed client-side, immediately scrubbed from the address bar via `history.replaceState`), held in `sessionStorage`, sent only as `Authorization: Bearer` on `fetch("/v1/runs?limit=1")` to prove connectivity; hash-based placeholders for the list/detail views arriving in slices 3–4.

## Deviation from issue text (flagged)

The slice proposes `403` for a `runs:write`-only key, but `hasScope` (`internal/server/auth.go:144`) documents and tests the superscope rule `runs:write ⇒ runs:read`. Keeping `/viz` consistent with every other read route: a `runs:write`-only key gets **200**; the 403 case is asserted with a scope-less key instead.

## Tests (TDD: failing 404s first, then implementation)

`internal/server/http_viz_test.go`:
- `/viz`, `/viz/`, `/viz/app.js`, `/viz/style.css` → 401 without token
- scope-less key → 403 `insufficient_scope` / `required: runs:read`; `runs:write`-only key → 200 (superscope)
- `runs:read` → 200 `text/html` shell referencing `app.js`/`style.css`; correct content types for both assets
- `/viz` → 301 → `/viz/`; path traversal (`..`, `%2e%2e`) never serves embedded content; missing asset → 404
- regression: `/healthz` stays 200 unauthenticated

## Verification actually run

- `go test ./internal/server/ -run 'TestViz' -count=1 -v` → 8/8 PASS
- `go test ./internal/server/... -count=1` → ok (incl. full existing suite)
- `go vet ./internal/server/ ./internal/server/viz/` → clean; `gofmt -l` on touched files → clean
- Real binary: built `harnessd`, booted in tmux (`HARNESS_ADDR=127.0.0.1:18099 HARNESS_AUTH_DISABLED=true`): `/viz` → 301, `/viz/` → 200 `text/html`, `app.js` → 200 `text/javascript`, `style.css` → 200 `text/css`
- `./scripts/test-regression.sh` (full `go test ./...`): all packages ok except `internal/provider/anthropic` `TestClientRetriesOn503`/`TestClientRetriesOn429` under full-suite load; both pass standalone in this worktree (`-count=3`) and on the clean main checkout — pre-existing load flake, unrelated to this diff.

## Out of scope (later slices)

harnesscli `viz` subcommand (2), real runs list/detail views (3), event timeline (4), search view (5), operations doc (6).

Manual smoke checklist for reviewers: start harnessd with an API key, open `http://ADDR/viz/?token=KEY`, confirm the badge flips to `connected — read-only` and the token disappears from the address bar.