### PR TITLE
feat(config): classify hot-swappable vs restart-only fields with reload diff

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,6 +1,5 @@
 # Engineering Log
 
-<<<<<<< HEAD
 ## 2026-07-19 (Coverage-Gate Fix — `internal/acp` Zero-Coverage Functions)
 
 - Post-merge regression gate (`scripts/test-regression.sh`) failed after epic #806 slice 1 landed: `coveragegate` flagged `(*Conn).drainLine` (conn.go) and `(*rpcError).Error` (jsonrpc.go) at 0.0%.
@@ -42,7 +41,7 @@
   `go test ./cmd/harnesscli/... -count=1` green; acceptance
   `printf '...initialize...' | harness acp` prints a single JSON-RPC result
   with capabilities and exits 0.
-=======
+
 ## 2026-07-19 (Unified /tasks Panel — Epic #814, Slice 1)
 
 - Added `GET /v1/tasks` (`internal/server/http_tasks.go`): a read-scoped union endpoint returning subagents, cron jobs, and pending delayed callbacks as one `Task` DTO (`id`, `type`, `status`, `label`, `started_at`, `age_seconds`, `actions`). Unconfigured sources are skipped, so an empty daemon returns `{"tasks": []}`; a failing source fails the request rather than silently dropping entries.
@@ -50,7 +49,6 @@
 - Tenant scoping reuses the existing per-source helpers verbatim (`filterSubagentsByTenant`, `filterCronJobsByTenant`) and mirrors the cron exact-match shape for callbacks; auth matches `/v1/subagents` and `/v1/cron/jobs` (`runs:read`).
 - Wired the daemon's `*tools.CallbackManager` into `server.ServerOptions.CallbackLister` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
 - Validation: failing-first tests in `internal/server/http_tasks_test.go` (7 handler tests) and `TestCallbackManagerListAll`; `go test ./internal/server/ ./cmd/harnessd/ -count=1` pass. `go test ./internal/harness/tools/ -count=1` has one pre-existing failure (`TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly`) that fails identically on main (a439dc9f) and is unrelated to this slice.
->>>>>>> 975b8d49 (feat(server): GET /v1/tasks union endpoint for subagents, cron, callbacks)
 
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 
@@ -1644,3 +1642,12 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
 - Existing OpenAI-compatible request code now supports the Codex backend's no-`/v1` endpoint path and applies `chatgpt-account-id` with the dynamic bearer credential. `HARNESS_PROVIDER=codex-subscription` selects it deterministically when imported credentials are present.
 - Added `harnesscli auth codex login|status|logout`; `/keys` renders the read-only ChatGPT subscription connection state rather than offering API-key entry.
 - Coverage includes OAuth request/error sanitization, import permissions/read-only behavior, catalog mirroring, bootstrap wiring, CLI lifecycle, TUI/server status, fake HTTPS request plus forced mid-session expiry refresh, and a grep-based no-token-logging guard.
+
+## 2026-07-19 (Epic #815 Slice 1 Config Reload Field Classification)
+
+- Change: new `internal/config/reload.go` — the single authoritative classification of every `Config` field as hot-swappable (takes effect on live reload for subsequent runs) or restart-only (wired once at startup, reported but never applied), plus the pure `ReloadDiff(old, new Config) ReloadReport` function later slices (runner swap, `POST /v1/config/reload`, SIGHUP, TUI `/reload`) build on.
+- Classification rationale (grounded in `cmd/harnessd/main.go` consumption): restart-only is exactly `addr` (listen socket bound once), `memory.db_driver`/`memory.db_dsn`/`memory.sqlite_path` (persistence handles opened once), and `mcp_servers` (server processes and tool registry wired once). Everything else — model, max_steps, cost ceiling, memory toggles/thresholds/LLM knobs, auto_compact, forensics, conclusion_watcher, hooks, cron timing — flows into per-run `RunnerConfig` or runtime policy and is hot-swappable.
+- Design: table-driven (`reloadFields` slice with path/class/equality probe per field) so report order is deterministic; `ReloadClassification()` exposes a copy for docs/validation; `ReloadReport` carries `Applied` + `RestartRequired` with `Changed()`/`NeedsRestart()` helpers. No behavior change to `Load`, `Defaults`, or `Resolve`.
+- Tests (TDD, written first and verified red as compile errors): model-only change hot-swappable; `addr` restart-only; memory split (`db_driver` restart-only vs `enabled` swappable); identical configs empty report; `mcp_servers` map change restart-only; slice field (`hooks.dirs`) detection; mixed-change determinism; reflection-based exhaustiveness guard failing any future `Config` field added without classification.
+- Validation: `go test ./internal/config/... -count=1` (green, 9 new tests); `gofmt`/`go vet` clean; every `reload.go` function at 100% statement coverage.
+- Learning: the regression coverage gate rejects any zero-coverage function repo-wide — the first `test-regression.sh` run failed solely on the untested `ReloadClass.String()` helper. Fixed by adding `TestReloadClassString` (including the defensive unknown-class branch) before re-running; the gate failure was self-inflicted, not a baseline issue.

--- a/docs/plans/815-config-reload.md
+++ b/docs/plans/815-config-reload.md
@@ -1,0 +1,62 @@
+# Plan: epic(config) #815 Slice 1 — classify hot-swappable vs restart-only fields with reload diff
+
+## Context
+
+- Problem: `harnessd` loads `config.Config` once at startup; any edit requires a full restart. Epic #815 adds live reload (`/reload`, `POST /v1/config/reload`, `SIGHUP`). Before anything can be applied at runtime, the repo needs one authoritative classification of which `Config` fields may change at runtime and a pure diff function both the server endpoint and the TUI will consume.
+- User impact: operators get correct, explicit "applied" vs "requires restart" reporting instead of silently ignored config edits.
+- Constraints: no behavior change to `Load`, `Defaults`, or `Resolve`; no new third-party dependencies; strict TDD per `docs/runbooks/testing.md`. This slice is pure config-package work — later slices (runner swap, HTTP endpoint, SIGHUP, TUI) are out of scope here.
+
+## Scope
+
+- In scope:
+  - New `internal/config/reload.go`: table-driven field classification (dotted TOML paths → hot-swappable | restart-only), `ReloadDiff(old, new Config) ReloadReport`, `ReloadReport` helpers, exported read-only access to the classification table.
+  - Package doc comment in `internal/config/config.go` gains a short "Reload classification" section pointing at the table.
+  - New `internal/config/reload_test.go` with behavior tests (TDD first).
+- Out of scope: applying the diff (Slice 2+), HTTP/SIGHUP/TUI triggers, docs runbook matrix (Slice 6), file-watcher auto reload.
+
+## Documentation Contract
+
+- Feature status: `implemented`
+- Public docs affected: none (no operator-facing surface yet — anti-ghost-feature rule)
+- Spec docs to update before code: this plan
+- Implementation notes to add after code: engineering-log entry per `docs/logs/engineering-log.md` convention
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`internal/config/reload_test.go`):
+  - model-only change reported as hot-swappable (`Applied=["model"]`, no restart)
+  - `addr` change reported as restart-only
+  - `memory.db_driver` restart-only while `memory.enabled` is hot-swappable
+  - identical configs produce an empty report
+  - mixed changes populate both lists in deterministic (table) order
+  - `mcp_servers` map change reported as restart-only
+  - slice-valued field change (`hooks.dirs`) detected
+  - exhaustiveness: every leaf field of `Config` (via reflection) is present in the classification table
+- Existing tests to update: none
+- Regression tests required: none (new capability, no bug)
+
+## Cross-Surface Impact Map
+
+- Config: new `reload.go` + package doc paragraph; no change to load/merge semantics.
+- Server API: None — Slice 3 wires the endpoint; this slice only provides the pure function it will call.
+- TUI state: None — Slice 5 consumes `ReloadReport` via the server response.
+- Regression tests: `go test ./internal/config/...` must stay green.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Document feature status and exact contract before code.
+- [x] Write failing tests first, watch them fail (compile error = red).
+- [x] Implement `internal/config/reload.go` minimally.
+- [x] Extend package doc comment with the reload classification summary.
+- [x] `gofmt`, `go vet`, `go test ./internal/config/... -count=1` green.
+- [x] Run `./scripts/test-regression.sh` if time permits.
+- [x] Engineering-log entry; update folder indexes if docs touched.
+- [ ] Commit, push `epic/815-config-reload`, open PR referencing #815. Do NOT merge.
+
+## Risks and Mitigations
+
+- Risk: classification drifts from `Config` as fields are added later.
+- Mitigation: reflection-based exhaustiveness test fails any PR that adds a `Config` field without classifying it.
+- Risk: misclassifying a startup-wired field as hot-swappable.
+- Mitigation: classification grounded in `cmd/harnessd/main.go` consumption (persistence handles `memory.db_driver`/`db_dsn`/`sqlite_path`, listen `addr`, and `mcp_servers` process wiring are restart-only; everything flowing into per-run `RunnerConfig` or runtime policy knobs is hot-swappable).

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,6 +5,7 @@
 - `819-plan-mode.md` — Epic #819 slice 1: pin plan-mode exit semantics across approval modes (in implementation).
 - `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
+- `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,12 @@
 //  4. Named profile: ~/.harness/profiles/<name>.toml
 //  5. CLI/env overrides: HARNESS_* environment variables
 //  6. Cloud/team constraints (future stub — not yet applied)
+//
+// Reload classification: every Config field is classified as hot-swappable
+// (takes effect on a live reload for subsequent runs) or restart-only
+// (wired once at startup; a reload reports it but never applies it). The
+// authoritative table lives in reload.go (ReloadClassification) and
+// ReloadDiff reports field changes split by class.
 package config
 
 import (

--- a/internal/config/reload.go
+++ b/internal/config/reload.go
@@ -1,0 +1,197 @@
+package config
+
+import (
+	"maps"
+	"slices"
+)
+
+// ReloadClass classifies how a Config field may change on a live reload.
+type ReloadClass int
+
+const (
+	// ReloadHotSwappable fields take effect for subsequent runs when a
+	// reload is triggered; no daemon restart is required.
+	ReloadHotSwappable ReloadClass = iota
+	// ReloadRestartOnly fields are wired once at startup (listen sockets,
+	// persistence handles, MCP server processes). A reload never applies
+	// them; it reports them as requiring a restart instead.
+	ReloadRestartOnly
+)
+
+// String returns a human-readable name for the reload class.
+func (c ReloadClass) String() string {
+	switch c {
+	case ReloadHotSwappable:
+		return "hot-swappable"
+	case ReloadRestartOnly:
+		return "restart-only"
+	default:
+		return "unknown"
+	}
+}
+
+// FieldClassification pairs a dotted TOML field path (e.g.
+// "memory.db_driver") with its reload class.
+type FieldClassification struct {
+	Path  string
+	Class ReloadClass
+}
+
+// reloadField is one row of the classification table: the dotted TOML path,
+// the reload class, and an equality probe used by ReloadDiff.
+type reloadField struct {
+	path  string
+	class ReloadClass
+	equal func(a, b Config) bool
+}
+
+// reloadFields is the single authoritative classification of every Config
+// field. The order is stable and defines the order of entries in a
+// ReloadReport. Keep it in sync with the Config struct — the exhaustiveness
+// test in reload_test.go fails if any field is missing or duplicated.
+//
+// Restart-only rationale:
+//   - addr: the HTTP listen socket is bound once at startup.
+//   - memory.db_driver / memory.db_dsn / memory.sqlite_path: persistence
+//     handles are opened once at startup.
+//   - mcp_servers: MCP server processes and the tool registry built from
+//     them are wired once at startup.
+//
+// Everything else is a per-run or runtime policy knob (model, step and cost
+// ceilings, auto-compaction, memory toggles and thresholds, forensics flags,
+// conclusion watcher, hooks, cron timing) and is hot-swappable.
+var reloadFields = []reloadField{
+	{"model", ReloadHotSwappable, func(a, b Config) bool { return a.Model == b.Model }},
+	{"max_steps", ReloadHotSwappable, func(a, b Config) bool { return a.MaxSteps == b.MaxSteps }},
+	{"addr", ReloadRestartOnly, func(a, b Config) bool { return a.Addr == b.Addr }},
+
+	{"cost.max_per_run_usd", ReloadHotSwappable, func(a, b Config) bool { return a.Cost.MaxPerRunUSD == b.Cost.MaxPerRunUSD }},
+
+	{"memory.enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.Enabled == b.Memory.Enabled }},
+	{"memory.mode", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.Mode == b.Memory.Mode }},
+	{"memory.db_driver", ReloadRestartOnly, func(a, b Config) bool { return a.Memory.DBDriver == b.Memory.DBDriver }},
+	{"memory.db_dsn", ReloadRestartOnly, func(a, b Config) bool { return a.Memory.DBDSN == b.Memory.DBDSN }},
+	{"memory.sqlite_path", ReloadRestartOnly, func(a, b Config) bool { return a.Memory.SQLitePath == b.Memory.SQLitePath }},
+	{"memory.default_enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.DefaultEnabled == b.Memory.DefaultEnabled }},
+	{"memory.observe_min_tokens", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.ObserveMinTokens == b.Memory.ObserveMinTokens }},
+	{"memory.snippet_max_tokens", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.SnippetMaxTokens == b.Memory.SnippetMaxTokens }},
+	{"memory.reflect_threshold_tokens", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.ReflectThresholdTokens == b.Memory.ReflectThresholdTokens }},
+	{"memory.llm_mode", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.LLMMode == b.Memory.LLMMode }},
+	{"memory.llm_provider", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.LLMProvider == b.Memory.LLMProvider }},
+	{"memory.llm_model", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.LLMModel == b.Memory.LLMModel }},
+	{"memory.llm_base_url", ReloadHotSwappable, func(a, b Config) bool { return a.Memory.LLMBaseURL == b.Memory.LLMBaseURL }},
+
+	{"auto_compact.enabled", ReloadHotSwappable, func(a, b Config) bool { return a.AutoCompact.Enabled == b.AutoCompact.Enabled }},
+	{"auto_compact.mode", ReloadHotSwappable, func(a, b Config) bool { return a.AutoCompact.Mode == b.AutoCompact.Mode }},
+	{"auto_compact.threshold", ReloadHotSwappable, func(a, b Config) bool { return a.AutoCompact.Threshold == b.AutoCompact.Threshold }},
+	{"auto_compact.keep_last", ReloadHotSwappable, func(a, b Config) bool { return a.AutoCompact.KeepLast == b.AutoCompact.KeepLast }},
+	{"auto_compact.model_context_window", ReloadHotSwappable, func(a, b Config) bool { return a.AutoCompact.ModelContextWindow == b.AutoCompact.ModelContextWindow }},
+
+	{"forensics.trace_tool_decisions", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.TraceToolDecisions == b.Forensics.TraceToolDecisions }},
+	{"forensics.detect_anti_patterns", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.DetectAntiPatterns == b.Forensics.DetectAntiPatterns }},
+	{"forensics.trace_hook_mutations", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.TraceHookMutations == b.Forensics.TraceHookMutations }},
+	{"forensics.capture_request_envelope", ReloadHotSwappable, func(a, b Config) bool {
+		return a.Forensics.CaptureRequestEnvelope == b.Forensics.CaptureRequestEnvelope
+	}},
+	{"forensics.snapshot_memory_snippet", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.SnapshotMemorySnippet == b.Forensics.SnapshotMemorySnippet }},
+	{"forensics.error_chain_enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.ErrorChainEnabled == b.Forensics.ErrorChainEnabled }},
+	{"forensics.error_context_depth", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.ErrorContextDepth == b.Forensics.ErrorContextDepth }},
+	{"forensics.capture_reasoning", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.CaptureReasoning == b.Forensics.CaptureReasoning }},
+	{"forensics.cost_anomaly_detection_enabled", ReloadHotSwappable, func(a, b Config) bool {
+		return a.Forensics.CostAnomalyDetectionEnabled == b.Forensics.CostAnomalyDetectionEnabled
+	}},
+	{"forensics.cost_anomaly_step_multiplier", ReloadHotSwappable, func(a, b Config) bool {
+		return a.Forensics.CostAnomalyStepMultiplier == b.Forensics.CostAnomalyStepMultiplier
+	}},
+	{"forensics.audit_trail_enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.AuditTrailEnabled == b.Forensics.AuditTrailEnabled }},
+	{"forensics.context_window_snapshot_enabled", ReloadHotSwappable, func(a, b Config) bool {
+		return a.Forensics.ContextWindowSnapshotEnabled == b.Forensics.ContextWindowSnapshotEnabled
+	}},
+	{"forensics.context_window_warning_threshold", ReloadHotSwappable, func(a, b Config) bool {
+		return a.Forensics.ContextWindowWarningThreshold == b.Forensics.ContextWindowWarningThreshold
+	}},
+	{"forensics.causal_graph_enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.CausalGraphEnabled == b.Forensics.CausalGraphEnabled }},
+	{"forensics.rollout_dir", ReloadHotSwappable, func(a, b Config) bool { return a.Forensics.RolloutDir == b.Forensics.RolloutDir }},
+
+	{"conclusion_watcher.enabled", ReloadHotSwappable, func(a, b Config) bool { return a.ConclusionWatcher.Enabled == b.ConclusionWatcher.Enabled }},
+	{"conclusion_watcher.intervention_mode", ReloadHotSwappable, func(a, b Config) bool {
+		return a.ConclusionWatcher.InterventionMode == b.ConclusionWatcher.InterventionMode
+	}},
+	{"conclusion_watcher.evaluator_enabled", ReloadHotSwappable, func(a, b Config) bool {
+		return a.ConclusionWatcher.EvaluatorEnabled == b.ConclusionWatcher.EvaluatorEnabled
+	}},
+	{"conclusion_watcher.evaluator_model", ReloadHotSwappable, func(a, b Config) bool {
+		return a.ConclusionWatcher.EvaluatorModel == b.ConclusionWatcher.EvaluatorModel
+	}},
+	{"conclusion_watcher.evaluator_api_key", ReloadHotSwappable, func(a, b Config) bool {
+		return a.ConclusionWatcher.EvaluatorAPIKey == b.ConclusionWatcher.EvaluatorAPIKey
+	}},
+
+	{"hooks.enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Hooks.Enabled == b.Hooks.Enabled }},
+	{"hooks.dirs", ReloadHotSwappable, func(a, b Config) bool { return slices.Equal(a.Hooks.Dirs, b.Hooks.Dirs) }},
+
+	{"cron.jitter_enabled", ReloadHotSwappable, func(a, b Config) bool { return a.Cron.JitterEnabled == b.Cron.JitterEnabled }},
+	{"cron.jitter_min_sec", ReloadHotSwappable, func(a, b Config) bool { return a.Cron.JitterMinSec == b.Cron.JitterMinSec }},
+	{"cron.jitter_max_sec", ReloadHotSwappable, func(a, b Config) bool { return a.Cron.JitterMaxSec == b.Cron.JitterMaxSec }},
+	{"cron.avoid_minute_marks", ReloadHotSwappable, func(a, b Config) bool { return slices.Equal(a.Cron.AvoidMinuteMarks, b.Cron.AvoidMinuteMarks) }},
+	{"cron.log_jittered_times", ReloadHotSwappable, func(a, b Config) bool { return a.Cron.LogJitteredTimes == b.Cron.LogJitteredTimes }},
+
+	{"mcp_servers", ReloadRestartOnly, func(a, b Config) bool { return maps.EqualFunc(a.MCPServers, b.MCPServers, mcpServerConfigEqual) }},
+}
+
+// mcpServerConfigEqual compares two MCP server configs field by field;
+// maps.Equal cannot be used because Args makes MCPServerConfig non-comparable.
+func mcpServerConfigEqual(a, b MCPServerConfig) bool {
+	return a.Transport == b.Transport &&
+		a.Command == b.Command &&
+		a.URL == b.URL &&
+		slices.Equal(a.Args, b.Args)
+}
+
+// ReloadReport describes the difference between two loaded configs, split by
+// reload class. Applied lists hot-swappable fields that changed and may take
+// effect for subsequent runs; RestartRequired lists restart-only fields that
+// changed but can only take effect after a daemon restart. Both lists follow
+// the stable order of the classification table.
+type ReloadReport struct {
+	Applied         []string
+	RestartRequired []string
+}
+
+// Changed reports whether the diff found any field change at all.
+func (r ReloadReport) Changed() bool {
+	return len(r.Applied) > 0 || len(r.RestartRequired) > 0
+}
+
+// NeedsRestart reports whether the diff found restart-only changes.
+func (r ReloadReport) NeedsRestart() bool {
+	return len(r.RestartRequired) > 0
+}
+
+// ReloadDiff compares old and new field by field per the classification
+// table and returns the resulting report. It is a pure function: it never
+// mutates either config and performs no I/O.
+func ReloadDiff(old, new Config) ReloadReport {
+	var report ReloadReport
+	for _, f := range reloadFields {
+		if f.equal(old, new) {
+			continue
+		}
+		if f.class == ReloadRestartOnly {
+			report.RestartRequired = append(report.RestartRequired, f.path)
+		} else {
+			report.Applied = append(report.Applied, f.path)
+		}
+	}
+	return report
+}
+
+// ReloadClassification returns a copy of the authoritative classification
+// table in stable order, for documentation, validation, and tests.
+func ReloadClassification() []FieldClassification {
+	out := make([]FieldClassification, len(reloadFields))
+	for i, f := range reloadFields {
+		out[i] = FieldClassification{Path: f.path, Class: f.class}
+	}
+	return out
+}

--- a/internal/config/reload_test.go
+++ b/internal/config/reload_test.go
@@ -1,0 +1,248 @@
+package config_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/config"
+)
+
+// TestReloadDiffModelOnlyChange verifies that changing only the model is
+// reported as a hot-swappable change that does not require a restart.
+func TestReloadDiffModelOnlyChange(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg
+	newCfg.Model = "gpt-4o"
+
+	report := config.ReloadDiff(oldCfg, newCfg)
+
+	if !report.Changed() {
+		t.Fatal("ReloadDiff reported no changes for a model change")
+	}
+	if report.NeedsRestart() {
+		t.Fatalf("model change must not require restart, got RestartRequired=%v", report.RestartRequired)
+	}
+	if len(report.Applied) != 1 || report.Applied[0] != "model" {
+		t.Errorf("Applied: got %v, want [model]", report.Applied)
+	}
+}
+
+// TestReloadDiffAddrChangeRequiresRestart verifies that changing the listen
+// address is reported as restart-only and never as applied.
+func TestReloadDiffAddrChangeRequiresRestart(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg
+	newCfg.Addr = ":9090"
+
+	report := config.ReloadDiff(oldCfg, newCfg)
+
+	if !report.NeedsRestart() {
+		t.Fatal("addr change must be reported as requiring restart")
+	}
+	if len(report.RestartRequired) != 1 || report.RestartRequired[0] != "addr" {
+		t.Errorf("RestartRequired: got %v, want [addr]", report.RestartRequired)
+	}
+	if len(report.Applied) != 0 {
+		t.Errorf("Applied: got %v, want empty for a restart-only change", report.Applied)
+	}
+}
+
+// TestReloadDiffMemoryFieldSplit verifies the memory section split: the
+// persistence backend selector (db_driver) is restart-only because store
+// handles are opened once at startup, while the runtime enable toggle is
+// hot-swappable.
+func TestReloadDiffMemoryFieldSplit(t *testing.T) {
+	base := config.Defaults()
+
+	driverChange := base
+	driverChange.Memory.DBDriver = "postgres"
+	report := config.ReloadDiff(base, driverChange)
+	if !report.NeedsRestart() {
+		t.Fatal("memory.db_driver change must require restart")
+	}
+	if len(report.RestartRequired) != 1 || report.RestartRequired[0] != "memory.db_driver" {
+		t.Errorf("RestartRequired: got %v, want [memory.db_driver]", report.RestartRequired)
+	}
+
+	enabledChange := base
+	enabledChange.Memory.Enabled = !base.Memory.Enabled
+	report = config.ReloadDiff(base, enabledChange)
+	if report.NeedsRestart() {
+		t.Fatalf("memory.enabled change must not require restart, got RestartRequired=%v", report.RestartRequired)
+	}
+	if len(report.Applied) != 1 || report.Applied[0] != "memory.enabled" {
+		t.Errorf("Applied: got %v, want [memory.enabled]", report.Applied)
+	}
+}
+
+// TestReloadDiffIdenticalConfigs verifies that diffing a config against
+// itself produces an empty report.
+func TestReloadDiffIdenticalConfigs(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.MCPServers = map[string]config.MCPServerConfig{
+		"tool": {Transport: "stdio", Command: "/bin/tool", Args: []string{"--verbose"}},
+	}
+
+	report := config.ReloadDiff(cfg, cfg)
+
+	if report.Changed() {
+		t.Errorf("identical configs must produce empty report, got Applied=%v RestartRequired=%v",
+			report.Applied, report.RestartRequired)
+	}
+	if report.NeedsRestart() {
+		t.Error("identical configs must not require restart")
+	}
+}
+
+// TestReloadDiffMCPServersChangeRequiresRestart verifies that adding,
+// removing, or altering an MCP server entry is restart-only, because MCP
+// server processes are wired once at startup.
+func TestReloadDiffMCPServersChangeRequiresRestart(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg
+	newCfg.MCPServers = map[string]config.MCPServerConfig{
+		"remote": {Transport: "http", URL: "http://localhost:3001/mcp"},
+	}
+
+	report := config.ReloadDiff(oldCfg, newCfg)
+
+	if !report.NeedsRestart() {
+		t.Fatal("mcp_servers change must require restart")
+	}
+	if len(report.RestartRequired) != 1 || report.RestartRequired[0] != "mcp_servers" {
+		t.Errorf("RestartRequired: got %v, want [mcp_servers]", report.RestartRequired)
+	}
+}
+
+// TestReloadDiffSliceFieldChange verifies that changes to slice-valued
+// fields (hook discovery dirs) are detected and classified.
+func TestReloadDiffSliceFieldChange(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg
+	newCfg.Hooks.Dirs = []string{"/srv/team-hooks"}
+
+	report := config.ReloadDiff(oldCfg, newCfg)
+
+	if report.NeedsRestart() {
+		t.Fatalf("hooks.dirs change must not require restart, got RestartRequired=%v", report.RestartRequired)
+	}
+	if len(report.Applied) != 1 || report.Applied[0] != "hooks.dirs" {
+		t.Errorf("Applied: got %v, want [hooks.dirs]", report.Applied)
+	}
+}
+
+// TestReloadDiffMixedChangesDeterministic verifies that a diff containing
+// both hot-swappable and restart-only changes populates both lists, and that
+// repeated diffs return entries in a stable order.
+func TestReloadDiffMixedChangesDeterministic(t *testing.T) {
+	oldCfg := config.Defaults()
+	newCfg := oldCfg
+	newCfg.Model = "gpt-4o"
+	newCfg.MaxSteps = 25
+	newCfg.Addr = ":9090"
+	newCfg.Memory.SQLitePath = "/tmp/other.db"
+	newCfg.AutoCompact.Threshold = 0.9
+
+	first := config.ReloadDiff(oldCfg, newCfg)
+	second := config.ReloadDiff(oldCfg, newCfg)
+
+	if !first.Changed() || !first.NeedsRestart() {
+		t.Fatalf("mixed diff must be changed and require restart, got %+v", first)
+	}
+	if !reflect.DeepEqual(first.Applied, second.Applied) ||
+		!reflect.DeepEqual(first.RestartRequired, second.RestartRequired) {
+		t.Fatalf("ReloadDiff must be deterministic: first=%+v second=%+v", first, second)
+	}
+	for _, want := range []string{"model", "max_steps", "auto_compact.threshold"} {
+		if !containsString(first.Applied, want) {
+			t.Errorf("Applied missing %q: got %v", want, first.Applied)
+		}
+	}
+	for _, want := range []string{"addr", "memory.sqlite_path"} {
+		if !containsString(first.RestartRequired, want) {
+			t.Errorf("RestartRequired missing %q: got %v", want, first.RestartRequired)
+		}
+	}
+}
+
+// TestReloadClassificationCoversEveryConfigField is the exhaustiveness
+// guard: every leaf field of Config (walked by reflection over the TOML
+// tags) must appear in the classification table, so a future field cannot
+// be added without an explicit reload-class decision.
+func TestReloadClassificationCoversEveryConfigField(t *testing.T) {
+	classified := make(map[string]bool)
+	for _, fc := range config.ReloadClassification() {
+		if fc.Path == "" {
+			t.Error("classification entry with empty path")
+			continue
+		}
+		if classified[fc.Path] {
+			t.Errorf("duplicate classification entry %q", fc.Path)
+		}
+		classified[fc.Path] = true
+	}
+
+	leaves := make(map[string]bool)
+	walkConfigLeaves(reflect.TypeOf(config.Config{}), "", leaves)
+
+	for path := range leaves {
+		if !classified[path] {
+			t.Errorf("config field %q is not classified in ReloadClassification()", path)
+		}
+	}
+	for path := range classified {
+		if !leaves[path] {
+			t.Errorf("classification entry %q does not correspond to a Config field", path)
+		}
+	}
+}
+
+// walkConfigLeaves records dotted TOML paths for every leaf field of typ.
+// Structs are walked recursively; maps, slices, and scalars are leaves.
+func walkConfigLeaves(typ reflect.Type, prefix string, out map[string]bool) {
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		tag := field.Tag.Get("toml")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		path := name
+		if prefix != "" {
+			path = prefix + "." + name
+		}
+		if field.Type.Kind() == reflect.Struct {
+			walkConfigLeaves(field.Type, path, out)
+			continue
+		}
+		out[path] = true
+	}
+}
+
+// TestReloadClassString verifies the human-readable class names used in
+// reload reporting, including the defensive unknown-class branch.
+func TestReloadClassString(t *testing.T) {
+	cases := []struct {
+		class config.ReloadClass
+		want  string
+	}{
+		{config.ReloadHotSwappable, "hot-swappable"},
+		{config.ReloadRestartOnly, "restart-only"},
+		{config.ReloadClass(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.class.String(); got != tc.want {
+			t.Errorf("ReloadClass(%d).String(): got %q, want %q", int(tc.class), got, tc.want)
+		}
+	}
+}
+
+func containsString(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Parent epic: #815. Part of #803.

## Slice 1 of epic #815 (config reload)

Single authoritative classification of every `config.Config` field as **hot-swappable** (takes effect on live reload for subsequent runs) or **restart-only** (wired once at startup; reported, never silently applied), plus the pure `ReloadDiff(old, new Config) ReloadReport` function that later slices (runner swap, `POST /v1/config/reload`, SIGHUP, TUI `/reload`) build on.

- New `internal/config/reload.go`: table-driven classification (`reloadFields`), `ReloadReport{Applied, RestartRequired}` with `Changed()`/`NeedsRestart()`, exported `ReloadClassification()` for docs/validation.
- Restart-only: `addr`, `memory.db_driver`/`db_dsn`/`sqlite_path`, `mcp_servers` — grounded in `cmd/harnessd` startup wiring. Everything else hot-swappable.
- Package doc comment documents the classification; no behavior change to `Load`/`Defaults`/`Resolve`.

## Tests (strict TDD — tests written first, verified red as compile errors)

`internal/config/reload_test.go`: model-only change hot-swappable; `addr` restart-only; memory split (`db_driver` restart vs `enabled` swappable); identical configs empty report; `mcp_servers` restart-only; slice-field detection; mixed-change determinism; reflection exhaustiveness guard (any future `Config` field must be classified); `ReloadClass.String` coverage.

## Verification

- `go test ./internal/config/... -count=1` — green (9 new tests)
- `gofmt`/`go vet` clean
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — `[regression] PASS`, `coveragegate: PASS (total=83.9%, min=80.0%, zero-functions=0)`