### PR TITLE
docs(plugins): decide plugin home and publish the manifest v1 contract

### DIFF
--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -392,11 +392,16 @@ func New(cfg TUIConfig) Model {
 	m.commandRegistry = m.buildCommandRegistry()
 	// Set default plugins directory (~/.config/harnesscli/plugins) and load any
 	// custom slash-command plugins from it. Errors and collisions are stored as
-	// warnings and shown to the user via a status message in Init().
+	// warnings and shown to the user via a status message in Init(). A non-empty
+	// legacy directory also adds a deprecation warning pointing at the
+	// installable bundle format.
 	if m.pluginsDir == "" {
 		m.pluginsDir = defaultPluginsDir()
 	}
 	m.pluginWarnings = LoadAndRegisterPlugins(m.commandRegistry, append([]string{m.pluginsDir}, installablePluginCommandDirs()...)...)
+	if warning := legacyPluginsDirWarning(m.pluginsDir); warning != "" {
+		m.pluginWarnings = append(m.pluginWarnings, warning)
+	}
 	// Wire help dialog with real command list and keybindings derived from the
 	// registered commands and the default key map.
 	m.helpDialog = buildHelpDialog(m.commandRegistry, m.keys)
@@ -1760,7 +1765,7 @@ func (m Model) Init() tea.Cmd {
 	}
 	// Schedule a status message when plugin warnings were collected at startup.
 	if len(m.pluginWarnings) > 0 {
-		msg := fmt.Sprintf("%d plugin(s) had errors loading", len(m.pluginWarnings))
+		msg := fmt.Sprintf("%d plugin warning(s) at startup", len(m.pluginWarnings))
 		cmds = append(cmds, func() tea.Msg {
 			return pluginWarningMsg{text: msg}
 		})

--- a/cmd/harnesscli/tui/model_plugins_test.go
+++ b/cmd/harnesscli/tui/model_plugins_test.go
@@ -57,3 +57,67 @@ func TestWithPluginsDirLoadsPluginsAndExposesWarnings(t *testing.T) {
 		t.Fatalf("unexpected plugin output: %q", result.Output)
 	}
 }
+
+// Legacy JSON plugins under ~/.config/harnesscli/plugins must keep registering
+// (deprecation is a warning, not a removal), and a non-empty legacy dir must
+// surface a startup warning pointing at the installable bundle format.
+func TestLegacyPluginsDirStillRegistersAndWarnsAtStartup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	legacyDir := filepath.Join(home, ".config", "harnesscli", "plugins")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatalf("create legacy plugins dir: %v", err)
+	}
+	legacyPlugin := `{
+		"name": "summarize",
+		"description": "Summarize the current topic",
+		"handler": "prompt",
+		"prompt_template": "Summarize: {args}"
+	}`
+	if err := os.WriteFile(filepath.Join(legacyDir, "summarize.json"), []byte(legacyPlugin), 0o644); err != nil {
+		t.Fatalf("write legacy plugin: %v", err)
+	}
+
+	model := New(DefaultTUIConfig())
+
+	// The legacy plugin still registers as a working slash command.
+	entry, ok := model.commandRegistry.Lookup("summarize")
+	if !ok {
+		t.Fatal("expected legacy JSON plugin command to remain registered")
+	}
+	result := entry.Handler(Command{Name: "summarize", Args: []string{"release", "notes"}})
+	if result.Status != CmdOK {
+		t.Fatalf("expected legacy plugin command to run, got %v with output %q", result.Status, result.Output)
+	}
+	if result.Output != "Summarize: release notes" {
+		t.Fatalf("unexpected legacy plugin output: %q", result.Output)
+	}
+
+	// ...and the non-empty legacy dir surfaces a deprecation warning that
+	// points at the installable bundle format.
+	warnings := model.PluginWarnings()
+	var found bool
+	for _, w := range warnings {
+		if strings.Contains(w, "deprecated") && strings.Contains(w, ".go-harness/plugins") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a legacy-dir deprecation warning pointing at the bundle home, got %v", warnings)
+	}
+}
+
+// An absent legacy dir must not produce the deprecation warning.
+func TestNoLegacyPluginsDirNoDeprecationWarning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	model := New(DefaultTUIConfig())
+	for _, w := range model.PluginWarnings() {
+		if strings.Contains(w, "deprecated") {
+			t.Fatalf("expected no deprecation warning without a legacy dir, got %q", w)
+		}
+	}
+}

--- a/cmd/harnesscli/tui/plugin_loader.go
+++ b/cmd/harnesscli/tui/plugin_loader.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	tuiplugin "go-agent-harness/cmd/harnesscli/tui/plugin"
 )
@@ -32,6 +34,35 @@ func LoadAndRegisterPlugins(registry *CommandRegistry, dirs ...string) []string 
 		return nil
 	}
 	return warnings
+}
+
+// legacyPluginsDirWarning returns a deprecation warning when dir (the legacy
+// ~/.config/harnesscli/plugins directory) contains JSON plugin definitions,
+// pointing the user at the installable bundle format and its plugin home. It
+// returns "" when the directory is missing, unreadable, or holds no JSON
+// files; broken files inside an existing dir are already surfaced as loader
+// errors by LoadAndRegisterPlugins.
+func legacyPluginsDirWarning(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	count := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) == ".json" {
+			count++
+		}
+	}
+	if count == 0 {
+		return ""
+	}
+	return fmt.Sprintf("legacy plugin directory %s contains %d JSON plugin(s); the legacy JSON plugin format is deprecated — migrate to installable plugin bundles (plugin.json manifest) under ~/.go-harness/plugins", dir, count)
 }
 
 func pluginCommandEntry(def tuiplugin.PluginDef) CommandEntry {

--- a/cmd/harnesscli/tui/plugin_loader_test.go
+++ b/cmd/harnesscli/tui/plugin_loader_test.go
@@ -72,3 +72,64 @@ func TestLoadAndRegisterPlugins_SkipsCommandCollisions(t *testing.T) {
 		t.Fatalf("expected built-in help command to remain intact, got status %v", result.Status)
 	}
 }
+
+func TestLegacyPluginsDirWarning_NonEmptyLegacyDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pluginJSON := `{
+		"name": "summarize",
+		"description": "Summarize the current topic",
+		"handler": "prompt",
+		"prompt_template": "Summarize: {args}"
+	}`
+	if err := os.WriteFile(filepath.Join(dir, "summarize.json"), []byte(pluginJSON), 0o644); err != nil {
+		t.Fatalf("write plugin file: %v", err)
+	}
+
+	warning := legacyPluginsDirWarning(dir)
+	if warning == "" {
+		t.Fatal("expected a deprecation warning for a legacy dir containing JSON plugins")
+	}
+	if !strings.Contains(warning, dir) {
+		t.Fatalf("expected warning to name the legacy dir %q, got %q", dir, warning)
+	}
+	if !strings.Contains(warning, "deprecated") {
+		t.Fatalf("expected warning to mark the legacy format deprecated, got %q", warning)
+	}
+	if !strings.Contains(warning, ".go-harness/plugins") {
+		t.Fatalf("expected warning to point at the bundle home, got %q", warning)
+	}
+	if !strings.Contains(warning, "plugin.json") {
+		t.Fatalf("expected warning to point at the bundle manifest, got %q", warning)
+	}
+}
+
+func TestLegacyPluginsDirWarning_NoWarningCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing dir", func(t *testing.T) {
+		t.Parallel()
+		if warning := legacyPluginsDirWarning(filepath.Join(t.TempDir(), "does-not-exist")); warning != "" {
+			t.Fatalf("expected no warning for a missing dir, got %q", warning)
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		t.Parallel()
+		if warning := legacyPluginsDirWarning(t.TempDir()); warning != "" {
+			t.Fatalf("expected no warning for an empty dir, got %q", warning)
+		}
+	})
+
+	t.Run("no json files", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("hi"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if warning := legacyPluginsDirWarning(dir); warning != "" {
+			t.Fatalf("expected no warning for a dir without JSON plugins, got %q", warning)
+		}
+	})
+}

--- a/docs/design/INDEX.md
+++ b/docs/design/INDEX.md
@@ -9,4 +9,4 @@
 - `plugins.md`: Plugin system design — Go-level hook model, plugin structure, conclusion-watcher reference, and the config-driven hooks layer (hook-file schema, discovery, trust model, wire protocol).
 # Installable plugin bundles
 
-- `installable-plugin-bundles.md`: Bundle layout, trust model, lifecycle, and marketplace format.
+- `installable-plugin-bundles.md`: Plugin home decision, `plugin.json` manifest v1 authoring contract, install layout, trust model, and marketplace format.

--- a/docs/design/installable-plugin-bundles.md
+++ b/docs/design/installable-plugin-bundles.md
@@ -1,9 +1,118 @@
 # Installable Plugin Bundles
 
-Status: implemented (Epic #748).
+Status: implemented (Epic #748). Manifest v1 authoring contract and plugin-home decision published under Epic #821 (slice 1). Items marked **planned** are later slices of Epic #821 and are not implemented yet.
 
-An installable bundle has `plugin.json` with schema version, kebab-case name, version, and optional relative `skills`, `commands`, `agents`, `hooks`, and `mcp` paths. Bundles install to `~/.go-harness/plugins/<name>/<version>` from a local directory, Git URL, or GitHub shorthand. Install validates the manifest and rejects traversal/symlinks before promotion.
+An installable bundle is a directory with a `plugin.json` manifest declaring optional `skills`, `commands`, `agents`, `hooks`, and `mcp` components. Bundles are installed from a local directory, git URL, or GitHub shorthand, validated without executing their content, and atomically promoted into a versioned plugin home. This document is the stable v1 authoring contract for that manifest and the lifecycle around it.
 
-Enable and trust are separate persisted state. Enabled bundles contribute skills and commands through the existing skills/TUI command loaders. Only enabled and trusted bundles contribute agent TOML profiles, validated MCP server configs, and lifecycle hooks. Remote bundles default untrusted.
+This system is distinct from the compile-time Go plugins under the repository's top-level `plugins/` directory (see `docs/design/plugins.md`), which are unrelated to installable bundles.
 
-Marketplace sources are local JSON indexes in this iteration, managed by `harnesscli plugin marketplace add|list|update`; a marketplace advertises name, description, and install source.
+## 1. Plugin home decision
+
+There is exactly one installable bundle home:
+
+- **Bundle home (canonical):** `$HARNESS_GLOBAL_DIR/plugins`, defaulting to `~/.go-harness/plugins` when `HARNESS_GLOBAL_DIR` is unset. `harnesscli plugin ...`, `harnessd` startup wiring, and the TUI bundle command loader all resolve this root.
+
+- **Legacy home (deprecated, still supported):** `~/.config/harnesscli/plugins/*.json` — single-file JSON `PluginDef` slash commands loaded by the TUI at startup. These keep loading indefinitely, but the format is frozen: no new capabilities will be added to it. When the directory exists and contains at least one `*.json` file, the TUI surfaces a startup warning pointing at the bundle format.
+
+Rationale: every managed surface (installer, state store, marketplace store, daemon skill/hook/MCP wiring, TUI trusted-command loader) already anchors on `$HARNESS_GLOBAL_DIR/plugins`; the legacy directory predates bundles and can only express prompt/bash slash commands, not skills, agents, hooks, or MCP servers.
+
+### Migrating a legacy JSON plugin to a bundle
+
+1. Create a bundle directory with a `plugin.json` (see §2) and a `commands/` directory.
+2. Move each legacy `*.json` file into `commands/` unchanged — bundle command directories accept the same `PluginDef` schema.
+3. `harnesscli plugin install /path/to/the/bundle` (a local install, so it is trusted by default).
+4. Restart the TUI, verify the command works, then delete the legacy file from `~/.config/harnesscli/plugins/`.
+
+## 2. Manifest v1 reference (`plugin.json`)
+
+The manifest is a single JSON object at the bundle root. Unknown fields are rejected (`json.Decoder.DisallowUnknownFields`), so typos fail install instead of being silently ignored.
+
+| Field | Type | Required | Rules |
+| --- | --- | --- | --- |
+| `schema_version` | integer | yes | Must be `1`. |
+| `name` | string | yes | Kebab-case: `^[a-z0-9]+(?:-[a-z0-9]+)*$`. |
+| `version` | string | yes | Safe path segment: `^[A-Za-z0-9][A-Za-z0-9._+-]*$`, never `.`, `..`, or absolute. Becomes the versioned install directory name. |
+| `description` | string | no | Free text shown in listings. |
+| `skills` | string | no | Relative path to a **directory** of skills (`SKILL.md` trees), loaded by the standard skills loader. |
+| `commands` | string | no | Relative path to a **directory** of slash-command definitions. Today each `*.json` file uses the legacy `PluginDef` schema (`name`, `description`, `handler` = `bash`/`prompt`, `command` or `prompt_template`). Markdown command files with `$ARGUMENTS` are **planned** (Epic #821, slice 4). |
+| `agents` | string | no | Relative path to a **directory** of agent TOML profiles, searched when resolving `--profile`. |
+| `hooks` | string | no | Relative path to a hook **file** (`*.json`, config-driven hooks schema: `event`, `kind` = `command`/`http`, `command`/`url`, optional `matcher`, `timeout_seconds`; see `docs/design/plugins.md`). Every `*.json` file in the declared file's directory is loaded. |
+| `mcp` | string | no | Relative path to an MCP servers **file**: a JSON array of `{name, transport, command, args, url}` entries (`transport` = `stdio` or `http`; `command`/`args` for stdio, `url` for http), validated by the same parser as `HARNESS_MCP_SERVERS`. |
+
+Path rules, enforced at install and on every load:
+
+- Declared paths must be relative and contained in the bundle root — absolute paths and `..` escapes are rejected.
+- `skills`, `commands`, `agents` must be existing directories; `hooks`, `mcp` must be existing files.
+- Install rejects any symlink anywhere in the staged bundle.
+- The loader only ever reads metadata and declared content; validation never executes bundle code.
+
+Validation errors name the offending field, e.g. `plugin manifest schema_version must be 1`, `plugin manifest name "My_Plugin" must be kebab-case`, `plugin manifest version ".." must be a safe path segment`, `skills: declared path "skils": ...`.
+
+### Example
+
+```json
+{
+  "schema_version": 1,
+  "name": "release-helper",
+  "version": "1.0.0",
+  "description": "Release-notes summarizer and release-flow hooks",
+  "skills": "skills",
+  "commands": "commands",
+  "hooks": "hooks/hooks.json",
+  "mcp": "mcp.json"
+}
+```
+
+```
+release-helper/
+├── plugin.json
+├── skills/
+│   └── release-notes/SKILL.md
+├── commands/
+│   └── summarize.json        # PluginDef: {"name":"summarize","handler":"prompt","prompt_template":"Summarize: {args}", ...}
+├── hooks/
+│   └── hooks.json            # config-driven hook definition(s)
+└── mcp.json                  # [{"name":"gh","transport":"stdio","command":"gh-mcp","args":["serve"]}]
+```
+
+## 3. Install layout and lifecycle
+
+```
+~/.go-harness/plugins/            # $HARNESS_GLOBAL_DIR/plugins
+├── state.json                    # per-plugin lifecycle state (enabled/trusted/source)
+├── marketplaces.json             # marketplace source indexes
+└── release-helper/               # <name>
+    └── 1.0.0/                    # <version> — the promoted bundle root
+        └── plugin.json ...
+```
+
+- **Sources** (`harnesscli plugin install <source>`): local directory path, git URL, or `owner/repo` shorthand (expands to `https://github.com/owner/repo.git`). Remote sources are cloned with `git clone --depth 1`; local directories are copied. Zip URLs and local zip files are **planned** (Epic #821, slice 3).
+- **Staging and promotion:** the source lands in a private `<root>/.install-*` staging directory, symlinks are rejected, the manifest is validated, and the tree is atomically renamed to `<name>/<version>`. A failed install leaves no partial bundle behind.
+- **State:** `state.json` records `name`, `version`, `source`, `remote`, `enabled`, `trusted` per plugin (`plugins.StateStore`). Re-installing an existing name (e.g. `harnesscli plugin update`) replaces the version directory but preserves the user's `enabled`/`trusted` flags — an update can never silently broaden execution authority.
+- **CLI today:** `harnesscli plugin install|list|uninstall|update|marketplace`. `plugin list` prints `enabled=` and `trusted=` per bundle. `plugin trust`/`untrust` are **planned** (Epic #821, slice 2).
+- **Activation:** bundle contents are discovered at process start. Skills, hooks, and MCP servers take effect at the next `harnessd` start; slash commands at the next TUI start. There is no hot-reload into a running daemon.
+
+## 4. Trust model
+
+`enabled` and `trusted` are independent persisted flags:
+
+- **Enabled** controls visibility: whether the bundle contributes anything at all.
+- **Trusted** controls executable authority: whether the bundle may run code or configuration with side effects.
+
+Defaults at install: **local installs are trusted; remote installs are untrusted** — remote content crosses a trust boundary and stays inert until the user explicitly grants trust (grant/revoke UX lands with the `plugin trust` CLI in slice 2; the `StateStore.SetTrusted` mechanism already exists and is covered by tests).
+
+| Declared surface | Requires |
+| --- | --- |
+| `skills` (SKILL.md trees into the skills loader) | enabled |
+| `commands` (TUI slash commands; `bash` handler can run a shell) | enabled **and** trusted |
+| `agents` (TOML profiles for `--profile`) | enabled **and** trusted |
+| `hooks` (shell/HTTP lifecycle hooks) | enabled **and** trusted |
+| `mcp` (MCP server configs registered at startup) | enabled **and** trusted |
+
+Untrusted bundles are therefore visible in `plugin list` but contribute nothing executable — fail-closed by construction: untrusted bundles never reach the hooks loader, the MCP registrar, the profile search path, or the TUI command registry.
+
+Trust follows the semantics of the config-driven hooks trust model (`internal/hooks/trust.go`): trust is an explicit, user-owned grant recorded locally — not a sandbox. A trusted bundle's hooks and commands execute with the user's privileges, so only trust bundles whose content you have reviewed. Sandboxing plugin code is an explicit non-goal.
+
+## 5. Marketplace
+
+Marketplace sources are local JSON indexes managed by `harnesscli plugin marketplace add|list|update`; a marketplace advertises name, description, and install source for each bundle. Installing from a marketplace entry uses the same installer and trust defaults as any other source.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,13 @@
 # Engineering Log
 
+## 2026-07-19 (Plugin Home Decision + Manifest v1 Contract — Epic #821 Slice 1)
+
+- Extended `docs/design/installable-plugin-bundles.md` into the stable v1 authoring contract: full `plugin.json` field reference with validation rules, install layout (`<name>/<version>` under `$HARNESS_GLOBAL_DIR/plugins`, default `~/.go-harness/plugins`), and the enabled-vs-trusted gating table grounded in the current loader wiring.
+- Decided the single plugin home: `~/.go-harness/plugins` is the bundle home; `~/.config/harnesscli/plugins/*.json` is legacy-but-supported with a documented migration path.
+- Added a TUI startup warning (`legacyPluginsDirWarning` in `cmd/harnesscli/tui/plugin_loader.go`, wired in `model.go`) when the legacy dir contains JSON plugins, pointing at the bundle format; startup status wording changed from "had errors loading" to "plugin warning(s) at startup" since warnings now include a non-error deprecation notice.
+- TDD: failing-first tests cover the warning surface (non-empty/missing/empty/JSON-free dirs) and that legacy JSON plugins still register as working slash commands while the warning surfaces.
+- Validation: `go test ./cmd/harnesscli/tui/ -run 'TestLegacyPluginsDir|TestNoLegacyPluginsDir|TestLoadAndRegisterPlugins|TestWithPluginsDir' -count=1` and the full touched-package runs below are green.
+
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 
 - Added `cmd/harness-acp` and `internal/harnessacp`, using pinned

--- a/docs/plans/821-plugin-system.md
+++ b/docs/plans/821-plugin-system.md
@@ -1,0 +1,50 @@
+# Plan: Epic #821 Slice 1 — plugin home decision + manifest v1 contract
+
+## Context
+
+- Problem: Two plugin homes coexist undecided (`~/.config/harnesscli/plugins/*.json` legacy vs `~/.go-harness/plugins` bundle root), and `plugin.json` has no published authoring contract. Trust is a dead end partly because the lifecycle is undocumented.
+- User impact: Contributors cannot author a bundle from docs alone; legacy JSON plugin users get no migration signal.
+- Constraints: Docs/contract slice only — do NOT implement the loader changes of later slices (trust CLI, zip, markdown commands, TUI manager). Legacy JSON plugins must keep loading. Strict TDD per `docs/runbooks/testing.md`.
+
+## Scope
+
+- In scope:
+  - Extend `docs/design/installable-plugin-bundles.md` into the manifest v1 authoring reference: full field reference, install layout (`<name>/<version>`), trust model, plugin-home decision (`~/.go-harness/plugins` / `$HARNESS_GLOBAL_DIR` = bundle home; `~/.config/harnesscli/plugins/*.json` = legacy-but-supported with deprecation path).
+  - Startup warning in `cmd/harnesscli/tui/plugin_loader.go` (wired in `model.go`) when the legacy dir is non-empty, pointing at the bundle format.
+  - Doc index updates: `docs/design/INDEX.md`, `docs/plans/INDEX.md` (this plan), engineering-log entry. `docs/INDEX.md` lists only folder indexes; top-level structure unchanged, so no edit per `docs/runbooks/documentation-maintenance.md` step 2.
+- Out of scope: trust CLI (slice 2), zip sources (slice 3), markdown commands (slice 4), `/plugins` TUI manager (slice 5), e2e (slice 6).
+
+## Documentation Contract
+
+- Feature status: `in implementation` (slice 1 of epic #821)
+- Public docs affected: none (no new user-facing behavior beyond a warning string)
+- Spec docs to update before code: `docs/design/installable-plugin-bundles.md`
+- Implementation notes to add after code: engineering-log entry
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `TestLegacyPluginsDirWarning_*` in `cmd/harnesscli/tui/plugin_loader_test.go`: non-empty legacy dir (has `.json`) yields a warning naming the bundle format/home; missing/empty/JSON-free dir yields none.
+  - Model-level: legacy dir with a valid JSON plugin still registers the command AND surfaces the deprecation warning via `PluginWarnings()`.
+- Existing tests to update: none expected (no test asserts the startup status message text; verified by grep).
+- Regression tests required: legacy JSON registration tests already exist (`TestLoadAndRegisterPlugins_*`) and must stay green.
+
+## Cross-Surface Impact Map
+
+- None. No provider/model flows, gateway routing, catalogs, API keys, or server/TUI provider plumbing touched. One TUI startup warning string and docs only.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Document feature status and exact contract before code (design doc).
+- [x] Write failing tests first; watch them fail (`undefined: legacyPluginsDirWarning`).
+- [x] Implement minimal code changes (warning func + wiring + status message wording).
+- [x] Update docs, status ledgers, and indexes.
+- [x] Update engineering log.
+- [ ] Run `go test ./cmd/harnesscli/... ./internal/plugins/... -count=1`; gofmt + go vet clean.
+- [ ] Push `epic/821-plugin-system` and open PR (no merge; worktree flow hands merge to maintainer).
+
+## Risks and Mitigations
+
+- Risk: Doc describes behavior the code does not have (ghost features).
+- Mitigation: Every contract claim is grounded in `internal/plugins` code read for this plan; planned later-slice items are explicitly marked as planned, per the anti-ghost-feature rule.

--- a/docs/plans/821-plugin-system.md
+++ b/docs/plans/821-plugin-system.md
@@ -41,8 +41,16 @@
 - [x] Implement minimal code changes (warning func + wiring + status message wording).
 - [x] Update docs, status ledgers, and indexes.
 - [x] Update engineering log.
-- [ ] Run `go test ./cmd/harnesscli/... ./internal/plugins/... -count=1`; gofmt + go vet clean.
-- [ ] Push `epic/821-plugin-system` and open PR (no merge; worktree flow hands merge to maintainer).
+- [x] Run `go test ./cmd/harnesscli/... ./internal/plugins/... -count=1`; gofmt + go vet clean. **Green (28 packages ok).**
+- [x] Push `epic/821-plugin-system` and open PR (no merge; worktree flow hands merge to maintainer). **PR #832.**
+
+## Verification Results
+
+- `GOCACHE=/tmp/go-build go test ./cmd/harnesscli/... ./internal/plugins/... -count=1` — PASS, all 28 packages `ok`.
+- `gofmt -l` on changed Go files — clean; `go vet ./cmd/harnesscli/tui/ ./internal/plugins/` — clean.
+- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — FAIL at the `go test ./...` stage in 3 packages, all unrelated to this slice (no TUI/plugin/doc coupling):
+  - `internal/harness/tools` `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly` — reproduced red on the clean `main` checkout in isolation (`go test ./internal/harness/tools/ -run TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly -count=1`), pre-existing.
+  - `internal/provider/openai` (4 retry-budget tests) and `internal/watcher` `TestMultipleWatchedDirs` — pass on `main` in isolation, fail only under full-suite parallel load; flaky, pre-existing.
 
 ## Risks and Mitigations
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,6 +1,7 @@
 # Plans Index
 
 - `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.
+- `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.


### PR DESCRIPTION
Parent epic: #821. Part of #803.