### PR TITLE
feat(server): GET /v1/tasks union endpoint for subagents, cron, callbacks

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -446,6 +446,7 @@ type serverBootstrapOptions struct {
 	triggers         triggerRuntime
 	rolloutDir       string
 	hooksSummary     hooks.Summary
+	callbackMgr      *htools.CallbackManager
 }
 
 func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
@@ -473,5 +474,6 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		LinearAdapter:    opts.triggers.linear,
 		RolloutDir:       opts.rolloutDir,
 		HooksSummary:     opts.hooksSummary,
+		CallbackLister:   opts.callbackMgr,
 	}
 }

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -941,6 +941,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		triggers:             triggerRuntime,
 		callbackStarter:      callbackStarter,
 		callbackBridge:       callbackBridge,
+		callbackMgr:          callbackMgr,
 		msgSummarizer:        msgSummarizer,
 		skillManager:         skillManager,
 		hooksSummary:         hooksSummary,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -82,6 +82,7 @@ type httpRuntimeOptions struct {
 	triggers             triggerRuntime
 	callbackStarter      *callbackRunStarter
 	callbackBridge       *harness.CallbackEventBridge
+	callbackMgr          *htools.CallbackManager
 	msgSummarizer        *lazySummarizer
 	skillManager         server.SkillManager
 	hooksSummary         hooks.Summary
@@ -282,6 +283,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		triggers:         opts.triggers,
 		rolloutDir:       opts.runnerCfg.RolloutDir,
 		hooksSummary:     opts.hooksSummary,
+		callbackMgr:      opts.callbackMgr,
 	}))
 
 	// Mount the MCP server at /mcp so external MCP clients can drive the harness.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,6 @@
 # Engineering Log
 
+<<<<<<< HEAD
 ## 2026-07-19 (Coverage-Gate Fix — `internal/acp` Zero-Coverage Functions)
 
 - Post-merge regression gate (`scripts/test-regression.sh`) failed after epic #806 slice 1 landed: `coveragegate` flagged `(*Conn).drainLine` (conn.go) and `(*rpcError).Error` (jsonrpc.go) at 0.0%.
@@ -41,6 +42,15 @@
   `go test ./cmd/harnesscli/... -count=1` green; acceptance
   `printf '...initialize...' | harness acp` prints a single JSON-RPC result
   with capabilities and exits 0.
+=======
+## 2026-07-19 (Unified /tasks Panel — Epic #814, Slice 1)
+
+- Added `GET /v1/tasks` (`internal/server/http_tasks.go`): a read-scoped union endpoint returning subagents, cron jobs, and pending delayed callbacks as one `Task` DTO (`id`, `type`, `status`, `label`, `started_at`, `age_seconds`, `actions`). Unconfigured sources are skipped, so an empty daemon returns `{"tasks": []}`; a failing source fails the request rather than silently dropping entries.
+- Added `CallbackManager.ListAll` (`internal/harness/tools/delayed_callback.go`) for cross-conversation enumeration of pending callbacks; fired/canceled callbacks stay excluded, matching `List` semantics.
+- Tenant scoping reuses the existing per-source helpers verbatim (`filterSubagentsByTenant`, `filterCronJobsByTenant`) and mirrors the cron exact-match shape for callbacks; auth matches `/v1/subagents` and `/v1/cron/jobs` (`runs:read`).
+- Wired the daemon's `*tools.CallbackManager` into `server.ServerOptions.CallbackLister` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
+- Validation: failing-first tests in `internal/server/http_tasks_test.go` (7 handler tests) and `TestCallbackManagerListAll`; `go test ./internal/server/ ./cmd/harnessd/ -count=1` pass. `go test ./internal/harness/tools/ -count=1` has one pre-existing failure (`TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly`) that fails identically on main (a439dc9f) and is unrelated to this slice.
+>>>>>>> 975b8d49 (feat(server): GET /v1/tasks union endpoint for subagents, cron, callbacks)
 
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 

--- a/docs/plans/814-tasks-panel.md
+++ b/docs/plans/814-tasks-panel.md
@@ -1,0 +1,57 @@
+# Plan: GET /v1/tasks union endpoint (epic #814, slice 1)
+
+## Context
+
+- Problem: background work (subagents, cron jobs, delayed callbacks) is only visible through separate surfaces; there is no single endpoint answering "what is running right now?".
+- User impact: TUI `/tasks` panel (later slices) and non-TUI clients need one authenticated union endpoint.
+- Constraints: slice 1 of epic #814 only — subagents + cron + callbacks. Bash jobs are slice 2, TUI panel is slice 3. Strict TDD per `docs/runbooks/testing.md`.
+
+## Scope
+
+- In scope:
+  - Unified `Task` DTO + `GET /v1/tasks` handler in `internal/server/http_tasks.go` (new).
+  - Route registration in `internal/server/http.go` next to `/v1/subagents` and `/v1/cron/jobs`, requiring `runs:read`.
+  - `CallbackManager.ListAll()` for cross-conversation enumeration of pending callbacks (`internal/harness/tools/delayed_callback.go`).
+  - Server wiring: new `CallbackLister` option on `ServerOptions`; pass the daemon's `*tools.CallbackManager` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
+- Out of scope: bash jobs in the union, any cancel/kill endpoint, TUI changes (later slices).
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (new endpoint; later slices own user-facing `/tasks` docs).
+- Spec docs to update before code: none.
+- Implementation notes to add after code: engineering log entry per runbook.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `internal/harness/tools/delayed_callback_test.go`: `ListAll` returns pending callbacks across conversations; fired/canceled excluded; empty manager returns empty.
+  - `internal/server/http_tasks_test.go`:
+    - empty union → 200 with `"tasks": []`;
+    - subagent entries map to `type=subagent` with status/label/age/actions;
+    - cron entries map to `type=cron`;
+    - callback entries map to `type=callback`;
+    - tenant filtering matches `/v1/subagents` and `/v1/cron/jobs` behavior;
+    - missing `runs:read` scope → 403; unauthenticated → 401 (auth enabled);
+    - nil sources are skipped (partial union still 200).
+- Existing tests to update: none expected.
+- Regression tests required: handler tests above are the regression net.
+
+## Cross-Surface Impact Map
+
+- Required? This adds a server API route but does not touch provider/model flows, gateway routing, model catalogs, API-key management, or provider plumbing → not required. Config: None. TUI state: None (slice 3). Regression tests: new handler tests listed above.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first (`internal/server/http_tasks_test.go`, `delayed_callback_test.go` addition).
+- [x] Implement `CallbackManager.ListAll`.
+- [x] Implement `internal/server/http_tasks.go` (DTO, mapping, tenant filter, sorting) + route in `http.go`.
+- [x] Wire `CallbackLister` through `ServerOptions` and `cmd/harnessd`.
+- [x] gofmt + go vet clean; `go test ./internal/server/... ./internal/harness/tools/... ./cmd/harnessd/... -count=1` green (one pre-existing `internal/harness/tools` failure also red on main — see engineering log).
+- [x] Update engineering log; commit, push `epic/814-tasks-panel`, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: tenant-scoping semantics differ per source (subagents normalize ""→"default"; cron exact-match with ""-caller passthrough).
+- Mitigation: reuse the existing helpers verbatim (`filterSubagentsByTenant`, `filterCronJobsByTenant`) and mirror the cron helper shape for callbacks, with tests for each.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -3,6 +3,7 @@
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.
 - `819-plan-mode.md` — Epic #819 slice 1: pin plan-mode exit semantics across approval modes (in implementation).
+- `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/harness/tools/delayed_callback.go
+++ b/internal/harness/tools/delayed_callback.go
@@ -280,6 +280,25 @@ func (m *CallbackManager) List(conversationID string) []CallbackInfo {
 	return result
 }
 
+// ListAll returns all callbacks across every conversation. Like List, it only
+// returns callbacks still tracked in the per-conversation index — pending
+// callbacks. Fired and canceled callbacks are removed from that index when
+// they transition, so they are excluded here too.
+func (m *CallbackManager) ListAll() []CallbackInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]CallbackInfo, 0, len(m.callbacks))
+	for _, ids := range m.byConv {
+		for _, id := range ids {
+			if cb, ok := m.callbacks[id]; ok {
+				result = append(result, cb.info)
+			}
+		}
+	}
+	return result
+}
+
 // Shutdown stops all pending callbacks and prevents new ones.
 func (m *CallbackManager) Shutdown() {
 	m.mu.Lock()

--- a/internal/harness/tools/delayed_callback_test.go
+++ b/internal/harness/tools/delayed_callback_test.go
@@ -242,6 +242,87 @@ func TestCallbackManagerList(t *testing.T) {
 	})
 }
 
+func TestCallbackManagerListAll(t *testing.T) {
+	t.Run("empty manager returns empty", func(t *testing.T) {
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter)
+		defer mgr.Shutdown()
+
+		callbacks := mgr.ListAll()
+		if len(callbacks) != 0 {
+			t.Errorf("expected empty list, got %d", len(callbacks))
+		}
+	})
+
+	t.Run("returns pending callbacks across conversations", func(t *testing.T) {
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter)
+		defer mgr.Shutdown()
+
+		info1, err := mgr.Set(setReq("conv-1", 10*time.Second, "check 1"))
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		info2, err := mgr.Set(setReq("conv-2", 20*time.Second, "check 2"))
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		if _, err := mgr.Set(setReq("conv-2", 30*time.Second, "check 3")); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		callbacks := mgr.ListAll()
+		if len(callbacks) != 3 {
+			t.Fatalf("expected 3 callbacks across conversations, got %d", len(callbacks))
+		}
+		byID := make(map[string]CallbackInfo, len(callbacks))
+		for _, cb := range callbacks {
+			byID[cb.ID] = cb
+		}
+		for _, want := range []CallbackInfo{info1, info2} {
+			got, ok := byID[want.ID]
+			if !ok {
+				t.Fatalf("ListAll missing callback %s", want.ID)
+			}
+			if got.ConversationID != want.ConversationID || got.Prompt != want.Prompt || got.State != CallbackStatePending {
+				t.Errorf("callback %s = %+v, want conversation %q prompt %q state pending", want.ID, got, want.ConversationID, want.Prompt)
+			}
+		}
+	})
+
+	t.Run("excludes fired and canceled callbacks", func(t *testing.T) {
+		starter := &mockRunStarter{}
+		mgr := NewCallbackManager(starter)
+		defer mgr.Shutdown()
+
+		keep, err := mgr.Set(setReq("conv-1", time.Hour, "keep"))
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		canceled, err := mgr.Set(setReq("conv-1", time.Hour, "cancel me"))
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		fired, err := mgr.Set(setReq("conv-2", 5*time.Second, "fire me"))
+		if err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		if _, err := mgr.Cancel(canceled.ID); err != nil {
+			t.Fatalf("Cancel: %v", err)
+		}
+		mgr.fire(fired.ID)
+
+		callbacks := mgr.ListAll()
+		if len(callbacks) != 1 {
+			t.Fatalf("expected only the pending callback, got %d: %+v", len(callbacks), callbacks)
+		}
+		if callbacks[0].ID != keep.ID {
+			t.Errorf("remaining callback = %s, want %s", callbacks[0].ID, keep.ID)
+		}
+	})
+}
+
 func TestCallbackManagerFire(t *testing.T) {
 	t.Run("fire calls StartRun", func(t *testing.T) {
 		starter := &mockRunStarter{}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -86,8 +86,12 @@ type ServerOptions struct {
 	HTTPClient        *http.Client
 	MCPConnector      MCPConnector
 	SubagentManager   subagents.Manager
-	ProviderRegistry  *catalog.ProviderRegistry
-	Checkpoints       checkpointManager
+	// CallbackLister enumerates pending delayed callbacks across all
+	// conversations for GET /v1/tasks (epic #814). Optional; when nil the
+	// tasks union simply contains no callback entries.
+	CallbackLister   CallbackLister
+	ProviderRegistry *catalog.ProviderRegistry
+	Checkpoints      checkpointManager
 	// Store is an optional persistence layer for run state.
 	// When provided, GET /v1/runs supports filtering and completed runs are
 	// retrievable after the runner forgets them.
@@ -207,6 +211,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		httpClient:        opts.HTTPClient,
 		mcpConnector:      opts.MCPConnector,
 		subagentManager:   opts.SubagentManager,
+		callbackLister:    opts.CallbackLister,
 		checkpoints:       opts.Checkpoints,
 		runStore:          opts.Store,
 		approvalBroker:    opts.ApprovalBroker,
@@ -289,6 +294,11 @@ func (s *Server) buildMux() http.Handler {
 	// /v1/cron — mixed methods; scope enforced inside handler.
 	mux.Handle("/v1/cron/jobs", auth(http.HandlerFunc(s.handleCronJobsRoot)))
 	mux.Handle("/v1/cron/jobs/", auth(http.HandlerFunc(s.handleCronJobByID)))
+
+	// GET /v1/tasks — unified list of background work (subagents, cron jobs,
+	// pending delayed callbacks; epic #814). Requires runs:read, consistent
+	// with the per-source list routes above.
+	mux.Handle("/v1/tasks", auth(read(http.HandlerFunc(s.handleTasks))))
 
 	// /v1/skills — GET requires runs:read; POST /verify requires runs:write.
 	mux.Handle("/v1/skills", auth(read(http.HandlerFunc(s.handleSkillsRoot))))
@@ -408,6 +418,11 @@ type Server struct {
 	mcpServers   map[string]connectedMCPServer
 
 	subagentManager subagents.Manager
+
+	// callbackLister enumerates pending delayed callbacks across all
+	// conversations for GET /v1/tasks (epic #814). When nil, callbacks are
+	// simply absent from the union.
+	callbackLister CallbackLister
 
 	// runStore is an optional persistence layer for run state (issue #7).
 	// When non-nil, GET /v1/runs supports filtering and run history survives restarts.

--- a/internal/server/http_tasks.go
+++ b/internal/server/http_tasks.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/store"
+	"go-agent-harness/internal/subagents"
+)
+
+// Task type values returned by GET /v1/tasks. bash_job arrives with the
+// background-jobs slice of epic #814; the union endpoint unions the three
+// daemon-reachable sources first.
+const (
+	TaskTypeSubagent = "subagent"
+	TaskTypeCron     = "cron"
+	TaskTypeCallback = "callback"
+)
+
+// Task action values advertise which stop/control operations the client can
+// invoke for a row. They map onto existing per-type endpoints
+// (POST /v1/subagents/{id}/cancel, DELETE /v1/cron/jobs/{id}, ...).
+const (
+	TaskActionCancel = "cancel"
+	TaskActionDelete = "delete"
+	TaskActionPause  = "pause"
+	TaskActionResume = "resume"
+)
+
+// CallbackLister enumerates delayed callbacks across all conversations for
+// the tasks union. *tools.CallbackManager satisfies it via ListAll.
+type CallbackLister interface {
+	ListAll() []tools.CallbackInfo
+}
+
+// Task is the unified DTO returned by GET /v1/tasks. It captures one piece of
+// background work — a managed subagent, a cron job, or a pending delayed
+// callback — with the fields the /tasks panel needs to render a row.
+type Task struct {
+	ID         string    `json:"id"`
+	Type       string    `json:"type"`
+	Status     string    `json:"status"`
+	Label      string    `json:"label"`
+	StartedAt  time.Time `json:"started_at"`
+	AgeSeconds int64     `json:"age_seconds"`
+	Actions    []string  `json:"actions"`
+}
+
+// handleTasks serves GET /v1/tasks: a union of every daemon-reachable piece of
+// background work (subagents, cron jobs, pending delayed callbacks). Sources
+// that are not configured are skipped, so an unconfigured daemon returns an
+// empty list rather than an error. Requires runs:read, matching /v1/subagents
+// and /v1/cron/jobs.
+func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if !hasScope(r.Context(), store.ScopeRunsRead) {
+		writeScopeError(w, store.ScopeRunsRead)
+		return
+	}
+
+	tasks := make([]Task, 0)
+	now := s.timeNow()
+
+	if s.subagentManager != nil {
+		items, err := s.subagentManager.List(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "list_failed", err.Error())
+			return
+		}
+		for _, item := range s.filterSubagentsByTenant(r, items) {
+			tasks = append(tasks, taskFromSubagent(item, now))
+		}
+	}
+
+	if s.cronClient != nil {
+		jobs, err := s.cronClient.ListJobs(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+			return
+		}
+		for _, job := range filterCronJobsByTenant(jobs, TenantIDFromContext(r.Context())) {
+			tasks = append(tasks, taskFromCronJob(job, now))
+		}
+	}
+
+	if s.callbackLister != nil {
+		caller := TenantIDFromContext(r.Context())
+		for _, info := range s.callbackLister.ListAll() {
+			// Mirror filterCronJobsByTenant: an empty caller tenant (auth
+			// disabled) sees everything; otherwise exact tenant match.
+			if caller != "" && info.TenantID != caller {
+				continue
+			}
+			tasks = append(tasks, taskFromCallback(info, now))
+		}
+	}
+
+	// Deterministic ordering: oldest first, ties broken by type then id, so
+	// clients and tests see a stable list regardless of map iteration order.
+	sort.Slice(tasks, func(i, j int) bool {
+		if !tasks[i].StartedAt.Equal(tasks[j].StartedAt) {
+			return tasks[i].StartedAt.Before(tasks[j].StartedAt)
+		}
+		if tasks[i].Type != tasks[j].Type {
+			return tasks[i].Type < tasks[j].Type
+		}
+		return tasks[i].ID < tasks[j].ID
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{"tasks": tasks})
+}
+
+// taskFromSubagent maps a managed subagent onto the unified DTO. Active
+// subagents can be cancelled; terminal ones can be deleted.
+func taskFromSubagent(item subagents.Subagent, now time.Time) Task {
+	label := item.BranchName
+	if label == "" {
+		label = item.RunID
+	}
+	actions := []string{TaskActionDelete}
+	switch item.Status {
+	case harness.RunStatusQueued, harness.RunStatusRunning, harness.RunStatusWaitingForUser, harness.RunStatusWaitingForApproval:
+		actions = []string{TaskActionCancel}
+	}
+	return Task{
+		ID:         item.ID,
+		Type:       TaskTypeSubagent,
+		Status:     string(item.Status),
+		Label:      label,
+		StartedAt:  item.CreatedAt,
+		AgeSeconds: taskAgeSeconds(item.CreatedAt, now),
+		Actions:    actions,
+	}
+}
+
+// taskFromCronJob maps a cron job onto the unified DTO. Active jobs can be
+// paused, paused jobs resumed; every job can be deleted.
+func taskFromCronJob(job tools.CronJob, now time.Time) Task {
+	actions := []string{TaskActionDelete}
+	switch job.Status {
+	case "active":
+		actions = []string{TaskActionPause, TaskActionDelete}
+	case "paused":
+		actions = []string{TaskActionResume, TaskActionDelete}
+	}
+	return Task{
+		ID:         job.ID,
+		Type:       TaskTypeCron,
+		Status:     job.Status,
+		Label:      job.Name,
+		StartedAt:  job.CreatedAt,
+		AgeSeconds: taskAgeSeconds(job.CreatedAt, now),
+		Actions:    actions,
+	}
+}
+
+// taskFromCallback maps a pending delayed callback onto the unified DTO.
+// CallbackManager.ListAll only returns pending callbacks, so the action set
+// is always [cancel].
+func taskFromCallback(info tools.CallbackInfo, now time.Time) Task {
+	return Task{
+		ID:         info.ID,
+		Type:       TaskTypeCallback,
+		Status:     string(info.State),
+		Label:      info.Prompt,
+		StartedAt:  info.CreatedAt,
+		AgeSeconds: taskAgeSeconds(info.CreatedAt, now),
+		Actions:    []string{TaskActionCancel},
+	}
+}
+
+// taskAgeSeconds computes a non-negative age in whole seconds. Clock skew or
+// zero timestamps clamp to 0 rather than producing negative ages.
+func taskAgeSeconds(started, now time.Time) int64 {
+	if started.IsZero() || now.Before(started) {
+		return 0
+	}
+	return int64(now.Sub(started).Seconds())
+}

--- a/internal/server/http_tasks_test.go
+++ b/internal/server/http_tasks_test.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/store"
+	"go-agent-harness/internal/subagents"
+)
+
+// mockCallbackLister is a test double for the CallbackLister option.
+type mockCallbackLister struct {
+	callbacks []tools.CallbackInfo
+}
+
+func (m mockCallbackLister) ListAll() []tools.CallbackInfo { return m.callbacks }
+
+// listTasks performs GET /v1/tasks and decodes the response body.
+func listTasks(t *testing.T, ts *httptest.Server, token string) (int, []Task) {
+	t.Helper()
+	code, body := doSubagentRequest(t, ts, http.MethodGet, token, "/v1/tasks", nil)
+	var decoded struct {
+		Tasks []Task `json:"tasks"`
+	}
+	if code == http.StatusOK {
+		if err := json.Unmarshal([]byte(body), &decoded); err != nil {
+			t.Fatalf("decode /v1/tasks response: %v (body %s)", err, body)
+		}
+	}
+	return code, decoded.Tasks
+}
+
+// TestTasksEndpoint_EmptyUnion verifies that a server with none of the task
+// sources configured still returns 200 with an empty (non-null) task list.
+func TestTasksEndpoint_EmptyUnion(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t)})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasks := listTasks(t, ts, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks: status %d, want 200", code)
+	}
+	if tasks == nil {
+		t.Fatal("GET /v1/tasks: tasks field is null, want []")
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("GET /v1/tasks: got %d tasks, want 0: %+v", len(tasks), tasks)
+	}
+}
+
+// TestTasksEndpoint_UnionsAllSources verifies that subagents, cron jobs, and
+// pending callbacks each contribute correctly typed entries to the union.
+func TestTasksEndpoint_UnionsAllSources(t *testing.T) {
+	t.Parallel()
+
+	started := time.Now().UTC().Add(-2 * time.Minute)
+	subMgr := &mockSubagentManager{
+		listFn: func(context.Context) ([]subagents.Subagent, error) {
+			return []subagents.Subagent{{
+				ID:         "sub-1",
+				RunID:      "run-1",
+				Status:     harness.RunStatusRunning,
+				BranchName: "workspace-sub-1",
+				CreatedAt:  started,
+				UpdatedAt:  started,
+			}}, nil
+		},
+	}
+	cronClient := newMockCronClient()
+	if _, err := cronClient.CreateJob(context.Background(), tools.CronCreateJobRequest{
+		Name:     "nightly-sync",
+		Schedule: "0 3 * * *",
+	}); err != nil {
+		t.Fatalf("seed cron job: %v", err)
+	}
+	callbacks := mockCallbackLister{callbacks: []tools.CallbackInfo{{
+		ID:             "cb-1",
+		ConversationID: "conv-1",
+		Prompt:         "check the deploy",
+		State:          tools.CallbackStatePending,
+		CreatedAt:      started,
+		FiresAt:        started.Add(5 * time.Minute),
+	}}}
+
+	handler := NewWithOptions(ServerOptions{
+		Runner:          testRunnerForAgents(t),
+		SubagentManager: subMgr,
+		CronClient:      cronClient,
+		CallbackLister:  callbacks,
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasks := listTasks(t, ts, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks: status %d, want 200", code)
+	}
+	if len(tasks) != 3 {
+		t.Fatalf("GET /v1/tasks: got %d tasks, want 3: %+v", len(tasks), tasks)
+	}
+
+	byType := make(map[string]Task, len(tasks))
+	for _, task := range tasks {
+		byType[task.Type] = task
+		if task.StartedAt.IsZero() {
+			t.Errorf("task %s (%s): started_at is zero", task.ID, task.Type)
+		}
+		if task.AgeSeconds < 0 {
+			t.Errorf("task %s (%s): negative age_seconds %d", task.ID, task.Type, task.AgeSeconds)
+		}
+	}
+
+	sub, ok := byType["subagent"]
+	if !ok {
+		t.Fatalf("no subagent task in union: %+v", tasks)
+	}
+	if sub.ID != "sub-1" || sub.Status != "running" || sub.Label == "" {
+		t.Errorf("subagent task = %+v, want id sub-1 status running non-empty label", sub)
+	}
+	if len(sub.Actions) != 1 || sub.Actions[0] != "cancel" {
+		t.Errorf("running subagent actions = %v, want [cancel]", sub.Actions)
+	}
+
+	cron, ok := byType["cron"]
+	if !ok {
+		t.Fatalf("no cron task in union: %+v", tasks)
+	}
+	if cron.Status != "active" || cron.Label != "nightly-sync" {
+		t.Errorf("cron task = %+v, want status active label nightly-sync", cron)
+	}
+
+	cb, ok := byType["callback"]
+	if !ok {
+		t.Fatalf("no callback task in union: %+v", tasks)
+	}
+	if cb.ID != "cb-1" || cb.Status != "pending" || cb.Label != "check the deploy" {
+		t.Errorf("callback task = %+v, want id cb-1 status pending label 'check the deploy'", cb)
+	}
+	if len(cb.Actions) != 1 || cb.Actions[0] != "cancel" {
+		t.Errorf("pending callback actions = %v, want [cancel]", cb.Actions)
+	}
+}
+
+// TestTasksEndpoint_SkipsUnconfiguredSources verifies the union degrades
+// gracefully: with only a cron client configured, only cron entries appear.
+func TestTasksEndpoint_SkipsUnconfiguredSources(t *testing.T) {
+	t.Parallel()
+
+	cronClient := newMockCronClient()
+	if _, err := cronClient.CreateJob(context.Background(), tools.CronCreateJobRequest{
+		Name:     "only-cron",
+		Schedule: "* * * * *",
+	}); err != nil {
+		t.Fatalf("seed cron job: %v", err)
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), CronClient: cronClient})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasks := listTasks(t, ts, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks: status %d, want 200", code)
+	}
+	if len(tasks) != 1 || tasks[0].Type != "cron" {
+		t.Fatalf("got %+v, want exactly one cron task", tasks)
+	}
+}
+
+// TestTasksEndpoint_SubagentListError verifies a failing source surfaces an
+// error rather than silently dropping that source from the union.
+func TestTasksEndpoint_SubagentListError(t *testing.T) {
+	t.Parallel()
+
+	subMgr := &mockSubagentManager{
+		listFn: func(context.Context) ([]subagents.Subagent, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), SubagentManager: subMgr})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := listTasks(t, ts, "")
+	if code != http.StatusInternalServerError {
+		t.Fatalf("GET /v1/tasks with failing subagent source: status %d, want 500", code)
+	}
+}
+
+// TestTasksEndpoint_TenantFiltering verifies that with auth enabled, each
+// caller only sees their own tenant's subagents, cron jobs, and callbacks —
+// matching the scoping of /v1/subagents and /v1/cron/jobs.
+func TestTasksEndpoint_TenantFiltering(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	tokenA, keyA := newSubagentTenantAPIKey(t, "tenant-alpha", "key A")
+	tokenB, keyB := newSubagentTenantAPIKey(t, "tenant-bravo", "key B")
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	subMgr := &mockSubagentManager{
+		listFn: func(context.Context) ([]subagents.Subagent, error) {
+			return []subagents.Subagent{
+				{ID: "sub-a", TenantID: "tenant-alpha", RunID: "run-a", Status: harness.RunStatusRunning, CreatedAt: time.Now().UTC()},
+				{ID: "sub-b", TenantID: "tenant-bravo", RunID: "run-b", Status: harness.RunStatusRunning, CreatedAt: time.Now().UTC()},
+			}, nil
+		},
+	}
+	cronClient := newMockCronClient()
+	if _, err := cronClient.CreateJob(context.Background(), tools.CronCreateJobRequest{Name: "job-a", Schedule: "* * * * *", TenantID: "tenant-alpha"}); err != nil {
+		t.Fatalf("seed cron A: %v", err)
+	}
+	if _, err := cronClient.CreateJob(context.Background(), tools.CronCreateJobRequest{Name: "job-b", Schedule: "* * * * *", TenantID: "tenant-bravo"}); err != nil {
+		t.Fatalf("seed cron B: %v", err)
+	}
+	callbacks := mockCallbackLister{callbacks: []tools.CallbackInfo{
+		{ID: "cb-a", TenantID: "tenant-alpha", Prompt: "a", State: tools.CallbackStatePending, CreatedAt: time.Now().UTC()},
+		{ID: "cb-b", TenantID: "tenant-bravo", Prompt: "b", State: tools.CallbackStatePending, CreatedAt: time.Now().UTC()},
+	}}
+
+	handler := NewWithOptions(ServerOptions{
+		Runner:          testRunnerForAgents(t),
+		Store:           ms,
+		SubagentManager: subMgr,
+		CronClient:      cronClient,
+		CallbackLister:  callbacks,
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasksA := listTasks(t, ts, tokenA)
+	if code != http.StatusOK {
+		t.Fatalf("list as A: status %d, want 200", code)
+	}
+	if len(tasksA) != 3 {
+		t.Fatalf("tenant A sees %d tasks, want 3: %+v", len(tasksA), tasksA)
+	}
+	for _, task := range tasksA {
+		switch task.ID {
+		case "sub-a", "cb-a":
+		case "job-1": // first mock cron job (tenant-alpha)
+		default:
+			t.Errorf("tenant A sees unexpected task %s (%s)", task.ID, task.Type)
+		}
+	}
+
+	code, tasksB := listTasks(t, ts, tokenB)
+	if code != http.StatusOK {
+		t.Fatalf("list as B: status %d, want 200", code)
+	}
+	if len(tasksB) != 3 {
+		t.Fatalf("tenant B sees %d tasks, want 3: %+v", len(tasksB), tasksB)
+	}
+	for _, task := range tasksB {
+		switch task.ID {
+		case "sub-b", "cb-b", "job-2":
+		default:
+			t.Errorf("tenant B sees unexpected task %s (%s)", task.ID, task.Type)
+		}
+	}
+}
+
+// TestTasksEndpoint_AuthEnforced verifies /v1/tasks requires authentication
+// and the runs:read scope when auth is enabled.
+func TestTasksEndpoint_AuthEnforced(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	rawNoScope, keyNoScope, err := store.GenerateAPIKey("tenant-alpha", "no-scope", []string{})
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	keyNoScope = minCostRehash(t, rawNoScope, keyNoScope)
+	if err := ms.CreateAPIKey(context.Background(), keyNoScope); err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	tokenRead, keyRead := newSubagentTenantAPIKey(t, "tenant-alpha", "reader")
+	if err := ms.CreateAPIKey(context.Background(), keyRead); err != nil {
+		t.Fatalf("CreateAPIKey reader: %v", err)
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	// Unauthenticated: 401.
+	if code, _ := listTasks(t, ts, ""); code != http.StatusUnauthorized {
+		t.Fatalf("GET /v1/tasks without token: status %d, want 401", code)
+	}
+	// Authenticated but missing runs:read: 403.
+	if code, _ := listTasks(t, ts, rawNoScope); code != http.StatusForbidden {
+		t.Fatalf("GET /v1/tasks without runs:read: status %d, want 403", code)
+	}
+	// runs:read token: 200.
+	if code, _ := listTasks(t, ts, tokenRead); code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks with runs:read: status %d, want 200", code)
+	}
+}
+
+// TestTasksEndpoint_MethodNotAllowed verifies non-GET methods are rejected.
+func TestTasksEndpoint_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t)})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/tasks", []byte(`{}`))
+	if code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /v1/tasks: status %d, want 405", code)
+	}
+}


### PR DESCRIPTION
Parent epic: #814. Part of #803.

## Slice 1 of epic #814 (unified /tasks background panel)

- New read-scoped `GET /v1/tasks` route (`internal/server/http_tasks.go`) returning a unified `Task` DTO (`id`, `type`: `subagent`|`cron`|`callback`, `status`, `label`, `started_at`, `age_seconds`, `actions`) aggregated from `SubagentManager`, `CronClient`, and the callback manager.
- `CallbackManager.ListAll` added for cross-conversation enumeration of pending callbacks (fired/canceled excluded, matching `List` semantics).
- Auth (`runs:read`) and tenant scoping consistent with `/v1/subagents` and `/v1/cron/jobs`; unconfigured sources are skipped, so an empty daemon returns `{"tasks": []}`.
- Daemon wiring: `ServerOptions.CallbackLister` fed from `cmd/harnessd`'s `CallbackManager`.

## Tests (strict TDD — failing first)

- `internal/server/http_tasks_test.go`: empty union, per-source typing, nil-source skip, source error → 500, tenant filtering across all three sources, 401/403 auth enforcement, 405 on POST.
- `internal/harness/tools/delayed_callback_test.go`: `TestCallbackManagerListAll` (empty, cross-conversation, fired/canceled exclusion).

## Verification

- `go test ./internal/server/ -count=1` — ok (22.5s)
- `go test ./cmd/harnessd/ -count=1` — ok (7.5s)
- `go test ./internal/harness/tools/ -run Callback -count=1` — ok (15 tests)
- `go test ./internal/harness/tools/ -count=1` — 1 pre-existing failure (`TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly`), fails identically on main (a439dc9f); unrelated to this slice.
- gofmt/go vet clean on all touched files.

Out of scope (later slices): bash jobs in the union + kill path (slice 2), TUI `/tasks` overlay (slice 3), panel actions (slice 4).