### PR TITLE
feat(acp): stdio JSON-RPC framing and initialize handshake

### DIFF
--- a/cmd/harnesscli/acp.go
+++ b/cmd/harnesscli/acp.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"go-agent-harness/internal/acp"
+)
+
+// stdin is the process standard input, swappable in tests (mirrors the
+// stdout/stderr pattern in main.go).
+var stdin io.Reader = os.Stdin
+
+// runACP implements "harness acp": it serves the Agent Client Protocol
+// (newline-delimited JSON-RPC 2.0) over stdin/stdout so ACP-compatible
+// editors (Zed, JetBrains via ACP) can drive go-code as a subprocess.
+// stdout is a pure protocol channel; all diagnostics go to stderr.
+func runACP(args []string) int {
+	fs := flag.NewFlagSet("acp", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	server := acp.NewServer(stdin, stdout, stderr)
+	if err := server.Serve(context.Background()); err != nil {
+		fmt.Fprintf(stderr, "harnesscli acp: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/harnesscli/acp_test.go
+++ b/cmd/harnesscli/acp_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// swapACPStdio redirects the package-level stdin/stdout/stderr used by runACP
+// and restores them when the test ends.
+func swapACPStdio(t *testing.T, in string) (outBuf, errBuf *bytes.Buffer) {
+	t.Helper()
+	origStdin, origStdout, origStderr := stdin, stdout, stderr
+	outBuf, errBuf = &bytes.Buffer{}, &bytes.Buffer{}
+	stdin = strings.NewReader(in)
+	stdout, stderr = outBuf, errBuf
+	t.Cleanup(func() {
+		stdin, stdout, stderr = origStdin, origStdout, origStderr
+	})
+	return outBuf, errBuf
+}
+
+func TestRunACP_InitializeOverStdio(t *testing.T) {
+	outBuf, errBuf := swapACPStdio(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`+"\n")
+
+	code := runACP(nil)
+	if code != 0 {
+		t.Fatalf("runACP = %d, want 0; stderr: %s", code, errBuf.String())
+	}
+
+	// stdout must carry exactly one protocol message and nothing else.
+	out := outBuf.String()
+	if strings.Count(out, "\n") != 1 || !strings.HasSuffix(out, "\n") {
+		t.Fatalf("stdout must contain exactly one newline-terminated message, got %q", out)
+	}
+	var resp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Result  json.RawMessage `json:"result"`
+		Error   *struct {
+			Code int `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimRight(out, "\n")), &resp); err != nil {
+		t.Fatalf("stdout is not a JSON-RPC response: %v (%q)", err, out)
+	}
+	if resp.JSONRPC != "2.0" || resp.ID != 1 || resp.Error != nil {
+		t.Fatalf("bad response: %q", out)
+	}
+	var result struct {
+		ProtocolVersion   int `json:"protocolVersion"`
+		AgentCapabilities struct {
+			LoadSession bool `json:"loadSession"`
+		} `json:"agentCapabilities"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v", err)
+	}
+	if result.ProtocolVersion != 1 || result.AgentCapabilities.LoadSession {
+		t.Fatalf("bad initialize result: %q", resp.Result)
+	}
+}
+
+func TestRunACP_ExitsCleanlyOnEOF(t *testing.T) {
+	outBuf, errBuf := swapACPStdio(t, "")
+	if code := runACP(nil); code != 0 {
+		t.Fatalf("runACP on empty stdin = %d, want 0; stderr: %s", code, errBuf.String())
+	}
+	if outBuf.Len() != 0 {
+		t.Fatalf("no input must produce no protocol output, got %q", outBuf.String())
+	}
+}
+
+func TestRunACP_DiagnosticsGoToStderrNotStdout(t *testing.T) {
+	// An unknown-method notification produces no protocol response; the
+	// diagnostic note must land on stderr, never stdout.
+	outBuf, errBuf := swapACPStdio(t,
+		`{"jsonrpc":"2.0","method":"session/cancel","params":{}}`+"\n")
+	if code := runACP(nil); code != 0 {
+		t.Fatalf("runACP = %d, want 0; stderr: %s", code, errBuf.String())
+	}
+	if outBuf.Len() != 0 {
+		t.Fatalf("notification must not write to stdout, got %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "session/cancel") {
+		t.Fatalf("expected a stderr diagnostic about the unknown notification, got %q", errBuf.String())
+	}
+}
+
+func TestDispatch_ACPRoutedToRunACP(t *testing.T) {
+	outBuf, errBuf := swapACPStdio(t,
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}`+"\n")
+	code := dispatch([]string{"acp"})
+	if code != 0 {
+		t.Fatalf("dispatch(acp) = %d, want 0; stderr: %s", code, errBuf.String())
+	}
+	// Proof we reached runACP and not the default run() path: stdout carries
+	// an ACP initialize result.
+	if !strings.Contains(outBuf.String(), `"agentCapabilities"`) {
+		t.Fatalf("dispatch(acp) did not serve the ACP handshake; stdout: %q", outBuf.String())
+	}
+}

--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -103,6 +103,8 @@ func dispatch(args []string) int {
 		return run(args)
 	}
 	switch args[0] {
+	case "acp":
+		return runACP(args[1:])
 	case "plugin":
 		return runPlugin(args[1:])
 	case "auth":

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -8,6 +8,34 @@
 - TDD: failing-first tests cover the warning surface (non-empty/missing/empty/JSON-free dirs) and that legacy JSON plugins still register as working slash commands while the warning surfaces.
 - Validation: `go test ./cmd/harnesscli/tui/ -run 'TestLegacyPluginsDir|TestNoLegacyPluginsDir|TestLoadAndRegisterPlugins|TestWithPluginsDir' -count=1` and the full touched-package runs below are green.
 
+## 2026-07-19 (ACP Server Mode — Epic #806, Slice 1)
+
+- Added `internal/acp`: a stdlib-only (`encoding/json`) newline-delimited
+  JSON-RPC 2.0 transport for the Agent Client Protocol — framed `Conn`
+  (partial lines, multiple messages per read, 16 MiB message cap with stream
+  realignment, goroutine-safe writer), envelope types, and spec error codes
+  (`-32700` parse, `-32600` invalid request, `-32601` method not found,
+  `-32602` invalid params).
+- `initialize` handshake negotiates protocol version (agent supports v1 only,
+  always replies 1 per spec) and returns agent capabilities:
+  `loadSession: false`, text-only `promptCapabilities`, `agentInfo`, empty
+  `authMethods`. Notifications and client→agent responses never get replies;
+  diagnostics go to a separate writer so stdout stays a pure protocol channel.
+- Wired `harness acp` (`runACP` in `cmd/harnesscli/acp.go`, dispatch case in
+  `cmd/harnesscli/auth.go`) serving the handshake over stdin/stdout.
+- Distinct from the pre-existing SDK-based `internal/harnessacp` /
+  `cmd/harness-acp` adapter (epic #746): this package is the epic-#806
+  stdlib-only implementation; session methods land in slices 2–4.
+- Bug found by TDD oversized-line test: `ReadLine` drained one line too many
+  when an over-cap message's newline arrived in the same read fragment;
+  fixed by only draining when the terminator is still unconsumed. Covered by
+  `TestConnReadLine/oversized_line...` and
+  `TestServerOversizedMessageRejectedStreamStaysAligned`.
+- Validation: `go test ./internal/acp/... -count=1` (also `-race`) and
+  `go test ./cmd/harnesscli/... -count=1` green; acceptance
+  `printf '...initialize...' | harness acp` prints a single JSON-RPC result
+  with capabilities and exits 0.
+
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 
 - Added `cmd/harness-acp` and `internal/harnessacp`, using pinned

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -1,0 +1,50 @@
+# Plan: ACP slice 1 — stdio JSON-RPC framing and initialize handshake
+
+Epic: #806 (parent #803). Slice 1 of 5. Branch: `epic/806-acp-server`.
+
+## Context
+
+- Problem: go-code has no Agent Client Protocol surface; editors (Zed, JetBrains) cannot spawn or drive it.
+- User impact: without ACP, go-code is invisible to ACP clients.
+- Constraints: this slice only covers newline-delimited JSON-RPC 2.0 framing over stdio plus the `initialize` handshake and spec-correct error handling. No sessions, no runs API, no SSE — those are slices 2–4. Stdlib only (`encoding/json`); no new dependencies. stdout carries protocol messages only; diagnostics go to stderr. A pre-existing `internal/harnessacp` + `cmd/harness-acp` adapter (based on `github.com/coder/acp-go-sdk`) exists; the epic deliberately specifies a new stdlib-only `internal/acp` package and a `harness acp` subcommand — do not touch the existing adapter.
+
+## Scope
+
+- In scope:
+  - New `internal/acp` package: framed reader/writer over `io.Reader`/`io.Writer` (newline-delimited JSON), goroutine-safe writer, JSON-RPC 2.0 envelope types and error codes (`-32700`, `-32600`, `-32601`, `-32602`).
+  - `initialize` handler: protocol-version negotiation (agent supports v1 only, always replies 1), agent capabilities (`loadSession: false`, `promptCapabilities{image,audio,embeddedContext: false}`), `agentInfo`, empty `authMethods`.
+  - New `cmd/harnesscli/acp.go` with `runACP(args)`; `case "acp"` in `dispatch` (`cmd/harnesscli/auth.go`).
+- Out of scope: `session/new`, `session/prompt`, `session/cancel`, `session/update`, `session/request_permission`, `--server` flag / runs API wiring (slices 2–4), docs/e2e (slice 5).
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (user-facing docs land in slice 5).
+- Spec docs to update before code: this plan.
+- Implementation notes to add after code: engineering-log entry.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `internal/acp`: framing (single message, partial line across reads, multiple messages per read, oversized line, goroutine-safe concurrent writes); `initialize` response shape + version negotiation; invalid params `-32602`; malformed JSON `-32700`; valid JSON / invalid request `-32600` table; unknown method `-32601`; notifications and response-shaped messages produce no output; EOF exits cleanly.
+  - `cmd/harnesscli`: `runACP` serves `initialize` over injected stdin/stdout and exits 0 on EOF; `dispatch(["acp"])` routes to `runACP`.
+- Existing tests to update: none.
+- Regression tests required: none beyond the above (new feature).
+
+## Cross-Surface Impact Map
+
+- None — no provider/model flow, gateway routing, model catalog, API-key, or TUI provider plumbing changes. New leaf package + one dispatch case only.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above; epic acceptance: `printf '...initialize...' | harness acp` prints a single JSON-RPC result with capabilities).
+- [ ] Write failing tests first.
+- [ ] Implement minimal code changes.
+- [ ] gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
+- [ ] Update docs indexes (plans INDEX) and engineering log.
+- [ ] Push branch and open PR (no merge — sibling agents continue later slices).
+
+## Risks and Mitigations
+
+- Risk: collision/confusion with existing `internal/harnessacp` (SDK-based adapter).
+- Mitigation: keep new code strictly in `internal/acp` + `cmd/harnesscli/acp.go`; do not modify the existing adapter; note the distinction in the PR body.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -4,6 +4,7 @@
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
+- `806-acp-server.md` — ACP server mode epic #806, slice 1: stdio JSON-RPC framing and initialize handshake in the stdlib-only `internal/acp` package plus the `harness acp` subcommand (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.

--- a/internal/acp/conn.go
+++ b/internal/acp/conn.go
@@ -1,0 +1,99 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+)
+
+// ErrMessageTooLarge is returned by ReadLine when a single message exceeds
+// maxMessageSize bytes. The remainder of the offending line is drained so the
+// stream stays aligned for the next message.
+var ErrMessageTooLarge = errors.New("acp: message exceeds maximum size")
+
+// maxMessageSize bounds a single inbound JSON-RPC message. A misbehaving or
+// hostile client cannot exhaust memory with an unbounded line. It is a var
+// (not a const) so tests can shrink it.
+var maxMessageSize = 16 * 1024 * 1024
+
+// Conn frames JSON-RPC 2.0 messages as newline-delimited JSON over an
+// io.Reader/io.Writer pair. Writes are goroutine-safe: concurrent WriteJSON
+// calls are serialized so messages never interleave.
+type Conn struct {
+	br *bufio.Reader
+	w  io.Writer
+	mu sync.Mutex // guards w
+}
+
+// NewConn returns a Conn reading newline-delimited JSON from r and writing
+// newline-delimited JSON to w.
+func NewConn(r io.Reader, w io.Writer) *Conn {
+	return &Conn{br: bufio.NewReader(r), w: w}
+}
+
+// ReadLine reads one message (a single line without its trailing newline).
+// Lines split across multiple reads and multiple lines delivered in one read
+// are both handled transparently. A final line without a trailing newline is
+// delivered as a complete message. Returns io.EOF when the stream is
+// exhausted and ErrMessageTooLarge (after draining the line) when a message
+// exceeds maxMessageSize.
+func (c *Conn) ReadLine() ([]byte, error) {
+	var buf []byte
+	for {
+		frag, err := c.br.ReadSlice('\n')
+		buf = append(buf, frag...)
+		if len(buf) > maxMessageSize {
+			if err != nil {
+				// The newline has not been consumed yet; discard the rest
+				// of the offending line. (When err == nil ReadSlice already
+				// consumed through the newline, so nothing remains to drain.)
+				c.drainLine()
+			}
+			return nil, ErrMessageTooLarge
+		}
+		switch {
+		case err == nil:
+			return bytes.TrimRight(buf, "\r\n"), nil
+		case errors.Is(err, bufio.ErrBufferFull):
+			continue // line longer than the read buffer; keep accumulating
+		case errors.Is(err, io.EOF) && len(buf) > 0:
+			// Final unterminated line: deliver it as a complete message.
+			return bytes.TrimRight(buf, "\r\n"), nil
+		default:
+			return nil, err
+		}
+	}
+}
+
+// drainLine discards bytes through the next newline so the stream stays
+// aligned after an oversized message. EOF mid-drain is fine: the stream is
+// over anyway.
+func (c *Conn) drainLine() {
+	for {
+		_, err := c.br.ReadSlice('\n')
+		if err == nil || errors.Is(err, io.EOF) {
+			return
+		}
+		// bufio.ErrBufferFull: line still going; loop again.
+	}
+}
+
+// WriteJSON marshals v as compact JSON and writes it as a single
+// newline-terminated line. It is safe for concurrent use; each call writes
+// exactly one message with no interleaving.
+func (c *Conn) WriteJSON(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, err := c.w.Write(data); err != nil {
+		return err
+	}
+	_, err = c.w.Write([]byte{'\n'})
+	return err
+}

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -1,0 +1,177 @@
+package acp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// chunkReader feeds its payload to the reader in fixed-size chunks so tests can
+// simulate messages that arrive split across multiple reads.
+type chunkReader struct {
+	data []byte
+	n    int
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	if len(p) > r.n {
+		p = p[:r.n]
+	}
+	copied := copy(p, r.data)
+	r.data = r.data[copied:]
+	return copied, nil
+}
+
+func TestConnReadLine(t *testing.T) {
+	t.Run("single newline-terminated message", func(t *testing.T) {
+		c := NewConn(strings.NewReader("{\"a\":1}\n"), io.Discard)
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine: %v", err)
+		}
+		if string(line) != `{"a":1}` {
+			t.Fatalf("got %q", line)
+		}
+		if _, err := c.ReadLine(); err != io.EOF {
+			t.Fatalf("expected io.EOF after message, got %v", err)
+		}
+	})
+
+	t.Run("partial line split across reads", func(t *testing.T) {
+		payload := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n"
+		c := NewConn(&chunkReader{data: []byte(payload), n: 3}, io.Discard)
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine: %v", err)
+		}
+		if string(line) != strings.TrimRight(payload, "\n") {
+			t.Fatalf("got %q", line)
+		}
+	})
+
+	t.Run("multiple messages delivered in one read", func(t *testing.T) {
+		c := NewConn(strings.NewReader("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n"), io.Discard)
+		want := []string{`{"a":1}`, `{"b":2}`, `{"c":3}`}
+		for i, w := range want {
+			line, err := c.ReadLine()
+			if err != nil {
+				t.Fatalf("message %d: %v", i, err)
+			}
+			if string(line) != w {
+				t.Fatalf("message %d: got %q want %q", i, line, w)
+			}
+		}
+	})
+
+	t.Run("oversized line is rejected and stream stays aligned", func(t *testing.T) {
+		big := strings.Repeat("x", maxMessageSize+10)
+		c := NewConn(strings.NewReader(big+"\n{\"ok\":true}\n"), io.Discard)
+		if _, err := c.ReadLine(); !errors.Is(err, ErrMessageTooLarge) {
+			t.Fatalf("expected ErrMessageTooLarge, got %v", err)
+		}
+		// The remainder of the oversized line must have been drained so the next
+		// read returns the following message, not garbage from the middle.
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine after oversized: %v", err)
+		}
+		if string(line) != `{"ok":true}` {
+			t.Fatalf("stream misaligned after oversized line, got %q", line[:min(len(line), 40)])
+		}
+	})
+
+	t.Run("final line without trailing newline is delivered", func(t *testing.T) {
+		c := NewConn(strings.NewReader(`{"a":1}`), io.Discard)
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine: %v", err)
+		}
+		if string(line) != `{"a":1}` {
+			t.Fatalf("got %q", line)
+		}
+	})
+
+	t.Run("CRLF line endings are normalized", func(t *testing.T) {
+		c := NewConn(strings.NewReader("{\"a\":1}\r\n"), io.Discard)
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine: %v", err)
+		}
+		if string(line) != `{"a":1}` {
+			t.Fatalf("got %q", line)
+		}
+	})
+}
+
+func TestConnWriteJSON(t *testing.T) {
+	t.Run("writes one compact newline-terminated JSON document", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := NewConn(strings.NewReader(""), &buf)
+		if err := c.WriteJSON(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"ok": true}}); err != nil {
+			t.Fatalf("WriteJSON: %v", err)
+		}
+		out := buf.String()
+		if !strings.HasSuffix(out, "\n") {
+			t.Fatalf("output not newline-terminated: %q", out)
+		}
+		if strings.Count(out, "\n") != 1 {
+			t.Fatalf("output must be a single line, got %q", out)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimRight(out, "\n")), &decoded); err != nil {
+			t.Fatalf("output is not valid JSON: %v", err)
+		}
+	})
+
+	t.Run("concurrent writes never interleave", func(t *testing.T) {
+		var buf bytes.Buffer
+		c := NewConn(strings.NewReader(""), &buf)
+		const goroutines = 8
+		const perGoroutine = 50
+		var wg sync.WaitGroup
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				for i := 0; i < perGoroutine; i++ {
+					if err := c.WriteJSON(map[string]int{"writer": g, "seq": i}); err != nil {
+						t.Errorf("WriteJSON: %v", err)
+						return
+					}
+				}
+			}(g)
+		}
+		wg.Wait()
+
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		if len(lines) != goroutines*perGoroutine {
+			t.Fatalf("got %d lines, want %d — writes were lost or torn", len(lines), goroutines*perGoroutine)
+		}
+		seen := make(map[[2]int]bool)
+		for _, ln := range lines {
+			var m map[string]int
+			if err := json.Unmarshal([]byte(ln), &m); err != nil {
+				t.Fatalf("interleaved/torn write produced invalid JSON line %q: %v", ln, err)
+			}
+			key := [2]int{m["writer"], m["seq"]}
+			if seen[key] {
+				t.Fatalf("duplicate line for %v", key)
+			}
+			seen[key] = true
+		}
+	})
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/acp/initialize.go
+++ b/internal/acp/initialize.go
@@ -1,0 +1,84 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Version is the agent implementation version reported in agentInfo. It is a
+// var so builds can stamp it via -ldflags "-X go-agent-harness/internal/acp.Version=...".
+var Version = "dev"
+
+// initializeRequest is the params shape of the ACP `initialize` method
+// (https://agentclientprotocol.com/protocol/initialization).
+type initializeRequest struct {
+	ProtocolVersion *int                `json:"protocolVersion"`
+	ClientInfo      *implementationInfo `json:"clientInfo,omitempty"`
+	// clientCapabilities is accepted but not acted on in this slice; it is
+	// kept in the raw params for later slices (fs, terminal).
+}
+
+// implementationInfo identifies a protocol peer (agentInfo / clientInfo).
+type implementationInfo struct {
+	Name    string `json:"name"`
+	Title   string `json:"title,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+// initializeResult is the result shape returned by `initialize`.
+type initializeResult struct {
+	ProtocolVersion   int                `json:"protocolVersion"`
+	AgentCapabilities agentCapabilities  `json:"agentCapabilities"`
+	AgentInfo         implementationInfo `json:"agentInfo"`
+	AuthMethods       []authMethod       `json:"authMethods"`
+}
+
+// agentCapabilities advertises what this agent supports. loadSession is
+// always false: session/load is out of scope for the epic. Only text and
+// resource-link prompt content is supported (the ACP baseline), so all
+// promptCapabilities flags are false.
+type agentCapabilities struct {
+	LoadSession        bool               `json:"loadSession"`
+	PromptCapabilities promptCapabilities `json:"promptCapabilities"`
+}
+
+type promptCapabilities struct {
+	Image           bool `json:"image"`
+	Audio           bool `json:"audio"`
+	EmbeddedContext bool `json:"embeddedContext"`
+}
+
+// authMethod describes one authentication method. None are supported in v1,
+// so initialize always returns an empty (non-nil) slice.
+type authMethod struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// handleInitialize negotiates the protocol version and returns the agent's
+// capabilities. The agent supports exactly ProtocolVersion, so per the spec
+// ("otherwise the Agent MUST respond with the latest version it supports") it
+// always answers ProtocolVersion regardless of the requested value; a client
+// that cannot speak it closes the connection.
+func handleInitialize(_ context.Context, params json.RawMessage) (any, *rpcError) {
+	var req initializeRequest
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &rpcError{Code: CodeInvalidParams, Message: "Invalid params: " + err.Error()}
+	}
+	if req.ProtocolVersion == nil {
+		return nil, &rpcError{Code: CodeInvalidParams, Message: "Invalid params: protocolVersion is required"}
+	}
+	return initializeResult{
+		ProtocolVersion: ProtocolVersion,
+		AgentCapabilities: agentCapabilities{
+			LoadSession:        false,
+			PromptCapabilities: promptCapabilities{Image: false, Audio: false, EmbeddedContext: false},
+		},
+		AgentInfo: implementationInfo{
+			Name:    "go-code",
+			Title:   "go-code",
+			Version: Version,
+		},
+		AuthMethods: []authMethod{},
+	}, nil
+}

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -1,0 +1,62 @@
+// Package acp implements the Agent Client Protocol (ACP) transport for
+// go-code: newline-delimited JSON-RPC 2.0 over stdio, as specified at
+// https://agentclientprotocol.com/protocol/overview. Editors such as Zed
+// spawn `harness acp` as a subprocess and drive it with methods like
+// `initialize` and `session/prompt`.
+//
+// stdout is a pure protocol channel: only JSON-RPC messages are written to
+// the outbound writer; all diagnostics go to the server's diagnostic writer
+// (stderr in the real CLI).
+package acp
+
+import "encoding/json"
+
+// ProtocolVersion is the ACP protocol major version this agent supports.
+// The agent supports exactly one version, so it always answers `initialize`
+// with this value; a client that cannot speak it closes the connection.
+const ProtocolVersion = 1
+
+// JSON-RPC 2.0 error codes (https://www.jsonrpc.org/specification#error_object).
+const (
+	// CodeParseError is returned when a line is not valid JSON.
+	CodeParseError = -32700
+	// CodeInvalidRequest is returned when a line is valid JSON but not a
+	// valid JSON-RPC request object.
+	CodeInvalidRequest = -32600
+	// CodeMethodNotFound is returned when no handler is registered for the
+	// requested method.
+	CodeMethodNotFound = -32601
+	// CodeInvalidParams is returned when a request's params fail validation.
+	CodeInvalidParams = -32602
+)
+
+// request is the wire shape of a JSON-RPC 2.0 request or notification.
+// ID is a pointer so that an absent "id" member (a notification) is
+// distinguishable from an explicit `"id": null`.
+type request struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id"`
+	Method  string           `json:"method"`
+	Params  json.RawMessage  `json:"params"`
+}
+
+// response is the wire shape of a JSON-RPC 2.0 response. Exactly one of
+// Result or Error is set; ID echoes the request id (null when the request id
+// could not be determined, e.g. a parse error).
+type response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+// rpcError is the JSON-RPC 2.0 error object.
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string { return e.Message }
+
+// nullID is the response id used when the request id is unknown.
+var nullID = json.RawMessage("null")

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -1,0 +1,148 @@
+package acp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Handler implements one JSON-RPC method. It returns either a result value
+// (marshaled into the response's "result" member) or a *rpcError describing
+// the failure. The returned rpcError is nil on success.
+type Handler func(ctx context.Context, params json.RawMessage) (any, *rpcError)
+
+// Server is a JSON-RPC 2.0 server speaking newline-delimited JSON over a
+// Conn. It answers the ACP `initialize` handshake out of the box; later
+// slices register session methods on top.
+type Server struct {
+	conn     *Conn
+	diag     io.Writer
+	handlers map[string]Handler
+}
+
+// NewServer returns a Server reading requests from r, writing protocol
+// responses to w, and writing human-readable diagnostics to diag (kept nil-
+// safe; pass io.Discard to silence). stdout stays a pure protocol channel:
+// nothing but JSON-RPC messages is ever written to w.
+func NewServer(r io.Reader, w io.Writer, diag io.Writer) *Server {
+	if diag == nil {
+		diag = io.Discard
+	}
+	s := &Server{
+		conn:     NewConn(r, w),
+		diag:     diag,
+		handlers: make(map[string]Handler),
+	}
+	s.Handle("initialize", handleInitialize)
+	return s
+}
+
+// Handle registers h for method, replacing any previous registration.
+func (s *Server) Handle(method string, h Handler) {
+	s.handlers[method] = h
+}
+
+// Serve reads and dispatches messages until the input reaches EOF (clean
+// shutdown, returns nil), the context is cancelled, or an I/O error occurs.
+func (s *Server) Serve(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line, err := s.conn.ReadLine()
+		if errors.Is(err, ErrMessageTooLarge) {
+			if werr := s.writeError(nullID, CodeInvalidRequest, "Invalid Request: message exceeds maximum size"); werr != nil {
+				return werr
+			}
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue // tolerate blank lines between messages
+		}
+		if err := s.dispatch(ctx, line); err != nil {
+			return err
+		}
+	}
+}
+
+// dispatch handles one raw message line: validate, route, respond.
+func (s *Server) dispatch(ctx context.Context, line []byte) error {
+	if !json.Valid(line) {
+		return s.writeError(nullID, CodeParseError, "Parse error")
+	}
+
+	var req request
+	if err := json.Unmarshal(line, &req); err != nil {
+		// Valid JSON but not an object-shaped request (array, bare string, ...).
+		return s.writeError(nullID, CodeInvalidRequest, "Invalid Request")
+	}
+
+	// A message carrying result/error but no method is a JSON-RPC response
+	// from the client (e.g. an answer to a future session/request_permission
+	// call). There is nothing to route it to yet; drop it quietly.
+	if req.Method == "" && (bytes.Contains(line, []byte(`"result"`)) || bytes.Contains(line, []byte(`"error"`))) {
+		fmt.Fprintf(s.diag, "acp: ignoring client response with no pending request (id %s)\n", idForLog(req.ID))
+		return nil
+	}
+
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		return s.writeError(requestID(req.ID), CodeInvalidRequest, "Invalid Request")
+	}
+
+	h, ok := s.handlers[req.Method]
+	if !ok {
+		if req.ID == nil {
+			fmt.Fprintf(s.diag, "acp: ignoring notification for unknown method %q\n", req.Method)
+			return nil
+		}
+		return s.writeError(requestID(req.ID), CodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method))
+	}
+
+	result, rpcErr := h(ctx, req.Params)
+	if req.ID == nil {
+		// Notifications never receive responses, success or error.
+		if rpcErr != nil {
+			fmt.Fprintf(s.diag, "acp: notification %q failed: %s\n", req.Method, rpcErr.Message)
+		}
+		return nil
+	}
+	if rpcErr != nil {
+		return s.writeError(requestID(req.ID), rpcErr.Code, rpcErr.Message)
+	}
+	return s.writeResult(requestID(req.ID), result)
+}
+
+// writeResult sends a success response.
+func (s *Server) writeResult(id json.RawMessage, result any) error {
+	return s.conn.WriteJSON(response{JSONRPC: "2.0", ID: id, Result: result})
+}
+
+// writeError sends an error response.
+func (s *Server) writeError(id json.RawMessage, code int, message string) error {
+	return s.conn.WriteJSON(response{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: message}})
+}
+
+// requestID returns the id to echo in a response: the request's id when one
+// was supplied, null otherwise.
+func requestID(id *json.RawMessage) json.RawMessage {
+	if id == nil {
+		return nullID
+	}
+	return *id
+}
+
+func idForLog(id *json.RawMessage) string {
+	if id == nil {
+		return "<absent>"
+	}
+	return string(*id)
+}

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -1,0 +1,313 @@
+package acp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// serveOnce drives a Server over the given input until EOF and returns the
+// raw response lines (one per line) plus whatever was written to the
+// diagnostic writer.
+func serveOnce(t *testing.T, input string) (lines []string, diag string) {
+	t.Helper()
+	var out, logw bytes.Buffer
+	s := NewServer(strings.NewReader(input), &out, &logw)
+	if err := s.Serve(context.Background()); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	trimmed := strings.TrimRight(out.String(), "\n")
+	if trimmed != "" {
+		lines = strings.Split(trimmed, "\n")
+	}
+	return lines, logw.String()
+}
+
+// rpcResponse is a test-side decoding of a JSON-RPC response line.
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func decodeResponses(t *testing.T, lines []string) []rpcResponse {
+	t.Helper()
+	out := make([]rpcResponse, 0, len(lines))
+	for _, ln := range lines {
+		var r rpcResponse
+		if err := json.Unmarshal([]byte(ln), &r); err != nil {
+			t.Fatalf("response line is not valid JSON: %q: %v", ln, err)
+		}
+		if r.JSONRPC != "2.0" {
+			t.Fatalf("response missing jsonrpc \"2.0\": %q", ln)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func TestServerInitializeReturnsCapabilities(t *testing.T) {
+	lines, diag := serveOnce(t, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true}}}}`+"\n")
+	if diag != "" {
+		t.Fatalf("unexpected diagnostics for a clean initialize: %q", diag)
+	}
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want exactly 1", len(resps))
+	}
+	r := resps[0]
+	if r.Error != nil {
+		t.Fatalf("initialize returned error: %+v", r.Error)
+	}
+	if string(r.ID) != "1" {
+		t.Fatalf("response id = %s, want 1 (echo of request id)", r.ID)
+	}
+
+	var result struct {
+		ProtocolVersion   int `json:"protocolVersion"`
+		AgentCapabilities struct {
+			LoadSession        bool `json:"loadSession"`
+			PromptCapabilities struct {
+				Image           bool `json:"image"`
+				Audio           bool `json:"audio"`
+				EmbeddedContext bool `json:"embeddedContext"`
+			} `json:"promptCapabilities"`
+		} `json:"agentCapabilities"`
+		AgentInfo struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"agentInfo"`
+		AuthMethods []any `json:"authMethods"`
+	}
+	if err := json.Unmarshal(r.Result, &result); err != nil {
+		t.Fatalf("result is not an initialize result: %v (%s)", err, r.Result)
+	}
+	if result.ProtocolVersion != ProtocolVersion {
+		t.Errorf("protocolVersion = %d, want %d", result.ProtocolVersion, ProtocolVersion)
+	}
+	if result.AgentCapabilities.LoadSession {
+		t.Errorf("loadSession must be advertised as false (session/load is out of scope)")
+	}
+	pc := result.AgentCapabilities.PromptCapabilities
+	if pc.Image || pc.Audio || pc.EmbeddedContext {
+		t.Errorf("promptCapabilities must advertise text-only prompts (all false), got %+v", pc)
+	}
+	if result.AgentInfo.Name == "" {
+		t.Errorf("agentInfo.name must be set")
+	}
+	if result.AuthMethods == nil {
+		t.Errorf("authMethods must be present as an empty array, not null/omitted")
+	}
+	if len(result.AuthMethods) != 0 {
+		t.Errorf("authMethods = %v, want empty (no auth required in v1)", result.AuthMethods)
+	}
+}
+
+func TestServerInitializeVersionNegotiation(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		{"client at our version", 1, 1},
+		{"client newer than us gets our latest", 7, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := `{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":` + jsonNumber(tc.requested) + `}}` + "\n"
+			lines, _ := serveOnce(t, msg)
+			resps := decodeResponses(t, lines)
+			if len(resps) != 1 || resps[0].Error != nil {
+				t.Fatalf("got %+v", resps)
+			}
+			var result struct {
+				ProtocolVersion int `json:"protocolVersion"`
+			}
+			if err := json.Unmarshal(resps[0].Result, &result); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if result.ProtocolVersion != tc.want {
+				t.Errorf("requested %d: protocolVersion = %d, want %d", tc.requested, result.ProtocolVersion, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerInitializeStringIDEchoed(t *testing.T) {
+	lines, _ := serveOnce(t, `{"jsonrpc":"2.0","id":"zed-1","method":"initialize","params":{"protocolVersion":1}}`+"\n")
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if string(resps[0].ID) != `"zed-1"` {
+		t.Fatalf("string id not echoed: %s", resps[0].ID)
+	}
+	if resps[0].Error != nil {
+		t.Fatalf("unexpected error: %+v", resps[0].Error)
+	}
+}
+
+func TestServerInitializeInvalidParams(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"missing protocolVersion", `{"jsonrpc":"2.0","id":3,"method":"initialize","params":{}}`},
+		{"missing params entirely", `{"jsonrpc":"2.0","id":3,"method":"initialize"}`},
+		{"protocolVersion wrong type", `{"jsonrpc":"2.0","id":3,"method":"initialize","params":{"protocolVersion":"one"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines, _ := serveOnce(t, tc.msg+"\n")
+			resps := decodeResponses(t, lines)
+			if len(resps) != 1 {
+				t.Fatalf("got %d responses, want 1", len(resps))
+			}
+			if resps[0].Error == nil || resps[0].Error.Code != CodeInvalidParams {
+				t.Fatalf("want -32602 invalid params, got %+v", resps[0].Error)
+			}
+			if string(resps[0].ID) != "3" {
+				t.Fatalf("error response must echo request id, got %s", resps[0].ID)
+			}
+		})
+	}
+}
+
+func TestServerMalformedJSONParseError(t *testing.T) {
+	lines, _ := serveOnce(t, "{not json\n")
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error == nil || resps[0].Error.Code != CodeParseError {
+		t.Fatalf("want -32700 parse error, got %+v", resps[0].Error)
+	}
+	if string(resps[0].ID) != "null" {
+		t.Fatalf("parse error id must be null, got %s", resps[0].ID)
+	}
+}
+
+func TestServerInvalidRequest(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"missing method", `{"jsonrpc":"2.0","id":5}`},
+		{"missing jsonrpc member", `{"id":5,"method":"initialize"}`},
+		{"wrong jsonrpc version", `{"jsonrpc":"1.0","id":5,"method":"initialize"}`},
+		{"array instead of request object", `[1,2,3]`},
+		{"bare string", `"hello"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines, _ := serveOnce(t, tc.msg+"\n")
+			resps := decodeResponses(t, lines)
+			if len(resps) != 1 {
+				t.Fatalf("got %d responses, want 1", len(resps))
+			}
+			if resps[0].Error == nil || resps[0].Error.Code != CodeInvalidRequest {
+				t.Fatalf("want -32600 invalid request, got line %q", lines[0])
+			}
+		})
+	}
+}
+
+func TestServerUnknownMethod(t *testing.T) {
+	lines, _ := serveOnce(t, `{"jsonrpc":"2.0","id":9,"method":"session/new","params":{}}`+"\n")
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error == nil || resps[0].Error.Code != CodeMethodNotFound {
+		t.Fatalf("want -32601 method not found, got %+v", resps[0].Error)
+	}
+	if string(resps[0].ID) != "9" {
+		t.Fatalf("error must echo request id, got %s", resps[0].ID)
+	}
+}
+
+func TestServerNotificationsGetNoResponse(t *testing.T) {
+	// An unknown-method notification (no id) must not produce a response, but
+	// must be logged to the diagnostic writer so stdout stays a clean protocol
+	// channel. The following initialize proves the stream stayed aligned.
+	input := `{"jsonrpc":"2.0","method":"session/cancel","params":{}}` + "\n" +
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n"
+	lines, diag := serveOnce(t, input)
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("notification must produce no response; got %d responses: %v", len(resps), lines)
+	}
+	if string(resps[0].ID) != "1" || resps[0].Error != nil {
+		t.Fatalf("initialize after notification broken: %+v", resps[0])
+	}
+	if !strings.Contains(diag, "session/cancel") {
+		t.Fatalf("unknown-method notification should be logged to diagnostics, got %q", diag)
+	}
+}
+
+func TestServerResponseShapedMessagesAreIgnored(t *testing.T) {
+	// A client→agent JSON-RPC response (id + result, no method) — e.g. an
+	// answer to a future session/request_permission call — must not be
+	// answered with an error.
+	input := `{"jsonrpc":"2.0","id":42,"result":{"outcome":"selected"}}` + "\n" +
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n"
+	lines, _ := serveOnce(t, input)
+	resps := decodeResponses(t, lines)
+	if len(resps) != 1 {
+		t.Fatalf("response-shaped message must not be answered; got %d responses: %v", len(resps), lines)
+	}
+	if string(resps[0].ID) != "1" {
+		t.Fatalf("wrong response: %+v", resps[0])
+	}
+}
+
+func TestServerSequentialRequestsAnsweredInOrder(t *testing.T) {
+	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"bogus/method"}` + "\n" +
+		"garbage\n" +
+		`{"jsonrpc":"2.0","id":4,"method":"initialize","params":{"protocolVersion":1}}` + "\n"
+	lines, _ := serveOnce(t, input)
+	resps := decodeResponses(t, lines)
+	if len(resps) != 4 {
+		t.Fatalf("got %d responses, want 4: %v", len(resps), lines)
+	}
+	if string(resps[0].ID) != "1" || resps[0].Error != nil {
+		t.Errorf("resp 0: want initialize result id=1, got %+v", resps[0])
+	}
+	if string(resps[1].ID) != "2" || resps[1].Error == nil || resps[1].Error.Code != CodeMethodNotFound {
+		t.Errorf("resp 1: want -32601 id=2, got %+v", resps[1])
+	}
+	if string(resps[2].ID) != "null" || resps[2].Error == nil || resps[2].Error.Code != CodeParseError {
+		t.Errorf("resp 2: want -32700 id=null, got %+v", resps[2])
+	}
+	if string(resps[3].ID) != "4" || resps[3].Error != nil {
+		t.Errorf("resp 3: want initialize result id=4, got %+v", resps[3])
+	}
+}
+
+func TestServerOversizedMessageRejectedStreamStaysAligned(t *testing.T) {
+	big := strings.Repeat("x", maxMessageSize+10)
+	input := big + "\n" + `{"jsonrpc":"2.0","id":7,"method":"initialize","params":{"protocolVersion":1}}` + "\n"
+	lines, _ := serveOnce(t, input)
+	resps := decodeResponses(t, lines)
+	if len(resps) != 2 {
+		t.Fatalf("got %d responses, want 2: first %v", len(resps), lines[0][:min(len(lines[0]), 80)])
+	}
+	if resps[0].Error == nil || (resps[0].Error.Code != CodeInvalidRequest && resps[0].Error.Code != CodeParseError) {
+		t.Fatalf("oversized message must be rejected with -32600 or -32700, got %+v", resps[0].Error)
+	}
+	if string(resps[1].ID) != "7" || resps[1].Error != nil {
+		t.Fatalf("stream misaligned after oversized message: %+v", resps[1])
+	}
+}
+
+func jsonNumber(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}


### PR DESCRIPTION
Parent epic: #806. Part of #803.

## What
Slice 1 of epic #806 (ACP server mode for Zed/JetBrains):

- New stdlib-only `internal/acp` package: newline-delimited JSON-RPC 2.0 framing over stdin/stdout (partial lines, multiple messages per read, 16 MiB message cap with stream realignment, goroutine-safe writer), envelope types, spec error codes (`-32700`/`-32600`/`-32601`/`-32602`).
- `initialize` handshake: protocol-version negotiation (v1) and agent capabilities — `loadSession: false`, text-only `promptCapabilities`, `agentInfo`, empty `authMethods`.
- `harness acp` subcommand (`runACP` in `cmd/harnesscli/acp.go` + dispatch case in `cmd/harnesscli/auth.go`). stdout is a pure protocol channel; diagnostics go to stderr.

Note: distinct from the pre-existing SDK-based `internal/harnessacp` + `cmd/harness-acp` adapter (epic #746); this PR does not modify it. Session methods (`session/new`, `session/prompt`, updates, permission bridge) land in slices 2–4.

## Tests (strict TDD — failing tests first)
- `internal/acp`: framing table tests (partial lines, multi-message reads, oversized line realignment, concurrent writes never interleave), initialize response shape + version negotiation, malformed JSON → `-32700`, invalid request table → `-32600`, unknown method → `-32601`, notifications/responses produce no output, EOF clean exit.
- `cmd/harnesscli`: `runACP` over injected stdio, diagnostics-to-stderr, `dispatch(["acp"])` routing.

## Validation run
- `go test ./internal/acp/... -count=1` — ok (also with `-race`)
- `go test ./cmd/harnesscli/... -count=1` — ok
- `go vet ./internal/acp/... ./cmd/harnesscli/` — clean; gofmt clean on touched files
- Acceptance: `printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}\n' | harness acp` prints a single JSON-RPC result with capabilities, exit 0

Do not merge — sibling slices continue on this epic.