### PR TITLE
feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint

### DIFF
--- a/docs/plans/817-compact-cmd.md
+++ b/docs/plans/817-compact-cmd.md
@@ -1,0 +1,63 @@
+# Plan: epic #817 slice 1 — preserve-instruction in CompactRun and the compact endpoint
+
+Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part of #803.
+This plan covers ONLY slice 1: `feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint`.
+
+## Context
+
+- Problem: the manual compact endpoint and `Runner.CompactRun` accept only `{mode, keep_last}` — callers cannot steer what the summarizer keeps. kimi-code's `/compact [instruction]` steers the summarizer with a free-text hint.
+- User impact: users compacting long sessions cannot protect critical context (e.g. "keep the SQL schema") from being distilled away.
+- Constraints: auto-compaction (`autoCompactMessages`) must remain byte-identical to today (no instruction); strip mode ignores the instruction; minimal diff scoped to slice 1 — no summary return value, no TUI, no SSE changes (later slices).
+
+## Scope
+
+- In scope:
+  - `CompactRunRequest.Instruction` (`internal/harness/runner.go`).
+  - `instruction` JSON field on `POST /v1/runs/{id}/compact` decode struct (`internal/server/http_runs.go`), plumbed to `CompactRun`.
+  - Instruction appended to the summarization prompt (as `Preserve especially: <instruction>`) in summarize/hybrid modes via the runner-backed summarizer.
+  - Behavior tests first (strict TDD).
+- Out of scope: slices 2–4 (summary in response, TUI `/compact`, transcript block); changing auto-compact thresholds/modes/fallback; changing the `tools.MessageSummarizer` interface (the instruction is carried by the runner-side summarizer wrapper, so the tools layer is untouched); `POST /v1/conversations/{id}/compact`.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (internal API additive field only).
+- Spec docs to update before code: none.
+- Implementation notes to add after code: none beyond this plan + folder index.
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`internal/harness/runner_compact_instruction_test.go`):
+  - summarize mode: instruction text appears in the provider-visible summarization prompt (capturing provider).
+  - hybrid mode: instruction text appears in the summarization prompt.
+  - strip mode: instruction never reaches the provider (no summarization call at all).
+  - empty instruction: summarization prompt is byte-identical to today's fixed prompt (no-op).
+  - auto-compact path: summarization prompt contains no preserve-instruction marker.
+- New server test (`internal/server/http_run_compact_instruction_test.go`):
+  - `POST /v1/runs/{id}/compact` with `{"mode":"summarize","instruction":"..."}` returns 200 and the instruction reaches the summarizer prompt.
+- Existing tests to update: none (additive only).
+- Regression tests required: existing `internal/server/http_compact_test.go`, `http_context_compact_test.go`, `internal/harness` compaction tests must pass unmodified.
+
+## Cross-Surface Impact Map
+
+- Config: None — no new config knob; instruction is per-request.
+- Server API: additive optional `instruction` field on the compact request body; response shape unchanged.
+- TUI state: None — slice 3 owns TUI.
+- Regression tests: listed above.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (per epic slice 1).
+- [ ] Write failing tests first.
+- [ ] Implement minimal code changes.
+- [ ] gofmt + go vet clean.
+- [ ] `go test ./internal/harness/ ./internal/server/ -count=1` green.
+- [ ] Update docs/plans/INDEX.md.
+- [ ] Commit, push `epic/817-compact-cmd`, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: changing the shared `MessageSummarizer` interface ripples into the tools layer.
+  - Mitigation: carry the instruction on the runner-side `runnerMessageSummarizer` wrapper; interface untouched.
+- Risk: empty/whitespace instruction altering today's prompt.
+  - Mitigation: trim; when empty use the exact existing prompt string; pinned by the no-op test.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -4,6 +4,7 @@
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.
 - `819-plan-mode.md` — Epic #819 slice 1: pin plan-mode exit semantics across approval modes (in implementation).
 - `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
+- `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -4095,6 +4095,10 @@ type CompactRunRequest struct {
 	// Mode must be one of "strip", "summarize", or "hybrid". Defaults to "strip".
 	Mode     string
 	KeepLast int
+	// Instruction is an optional free-text hint telling the summarizer what to
+	// preserve (e.g. "keep the SQL schema"). It only affects summarize/hybrid
+	// modes; strip mode ignores it. Empty means no instruction.
+	Instruction string
 }
 
 // CompactRunResult holds the result of a CompactRun call.
@@ -4156,6 +4160,11 @@ func (r *Runner) CompactRun(ctx context.Context, runID string, req CompactRunReq
 
 	beforeCount := len(snap)
 	summarizer := r.newMessageSummarizerWithModel(summarizerModel)
+	if inst := strings.TrimSpace(req.Instruction); inst != "" {
+		// A preserve-instruction steers the summarizer (summarize/hybrid only;
+		// strip never invokes the summarizer, so it ignores the instruction).
+		summarizer = r.newMessageSummarizerWithInstruction(summarizerModel, inst)
+	}
 	compacted, err := compactMessagesHTTP(ctx, snap, mode, keepLast, summarizer)
 	if err != nil {
 		return CompactRunResult{}, fmt.Errorf("compaction failed: %w", err)
@@ -4600,6 +4609,19 @@ func (r *Runner) SummarizeMessages(ctx context.Context, messages []Message) (str
 // This is used to honour per-request RoleModels.Summarizer overrides during
 // auto-compaction, where the resolved model is stored in runState.
 func (r *Runner) SummarizeMessagesWithModel(ctx context.Context, messages []Message, overrideModel string) (string, error) {
+	return r.summarizeMessagesWithModelAndInstruction(ctx, messages, overrideModel, "")
+}
+
+// summarizeMessagesPrompt is the fixed prompt sent as the final message of
+// every summarization request.
+const summarizeMessagesPrompt = "Please provide a concise summary of this conversation so far, suitable for use as context in a continuation. Include key facts, decisions, and outputs. Be concise."
+
+// summarizeMessagesWithModelAndInstruction is the internal workhorse behind
+// SummarizeMessagesWithModel. When instruction is non-empty (after trimming)
+// it is appended to the summarization prompt as a preserve-hint, so callers of
+// manual compaction can steer what the summary keeps. Auto-compaction passes
+// an empty instruction and gets the byte-identical legacy prompt.
+func (r *Runner) summarizeMessagesWithModelAndInstruction(ctx context.Context, messages []Message, overrideModel, instruction string) (string, error) {
 	if r.provider == nil {
 		return "", fmt.Errorf("provider not configured")
 	}
@@ -4615,11 +4637,15 @@ func (r *Runner) SummarizeMessagesWithModel(ctx context.Context, messages []Mess
 	if overrideModel != "" {
 		model = overrideModel
 	}
+	prompt := summarizeMessagesPrompt
+	if inst := strings.TrimSpace(instruction); inst != "" {
+		prompt += "\n\nPreserve especially: " + inst
+	}
 	req := CompletionRequest{
 		Model: model,
 		Messages: append(copyMessages(messages), Message{
 			Role:    "user",
-			Content: "Please provide a concise summary of this conversation so far, suitable for use as context in a continuation. Include key facts, decisions, and outputs. Be concise.",
+			Content: prompt,
 		}),
 	}
 	result, err := r.provider.Complete(ctx, req)
@@ -4635,9 +4661,12 @@ func (r *Runner) SummarizeMessagesWithModel(ctx context.Context, messages []Mess
 // runnerMessageSummarizer adapts *Runner to the tools.MessageSummarizer interface.
 // overrideModel, when non-empty, is passed to SummarizeMessagesWithModel so that
 // per-request Summarizer role model overrides are honoured during compaction.
+// instruction, when non-empty, is appended to the summarization prompt as a
+// preserve-hint (manual /compact only; auto-compaction leaves it empty).
 type runnerMessageSummarizer struct {
 	runner        *Runner
 	overrideModel string
+	instruction   string
 }
 
 func (s *runnerMessageSummarizer) SummarizeMessages(ctx context.Context, msgs []map[string]any) (string, error) {
@@ -4658,7 +4687,7 @@ func (s *runnerMessageSummarizer) SummarizeMessages(ctx context.Context, msgs []
 		}
 		converted = append(converted, msg)
 	}
-	return s.runner.SummarizeMessagesWithModel(ctx, converted, s.overrideModel)
+	return s.runner.summarizeMessagesWithModelAndInstruction(ctx, converted, s.overrideModel, s.instruction)
 }
 
 // NewMessageSummarizer returns a tools.MessageSummarizer backed by this runner.
@@ -4671,6 +4700,14 @@ func (r *Runner) NewMessageSummarizer() htools.MessageSummarizer {
 // runner-level config. Pass "" to use the default resolution order.
 func (r *Runner) newMessageSummarizerWithModel(overrideModel string) htools.MessageSummarizer {
 	return &runnerMessageSummarizer{runner: r, overrideModel: overrideModel}
+}
+
+// newMessageSummarizerWithInstruction is like newMessageSummarizerWithModel but
+// additionally appends instruction to the summarization prompt as a
+// preserve-hint. Used by manual CompactRun when the caller supplies a
+// preserve-instruction.
+func (r *Runner) newMessageSummarizerWithInstruction(overrideModel, instruction string) htools.MessageSummarizer {
+	return &runnerMessageSummarizer{runner: r, overrideModel: overrideModel, instruction: instruction}
 }
 
 // GetSummarizer returns a MessageSummarizer backed by this runner, or nil if no

--- a/internal/harness/runner_compact_instruction_test.go
+++ b/internal/harness/runner_compact_instruction_test.go
@@ -1,0 +1,346 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Tests in this file cover epic #817 slice 1: a preserve-instruction accepted by
+// CompactRun and threaded into the summarize/hybrid summarization prompt.
+
+// compactInstructionProvider records every CompletionRequest it receives
+// (slice copy of messages; strings are immutable) and returns scripted
+// results, optionally gating a specific call index so tests can compact
+// mid-run.
+type compactInstructionProvider struct {
+	mu       sync.Mutex
+	calls    int
+	requests []CompletionRequest
+	results  []CompletionResult
+	gate     func(idx int)
+}
+
+func (p *compactInstructionProvider) Complete(_ context.Context, req CompletionRequest) (CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	captured := CompletionRequest{
+		Model:    req.Model,
+		Messages: copyMessages(req.Messages),
+	}
+	p.requests = append(p.requests, captured)
+	var result CompletionResult
+	if idx < len(p.results) {
+		result = p.results[idx]
+	}
+	gate := p.gate
+	p.mu.Unlock()
+
+	if gate != nil {
+		gate(idx)
+	}
+	return result, nil
+}
+
+func (p *compactInstructionProvider) snapshot() []CompletionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]CompletionRequest(nil), p.requests...)
+}
+
+func (p *compactInstructionProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// summarizationRequests returns the captured requests whose final message is
+// the summarization prompt (i.e. calls made by the compaction summarizer,
+// not by the run's step loop).
+func summarizationRequests(reqs []CompletionRequest) []CompletionRequest {
+	var out []CompletionRequest
+	for _, r := range reqs {
+		if len(r.Messages) == 0 {
+			continue
+		}
+		last := r.Messages[len(r.Messages)-1]
+		if last.Role == "user" && strings.HasPrefix(last.Content, "Please provide a concise summary") {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// startThreeStepGatedRun starts a run whose provider scripts three tool-call
+// steps and then blocks the fourth LLM call on gateRelease, returning the
+// runner and run ID once the fourth call is in flight. At that point
+// state.messages holds user + 3x(assistant+tool) = 7 messages = 4 turns, so
+// CompactRun with KeepLast=1 has a non-empty compaction zone.
+func startThreeStepGatedRun(t *testing.T, prov *compactInstructionProvider, toolOutput string, gateRelease <-chan struct{}) (*Runner, string) {
+	t.Helper()
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return toolOutput, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel: "test",
+		MaxSteps:     6,
+	})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	// Wait until the 4th LLM call (idx 3) is in flight and gated.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if prov.callCount() >= 4 {
+			return runner, run.ID
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for step 4 gate (calls=%d)", prov.callCount())
+	return nil, ""
+}
+
+// threeStepToolCallResults scripts three echo_json tool-call steps, a gated
+// final answer, and a summarization result.
+func threeStepToolCallResults() []CompletionResult {
+	return []CompletionResult{
+		{ToolCalls: []ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+		{ToolCalls: []ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{"message":"s2"}`}}},
+		{ToolCalls: []ToolCall{{ID: "call-3", Name: "echo_json", Arguments: `{"message":"s3"}`}}},
+		{Content: "done"},
+		{Content: "a compact summary"},
+	}
+}
+
+func newGatedInstructionProvider(gateRelease <-chan struct{}) *compactInstructionProvider {
+	return &compactInstructionProvider{
+		results: threeStepToolCallResults(),
+		gate: func(idx int) {
+			if idx == 3 {
+				<-gateRelease
+			}
+		},
+	}
+}
+
+// TestCompactRun_InstructionReachesSummarizerPrompt_Summarize verifies that a
+// preserve-instruction passed to CompactRun in summarize mode is appended to
+// the provider-visible summarization prompt.
+func TestCompactRun_InstructionReachesSummarizerPrompt_Summarize(t *testing.T) {
+	t.Parallel()
+
+	gateRelease := make(chan struct{})
+	prov := newGatedInstructionProvider(gateRelease)
+	runner, runID := startThreeStepGatedRun(t, prov, `{"echo":"ok"}`, gateRelease)
+
+	_, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+		Mode:        "summarize",
+		KeepLast:    1,
+		Instruction: "keep the SQL schema",
+	})
+	if err != nil {
+		t.Fatalf("CompactRun summarize: %v", err)
+	}
+	close(gateRelease)
+
+	summaries := summarizationRequests(prov.snapshot())
+	if len(summaries) != 1 {
+		t.Fatalf("expected exactly 1 summarization call, got %d", len(summaries))
+	}
+	last := summaries[0].Messages[len(summaries[0].Messages)-1]
+	if !strings.Contains(last.Content, "keep the SQL schema") {
+		t.Errorf("summarization prompt missing preserve-instruction; got: %q", last.Content)
+	}
+}
+
+// TestCompactRun_InstructionReachesSummarizerPrompt_Hybrid verifies the
+// instruction also reaches the summarizer in hybrid mode, where only large
+// tool outputs are summarized.
+func TestCompactRun_InstructionReachesSummarizerPrompt_Hybrid(t *testing.T) {
+	t.Parallel()
+
+	gateRelease := make(chan struct{})
+	prov := newGatedInstructionProvider(gateRelease)
+
+	// Tool output above the 500-token hybrid threshold (~2000 runes).
+	largeOutput := strings.Repeat("x", 2400)
+	runner, runID := startThreeStepGatedRun(t, prov, largeOutput, gateRelease)
+
+	_, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+		Mode:        "hybrid",
+		KeepLast:    1,
+		Instruction: "keep the failing test output",
+	})
+	if err != nil {
+		t.Fatalf("CompactRun hybrid: %v", err)
+	}
+	close(gateRelease)
+
+	summaries := summarizationRequests(prov.snapshot())
+	if len(summaries) != 1 {
+		t.Fatalf("expected exactly 1 summarization call, got %d", len(summaries))
+	}
+	last := summaries[0].Messages[len(summaries[0].Messages)-1]
+	if !strings.Contains(last.Content, "keep the failing test output") {
+		t.Errorf("hybrid summarization prompt missing preserve-instruction; got: %q", last.Content)
+	}
+}
+
+// TestCompactRun_InstructionIgnoredInStripMode verifies strip mode never
+// invokes the summarizer, so the instruction never reaches the provider.
+func TestCompactRun_InstructionIgnoredInStripMode(t *testing.T) {
+	t.Parallel()
+
+	gateRelease := make(chan struct{})
+	prov := newGatedInstructionProvider(gateRelease)
+	runner, runID := startThreeStepGatedRun(t, prov, `{"echo":"ok"}`, gateRelease)
+
+	callsBefore := prov.callCount()
+	_, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+		Mode:        "strip",
+		KeepLast:    1,
+		Instruction: "keep the SQL schema",
+	})
+	if err != nil {
+		t.Fatalf("CompactRun strip: %v", err)
+	}
+	close(gateRelease)
+
+	if got := prov.callCount(); got != callsBefore {
+		t.Errorf("strip mode issued %d new provider call(s); summarizer must not run in strip mode", got-callsBefore)
+	}
+	for _, r := range prov.snapshot() {
+		for _, m := range r.Messages {
+			if strings.Contains(m.Content, "keep the SQL schema") {
+				t.Errorf("strip mode leaked instruction into a provider request: %q", m.Content)
+			}
+		}
+	}
+}
+
+// TestCompactRun_EmptyInstructionIsNoOp verifies that an empty (or
+// whitespace-only) instruction leaves the summarization prompt byte-identical
+// to the fixed prompt used before this feature existed.
+func TestCompactRun_EmptyInstructionIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	const fixedPrompt = "Please provide a concise summary of this conversation so far, suitable for use as context in a continuation. Include key facts, decisions, and outputs. Be concise."
+
+	for _, instruction := range []string{"", "   "} {
+		instruction := instruction
+		t.Run("instruction="+strings.TrimSpace(instruction), func(t *testing.T) {
+			t.Parallel()
+
+			gateRelease := make(chan struct{})
+			prov := newGatedInstructionProvider(gateRelease)
+			runner, runID := startThreeStepGatedRun(t, prov, `{"echo":"ok"}`, gateRelease)
+
+			_, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+				Mode:        "summarize",
+				KeepLast:    1,
+				Instruction: instruction,
+			})
+			if err != nil {
+				t.Fatalf("CompactRun summarize: %v", err)
+			}
+			close(gateRelease)
+
+			summaries := summarizationRequests(prov.snapshot())
+			if len(summaries) != 1 {
+				t.Fatalf("expected exactly 1 summarization call, got %d", len(summaries))
+			}
+			last := summaries[0].Messages[len(summaries[0].Messages)-1]
+			if last.Content != fixedPrompt {
+				t.Errorf("empty instruction changed the summarization prompt:\n got: %q\nwant: %q", last.Content, fixedPrompt)
+			}
+		})
+	}
+}
+
+// TestAutoCompact_SummarizationPromptHasNoInstruction is a regression guard:
+// the auto-compaction path must keep sending the instruction-free prompt.
+func TestAutoCompact_SummarizationPromptHasNoInstruction(t *testing.T) {
+	t.Parallel()
+
+	registry := NewRegistry()
+	if err := registry.Register(ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	prov := &compactInstructionProvider{
+		results: []CompletionResult{
+			{ToolCalls: []ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+			{Content: "auto summary"},
+			{Content: "done"},
+		},
+	}
+
+	runner := NewRunner(prov, registry, RunnerConfig{
+		DefaultModel:         "test",
+		MaxSteps:             4,
+		AutoCompactEnabled:   true,
+		ModelContextWindow:   100,
+		AutoCompactThreshold: 0.80,
+		AutoCompactKeepLast:  1,
+		AutoCompactMode:      "summarize",
+	})
+
+	// 400 runes ≈ 100 tokens > 80% of the 100-token window → auto-compact fires.
+	run, err := runner.StartRun(RunRequest{Prompt: strings.Repeat("x", 400)})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		state, ok := runner.GetRun(run.ID)
+		if !ok {
+			t.Fatal("run disappeared")
+		}
+		if state.Status == RunStatusCompleted || state.Status == RunStatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	state, ok := runner.GetRun(run.ID)
+	if !ok {
+		t.Fatal("run not found")
+	}
+	if state.Status != RunStatusCompleted {
+		t.Fatalf("expected completed, got %q", state.Status)
+	}
+
+	summaries := summarizationRequests(prov.snapshot())
+	if len(summaries) == 0 {
+		t.Fatal("expected auto-compaction to issue a summarization call, got none")
+	}
+	for _, r := range summaries {
+		last := r.Messages[len(r.Messages)-1]
+		if strings.Contains(last.Content, "Preserve especially") {
+			t.Errorf("auto-compaction summarization prompt gained an instruction marker: %q", last.Content)
+		}
+	}
+}

--- a/internal/server/http_run_compact_instruction_test.go
+++ b/internal/server/http_run_compact_instruction_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+)
+
+// compactInstructionCaptureProvider records every CompletionRequest it
+// receives and returns scripted results, gating the 4th call (idx 3) so the
+// test can compact the run mid-flight.
+type compactInstructionCaptureProvider struct {
+	mu         sync.Mutex
+	calls      int
+	requests   []harness.CompletionRequest
+	results    []harness.CompletionResult
+	beforeCall func(idx int)
+}
+
+func (p *compactInstructionCaptureProvider) Complete(_ context.Context, req harness.CompletionRequest) (harness.CompletionResult, error) {
+	p.mu.Lock()
+	idx := p.calls
+	p.calls++
+	captured := harness.CompletionRequest{
+		Model:    req.Model,
+		Messages: append([]harness.Message(nil), req.Messages...),
+	}
+	p.requests = append(p.requests, captured)
+	var result harness.CompletionResult
+	if idx < len(p.results) {
+		result = p.results[idx]
+	}
+	beforeCall := p.beforeCall
+	p.mu.Unlock()
+
+	if beforeCall != nil {
+		beforeCall(idx)
+	}
+	return result, nil
+}
+
+func (p *compactInstructionCaptureProvider) snapshot() []harness.CompletionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]harness.CompletionRequest(nil), p.requests...)
+}
+
+func (p *compactInstructionCaptureProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// TestCompactEndpointInstructionReachesSummarizer verifies the run compact
+// endpoint accepts an optional instruction field and threads it into the
+// summarization prompt sent to the provider (epic #817 slice 1).
+func TestCompactEndpointInstructionReachesSummarizer(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	provider := &compactInstructionCaptureProvider{
+		results: []harness.CompletionResult{
+			{ToolCalls: []harness.ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{"message":"s2"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-3", Name: "echo_json", Arguments: `{"message":"s3"}`}}},
+			{Content: "done"},
+			{Content: "a compact summary"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+
+	registry := harness.NewRegistry()
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     6,
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.RunID == "" {
+		t.Fatal("expected run_id in response")
+	}
+
+	// Wait for the run to be blocked in the 4th LLM call: 4 turns in state.
+	<-blockCh
+
+	compactRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/compact",
+		"application/json",
+		bytes.NewBufferString(`{"mode":"summarize","keep_last":1,"instruction":"keep the SQL schema"}`),
+	)
+	if err != nil {
+		t.Fatalf("compact request: %v", err)
+	}
+	defer compactRes.Body.Close()
+
+	if compactRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(compactRes.Body)
+		t.Fatalf("expected 200, got %d: %s", compactRes.StatusCode, string(body))
+	}
+
+	var result struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.NewDecoder(compactRes.Body).Decode(&result); err != nil {
+		t.Fatalf("decode compact response: %v", err)
+	}
+	if !result.OK {
+		t.Error("expected ok=true in compact response")
+	}
+
+	// The summarization call must carry the preserve-instruction in its final
+	// (prompt) message.
+	foundInstruction := false
+	summarizationCalls := 0
+	for _, req := range provider.snapshot() {
+		if len(req.Messages) == 0 {
+			continue
+		}
+		last := req.Messages[len(req.Messages)-1]
+		if last.Role == "user" && strings.HasPrefix(last.Content, "Please provide a concise summary") {
+			summarizationCalls++
+			if strings.Contains(last.Content, "keep the SQL schema") {
+				foundInstruction = true
+			}
+		}
+	}
+	if summarizationCalls != 1 {
+		t.Fatalf("expected exactly 1 summarization call, got %d", summarizationCalls)
+	}
+	if !foundInstruction {
+		t.Error("summarization prompt does not contain the instruction from the compact request")
+	}
+
+	close(releaseCh)
+
+	// Let the run finish cleanly.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		checkRes, err := http.Get(ts.URL + "/v1/runs/" + created.RunID)
+		if err == nil {
+			var runState struct {
+				Status string `json:"status"`
+			}
+			json.NewDecoder(checkRes.Body).Decode(&runState)
+			checkRes.Body.Close()
+			if runState.Status == "completed" || runState.Status == "failed" {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestCompactEndpointWithoutInstructionUnchanged verifies the endpoint still
+// accepts requests without an instruction field and that the summarization
+// prompt remains the fixed, instruction-free prompt (backward compatible).
+func TestCompactEndpointWithoutInstructionUnchanged(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	provider := &compactInstructionCaptureProvider{
+		results: []harness.CompletionResult{
+			{ToolCalls: []harness.ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{"message":"s2"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-3", Name: "echo_json", Arguments: `{"message":"s3"}`}}},
+			{Content: "done"},
+			{Content: "a compact summary"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+
+	registry := harness.NewRegistry()
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     6,
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	<-blockCh
+
+	// No instruction field at all — the pre-feature request shape.
+	compactRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/compact",
+		"application/json",
+		bytes.NewBufferString(`{"mode":"summarize","keep_last":1}`),
+	)
+	if err != nil {
+		t.Fatalf("compact request: %v", err)
+	}
+	defer compactRes.Body.Close()
+
+	if compactRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(compactRes.Body)
+		t.Fatalf("expected 200, got %d: %s", compactRes.StatusCode, string(body))
+	}
+
+	const fixedPrompt = "Please provide a concise summary of this conversation so far, suitable for use as context in a continuation. Include key facts, decisions, and outputs. Be concise."
+	summarizationCalls := 0
+	for _, req := range provider.snapshot() {
+		if len(req.Messages) == 0 {
+			continue
+		}
+		last := req.Messages[len(req.Messages)-1]
+		if last.Role == "user" && strings.HasPrefix(last.Content, "Please provide a concise summary") {
+			summarizationCalls++
+			if last.Content != fixedPrompt {
+				t.Errorf("instruction-free request changed the summarization prompt:\n got: %q\nwant: %q", last.Content, fixedPrompt)
+			}
+		}
+	}
+	if summarizationCalls != 1 {
+		t.Fatalf("expected exactly 1 summarization call, got %d", summarizationCalls)
+	}
+
+	close(releaseCh)
+}

--- a/internal/server/http_runs.go
+++ b/internal/server/http_runs.go
@@ -607,8 +607,9 @@ func (s *Server) handleRunCompact(w http.ResponseWriter, r *http.Request, runID 
 	}
 
 	var req struct {
-		Mode     string `json:"mode"`
-		KeepLast int    `json:"keep_last"`
+		Mode        string `json:"mode"`
+		KeepLast    int    `json:"keep_last"`
+		Instruction string `json:"instruction"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
@@ -616,8 +617,9 @@ func (s *Server) handleRunCompact(w http.ResponseWriter, r *http.Request, runID 
 	}
 
 	result, err := s.runner.CompactRun(r.Context(), runID, harness.CompactRunRequest{
-		Mode:     req.Mode,
-		KeepLast: req.KeepLast,
+		Mode:        req.Mode,
+		KeepLast:    req.KeepLast,
+		Instruction: req.Instruction,
 	})
 	if err != nil {
 		if errors.Is(err, harness.ErrRunNotFound) {


### PR DESCRIPTION
Parent epic: #817. Part of #803.

## What

Epic #817 slice 1 (of 4). Lets callers steer what the compaction summarizer keeps:

- `CompactRunRequest.Instruction` (`internal/harness/runner.go`) and an optional `instruction` JSON field on `POST /v1/runs/{id}/compact` (`internal/server/http_runs.go`).
- When set, the instruction is appended to the summarization prompt as a preserve-hint (`Preserve especially: <instruction>`) in summarize/hybrid modes, via the runner-backed message summarizer.
- Strip mode never invokes the summarizer, so it ignores the instruction.
- Auto-compaction (`autoCompactMessages`) passes no instruction — prompt byte-identical to before.
- `tools.MessageSummarizer` interface untouched: the instruction rides on the runner-side `runnerMessageSummarizer` wrapper built per `CompactRun` call.

## Tests (strict TDD — failing tests written first)

- `internal/harness/runner_compact_instruction_test.go`:
  - summarize + hybrid: instruction appears in the provider-visible summarization prompt (capturing provider)
  - strip: instruction never reaches the provider (no summarization call at all)
  - empty/whitespace instruction: prompt byte-identical to the legacy fixed prompt
  - auto-compact: summarization prompt carries no preserve-hint (regression guard)
- `internal/server/http_run_compact_instruction_test.go`:
  - endpoint accepts `instruction` and threads it to the summarizer end-to-end
  - request shape without `instruction` behaves exactly as before

## Verification (actually run)

- `go test ./internal/harness/ -run 'TestCompactRun_Instruction|TestCompactRun_EmptyInstruction|TestAutoCompact_SummarizationPromptHasNoInstruction' -count=1 -v` — PASS (all 5, incl. subtests)
- `go test ./internal/server/ -run 'TestCompactEndpointInstructionReachesSummarizer|TestCompactEndpointWithoutInstructionUnchanged' -count=1 -v` — PASS
- `go test ./internal/harness/ ./internal/server/ -count=1` — ok (49.5s, 36.2s)
- `go test ./internal/harness/ -race -run 'Compact|Summarize' -count=1` — ok (13.8s)
- `gofmt` / `go vet` clean on touched packages

## Acceptance (from epic)

`curl -X POST localhost:PORT/v1/runs/<id>/compact -d '{"mode":"summarize","instruction":"keep the SQL schema"}'` succeeds and the summarizer prompt contains the instruction — covered by `TestCompactEndpointInstructionReachesSummarizer`.

Later slices (#817): summary in response, TUI `/compact`, transcript block — not in this PR.