### PR TITLE
feat(harness): add ConversationStore.UndoPrompts with compaction-boundary guard

### DIFF
--- a/docs/plans/805-undo-prompts.md
+++ b/docs/plans/805-undo-prompts.md
@@ -1,0 +1,62 @@
+# Plan: 805-undo-prompts — Slice 1: ConversationStore.UndoPrompts
+
+Parent epic: #805 (`/undo` — remove recent prompts from the active context). Parent tracker: #803.
+This plan covers **Slice 1 only**: `feat(harness): add ConversationStore.UndoPrompts with compaction-boundary guard`.
+
+## Context
+
+- Problem: a mis-typed or derailing prompt currently lives in go-code's context forever; the only escape is `/clear`, which destroys the whole session. kimi-code's `/undo [count]` trims the last N user prompts plus everything after them.
+- User impact: store-level truncation is the foundation for the server route (Slice 2) and TUI command (Slices 3–4).
+- Constraints: transactional; must refuse undo across a compaction boundary; must persist an undo-boundary marker; strict TDD per `docs/runbooks/testing.md`; reuse the `CompactConversation` transactional pattern in `internal/harness/conversation_store_sqlite.go`.
+
+## Scope
+
+- In scope:
+  - `UndoPrompts(ctx, convID string, count int) (removedFromStep int, err error)` on `ConversationStore` (`internal/harness/conversation_store.go`).
+  - SQLite implementation in `internal/harness/conversation_store_sqlite.go` (Nth-from-last non-meta `user` message lookup, compaction guard, transactional delete, `is_meta` marker insert, `msg_count`/`updated_at` maintenance).
+  - Typed sentinel errors `ErrUndoCrossesCompaction` and `ErrUndoCountOutOfRange` for server-side 409/400 mapping in Slice 2.
+  - Behavior tests in `internal/harness/conversation_undo_test.go` (mirrors `conversation_compact_test.go` file layout).
+  - Stub implementations on all in-repo `ConversationStore` fakes so the repo compiles.
+- Out of scope: server route, TUI command/picker, redo, rewind coupling, in-place prompt editing (later slices / out of epic scope).
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (store-level change; user-facing docs land with the TUI slice).
+- Spec docs to update before code: this plan.
+- Implementation notes to add after code: engineering-log entry lands with Slice 2 per epic doc-requirements; folder index update for this plan file.
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`internal/harness/conversation_undo_test.go`):
+  - `TestUndoPrompts_RemovesLastPromptAndTail` — undo 1 removes the last user prompt and trailing assistant/tool messages; `removedFromStep` is the prompt's step; `LoadMessages` round-trip reflects truncation.
+  - `TestUndoPrompts_WalksBackNUserPromptsSkippingMeta` — undo N targets the Nth-from-last non-meta user message; interleaved `is_meta` user-role messages are not counted.
+  - `TestUndoPrompts_CountOutOfRange` — count 0, negative count, and count greater than the number of user prompts all return `ErrUndoCountOutOfRange`.
+  - `TestUndoPrompts_RefusesToCrossCompactionBoundary` — target step at or below the max `is_compact_summary` step returns `ErrUndoCrossesCompaction`; undo above the boundary still succeeds.
+  - `TestUndoPrompts_PersistsBoundaryMarker` — an `is_meta` marker message exists at `removedFromStep` after undo and round-trips through `LoadMessages`; a subsequent undo skips the marker.
+  - `TestUndoPrompts_ConversationNotFound` — unknown convID errors.
+- Existing tests to update: none (new capability).
+- Regression tests required: repo-wide compile check (`go build ./...`, `go vet ./...`) forces all fakes to satisfy the extended interface.
+
+## Cross-Surface Impact Map
+
+- Not a provider/model flow change — no impact map required. Server API and TUI surfaces are explicitly later slices.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above).
+- [x] Document feature status and exact contract before code (this plan).
+- [x] Write failing tests first; verify they fail to compile/run for the right reason (no `UndoPrompts` symbol).
+- [x] Implement minimal code changes (interface + SQLite store + sentinel errors + fake stubs).
+- [x] Run `go test ./internal/harness/ -run Undo -count=1` green.
+- [x] Run `go test` on every touched package (`internal/harness`, `internal/server` if fakes touched).
+- [x] gofmt + go vet clean.
+- [x] Update `docs/plans/INDEX.md` with this plan (documentation-maintenance runbook).
+- [ ] Commit, push `epic/805-undo-prompts`, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: marker message could be counted as an undo target on later undos, corrupting count semantics.
+  - Mitigation: marker is `is_meta = 1`; the target query filters `role = 'user' AND is_meta = 0`; covered by the subsequent-undo test.
+- Risk: other worktree slices implement the same interface extension concurrently and conflict.
+  - Mitigation: keep the diff minimal and exactly to the epic-specified signature so any merge conflict is trivial.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,6 +5,7 @@
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
 - `806-acp-server.md` — ACP server mode epic #806, slice 1: stdio JSON-RPC framing and initialize handshake in the stdlib-only `internal/acp` package plus the `harness acp` subcommand (in implementation).
+- `805-undo-prompts.md` — Epic #805 Slice 1 plan: `ConversationStore.UndoPrompts` with compaction-boundary guard (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.

--- a/internal/harness/conversation_store.go
+++ b/internal/harness/conversation_store.go
@@ -2,7 +2,19 @@ package harness
 
 import (
 	"context"
+	"errors"
 	"time"
+)
+
+// Typed errors returned by ConversationStore.UndoPrompts so transport layers
+// can map them to precise status codes (e.g. 400 vs 409).
+var (
+	// ErrUndoCountOutOfRange is returned when count is less than 1 or the
+	// conversation holds fewer than count non-meta user prompts.
+	ErrUndoCountOutOfRange = errors.New("undo count out of range")
+	// ErrUndoCrossesCompaction is returned when the undo target prompt sits at
+	// or below the most recent compaction summary, where undo is forbidden.
+	ErrUndoCrossesCompaction = errors.New("undo crosses compaction boundary")
 )
 
 // Conversation holds metadata for a conversation.
@@ -84,6 +96,19 @@ type ConversationStore interface {
 	// keepFromStep > max_step keeps no existing messages (only the summary remains).
 	// Returns an error if the conversation does not exist or keepFromStep < 0.
 	CompactConversation(ctx context.Context, convID string, keepFromStep int, summary Message) error
+	// UndoPrompts removes the last count non-meta user prompts and every message
+	// after them from the conversation, transactionally. It locates the
+	// Nth-from-last user prompt (count=1 is the most recent), deletes it and all
+	// messages with a higher step, and persists an is_meta undo-boundary marker
+	// at the removed step so the truncation round-trips through LoadMessages and
+	// export. It returns the step from which messages were removed.
+	//
+	// Returns ErrUndoCountOutOfRange when count < 1 or fewer than count non-meta
+	// user prompts exist, and ErrUndoCrossesCompaction when the target prompt's
+	// step is at or below the most recent is_compact_summary message. A failed
+	// undo leaves the conversation unchanged. Returns an error if the
+	// conversation does not exist.
+	UndoPrompts(ctx context.Context, convID string, count int) (removedFromStep int, err error)
 }
 
 // PlanContentStore is an optional run-scoped extension implemented by the

--- a/internal/harness/conversation_store_sqlite.go
+++ b/internal/harness/conversation_store_sqlite.go
@@ -846,6 +846,88 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 	return tx.Commit()
 }
 
+// UndoPrompts removes the last count non-meta user prompts and all messages
+// after them in one transaction, then persists an is_meta undo-boundary marker
+// at the step the target prompt occupied. The target is the Nth-from-last
+// message with role 'user' and is_meta = 0 (count=1 is the most recent prompt).
+// The undo is refused with ErrUndoCrossesCompaction when the target step is at
+// or below the most recent is_compact_summary message, and with
+// ErrUndoCountOutOfRange when count is invalid or too few prompts exist.
+func (s *SQLiteConversationStore) UndoPrompts(ctx context.Context, convID string, count int) (int, error) {
+	if count < 1 {
+		return 0, fmt.Errorf("%w: count must be >= 1, got %d", ErrUndoCountOutOfRange, count)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("undo: begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Verify the conversation exists.
+	var exists int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM conversations WHERE id = ?`, convID).Scan(&exists); err != nil {
+		return 0, fmt.Errorf("undo: check conversation: %w", err)
+	}
+	if exists == 0 {
+		return 0, fmt.Errorf("undo: conversation %q not found", convID)
+	}
+
+	// Locate the Nth-from-last non-meta user prompt: newest-first, the row at
+	// OFFSET count-1. Meta messages (skill injections, prior undo markers) are
+	// not prompts and are never counted.
+	var targetStep int
+	err = tx.QueryRowContext(ctx, `
+SELECT step FROM conversation_messages
+WHERE conversation_id = ? AND role = 'user' AND is_meta = 0
+ORDER BY step DESC
+LIMIT 1 OFFSET ?
+`, convID, count-1).Scan(&targetStep)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("%w: conversation %q has fewer than %d non-meta user prompt(s)", ErrUndoCountOutOfRange, convID, count)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("undo: locate target prompt: %w", err)
+	}
+
+	// Compaction-boundary guard: prompts at or below the most recent compaction
+	// summary cannot be undone (kimi-code semantics).
+	var boundary int
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(step), -1) FROM conversation_messages WHERE conversation_id = ? AND is_compact_summary = 1`, convID).Scan(&boundary); err != nil {
+		return 0, fmt.Errorf("undo: compaction boundary: %w", err)
+	}
+	if targetStep <= boundary {
+		return 0, fmt.Errorf("%w: target prompt at step %d is at or below compaction summary at step %d", ErrUndoCrossesCompaction, targetStep, boundary)
+	}
+
+	// Delete the target prompt and everything after it.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM conversation_messages WHERE conversation_id = ? AND step >= ?`, convID, targetStep); err != nil {
+		return 0, fmt.Errorf("undo: delete messages: %w", err)
+	}
+
+	// Persist an undo-boundary marker so the truncation is visible to reload,
+	// export, and forensics. The marker is meta, so the target query above
+	// skips it and repeated undos keep walking real prompts.
+	marker := fmt.Sprintf("undo boundary: removed %d prompt(s); conversation truncated from step %d", count, targetStep)
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO conversation_messages (conversation_id, step, role, content, is_meta)
+VALUES (?, ?, 'system', ?, 1)
+`, convID, targetStep, marker); err != nil {
+		return 0, fmt.Errorf("undo: insert boundary marker: %w", err)
+	}
+
+	// Keep conversation metadata consistent with the truncated history.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := tx.ExecContext(ctx, `UPDATE conversations SET msg_count=(SELECT COUNT(*) FROM conversation_messages WHERE conversation_id=?), updated_at=? WHERE id=?`, convID, now, convID); err != nil {
+		return 0, fmt.Errorf("undo: update conversation: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("undo: commit: %w", err)
+	}
+	return targetStep, nil
+}
+
 // SearchMessages performs a full-text search over message content using the FTS5 index.
 // When tenantID is non-empty, results are restricted to conversations owned by that
 // tenant by joining the FTS hits against the conversations table on conversation_id.

--- a/internal/harness/conversation_undo_test.go
+++ b/internal/harness/conversation_undo_test.go
@@ -1,0 +1,298 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Epic #805 Slice 1: ConversationStore.UndoPrompts tests
+// ---------------------------------------------------------------------------
+
+func TestUndoPrompts_RemovesLastPromptAndTail(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2", ToolCalls: []ToolCall{{ID: "call_1", Name: "read_file", Arguments: `{"path":"x"}`}}},
+		{Role: "tool", ToolCallID: "call_1", Name: "read_file", Content: "file body"},
+		{Role: "assistant", Content: "a3"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-basic", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	removedFromStep, err := store.UndoPrompts(ctx, "conv-undo-basic", 1)
+	if err != nil {
+		t.Fatalf("UndoPrompts: %v", err)
+	}
+	if removedFromStep != 2 {
+		t.Errorf("removedFromStep: got %d, want %d (step of prompt q2)", removedFromStep, 2)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-undo-basic")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	// q1, a1 remain; the undo-boundary marker is appended at the removed step.
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 messages after undo (2 kept + marker), got %d: %+v", len(loaded), loaded)
+	}
+	if loaded[0].Role != "user" || loaded[0].Content != "q1" {
+		t.Errorf("message[0]: got %+v, want user q1", loaded[0])
+	}
+	if loaded[1].Role != "assistant" || loaded[1].Content != "a1" {
+		t.Errorf("message[1]: got %+v, want assistant a1", loaded[1])
+	}
+}
+
+func TestUndoPrompts_WalksBackNUserPromptsSkippingMeta(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "system", Content: "skill instructions", IsMeta: true},
+		{Role: "user", Content: "hidden meta note", IsMeta: true},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "q3"},
+		{Role: "assistant", Content: "a3"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-n", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	// count=2 must target q2 (step 4): the is_meta user-role message at step 3
+	// is not a prompt and must not be counted.
+	removedFromStep, err := store.UndoPrompts(ctx, "conv-undo-n", 2)
+	if err != nil {
+		t.Fatalf("UndoPrompts: %v", err)
+	}
+	if removedFromStep != 4 {
+		t.Errorf("removedFromStep: got %d, want %d (step of prompt q2)", removedFromStep, 4)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-undo-n")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	// Steps 0..3 kept (including both meta messages) plus the marker at step 4.
+	if len(loaded) != 5 {
+		t.Fatalf("expected 5 messages after undo (4 kept + marker), got %d: %+v", len(loaded), loaded)
+	}
+	wantContents := []string{"q1", "a1", "skill instructions", "hidden meta note"}
+	for i, want := range wantContents {
+		if loaded[i].Content != want {
+			t.Errorf("message[%d].Content: got %q, want %q", i, loaded[i].Content, want)
+		}
+	}
+	if !loaded[2].IsMeta || !loaded[3].IsMeta {
+		t.Errorf("meta flags must survive undo: msg[2].IsMeta=%v msg[3].IsMeta=%v", loaded[2].IsMeta, loaded[3].IsMeta)
+	}
+}
+
+func TestUndoPrompts_CountOutOfRange(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-range", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	cases := map[string]int{
+		"zero count":               0,
+		"negative count":           -2,
+		"more counts than prompts": 3,
+	}
+	for name, count := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := store.UndoPrompts(ctx, "conv-undo-range", count)
+			if err == nil {
+				t.Fatalf("UndoPrompts(count=%d): expected error, got nil", count)
+			}
+			if !errors.Is(err, ErrUndoCountOutOfRange) {
+				t.Errorf("UndoPrompts(count=%d): got %v, want errors.Is ErrUndoCountOutOfRange", count, err)
+			}
+		})
+	}
+
+	// A failed undo must leave the conversation untouched.
+	loaded, err := store.LoadMessages(ctx, "conv-undo-range")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != len(msgs) {
+		t.Fatalf("conversation mutated by failed undo: got %d messages, want %d", len(loaded), len(msgs))
+	}
+	for i, m := range msgs {
+		if loaded[i].Content != m.Content {
+			t.Errorf("message[%d].Content: got %q, want %q", i, loaded[i].Content, m.Content)
+		}
+	}
+}
+
+func TestUndoPrompts_RefusesToCrossCompactionBoundary(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	// A compaction summary can sit mid-history when the runner persists its
+	// in-memory compacted context via SaveConversation.
+	msgs := []Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "system", Content: "summary of earlier context", IsCompactSummary: true},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "q3"},
+		{Role: "assistant", Content: "a3"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-compact", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	// count=3 targets the oldest prompt q1 at step 0, which is at/below the
+	// compaction summary at step 2 — must be refused and leave history untouched.
+	_, err := store.UndoPrompts(ctx, "conv-undo-compact", 3)
+	if err == nil {
+		t.Fatal("UndoPrompts across compaction boundary: expected error, got nil")
+	}
+	if !errors.Is(err, ErrUndoCrossesCompaction) {
+		t.Errorf("got %v, want errors.Is ErrUndoCrossesCompaction", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-undo-compact")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != len(msgs) {
+		t.Fatalf("conversation mutated by refused undo: got %d messages, want %d", len(loaded), len(msgs))
+	}
+
+	// count=1 targets q3 at step 5, above the boundary — must succeed.
+	removedFromStep, err := store.UndoPrompts(ctx, "conv-undo-compact", 1)
+	if err != nil {
+		t.Fatalf("UndoPrompts above boundary: %v", err)
+	}
+	if removedFromStep != 5 {
+		t.Errorf("removedFromStep: got %d, want %d (step of prompt q3)", removedFromStep, 5)
+	}
+
+	// Undo is allowed right up to the boundary: q2 at step 3 is still above the
+	// summary at step 2.
+	secondStep, err := store.UndoPrompts(ctx, "conv-undo-compact", 1)
+	if err != nil {
+		t.Fatalf("UndoPrompts up to boundary: %v", err)
+	}
+	if secondStep != 3 {
+		t.Errorf("second removedFromStep: got %d, want %d (step of prompt q2)", secondStep, 3)
+	}
+
+	// Now only q1 (step 0) remains, at/below the boundary: every further undo
+	// must hit the boundary guard, not the range guard.
+	_, err = store.UndoPrompts(ctx, "conv-undo-compact", 1)
+	if !errors.Is(err, ErrUndoCrossesCompaction) {
+		t.Errorf("post-undo boundary check: got %v, want errors.Is ErrUndoCrossesCompaction", err)
+	}
+}
+
+func TestUndoPrompts_PersistsBoundaryMarker(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	msgs := []Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-marker", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	removedFromStep, err := store.UndoPrompts(ctx, "conv-undo-marker", 1)
+	if err != nil {
+		t.Fatalf("UndoPrompts: %v", err)
+	}
+
+	loaded, err := store.LoadMessages(ctx, "conv-undo-marker")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 messages (2 kept + marker), got %d: %+v", len(loaded), loaded)
+	}
+	marker := loaded[2]
+	if !marker.IsMeta {
+		t.Error("undo-boundary marker must be persisted with IsMeta=true")
+	}
+	if marker.Content == "" {
+		t.Error("undo-boundary marker must carry human-readable content")
+	}
+	if marker.IsCompactSummary {
+		t.Error("undo-boundary marker must not be flagged as a compaction summary")
+	}
+	// The marker occupies the step the removed prompt held, keeping steps contiguous.
+	if removedFromStep != 2 {
+		t.Errorf("removedFromStep: got %d, want 2", removedFromStep)
+	}
+
+	// Conversation metadata stays consistent with the truncated history.
+	convs, err := store.ListConversations(ctx, ConversationFilter{}, 10, 0)
+	if err != nil {
+		t.Fatalf("ListConversations: %v", err)
+	}
+	if len(convs) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(convs))
+	}
+	if convs[0].MsgCount != len(loaded) {
+		t.Errorf("msg_count: got %d, want %d (including marker)", convs[0].MsgCount, len(loaded))
+	}
+
+	// A subsequent undo skips the marker and targets the next real prompt (q1).
+	secondStep, err := store.UndoPrompts(ctx, "conv-undo-marker", 1)
+	if err != nil {
+		t.Fatalf("second UndoPrompts: %v", err)
+	}
+	if secondStep != 0 {
+		t.Errorf("second removedFromStep: got %d, want 0 (step of prompt q1)", secondStep)
+	}
+	loaded, err = store.LoadMessages(ctx, "conv-undo-marker")
+	if err != nil {
+		t.Fatalf("LoadMessages after second undo: %v", err)
+	}
+	if len(loaded) != 1 || !loaded[0].IsMeta {
+		t.Fatalf("expected only the new marker to remain, got %+v", loaded)
+	}
+}
+
+func TestUndoPrompts_ConversationNotFound(t *testing.T) {
+	t.Parallel()
+	store := newTestConversationStore(t)
+	ctx := context.Background()
+
+	_, err := store.UndoPrompts(ctx, "no-such-conversation", 1)
+	if err == nil {
+		t.Fatal("expected error for unknown conversation, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention the conversation was not found, got: %v", err)
+	}
+}

--- a/internal/harness/runner_prune_test.go
+++ b/internal/harness/runner_prune_test.go
@@ -304,3 +304,7 @@ func (s *memoryConversationStore) PinConversation(context.Context, string, bool)
 func (s *memoryConversationStore) CompactConversation(context.Context, string, int, Message) error {
 	return nil
 }
+
+func (s *memoryConversationStore) UndoPrompts(context.Context, string, int) (int, error) {
+	return 0, nil
+}

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -2368,6 +2368,9 @@ func (f *failingConversationStore) PinConversation(_ context.Context, _ string, 
 func (f *failingConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
 	return fmt.Errorf("store compact failed")
 }
+func (f *failingConversationStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, fmt.Errorf("store undo failed")
+}
 func (f *failingConversationStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
 	return fmt.Errorf("store update meta failed")
 }
@@ -2416,6 +2419,9 @@ func (c *capturingConversationStore) PinConversation(_ context.Context, _ string
 }
 func (c *capturingConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
 	return nil
+}
+func (c *capturingConversationStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
 }
 func (c *capturingConversationStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
 	return nil

--- a/internal/harness/tools_contract_test.go
+++ b/internal/harness/tools_contract_test.go
@@ -212,6 +212,9 @@ func (m *contractMockConversationStore) PinConversation(_ context.Context, _ str
 func (m *contractMockConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
 	return nil
 }
+func (m *contractMockConversationStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
 func (m *contractMockConversationStore) GetConversationOwner(_ context.Context, _ string) (*Conversation, error) {
 	return nil, nil
 }

--- a/internal/harness/tools_default_search_tenant_test.go
+++ b/internal/harness/tools_default_search_tenant_test.go
@@ -51,6 +51,9 @@ func (s *spyConversationStore) PinConversation(_ context.Context, _ string, _ bo
 func (s *spyConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
 	return nil
 }
+func (s *spyConversationStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
 
 // TestConversationStoreAdapter_SearchScoped verifies that SearchConversations
 // threads the run's TenantID (from context RunMetadata) into SearchMessages,

--- a/internal/harness/tools_default_test.go
+++ b/internal/harness/tools_default_test.go
@@ -297,6 +297,9 @@ func (m *mockConvStore) PinConversation(_ context.Context, _ string, _ bool) err
 func (m *mockConvStore) CompactConversation(_ context.Context, _ string, _ int, _ Message) error {
 	return nil
 }
+func (m *mockConvStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
 func (m *mockConvStore) GetConversationOwner(_ context.Context, _ string) (*Conversation, error) {
 	return nil, nil
 }

--- a/internal/server/http_replay_fork_history_test.go
+++ b/internal/server/http_replay_fork_history_test.go
@@ -91,6 +91,9 @@ func (f *forkHistoryConvStore) PinConversation(_ context.Context, _ string, _ bo
 func (f *forkHistoryConvStore) CompactConversation(_ context.Context, _ string, _ int, _ harness.Message) error {
 	return nil
 }
+func (f *forkHistoryConvStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
 
 // multiTurnForkRollout is a hand-authored rollout with two user turns
 // (run.started's prompt, then a steering.received turn) so that forking at

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -713,6 +713,9 @@ func (m *mockConversationStore) PinConversation(_ context.Context, _ string, _ b
 func (m *mockConversationStore) CompactConversation(_ context.Context, _ string, _ int, _ harness.Message) error {
 	return nil
 }
+func (m *mockConversationStore) UndoPrompts(_ context.Context, _ string, _ int) (int, error) {
+	return 0, nil
+}
 func (m *mockConversationStore) UpdateConversationMeta(_ context.Context, _, _, _ string) error {
 	return nil
 }


### PR DESCRIPTION
Parent epic: #805. Part of #803.

## What

Slice 1 of the `/undo` epic: the store-level foundation.

- `UndoPrompts(ctx, convID string, count int) (removedFromStep int, err error)` added to `ConversationStore` (`internal/harness/conversation_store.go`).
- Transactional SQLite implementation (`internal/harness/conversation_store_sqlite.go`): locates the Nth-from-last non-meta `user` message by `step` (newest-first, `OFFSET count-1`), verifies its step is greater than the max `is_compact_summary` step, deletes it and all later messages in one transaction, then inserts an `is_meta` undo-boundary marker at the removed step so the truncation round-trips through reload and export.
- Typed sentinel errors `ErrUndoCrossesCompaction` (→ 409 in Slice 2) and `ErrUndoCountOutOfRange` (→ 400 in Slice 2).
- All in-repo `ConversationStore` fakes (harness + server test mocks) updated to satisfy the extended interface.

## Tests (strict TDD: red verified before implementation)

New `internal/harness/conversation_undo_test.go`:
- undo 1 removes the last prompt and trailing assistant/tool messages; `LoadMessages` reflects the truncation
- undo N walks back N user prompts skipping `is_meta` messages
- count 0 / negative / greater than prompt count → `ErrUndoCountOutOfRange`, conversation untouched
- target step at/below a compaction summary → `ErrUndoCrossesCompaction`; undo above the boundary still succeeds
- `is_meta` marker persisted at the removed step; `msg_count` stays consistent; a subsequent undo skips the marker
- unknown conversation → not-found error

Verified:
- `go test ./internal/harness/ -run Undo -count=1` — PASS (6/6)
- `go test ./internal/harness/... ./internal/server/... -count=1` — PASS (8 packages)
- `go vet ./internal/harness/... ./internal/server/...` — clean; touched files gofmt-clean
- `go build ./...` — clean (benchmark `reference_solutions` build quirks are pre-existing on main, verified)

Plan: `docs/plans/805-undo-prompts.md`.