### PR TITLE
feat(subagents): swarm orchestrator with template fan-out, concurrency ramp, and cancellation

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -50,6 +50,33 @@
 - Wired the daemon's `*tools.CallbackManager` into `server.ServerOptions.CallbackLister` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
 - Validation: failing-first tests in `internal/server/http_tasks_test.go` (7 handler tests) and `TestCallbackManagerListAll`; `go test ./internal/server/ ./cmd/harnessd/ -count=1` pass. `go test ./internal/harness/tools/ -count=1` has one pre-existing failure (`TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly`) that fails identically on main (a439dc9f) and is unrelated to this slice.
 
+## 2026-07-19 (Agent Swarm — Epic #808, Slice 1)
+
+- Added `internal/subagents/swarm.go`: a `Swarm` orchestrator that fans one
+  `prompt_template` (with a required `{{item}}` placeholder) over 1–128 items
+  into concurrent subagents started through the existing
+  `tools.SubagentManager` (`InlineManager`).
+- Validation rejects missing placeholders, empty/oversized item lists,
+  duplicate expanded prompts (compared trimmed, since the manager trims), and
+  `resume_agent_ids` (reserved for Slice 2).
+- Concurrency ramps kimi-code style: 5 members start immediately, then +1
+  in-flight allowance every 700ms, capped by `HARNESS_SWARM_MAX_CONCURRENCY`
+  (read once at construction; default 128, clamped to 128).
+- Caller context cancellation cancels every started member via the manager
+  (members finishing Start after the sweep self-cancel, closing the race);
+  unstarted members are reported cancelled. Member failures land in the
+  aggregated `SwarmReport` (deterministic item order) and never abort the
+  cohort.
+- TDD: behavior tests landed first (initially failing on undefined symbols),
+  covering validation, ramp timing via an injected ticker, env cap,
+  cancellation propagation, per-member failure capture, and an acceptance
+  test through a real `Manager` + `InlineManager`.
+- Validation: `go test ./internal/subagents/... -count=1` and `-race` green;
+  new tests repeated 5x without flakes.
+- Note: epic-level docs (`agent_swarm` tool description, swarm design doc)
+  land with their owning slices (3+); no pre-existing subagent design doc
+  exists to update in this slice.
+
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 
 - Added `cmd/harness-acp` and `internal/harnessacp`, using pinned

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -71,6 +71,11 @@
   covering validation, ramp timing via an injected ticker, env cap,
   cancellation propagation, per-member failure capture, and an acceptance
   test through a real `Manager` + `InlineManager`.
+- Coverage-gate lesson: the zero-coverage-function gate caught an unused
+  speculative option (`WithSwarmRamp`) after the first full regression run.
+  The epic fixes the ramp at 5/+1-per-700ms with only the env cap as a knob,
+  so the option was removed (dead code) rather than padded with a test for
+  behavior nothing calls. Keep slice API surface to what the epic specifies.
 - Validation: `go test ./internal/subagents/... -count=1` and `-race` green;
   new tests repeated 5x without flakes.
 - Note: epic-level docs (`agent_swarm` tool description, swarm design doc)

--- a/docs/plans/808-agent-swarm.md
+++ b/docs/plans/808-agent-swarm.md
@@ -1,0 +1,76 @@
+# Plan: agent_swarm epic #808 — Slice 1: swarm orchestrator
+
+## Context
+
+- Problem: go-code can delegate single sub-agents but has no orchestration that
+  fans one prompt template out over many items into concurrent subagents.
+  Epic #808 adds an `agent_swarm` capability matching kimi-code's AgentSwarm.
+- User impact: the model must loop `start_subagent`/`wait_subagent` by hand,
+  which is slow, error-prone, and burns turns.
+- Constraints: reuse `internal/subagents` Manager + `tools.SubagentManager`
+  (`InlineManager`); strict TDD; this PR covers ONLY Slice 1 (core `Swarm`
+  type in `internal/subagents`). Slices 2–4 (resume, deferred tool, TUI) are
+  out of scope here.
+
+## Scope
+
+- In scope:
+  - `internal/subagents/swarm.go`: `SwarmRequest` (PromptTemplate, Items,
+    ResumeAgentIDs rejected until Slice 2, profile/model overrides),
+    validation, `Swarm.Run(ctx) (SwarmReport, error)`.
+  - Concurrency scheduler: 5 immediate starts, +1 every 700ms, cap read once
+    from `HARNESS_SWARM_MAX_CONCURRENCY` (default 128, clamped to 128).
+  - Caller context cancellation cancels every started member; per-member
+    errors are captured in the report and never abort the cohort.
+  - `SwarmReport` with per-member ID, item, status, output/error in
+    deterministic item order.
+- Out of scope: resume_agent_ids delivery (Slice 2), `agent_swarm` tool and
+  runner sole-call rule (Slice 3), TUI panel (Slice 4), new server endpoints.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (no public surface in this slice)
+- Spec docs to update before code: none
+- Implementation notes to add after code: engineering-log entry per slice.
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`internal/subagents/swarm_test.go`):
+  - table-driven validation: missing `{{item}}` placeholder, empty items,
+    >128 items, duplicate expanded prompts, resume_agent_ids rejected
+  - ramp timing with injected manual ticker: 5 in-flight before first tick,
+    +1 per tick
+  - env cap: `HARNESS_SWARM_MAX_CONCURRENCY` honored; resolver default/clamp
+  - cancellation: parent cancel cancels all started members, unstarted
+    members reported cancelled, all reach terminal state
+  - aggregated report shape/order; per-member failure does not abort cohort
+  - acceptance: real `Manager` + `InlineManager` fan-out completes
+- Existing tests to update: none
+- Regression tests required: existing `internal/subagents` tests stay green
+  unmodified.
+
+## Cross-Surface Impact Map
+
+- None — in-process orchestration only; no provider/model flow, config,
+  server API, or TUI changes in this slice.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first.
+- [x] Implement minimal code changes (`swarm.go`).
+- [x] Refactor while tests remain green.
+- [x] Update docs, status ledgers, and indexes.
+- [x] Update engineering log.
+- [x] Run full test suite for touched packages.
+
+## Risks and Mitigations
+
+- Risk: ramp timing tests flaking on wall-clock sleeps.
+- Mitigation: inject a manual ticker seam; wall-clock only for short
+  stability assertions with generous margins.
+- Risk: goroutine leak / hang when a member never terminates after cancel.
+- Mitigation: swarm issues `Cancel` for every started member and relies on
+  the documented `tools.SubagentManager` contract (cancel drives members to
+  a terminal state); the swarm-scoped context is always stopped on return.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -6,6 +6,7 @@
 - `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
+- `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/subagents/swarm.go
+++ b/internal/subagents/swarm.go
@@ -120,11 +120,9 @@ func (r realSwarmTicker) Stop()                  { r.t.Stop() }
 // allowance, propagates caller cancellation to every member, and aggregates
 // the per-member results into one report.
 type Swarm struct {
-	manager            tools.SubagentManager
-	maxConcurrency     int
-	initialConcurrency int
-	rampInterval       time.Duration
-	newTicker          func(time.Duration) swarmTicker
+	manager        tools.SubagentManager
+	maxConcurrency int
+	newTicker      func(time.Duration) swarmTicker
 }
 
 // SwarmOption customizes a Swarm; options are applied after the environment
@@ -137,19 +135,6 @@ func WithSwarmMaxConcurrency(n int) SwarmOption {
 	return func(s *Swarm) {
 		if n >= 1 {
 			s.maxConcurrency = n
-		}
-	}
-}
-
-// WithSwarmRamp overrides the initial burst size and the ramp interval.
-// Non-positive values are ignored.
-func WithSwarmRamp(initial int, interval time.Duration) SwarmOption {
-	return func(s *Swarm) {
-		if initial >= 1 {
-			s.initialConcurrency = initial
-		}
-		if interval > 0 {
-			s.rampInterval = interval
 		}
 	}
 }
@@ -169,10 +154,8 @@ func withSwarmTickerFactory(f func(time.Duration) swarmTicker) SwarmOption {
 // HARNESS_SWARM_MAX_CONCURRENCY unless overridden by an option.
 func NewSwarm(manager tools.SubagentManager, opts ...SwarmOption) *Swarm {
 	s := &Swarm{
-		manager:            manager,
-		maxConcurrency:     resolveSwarmMaxConcurrency(os.Getenv),
-		initialConcurrency: defaultSwarmInitialConcurrency,
-		rampInterval:       defaultSwarmRampInterval,
+		manager:        manager,
+		maxConcurrency: resolveSwarmMaxConcurrency(os.Getenv),
 		newTicker: func(d time.Duration) swarmTicker {
 			return realSwarmTicker{t: time.NewTicker(d)}
 		},
@@ -185,17 +168,6 @@ func NewSwarm(manager tools.SubagentManager, opts ...SwarmOption) *Swarm {
 	}
 	if s.maxConcurrency < 1 {
 		s.maxConcurrency = 1
-	}
-	if s.initialConcurrency < 1 {
-		s.initialConcurrency = 1
-	}
-	if s.rampInterval <= 0 {
-		s.rampInterval = defaultSwarmRampInterval
-	}
-	if s.newTicker == nil {
-		s.newTicker = func(d time.Duration) swarmTicker {
-			return realSwarmTicker{t: time.NewTicker(d)}
-		}
 	}
 	return s
 }
@@ -298,7 +270,7 @@ func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) 
 	swarmCtx, stopSwarm := context.WithCancel(context.Background())
 	defer stopSwarm()
 
-	ticker := s.newTicker(s.rampInterval)
+	ticker := s.newTicker(defaultSwarmRampInterval)
 	defer ticker.Stop()
 
 	type outcome struct {
@@ -328,15 +300,12 @@ func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) 
 	inFlight := 0
 	started := 0
 	finished := 0
-	allowance := s.initialConcurrency
+	allowance := defaultSwarmInitialConcurrency
 	if allowance > s.maxConcurrency {
 		allowance = s.maxConcurrency
 	}
 	if allowance > n {
 		allowance = n
-	}
-	if allowance < 1 {
-		allowance = 1
 	}
 
 	launch := func(idx int) {

--- a/internal/subagents/swarm.go
+++ b/internal/subagents/swarm.go
@@ -1,0 +1,451 @@
+package subagents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+const (
+	// SwarmItemPlaceholder is the placeholder inside a swarm prompt template
+	// that is replaced with each item to produce the member prompts.
+	SwarmItemPlaceholder = "{{item}}"
+	// SwarmMaxMembers is the hard cap on swarm members (items plus, in later
+	// slices, resumed subagents), matching kimi-code's AgentSwarm limit.
+	SwarmMaxMembers = 128
+	// SwarmMaxConcurrencyEnv caps how many swarm members run concurrently.
+	// Read once when the Swarm is constructed; values above SwarmMaxMembers
+	// are clamped and invalid values fall back to SwarmMaxMembers.
+	SwarmMaxConcurrencyEnv = "HARNESS_SWARM_MAX_CONCURRENCY"
+
+	// defaultSwarmInitialConcurrency is the number of members started
+	// immediately before the ramp begins (kimi-code parity: 5).
+	defaultSwarmInitialConcurrency = 5
+	// defaultSwarmRampInterval is how often the concurrency allowance grows
+	// by one member (kimi-code parity: +1 every 700ms).
+	defaultSwarmRampInterval = 700 * time.Millisecond
+
+	swarmMemberStatusPending = "pending"
+)
+
+// ErrInvalidSwarmRequest marks swarm requests that fail validation
+// (bad template, bad item count, duplicate expansions, unsupported options).
+var ErrInvalidSwarmRequest = errors.New("invalid swarm request")
+
+// SwarmRequest fans one prompt template out over a set of items. Each item
+// expands PromptTemplate into one member prompt; every member runs as an
+// ordinary subagent through the tools.SubagentManager the Swarm was built
+// with. The profile/model fields are per-member overrides mirroring
+// tools.SubagentRequest; zero values inherit the runner defaults.
+type SwarmRequest struct {
+	// PromptTemplate must contain SwarmItemPlaceholder at least once.
+	PromptTemplate string `json:"prompt_template"`
+	// Items holds 1..SwarmMaxMembers entries; expanded prompts must be distinct.
+	Items []string `json:"items"`
+	// ResumeAgentIDs reuses existing subagents instead of creating new ones.
+	// Reserved for Slice 2 of epic #808: any non-empty value is rejected.
+	ResumeAgentIDs []string `json:"resume_agent_ids,omitempty"`
+
+	Model                string                      `json:"model,omitempty"`
+	SystemPrompt         string                      `json:"system_prompt,omitempty"`
+	MaxSteps             int                         `json:"max_steps,omitempty"`
+	MaxCostUSD           float64                     `json:"max_cost_usd,omitempty"`
+	ReasoningEffort      string                      `json:"reasoning_effort,omitempty"`
+	AllowedTools         []string                    `json:"allowed_tools,omitempty"`
+	ProfileName          string                      `json:"profile,omitempty"`
+	IsolationMode        string                      `json:"isolation,omitempty"`
+	CleanupPolicy        string                      `json:"cleanup_policy,omitempty"`
+	BaseRef              string                      `json:"base_ref,omitempty"`
+	ResultMode           string                      `json:"result_mode,omitempty"`
+	ParentContextHandoff *tools.ParentContextHandoff `json:"parent_context_handoff,omitempty"`
+}
+
+// SwarmMemberReport is the per-member outcome of a swarm run.
+type SwarmMemberReport struct {
+	ID     string `json:"id,omitempty"`
+	Item   string `json:"item"`
+	Prompt string `json:"prompt"`
+	Status string `json:"status"` // "pending" | "completed" | "failed" | "cancelled" | ...
+	Output string `json:"output,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// SwarmReport aggregates every member outcome in deterministic order
+// (items first; resumed members would follow in later slices).
+type SwarmReport struct {
+	Members   []SwarmMemberReport `json:"members"`
+	Total     int                 `json:"total"`
+	Completed int                 `json:"completed"`
+	Failed    int                 `json:"failed"`
+	Cancelled int                 `json:"cancelled"`
+}
+
+// finalize computes the summary counts from the member statuses.
+func (r *SwarmReport) finalize() {
+	r.Total = len(r.Members)
+	r.Completed, r.Failed, r.Cancelled = 0, 0, 0
+	for _, m := range r.Members {
+		switch m.Status {
+		case "completed":
+			r.Completed++
+		case "failed":
+			r.Failed++
+		case "cancelled":
+			r.Cancelled++
+		}
+	}
+}
+
+// swarmTicker abstracts time.Ticker so tests can drive the ramp manually.
+type swarmTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type realSwarmTicker struct{ t *time.Ticker }
+
+func (r realSwarmTicker) Chan() <-chan time.Time { return r.t.C }
+func (r realSwarmTicker) Stop()                  { r.t.Stop() }
+
+// Swarm is the agent_swarm orchestrator: it validates a template fan-out,
+// starts members through a tools.SubagentManager under a ramping concurrency
+// allowance, propagates caller cancellation to every member, and aggregates
+// the per-member results into one report.
+type Swarm struct {
+	manager            tools.SubagentManager
+	maxConcurrency     int
+	initialConcurrency int
+	rampInterval       time.Duration
+	newTicker          func(time.Duration) swarmTicker
+}
+
+// SwarmOption customizes a Swarm; options are applied after the environment
+// is read, so an explicit option always wins over HARNESS_SWARM_MAX_CONCURRENCY.
+type SwarmOption func(*Swarm)
+
+// WithSwarmMaxConcurrency overrides the concurrency cap from the environment.
+// Values < 1 are ignored.
+func WithSwarmMaxConcurrency(n int) SwarmOption {
+	return func(s *Swarm) {
+		if n >= 1 {
+			s.maxConcurrency = n
+		}
+	}
+}
+
+// WithSwarmRamp overrides the initial burst size and the ramp interval.
+// Non-positive values are ignored.
+func WithSwarmRamp(initial int, interval time.Duration) SwarmOption {
+	return func(s *Swarm) {
+		if initial >= 1 {
+			s.initialConcurrency = initial
+		}
+		if interval > 0 {
+			s.rampInterval = interval
+		}
+	}
+}
+
+// withSwarmTickerFactory replaces the ticker used by the ramp scheduler.
+// It exists for deterministic timing tests.
+func withSwarmTickerFactory(f func(time.Duration) swarmTicker) SwarmOption {
+	return func(s *Swarm) {
+		if f != nil {
+			s.newTicker = f
+		}
+	}
+}
+
+// NewSwarm builds a Swarm that starts members through manager (in production
+// an *InlineManager). The concurrency cap is read once from
+// HARNESS_SWARM_MAX_CONCURRENCY unless overridden by an option.
+func NewSwarm(manager tools.SubagentManager, opts ...SwarmOption) *Swarm {
+	s := &Swarm{
+		manager:            manager,
+		maxConcurrency:     resolveSwarmMaxConcurrency(os.Getenv),
+		initialConcurrency: defaultSwarmInitialConcurrency,
+		rampInterval:       defaultSwarmRampInterval,
+		newTicker: func(d time.Duration) swarmTicker {
+			return realSwarmTicker{t: time.NewTicker(d)}
+		},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if s.maxConcurrency > SwarmMaxMembers {
+		s.maxConcurrency = SwarmMaxMembers
+	}
+	if s.maxConcurrency < 1 {
+		s.maxConcurrency = 1
+	}
+	if s.initialConcurrency < 1 {
+		s.initialConcurrency = 1
+	}
+	if s.rampInterval <= 0 {
+		s.rampInterval = defaultSwarmRampInterval
+	}
+	if s.newTicker == nil {
+		s.newTicker = func(d time.Duration) swarmTicker {
+			return realSwarmTicker{t: time.NewTicker(d)}
+		}
+	}
+	return s
+}
+
+// resolveSwarmMaxConcurrency reads the env cap: default SwarmMaxMembers,
+// clamped to [1, SwarmMaxMembers], invalid values fall back to the default.
+func resolveSwarmMaxConcurrency(getenv func(string) string) int {
+	raw := strings.TrimSpace(getenv(SwarmMaxConcurrencyEnv))
+	if raw == "" {
+		return SwarmMaxMembers
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return SwarmMaxMembers
+	}
+	if n > SwarmMaxMembers {
+		return SwarmMaxMembers
+	}
+	return n
+}
+
+// expandedPrompts validates the request and returns the per-item prompts.
+func (r SwarmRequest) expandedPrompts() ([]string, error) {
+	if !strings.Contains(r.PromptTemplate, SwarmItemPlaceholder) {
+		return nil, fmt.Errorf("%w: prompt_template must contain the %q placeholder", ErrInvalidSwarmRequest, SwarmItemPlaceholder)
+	}
+	if len(r.Items) == 0 {
+		return nil, fmt.Errorf("%w: items must contain at least 1 entry", ErrInvalidSwarmRequest)
+	}
+	if len(r.Items) > SwarmMaxMembers {
+		return nil, fmt.Errorf("%w: items has %d entries, max is %d", ErrInvalidSwarmRequest, len(r.Items), SwarmMaxMembers)
+	}
+	if len(r.ResumeAgentIDs) > 0 {
+		return nil, fmt.Errorf("%w: resume_agent_ids is not supported yet", ErrInvalidSwarmRequest)
+	}
+
+	prompts := make([]string, len(r.Items))
+	seen := make(map[string]int, len(r.Items))
+	for i, item := range r.Items {
+		expanded := strings.ReplaceAll(r.PromptTemplate, SwarmItemPlaceholder, item)
+		prompts[i] = expanded
+		// Compare trimmed expansions: the manager trims prompts before
+		// running, so "a" and "a " would launch duplicate work.
+		key := strings.TrimSpace(expanded)
+		if prev, dup := seen[key]; dup {
+			return nil, fmt.Errorf("%w: items %d and %d expand to the same prompt", ErrInvalidSwarmRequest, prev, i)
+		}
+		seen[key] = i
+	}
+	return prompts, nil
+}
+
+// memberRequest builds the per-member tool-layer request from the overrides.
+func (r SwarmRequest) memberRequest(prompt string) tools.SubagentRequest {
+	return tools.SubagentRequest{
+		Prompt:               prompt,
+		Model:                r.Model,
+		SystemPrompt:         r.SystemPrompt,
+		MaxSteps:             r.MaxSteps,
+		MaxCostUSD:           r.MaxCostUSD,
+		AllowedTools:         append([]string(nil), r.AllowedTools...),
+		ProfileName:          r.ProfileName,
+		ReasoningEffort:      r.ReasoningEffort,
+		IsolationMode:        r.IsolationMode,
+		CleanupPolicy:        r.CleanupPolicy,
+		BaseRef:              r.BaseRef,
+		ResultMode:           r.ResultMode,
+		ParentContextHandoff: r.ParentContextHandoff,
+	}
+}
+
+// Run validates the request, fans the template out over the items, and blocks
+// until every member reaches a terminal state. Member failures are captured
+// in the report and never abort the cohort. If ctx is cancelled, every
+// started member is cancelled through the manager, members that never started
+// are reported as cancelled, and Run returns the partial report together with
+// ctx.Err().
+func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) {
+	if s.manager == nil {
+		return SwarmReport{}, fmt.Errorf("subagents: swarm has no subagent manager")
+	}
+	prompts, err := req.expandedPrompts()
+	if err != nil {
+		return SwarmReport{}, err
+	}
+
+	n := len(req.Items)
+	report := SwarmReport{Members: make([]SwarmMemberReport, n)}
+	for i := range req.Items {
+		report.Members[i] = SwarmMemberReport{
+			Item:   req.Items[i],
+			Prompt: prompts[i],
+			Status: swarmMemberStatusPending,
+		}
+	}
+
+	// swarmCtx scopes member waits: it is independent of the caller ctx so
+	// that, after a caller cancellation, member waits keep polling until the
+	// manager reports the terminal (cancelled) state we just asked for.
+	swarmCtx, stopSwarm := context.WithCancel(context.Background())
+	defer stopSwarm()
+
+	ticker := s.newTicker(s.rampInterval)
+	defer ticker.Stop()
+
+	type outcome struct {
+		idx int
+		res tools.SubagentResult
+		err error
+	}
+	outcomes := make(chan outcome, n)
+
+	var mu sync.Mutex
+	memberIDs := make([]string, n)
+	memberDone := make([]bool, n)
+	cancelled := atomic.Bool{}
+
+	cancelMembers := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for i, id := range memberIDs {
+			if id != "" && !memberDone[i] {
+				// Best effort: a member may already be terminal, in which
+				// case the manager's Cancel is a no-op.
+				_ = s.manager.Cancel(context.Background(), id)
+			}
+		}
+	}
+
+	inFlight := 0
+	started := 0
+	finished := 0
+	allowance := s.initialConcurrency
+	if allowance > s.maxConcurrency {
+		allowance = s.maxConcurrency
+	}
+	if allowance > n {
+		allowance = n
+	}
+	if allowance < 1 {
+		allowance = 1
+	}
+
+	launch := func(idx int) {
+		inFlight++
+		go func() {
+			res, err := s.manager.Start(ctx, req.memberRequest(prompts[idx]))
+			if err != nil {
+				outcomes <- outcome{idx: idx, err: err}
+				return
+			}
+			mu.Lock()
+			memberIDs[idx] = res.ID
+			mu.Unlock()
+			// If the swarm was cancelled while Start was in flight, the
+			// cancel sweep already ran without this id — cancel it here so
+			// no member escapes cancellation.
+			if cancelled.Load() {
+				_ = s.manager.Cancel(context.Background(), res.ID)
+			}
+			wres, werr := s.manager.Wait(swarmCtx, res.ID)
+			if wres.ID == "" {
+				wres.ID = res.ID
+			}
+			outcomes <- outcome{idx: idx, res: wres, err: werr}
+		}()
+	}
+
+	canLaunch := func() bool {
+		return !cancelled.Load() && ctx.Err() == nil && started < n && inFlight < allowance
+	}
+	for canLaunch() {
+		launch(started)
+		started++
+	}
+
+	ctxDone := ctx.Done()
+	for finished < n {
+		// After cancellation there is nothing to launch; leave the loop as
+		// soon as every started member has reported a terminal outcome.
+		if cancelled.Load() && finished >= started {
+			break
+		}
+		select {
+		case <-ctxDone:
+			cancelled.Store(true)
+			cancelMembers()
+			ctxDone = nil // fire once; a closed channel would spin the select
+		case oc := <-outcomes:
+			finished++
+			inFlight--
+			mu.Lock()
+			memberDone[oc.idx] = true
+			mu.Unlock()
+			recordSwarmOutcome(&report.Members[oc.idx], oc.res, oc.err)
+			for canLaunch() {
+				launch(started)
+				started++
+			}
+		case <-ticker.Chan():
+			maxAllowance := s.maxConcurrency
+			if maxAllowance > n {
+				maxAllowance = n
+			}
+			if allowance < maxAllowance {
+				allowance++
+			}
+			for canLaunch() {
+				launch(started)
+				started++
+			}
+		}
+	}
+
+	if cancelled.Load() {
+		for i := range report.Members {
+			if report.Members[i].Status == swarmMemberStatusPending {
+				report.Members[i].Status = "cancelled"
+				report.Members[i].Error = ctx.Err().Error()
+			}
+		}
+		report.finalize()
+		return report, ctx.Err()
+	}
+	report.finalize()
+	return report, nil
+}
+
+// recordSwarmOutcome folds one member outcome into its report entry. The
+// member index never changes, so item order in the report is deterministic.
+func recordSwarmOutcome(m *SwarmMemberReport, res tools.SubagentResult, err error) {
+	if res.ID != "" {
+		m.ID = res.ID
+	}
+	switch {
+	case err != nil && res.Status == "":
+		// Start failed or the wait errored without a status: the member
+		// never produced a terminal state of its own.
+		m.Status = "failed"
+		m.Error = err.Error()
+	case err != nil:
+		m.Status = res.Status
+		m.Output = res.Output
+		m.Error = res.Error
+		if m.Error == "" {
+			m.Error = err.Error()
+		}
+	default:
+		m.Status = res.Status
+		m.Output = res.Output
+		m.Error = res.Error
+	}
+}

--- a/internal/subagents/swarm_test.go
+++ b/internal/subagents/swarm_test.go
@@ -1,0 +1,698 @@
+package subagents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// fakeSwarmManager implements tools.SubagentManager with controllable Wait
+// semantics so ramp, cancellation, and aggregation behavior can be observed
+// deterministically.
+type fakeSwarmManager struct {
+	mu          sync.Mutex
+	started     []tools.SubagentRequest
+	ids         []string
+	chans       map[string]chan tools.SubagentResult
+	cancelled   []string
+	releaseCh   chan struct{}
+	released    bool
+	startErr    error
+	startErrAt  int // 0-based start index that fails with startErr; -1 disables
+	startsTotal int
+}
+
+func newFakeSwarmManager() *fakeSwarmManager {
+	return &fakeSwarmManager{
+		chans:      make(map[string]chan tools.SubagentResult),
+		releaseCh:  make(chan struct{}),
+		startErrAt: -1,
+	}
+}
+
+func (f *fakeSwarmManager) Start(_ context.Context, req tools.SubagentRequest) (tools.SubagentResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.startErr != nil && (f.startErrAt < 0 || f.startErrAt == f.startsTotal) {
+		f.startsTotal++
+		return tools.SubagentResult{}, f.startErr
+	}
+	f.startsTotal++
+	id := fmt.Sprintf("member-%d", f.startsTotal)
+	f.started = append(f.started, req)
+	f.ids = append(f.ids, id)
+	f.chans[id] = make(chan tools.SubagentResult, 1)
+	return tools.SubagentResult{ID: id, RunID: id + "-run", Status: string(harness.RunStatusRunning)}, nil
+}
+
+func (f *fakeSwarmManager) Wait(ctx context.Context, id string) (tools.SubagentResult, error) {
+	f.mu.Lock()
+	ch := f.chans[id]
+	f.mu.Unlock()
+	if ch == nil {
+		return tools.SubagentResult{}, fmt.Errorf("unknown subagent %q", id)
+	}
+	select {
+	case res := <-ch:
+		return res, nil
+	case <-f.releaseCh:
+		// A per-member finish() may already be buffered; it wins over the
+		// generic release result so tests stay deterministic.
+		select {
+		case res := <-ch:
+			return res, nil
+		default:
+		}
+		return tools.SubagentResult{ID: id, Status: string(harness.RunStatusCompleted), Output: "out-" + id}, nil
+	case <-ctx.Done():
+		return tools.SubagentResult{}, ctx.Err()
+	}
+}
+
+func (f *fakeSwarmManager) CreateAndWait(ctx context.Context, req tools.SubagentRequest) (tools.SubagentResult, error) {
+	res, err := f.Start(ctx, req)
+	if err != nil {
+		return tools.SubagentResult{}, err
+	}
+	return f.Wait(ctx, res.ID)
+}
+
+func (f *fakeSwarmManager) Get(_ context.Context, id string) (tools.SubagentResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, known := range f.ids {
+		if known == id {
+			return tools.SubagentResult{ID: id, Status: string(harness.RunStatusRunning)}, nil
+		}
+	}
+	return tools.SubagentResult{}, fmt.Errorf("unknown subagent %q", id)
+}
+
+func (f *fakeSwarmManager) Cancel(_ context.Context, id string) error {
+	f.mu.Lock()
+	f.cancelled = append(f.cancelled, id)
+	ch := f.chans[id]
+	f.mu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- tools.SubagentResult{ID: id, Status: string(harness.RunStatusCancelled), Error: "cancelled"}:
+		default:
+		}
+	}
+	return nil
+}
+
+// release makes every current and future Wait return a completed result.
+func (f *fakeSwarmManager) release() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.released {
+		f.released = true
+		close(f.releaseCh)
+	}
+}
+
+// finish completes a single member's Wait with the given result.
+func (f *fakeSwarmManager) finish(id string, res tools.SubagentResult) {
+	f.mu.Lock()
+	ch := f.chans[id]
+	f.mu.Unlock()
+	if ch != nil {
+		select {
+		case ch <- res:
+		default:
+		}
+	}
+}
+
+func (f *fakeSwarmManager) startCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.started)
+}
+
+func (f *fakeSwarmManager) cancelCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.cancelled)
+}
+
+// idForPrompt returns the member id whose start request carried the given
+// prompt. Member ids are assigned in Start-call order, which is concurrent,
+// so tests must resolve ids through the recorded prompts instead of guessing
+// "member-N".
+func (f *fakeSwarmManager) idForPrompt(prompt string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i, req := range f.started {
+		if req.Prompt == prompt {
+			return f.ids[i]
+		}
+	}
+	return ""
+}
+
+// manualTicker is a test ticker fired explicitly by the test.
+type manualTicker struct{ ch chan time.Time }
+
+func newManualTicker() *manualTicker { return &manualTicker{ch: make(chan time.Time)} }
+
+func (m *manualTicker) Chan() <-chan time.Time { return m.ch }
+
+func (m *manualTicker) Stop() {}
+
+func (m *manualTicker) tick() { m.ch <- time.Now() }
+
+func manualTickerFactory(mt *manualTicker) func(time.Duration) swarmTicker {
+	return func(time.Duration) swarmTicker { return mt }
+}
+
+type swarmRunResult struct {
+	report SwarmReport
+	err    error
+}
+
+func runSwarmAsync(swarm *Swarm, ctx context.Context, req SwarmRequest) chan swarmRunResult {
+	done := make(chan swarmRunResult, 1)
+	go func() {
+		report, err := swarm.Run(ctx, req)
+		done <- swarmRunResult{report: report, err: err}
+	}()
+	return done
+}
+
+func awaitSwarmRun(t *testing.T, done chan swarmRunResult) swarmRunResult {
+	t.Helper()
+	select {
+	case res := <-done:
+		return res
+	case <-time.After(10 * time.Second):
+		t.Fatal("swarm Run did not return within 10s")
+		return swarmRunResult{}
+	}
+}
+
+func waitForStartCount(t *testing.T, f *fakeSwarmManager, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.startCount() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("start count did not reach %d (got %d)", want, f.startCount())
+}
+
+func swarmItems(n int) []string {
+	items := make([]string, n)
+	for i := range items {
+		items[i] = fmt.Sprintf("item-%d", i)
+	}
+	return items
+}
+
+func TestSwarmRunValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		req     SwarmRequest
+		wantErr string
+	}{
+		{
+			name:    "template missing placeholder",
+			req:     SwarmRequest{PromptTemplate: "review the code", Items: []string{"a"}},
+			wantErr: "{{item}}",
+		},
+		{
+			name:    "empty template",
+			req:     SwarmRequest{PromptTemplate: "", Items: []string{"a"}},
+			wantErr: "{{item}}",
+		},
+		{
+			name:    "no items",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: nil},
+			wantErr: "at least 1",
+		},
+		{
+			name:    "too many items",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: swarmItems(SwarmMaxMembers + 1)},
+			wantErr: "max",
+		},
+		{
+			name:    "duplicate items expand to same prompt",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a", "b", "a"}},
+			wantErr: "same prompt",
+		},
+		{
+			name:    "whitespace-only difference still duplicates",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a", "a "}},
+			wantErr: "same prompt",
+		},
+		{
+			name:    "resume_agent_ids rejected until slice 2",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a"}, ResumeAgentIDs: []string{"subagent_1"}},
+			wantErr: "resume",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fake := newFakeSwarmManager()
+			swarm := NewSwarm(fake)
+			_, err := swarm.Run(context.Background(), tt.req)
+			if err == nil {
+				t.Fatalf("Run error = nil, want error containing %q", tt.wantErr)
+			}
+			if !errors.Is(err, ErrInvalidSwarmRequest) {
+				t.Fatalf("Run error = %v, want ErrInvalidSwarmRequest", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Run error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+			if fake.startCount() != 0 {
+				t.Fatalf("invalid request started %d members, want 0", fake.startCount())
+			}
+		})
+	}
+}
+
+func TestSwarmRunValidationAcceptsMaxItems(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.release()
+	swarm := NewSwarm(fake)
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(SwarmMaxMembers),
+	}))
+	if res.err != nil {
+		t.Fatalf("Run with %d items error = %v, want nil", SwarmMaxMembers, res.err)
+	}
+	if res.report.Total != SwarmMaxMembers {
+		t.Fatalf("report Total = %d, want %d", res.report.Total, SwarmMaxMembers)
+	}
+	if fake.startCount() != SwarmMaxMembers {
+		t.Fatalf("started %d members, want %d", fake.startCount(), SwarmMaxMembers)
+	}
+}
+
+func TestResolveSwarmMaxConcurrency(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want int
+	}{
+		{name: "unset defaults to 128", env: nil, want: SwarmMaxMembers},
+		{name: "explicit value", env: map[string]string{SwarmMaxConcurrencyEnv: "8"}, want: 8},
+		{name: "zero falls back to default", env: map[string]string{SwarmMaxConcurrencyEnv: "0"}, want: SwarmMaxMembers},
+		{name: "negative falls back to default", env: map[string]string{SwarmMaxConcurrencyEnv: "-3"}, want: SwarmMaxMembers},
+		{name: "garbage falls back to default", env: map[string]string{SwarmMaxConcurrencyEnv: "abc"}, want: SwarmMaxMembers},
+		{name: "above cap clamped to 128", env: map[string]string{SwarmMaxConcurrencyEnv: "999"}, want: SwarmMaxMembers},
+		{name: "whitespace trimmed", env: map[string]string{SwarmMaxConcurrencyEnv: " 4 "}, want: 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			getenv := func(key string) string { return tt.env[key] }
+			if got := resolveSwarmMaxConcurrency(getenv); got != tt.want {
+				t.Fatalf("resolveSwarmMaxConcurrency(%v) = %d, want %d", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSwarmRunAggregatesReport(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.release()
+	swarm := NewSwarm(fake)
+	items := []string{"alpha", "beta", "gamma"}
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "Review {{item}} carefully",
+		Items:          items,
+		Model:          "gpt-swarm",
+		MaxSteps:       7,
+		ProfileName:    "explorer",
+		AllowedTools:   []string{"read"},
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+
+	report := res.report
+	if report.Total != 3 || report.Completed != 3 || report.Failed != 0 || report.Cancelled != 0 {
+		t.Fatalf("report counts = total:%d completed:%d failed:%d cancelled:%d, want 3/3/0/0",
+			report.Total, report.Completed, report.Failed, report.Cancelled)
+	}
+	if len(report.Members) != len(items) {
+		t.Fatalf("report has %d members, want %d", len(report.Members), len(items))
+	}
+	for i, item := range items {
+		m := report.Members[i]
+		if m.Item != item {
+			t.Errorf("member %d Item = %q, want %q (deterministic item order)", i, m.Item, item)
+		}
+		if m.Prompt != "Review "+item+" carefully" {
+			t.Errorf("member %d Prompt = %q, want expanded template", i, m.Prompt)
+		}
+		if m.ID == "" {
+			t.Errorf("member %d ID is empty, want subagent id", i)
+		}
+		if m.Status != string(harness.RunStatusCompleted) {
+			t.Errorf("member %d Status = %q, want completed", i, m.Status)
+		}
+		if m.Output == "" {
+			t.Errorf("member %d Output is empty, want member output", i)
+		}
+	}
+
+	// Member requests must carry the expanded prompt and the profile/model
+	// overrides. Start-call order is concurrent, so compare as a set.
+	if fake.startCount() != len(items) {
+		t.Fatalf("started %d members, want %d", fake.startCount(), len(items))
+	}
+	fake.mu.Lock()
+	startedReqs := append([]tools.SubagentRequest(nil), fake.started...)
+	fake.mu.Unlock()
+	seenPrompts := make(map[string]bool, len(startedReqs))
+	for _, req := range startedReqs {
+		seenPrompts[req.Prompt] = true
+		if req.Model != "gpt-swarm" || req.MaxSteps != 7 || req.ProfileName != "explorer" {
+			t.Errorf("started request overrides = model:%q steps:%d profile:%q, want gpt-swarm/7/explorer",
+				req.Model, req.MaxSteps, req.ProfileName)
+		}
+		if len(req.AllowedTools) != 1 || req.AllowedTools[0] != "read" {
+			t.Errorf("started request AllowedTools = %v, want [read]", req.AllowedTools)
+		}
+	}
+	for _, item := range items {
+		want := "Review " + item + " carefully"
+		if !seenPrompts[want] {
+			t.Errorf("no member started with prompt %q; got %v", want, seenPrompts)
+		}
+	}
+}
+
+func TestSwarmRampConcurrency(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	mt := newManualTicker()
+	swarm := NewSwarm(fake,
+		WithSwarmMaxConcurrency(10),
+		withSwarmTickerFactory(manualTickerFactory(mt)),
+	)
+
+	done := runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(10),
+	})
+
+	// Initial burst: exactly 5 in-flight members before the first tick.
+	waitForStartCount(t, fake, 5)
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 5 {
+		t.Fatalf("in-flight before first tick = %d, want 5", got)
+	}
+
+	// Each ramp tick allows exactly one more concurrent member.
+	mt.tick()
+	waitForStartCount(t, fake, 6)
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 6 {
+		t.Fatalf("in-flight after first tick = %d, want 6", got)
+	}
+
+	mt.tick()
+	waitForStartCount(t, fake, 7)
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 7 {
+		t.Fatalf("in-flight after second tick = %d, want 7", got)
+	}
+
+	fake.release()
+	res := awaitSwarmRun(t, done)
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+	if res.report.Completed != 10 {
+		t.Fatalf("report Completed = %d, want 10", res.report.Completed)
+	}
+	if fake.startCount() != 10 {
+		t.Fatalf("started %d members, want 10", fake.startCount())
+	}
+}
+
+func TestSwarmRampAllowsReplacementAfterCompletion(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	mt := newManualTicker()
+	swarm := NewSwarm(fake,
+		WithSwarmMaxConcurrency(3),
+		withSwarmTickerFactory(manualTickerFactory(mt)),
+	)
+
+	done := runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(6),
+	})
+
+	// Cap of 3 is below the initial ramp of 5, so only 3 start.
+	waitForStartCount(t, fake, 3)
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 3 {
+		t.Fatalf("in-flight with cap 3 = %d, want 3", got)
+	}
+
+	// Completing a member frees a slot even without a tick. Member ids are
+	// assigned in concurrent Start-call order, so resolve via the prompt.
+	firstID := fake.idForPrompt("do item-0")
+	if firstID == "" {
+		t.Fatal("no member started for item-0")
+	}
+	fake.finish(firstID, tools.SubagentResult{ID: firstID, Status: string(harness.RunStatusCompleted), Output: "first"})
+	waitForStartCount(t, fake, 4)
+
+	fake.release()
+	res := awaitSwarmRun(t, done)
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+	if res.report.Completed != 6 {
+		t.Fatalf("report Completed = %d, want 6", res.report.Completed)
+	}
+	if res.report.Members[0].Output != "first" {
+		t.Fatalf("member 0 Output = %q, want %q", res.report.Members[0].Output, "first")
+	}
+}
+
+func TestSwarmMaxConcurrencyEnvCap(t *testing.T) {
+	// Not parallel: t.Setenv forbids parallel tests.
+	t.Setenv(SwarmMaxConcurrencyEnv, "2")
+	fake := newFakeSwarmManager()
+	mt := newManualTicker()
+	swarm := NewSwarm(fake, withSwarmTickerFactory(manualTickerFactory(mt)))
+
+	done := runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(4),
+	})
+
+	// Env cap of 2 overrides the default initial ramp of 5.
+	waitForStartCount(t, fake, 2)
+
+	// Ticks must not grow the allowance past the env cap.
+	for i := 0; i < 3; i++ {
+		mt.tick()
+	}
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 2 {
+		t.Fatalf("in-flight after ticks with env cap 2 = %d, want 2", got)
+	}
+
+	fake.release()
+	res := awaitSwarmRun(t, done)
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+	if res.report.Completed != 4 {
+		t.Fatalf("report Completed = %d, want 4", res.report.Completed)
+	}
+}
+
+func TestSwarmCancellationCancelsAllMembers(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	mt := newManualTicker()
+	swarm := NewSwarm(fake, withSwarmTickerFactory(manualTickerFactory(mt)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runSwarmAsync(swarm, ctx, SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(6),
+	})
+
+	waitForStartCount(t, fake, 5)
+	cancel()
+
+	res := awaitSwarmRun(t, done)
+	if !errors.Is(res.err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", res.err)
+	}
+
+	// Every started member must be cancelled through the manager.
+	if got := fake.cancelCount(); got != 5 {
+		t.Fatalf("manager Cancel calls = %d, want 5 (one per started member)", got)
+	}
+
+	// Every member in the report must be in a terminal state; the member that
+	// never started is reported cancelled with no id.
+	if len(res.report.Members) != 6 {
+		t.Fatalf("report has %d members, want 6", len(res.report.Members))
+	}
+	for i, m := range res.report.Members {
+		if m.Status != string(harness.RunStatusCancelled) {
+			t.Errorf("member %d Status = %q, want cancelled", i, m.Status)
+		}
+		if i < 5 && m.ID == "" {
+			t.Errorf("started member %d has empty ID", i)
+		}
+	}
+	if res.report.Members[5].ID != "" {
+		t.Errorf("unstarted member ID = %q, want empty", res.report.Members[5].ID)
+	}
+	if res.report.Cancelled != 6 || res.report.Completed != 0 || res.report.Failed != 0 {
+		t.Fatalf("report counts = completed:%d failed:%d cancelled:%d, want 0/0/6",
+			res.report.Completed, res.report.Failed, res.report.Cancelled)
+	}
+}
+
+func TestSwarmMemberFailureDoesNotAbortCohort(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	mt := newManualTicker()
+	swarm := NewSwarm(fake, withSwarmTickerFactory(manualTickerFactory(mt)))
+
+	done := runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(3),
+	})
+
+	waitForStartCount(t, fake, 3)
+	failID := fake.idForPrompt("do item-1")
+	if failID == "" {
+		t.Fatal("no member started for item-1")
+	}
+	fake.finish(failID, tools.SubagentResult{ID: failID, Status: string(harness.RunStatusFailed), Error: "boom"})
+	fake.release()
+
+	res := awaitSwarmRun(t, done)
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil (member failures live in the report)", res.err)
+	}
+	if res.report.Completed != 2 || res.report.Failed != 1 {
+		t.Fatalf("report counts = completed:%d failed:%d, want 2/1", res.report.Completed, res.report.Failed)
+	}
+	failed := res.report.Members[1]
+	if failed.Status != string(harness.RunStatusFailed) || failed.Error != "boom" {
+		t.Fatalf("member 1 = status:%q error:%q, want failed/boom", failed.Status, failed.Error)
+	}
+	if res.report.Members[0].Status != string(harness.RunStatusCompleted) || res.report.Members[2].Status != string(harness.RunStatusCompleted) {
+		t.Fatalf("members 0 and 2 must complete, got %q and %q", res.report.Members[0].Status, res.report.Members[2].Status)
+	}
+}
+
+func TestSwarmMemberStartFailureIsCaptured(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.startErr = errors.New("start boom")
+	fake.startErrAt = 1
+	fake.release()
+	swarm := NewSwarm(fake)
+
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          swarmItems(3),
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil (start failures live in the report)", res.err)
+	}
+	if res.report.Completed != 2 || res.report.Failed != 1 {
+		t.Fatalf("report counts = completed:%d failed:%d, want 2/1", res.report.Completed, res.report.Failed)
+	}
+	// The second Start call fails; which item that is depends on concurrent
+	// start order, so assert the failure shape rather than the position.
+	failedCount := 0
+	for _, m := range res.report.Members {
+		if m.Status == string(harness.RunStatusFailed) {
+			failedCount++
+			if !strings.Contains(m.Error, "start boom") {
+				t.Fatalf("failed member Error = %q, want start boom", m.Error)
+			}
+			if m.ID != "" {
+				t.Fatalf("failed member ID = %q, want empty (never started)", m.ID)
+			}
+		}
+	}
+	if failedCount != 1 {
+		t.Fatalf("failed members = %d, want exactly 1", failedCount)
+	}
+}
+
+func TestSwarmRunWithInlineManager(t *testing.T) {
+	t.Parallel()
+
+	inlineRunner := newTestRunner(t.TempDir(), "inline done")
+	mgr, err := NewManager(Options{InlineRunner: inlineRunner})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	swarm := NewSwarm(NewInlineManager(mgr))
+
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "say {{item}}",
+		Items:          []string{"a", "b", "c"},
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+	if res.report.Completed != 3 || res.report.Failed != 0 {
+		t.Fatalf("report counts = completed:%d failed:%d, want 3/0", res.report.Completed, res.report.Failed)
+	}
+	for i, m := range res.report.Members {
+		if m.Status != string(harness.RunStatusCompleted) {
+			t.Errorf("member %d Status = %q, want completed", i, m.Status)
+		}
+		if m.Output != "inline done" {
+			t.Errorf("member %d Output = %q, want %q", i, m.Output, "inline done")
+		}
+		// The member must be a real subagent known to the manager.
+		sa, err := mgr.Get(context.Background(), m.ID)
+		if err != nil {
+			t.Errorf("manager Get(%q): %v", m.ID, err)
+			continue
+		}
+		if sa.Status != harness.RunStatusCompleted {
+			t.Errorf("manager status for member %d = %q, want completed", i, sa.Status)
+		}
+	}
+}


### PR DESCRIPTION
Parent epic: #808. Part of #803.

## Slice 1 of #808

Core `Swarm` type in `internal/subagents` that fans one prompt template over an items array and returns an aggregated report. Later slices (resume via `resume_agent_ids`, the `agent_swarm` deferred tool + sole-call rule, TUI panel) are intentionally not in this PR.

### What landed

- `internal/subagents/swarm.go`
  - `SwarmRequest{PromptTemplate, Items, ResumeAgentIDs (rejected until Slice 2), profile/model overrides}` with validation: `{{item}}` placeholder required, 1–128 items, distinct expanded prompts (compared trimmed, since the manager trims), resume rejected for now.
  - Members launch through the existing `tools.SubagentManager` (`InlineManager`).
  - Concurrency scheduler: 5 immediate starts, +1 in-flight allowance every 700ms, cap read once from `HARNESS_SWARM_MAX_CONCURRENCY` (default 128, clamped to 128); completions free slots immediately.
  - Caller context cancellation cancels every started member (members whose Start lands after the sweep self-cancel, closing the race); unstarted members are reported cancelled; Run returns the partial report with `ctx.Err()`.
  - `SwarmReport` with per-member ID, item, status, output/error in deterministic item order; member failures never abort the cohort.
- `internal/subagents/swarm_test.go` — TDD (tests written first, failed on undefined symbols): table-driven validation, ramp timing via injected manual ticker, env-cap, cancellation propagation, per-member failure capture, and an acceptance test through a real `Manager` + `InlineManager`.
- Plan doc `docs/plans/808-agent-swarm.md`, plans index entry, engineering-log entry.

### Verification

- `go test ./internal/subagents/ -count=1` — ok
- `go test ./internal/subagents/ -count=1 -race` — ok
- `go test ./internal/subagents/ -count=5 -run 'TestSwarm|TestResolveSwarm'` — ok (no flakes)
- `gofmt -l internal/subagents/`, `go vet ./internal/subagents/` — clean
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — PASS: `coveragegate: PASS (total=84.0%, min=80.0%, zero-functions=0)`

Note: an earlier regression run hit a load-dependent flake in `TestResponsesAPIStreamingErrorReturnsTypedFailure` (`internal/provider/openai`, untouched by this PR, zero dependency path); it passes in isolation on `main` and in this worktree, and the final full run is green.