### PR TITLE
feat(mcp): static HTTP headers and typed auth errors for MCP HTTP transport

### DIFF
--- a/cmd/harnessd/mcp_setup.go
+++ b/cmd/harnessd/mcp_setup.go
@@ -104,6 +104,7 @@ func registerMCPServersFromConfig(
 			Command:   srv.Command,
 			Args:      srv.Args,
 			URL:       srv.URL,
+			Headers:   srv.Headers,
 		}
 		if addErr := manager.AddServer(sc); addErr != nil {
 			logf("warning: failed to register TOML MCP server %q: %v", name, addErr)

--- a/cmd/harnessd/mcp_setup_test.go
+++ b/cmd/harnessd/mcp_setup_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"sort"
 	"testing"
+	"time"
 
 	"go-agent-harness/internal/config"
 	"go-agent-harness/internal/mcp"
@@ -200,5 +205,99 @@ func TestRegisterMCPServersFromConfig_EmptyBoth(t *testing.T) {
 	servers := manager.ListServers()
 	if len(servers) != 0 {
 		t.Fatalf("expected 0 servers, got %v", servers)
+	}
+}
+
+// bearerGatedMCPServer returns a mock MCP HTTP server that responds 401 unless
+// the request carries "Authorization: Bearer x", and otherwise speaks enough
+// JSON-RPC to initialize and list one tool.
+func bearerGatedMCPServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer x" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			Method string          `json:"method"`
+			ID     json.RawMessage `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		resp := map[string]any{"jsonrpc": "2.0", "id": req.ID}
+		switch req.Method {
+		case "initialize":
+			resp["result"] = map[string]any{
+				"protocolVersion": "2025-11-25",
+				"capabilities":    map[string]any{},
+				"serverInfo":      map[string]any{"name": "gated", "version": "1.0"},
+			}
+		case "tools/list":
+			resp["result"] = map[string]any{"tools": []map[string]any{
+				{"name": "gated-tool", "description": "A gated tool", "inputSchema": map[string]any{"type": "object"}},
+			}}
+		default:
+			resp["error"] = map[string]any{"code": -32601, "message": "method not found"}
+		}
+		data, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+}
+
+// TestRegisterMCPServersFromConfig_TOMLHeadersPassedThrough verifies that
+// headers from a TOML [mcp_servers.*] entry are wired into the registered
+// mcp.ServerConfig: a bearer-gated HTTP server registered via
+// registerMCPServersFromConfig is reachable end to end.
+func TestRegisterMCPServersFromConfig_TOMLHeadersPassedThrough(t *testing.T) {
+	srv := bearerGatedMCPServer(t)
+	defer srv.Close()
+
+	manager := mcp.NewClientManager()
+	defer manager.Close()
+
+	toml := map[string]config.MCPServerConfig{
+		"gated": {
+			Transport: "http",
+			URL:       srv.URL,
+			Headers:   map[string]string{"Authorization": "Bearer x"},
+		},
+	}
+	registerMCPServersFromConfig(manager, toml, nil, func(string, ...any) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tools, err := manager.DiscoverTools(ctx, "gated")
+	if err != nil {
+		t.Fatalf("DiscoverTools with TOML-configured headers: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "gated-tool" {
+		t.Fatalf("unexpected tools: %v", tools)
+	}
+}
+
+// TestRegisterMCPServersFromConfig_TOMLWithoutHeaders_Gets401 is the negative
+// companion: the same gated server registered without headers fails, proving
+// the pass-through above (not the mock) is what authorized the request.
+func TestRegisterMCPServersFromConfig_TOMLWithoutHeaders_Gets401(t *testing.T) {
+	srv := bearerGatedMCPServer(t)
+	defer srv.Close()
+
+	manager := mcp.NewClientManager()
+	defer manager.Close()
+
+	toml := map[string]config.MCPServerConfig{
+		"gated": {Transport: "http", URL: srv.URL},
+	}
+	registerMCPServersFromConfig(manager, toml, nil, func(string, ...any) {})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := manager.DiscoverTools(ctx, "gated"); err == nil {
+		t.Fatal("expected 401 error without configured headers, got nil")
 	}
 }

--- a/docs/plans/809-mcp-oauth.md
+++ b/docs/plans/809-mcp-oauth.md
@@ -1,0 +1,53 @@
+# Plan: MCP HTTP static headers and typed auth errors (epic #809, slice 1)
+
+## Context
+
+- Problem: the MCP HTTP transport (`internal/mcp/http_conn.go`) sends no credentials — `ServerConfig` has no header support, and any non-2xx response (including 401/403) collapses into a generic error string, so auth failures are indistinguishable from other failures.
+- User impact: no way to use an OAuth-protected (or static-bearer) remote MCP server at all; no actionable error on auth failure.
+- Constraints: slice 1 of epic #809 only — static headers + typed 401/403 errors. OAuth flow, token store, CLI login, and docs slices are out of scope. No new third-party dependencies.
+
+## Scope
+
+- In scope:
+  - `Headers map[string]string` on `mcp.ServerConfig` (`internal/mcp/mcp.go`).
+  - `headers` in TOML `MCPServerConfig` (`internal/config/config.go`) and pass-through in `cmd/harnessd/mcp_setup.go`.
+  - `headers` key in `HARNESS_MCP_SERVERS` JSON parsing (`internal/mcp/config.go`).
+  - Header injection in `httpConn.sendRequest` (`internal/mcp/http_conn.go`).
+  - Sentinel errors `ErrUnauthorized` / `ErrForbidden` returned (wrapped, `errors.Is`-compatible) on 401/403; other non-2xx handling unchanged.
+- Out of scope: OAuth 2.1 flow, token store, `harnesscli mcp login`, SSE legacy transport, per-run `MCPServerConfig` in `internal/harness/scoped_mcp.go` (separate type; not cited by the slice).
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none in this slice (docs are slice 5).
+- Spec docs to update before code: none.
+- Implementation notes to add after code: none beyond this plan and the folder index.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `internal/mcp/http_conn_test.go`: headers attached on initialize/list/call; table-driven 401→`ErrUnauthorized`, 403→`ErrForbidden`, other non-2xx unchanged; end-to-end bearer-gated mock server reachable via config; typed error survives `ClientManager` wrapping (`errors.Is`).
+  - `internal/mcp/config_test.go`: env JSON `headers` round-trip.
+  - `internal/config/config_test.go`: TOML `[mcp_servers.*.headers]` decode.
+  - `cmd/harnessd/mcp_setup_test.go`: TOML headers passed through (behavioral: register via `registerMCPServersFromConfig` against a bearer-gated mock server, DiscoverTools succeeds).
+- Existing tests to update: none.
+- Regression tests required: covered by the new tests above.
+
+## Cross-Surface Impact Map
+
+- Not a provider/model flow change — impact map not required. Touches config schema additively (`headers` key only), no server API or TUI state changes.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first; verify they fail for the right reason.
+- [x] Implement minimal code changes (5 files listed above).
+- [x] gofmt + go vet clean.
+- [x] Run `go test ./internal/mcp/... ./internal/config/... ./cmd/harnessd/... -count=1`.
+- [x] Update `docs/plans/INDEX.md`.
+- [ ] Commit, push `epic/809-mcp-oauth`, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: configured headers overriding protocol headers (`Content-Type`, `Accept`) could break the transport.
+- Mitigation: apply protocol headers first, then configured headers via `Header.Set`, so explicit user config wins predictably; document the behavior in the struct comment.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -7,6 +7,7 @@
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
+- `809-mcp-oauth.md` — Epic #809 slice 1: static HTTP headers and typed auth errors for the MCP HTTP transport (in implementation).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,14 @@ type HooksConfig struct {
 //	[mcp_servers.remote-tool]
 //	transport = "http"
 //	url = "http://localhost:3001/mcp"
+//
+// Example TOML (http with static headers, e.g. bearer auth):
+//
+//	[mcp_servers.authed-tool]
+//	transport = "http"
+//	url = "https://mcp.example.com/mcp"
+//	[mcp_servers.authed-tool.headers]
+//	Authorization = "Bearer <token>"
 type MCPServerConfig struct {
 	// Transport must be "stdio" or "http".
 	Transport string `toml:"transport"`
@@ -168,6 +176,10 @@ type MCPServerConfig struct {
 
 	// HTTP transport: the MCP server endpoint URL.
 	URL string `toml:"url"`
+
+	// HTTP transport: static headers sent with every request, e.g.
+	// "Authorization" = "Bearer <token>". Ignored on the stdio transport.
+	Headers map[string]string `toml:"headers"`
 }
 
 // CronConfig holds cron scheduler configuration.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1000,3 +1000,103 @@ dirs = ["/project-hooks"]
 		t.Errorf("Hooks.Dirs: got %v, want project layer override", cfg.Hooks.Dirs)
 	}
 }
+
+// TestMCPServerHeadersLoadedFromTOML verifies that a [mcp_servers.*.headers]
+// table in TOML is decoded into MCPServerConfig.Headers.
+func TestMCPServerHeadersLoadedFromTOML(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[mcp_servers.authed]
+transport = "http"
+url = "https://mcp.example.com/mcp"
+
+[mcp_servers.authed.headers]
+Authorization = "Bearer secret-token"
+X-Tenant = "acme"
+
+[mcp_servers.plain]
+transport = "http"
+url = "http://localhost:3001/mcp"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := config.LoadOptions{
+		UserConfigPath: cfgPath,
+		Getenv:         func(string) string { return "" },
+	}
+	result, err := config.Load(opts)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	authed, ok := result.MCPServers["authed"]
+	if !ok {
+		t.Fatal("MCPServers: missing key \"authed\"")
+	}
+	if len(authed.Headers) != 2 {
+		t.Fatalf("authed.Headers: got %d entries, want 2 (%v)", len(authed.Headers), authed.Headers)
+	}
+	if got := authed.Headers["Authorization"]; got != "Bearer secret-token" {
+		t.Errorf("authed.Headers[Authorization]: got %q, want %q", got, "Bearer secret-token")
+	}
+	if got := authed.Headers["X-Tenant"]; got != "acme" {
+		t.Errorf("authed.Headers[X-Tenant]: got %q, want %q", got, "acme")
+	}
+
+	plain, ok := result.MCPServers["plain"]
+	if !ok {
+		t.Fatal("MCPServers: missing key \"plain\"")
+	}
+	if len(plain.Headers) != 0 {
+		t.Errorf("plain.Headers: got %v, want empty when no headers table present", plain.Headers)
+	}
+}
+
+// TestMCPServerHeadersLayerOverride verifies that a higher-priority config
+// layer can replace a server's headers wholesale.
+func TestMCPServerHeadersLayerOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	userConfig := filepath.Join(tmpDir, "user.toml")
+	projectConfig := filepath.Join(tmpDir, "project.toml")
+
+	if err := os.WriteFile(userConfig, []byte(`
+[mcp_servers.authed]
+transport = "http"
+url = "https://mcp.example.com/mcp"
+
+[mcp_servers.authed.headers]
+Authorization = "Bearer user-token"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(projectConfig, []byte(`
+[mcp_servers.authed]
+transport = "http"
+url = "https://mcp.example.com/mcp"
+
+[mcp_servers.authed.headers]
+Authorization = "Bearer project-token"
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := config.LoadOptions{
+		UserConfigPath:    userConfig,
+		ProjectConfigPath: projectConfig,
+		Getenv:            func(string) string { return "" },
+	}
+	result, err := config.Load(opts)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	authed, ok := result.MCPServers["authed"]
+	if !ok {
+		t.Fatal("MCPServers: missing key \"authed\"")
+	}
+	if got := authed.Headers["Authorization"]; got != "Bearer project-token" {
+		t.Errorf("authed.Headers[Authorization]: got %q, want project-layer value %q", got, "Bearer project-token")
+	}
+}

--- a/internal/mcp/config.go
+++ b/internal/mcp/config.go
@@ -76,11 +76,12 @@ func parseMCPServersJSON(raw string) ([]ServerConfig, error) {
 // inferring the Transport field when it is not explicitly set.
 func parseSingleServerConfig(raw json.RawMessage) (ServerConfig, error) {
 	var obj struct {
-		Name      string   `json:"name"`
-		Transport string   `json:"transport"`
-		Command   string   `json:"command"`
-		Args      []string `json:"args"`
-		URL       string   `json:"url"`
+		Name      string            `json:"name"`
+		Transport string            `json:"transport"`
+		Command   string            `json:"command"`
+		Args      []string          `json:"args"`
+		URL       string            `json:"url"`
+		Headers   map[string]string `json:"headers"`
 	}
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return ServerConfig{}, fmt.Errorf("invalid JSON object: %w", err)
@@ -92,6 +93,7 @@ func parseSingleServerConfig(raw json.RawMessage) (ServerConfig, error) {
 		Command:   strings.TrimSpace(obj.Command),
 		Args:      obj.Args,
 		URL:       strings.TrimSpace(obj.URL),
+		Headers:   obj.Headers,
 	}
 
 	// Infer transport when not explicitly set.

--- a/internal/mcp/config_test.go
+++ b/internal/mcp/config_test.go
@@ -624,3 +624,87 @@ func TestParseMCPServersEnv_HTTPTestServer(t *testing.T) {
 		t.Fatalf("expected 1 server registered, got %d", len(servers))
 	}
 }
+
+// TestParseMCPServersEnv_HeadersRoundTrip verifies that the "headers" key in
+// HARNESS_MCP_SERVERS JSON entries is parsed into ServerConfig.Headers.
+func TestParseMCPServersEnv_HeadersRoundTrip(t *testing.T) {
+	raw := `[
+		{
+			"name": "authed-http",
+			"transport": "http",
+			"url": "http://localhost:9999/mcp",
+			"headers": {"Authorization": "Bearer tok-123", "X-Tenant": "acme"}
+		},
+		{
+			"name": "plain-http",
+			"transport": "http",
+			"url": "http://localhost:9998/mcp"
+		}
+	]`
+	configs, err := ParseMCPServersEnvWith(func(key string) string {
+		if key == EnvVarMCPServers {
+			return raw
+		}
+		return ""
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 configs, got %d", len(configs))
+	}
+
+	authed := configs[0]
+	if authed.Name != "authed-http" {
+		t.Fatalf("unexpected first config: %+v", authed)
+	}
+	if len(authed.Headers) != 2 {
+		t.Fatalf("Headers: got %d entries, want 2 (%v)", len(authed.Headers), authed.Headers)
+	}
+	if got := authed.Headers["Authorization"]; got != "Bearer tok-123" {
+		t.Errorf("Headers[Authorization] = %q, want %q", got, "Bearer tok-123")
+	}
+	if got := authed.Headers["X-Tenant"]; got != "acme" {
+		t.Errorf("Headers[X-Tenant] = %q, want %q", got, "acme")
+	}
+
+	plain := configs[1]
+	if plain.Name != "plain-http" {
+		t.Fatalf("unexpected second config: %+v", plain)
+	}
+	if len(plain.Headers) != 0 {
+		t.Errorf("Headers: got %v, want empty for server without headers key", plain.Headers)
+	}
+}
+
+// TestParseMCPServersEnv_HeadersWrongType_Skipped verifies that an entry whose
+// "headers" value is not a JSON object of strings is skipped as invalid while
+// valid sibling entries still load.
+func TestParseMCPServersEnv_HeadersWrongType_Skipped(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"headers as string", `{"name":"bad","url":"http://x/mcp","headers":"Bearer tok"}`},
+		{"headers as array", `{"name":"bad","url":"http://x/mcp","headers":["Authorization: Bearer tok"]}`},
+		{"headers with non-string value", `{"name":"bad","url":"http://x/mcp","headers":{"Authorization":42}}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			raw := `[` + tc.raw + `,{"name":"good","url":"http://y/mcp"}]`
+			configs, err := ParseMCPServersEnvWith(func(key string) string {
+				if key == EnvVarMCPServers {
+					return raw
+				}
+				return ""
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(configs) != 1 || configs[0].Name != "good" {
+				t.Fatalf("expected only the valid entry to load, got %+v", configs)
+			}
+		})
+	}
+}

--- a/internal/mcp/http_conn.go
+++ b/internal/mcp/http_conn.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,11 +16,24 @@ import (
 	"time"
 )
 
+// Sentinel errors for MCP HTTP transport authentication failures. They are
+// wrapped (see %w) in the returned error, so callers can use errors.Is to
+// distinguish an auth failure from other transport or protocol errors.
+var (
+	// ErrUnauthorized is returned when the server responds with HTTP 401,
+	// meaning the request lacked valid authentication credentials.
+	ErrUnauthorized = errors.New("mcp: unauthorized (authentication required)")
+	// ErrForbidden is returned when the server responds with HTTP 403,
+	// meaning the presented credentials were rejected or lack permission.
+	ErrForbidden = errors.New("mcp: forbidden (access denied)")
+)
+
 // httpConn implements Conn over HTTP using JSON-RPC 2.0.
 // It supports both application/json and text/event-stream (SSE) responses.
 type httpConn struct {
 	name     string
 	endpoint string
+	headers  map[string]string
 	client   *http.Client
 
 	idCounter         atomic.Int64
@@ -44,6 +58,7 @@ func dialHTTP(cfg ServerConfig) (Conn, error) {
 	return &httpConn{
 		name:     cfg.Name,
 		endpoint: cfg.URL,
+		headers:  cfg.Headers,
 		client:   &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
@@ -200,6 +215,11 @@ func (c *httpConn) sendRequest(ctx context.Context, method string, params any) (
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	// Apply configured static headers after the protocol headers so an
+	// explicitly configured value wins on collision.
+	for k, v := range c.headers {
+		httpReq.Header.Set(k, v)
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -208,6 +228,12 @@ func (c *httpConn) sendRequest(ctx context.Context, method string, params any) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		switch resp.StatusCode {
+		case http.StatusUnauthorized:
+			return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s: %w", c.name, resp.StatusCode, resp.Status, ErrUnauthorized)
+		case http.StatusForbidden:
+			return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s: %w", c.name, resp.StatusCode, resp.Status, ErrForbidden)
+		}
 		return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s", c.name, resp.StatusCode, resp.Status)
 	}
 

--- a/internal/mcp/http_conn_test.go
+++ b/internal/mcp/http_conn_test.go
@@ -3,6 +3,7 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -807,5 +808,344 @@ func TestClientManager_HTTP_ConcurrentDiscoverAndExecute_Race(t *testing.T) {
 		if err != nil {
 			t.Errorf("concurrent operation error: %v", err)
 		}
+	}
+}
+
+// --- Slice 1 (epic #809): static headers and typed auth errors ---
+
+// headerRecordingServer is a mock MCP HTTP server that records the headers of
+// every request, keyed by JSON-RPC method, and optionally requires a specific
+// Authorization header value (responding 401 otherwise).
+type headerRecordingServer struct {
+	t *testing.T
+
+	mu          sync.Mutex
+	gotHeaders  map[string]http.Header // method -> headers of last request
+	requireAuth string                 // if non-empty, required Authorization header value
+}
+
+func newHeaderRecordingServer(t *testing.T, requireAuth string) (*httptest.Server, *headerRecordingServer) {
+	t.Helper()
+	rec := &headerRecordingServer{t: t, gotHeaders: make(map[string]http.Header), requireAuth: requireAuth}
+	srv := httptest.NewServer(http.HandlerFunc(rec.serve))
+	return srv, rec
+}
+
+func (rec *headerRecordingServer) serve(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Method string          `json:"method"`
+		ID     json.RawMessage `json:"id"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	rec.mu.Lock()
+	rec.gotHeaders[req.Method] = r.Header.Clone()
+	rec.mu.Unlock()
+
+	if rec.requireAuth != "" && r.Header.Get("Authorization") != rec.requireAuth {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+	}
+	switch req.Method {
+	case "initialize":
+		resp["result"] = map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"serverInfo":      map[string]any{"name": "rec", "version": "1.0"},
+		}
+	case "tools/list":
+		resp["result"] = map[string]any{"tools": []map[string]any{
+			{"name": "ping", "description": "Ping", "inputSchema": map[string]any{"type": "object"}},
+		}}
+	case "tools/call":
+		resp["result"] = map[string]any{
+			"content": []map[string]any{{"type": "text", "text": `{"ok":true}`}},
+		}
+	default:
+		resp["error"] = map[string]any{"code": -32601, "message": "method not found"}
+	}
+
+	data, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(data)
+}
+
+func (rec *headerRecordingServer) headerForMethod(method, key string) string {
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return rec.gotHeaders[method].Get(key)
+}
+
+// TestHTTPConn_HeadersAttachedToEveryRequest verifies that every configured
+// static header is sent on initialize, tools/list, and tools/call requests.
+func TestHTTPConn_HeadersAttachedToEveryRequest(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := newHeaderRecordingServer(t, "")
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "hdr-test",
+		Transport: "http",
+		URL:       srv.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer static-token",
+			"X-Tenant":      "acme",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := conn.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if _, err := conn.ListTools(ctx); err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if _, err := conn.CallTool(ctx, "ping", json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	for _, method := range []string{"initialize", "tools/list", "tools/call"} {
+		if got := rec.headerForMethod(method, "Authorization"); got != "Bearer static-token" {
+			t.Errorf("%s: Authorization header = %q, want %q", method, got, "Bearer static-token")
+		}
+		if got := rec.headerForMethod(method, "X-Tenant"); got != "acme" {
+			t.Errorf("%s: X-Tenant header = %q, want %q", method, got, "acme")
+		}
+		// Protocol headers must remain intact when custom headers are set.
+		if got := rec.headerForMethod(method, "Content-Type"); got != "application/json" {
+			t.Errorf("%s: Content-Type header = %q, want %q", method, got, "application/json")
+		}
+	}
+}
+
+// TestHTTPConn_NoHeadersConfigured_SendsNoAuthorization verifies the zero
+// value behavior: no Authorization header is sent when none is configured.
+func TestHTTPConn_NoHeadersConfigured_SendsNoAuthorization(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := newHeaderRecordingServer(t, "")
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "no-hdr",
+		Transport: "http",
+		URL:       srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := conn.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := rec.headerForMethod("initialize", "Authorization"); got != "" {
+		t.Errorf("Authorization header = %q, want empty", got)
+	}
+}
+
+// TestHTTPConn_TypedAuthErrors verifies that 401 and 403 responses map to the
+// exported sentinel errors (errors.Is-compatible) while other non-2xx
+// statuses keep the existing generic error behavior.
+func TestHTTPConn_TypedAuthErrors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		status       int
+		sentinel     error // nil means no auth sentinel expected
+		wantContains string
+	}{
+		{"401 maps to ErrUnauthorized", http.StatusUnauthorized, mcp.ErrUnauthorized, "401"},
+		{"403 maps to ErrForbidden", http.StatusForbidden, mcp.ErrForbidden, "403"},
+		{"400 stays generic", http.StatusBadRequest, nil, "400"},
+		{"500 stays generic", http.StatusInternalServerError, nil, "500"},
+		{"503 stays generic", http.StatusServiceUnavailable, nil, "503"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newMockMCPHTTPServer(t, mockHTTPMCPServerOpts{non2xxStatus: tc.status})
+			defer srv.Close()
+
+			conn := mcp.NewHTTPConnForTest("typed-err", srv.URL)
+			defer conn.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			err := conn.Initialize(ctx)
+			if err == nil {
+				t.Fatalf("expected error from %d response, got nil", tc.status)
+			}
+
+			if tc.sentinel != nil {
+				if !errors.Is(err, tc.sentinel) {
+					t.Errorf("errors.Is(err, %v) = false for error %q", tc.sentinel, err.Error())
+				}
+			} else {
+				if errors.Is(err, mcp.ErrUnauthorized) {
+					t.Errorf("errors.Is(err, ErrUnauthorized) = true for %d, want false", tc.status)
+				}
+				if errors.Is(err, mcp.ErrForbidden) {
+					t.Errorf("errors.Is(err, ErrForbidden) = true for %d, want false", tc.status)
+				}
+			}
+
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Errorf("error %q does not contain status %q", err.Error(), tc.wantContains)
+			}
+		})
+	}
+}
+
+// TestHTTPConn_CallTool_TypedAuthError verifies the typed auth error also
+// surfaces from tools/call, not just initialize.
+func TestHTTPConn_CallTool_TypedAuthError(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockMCPHTTPServer(t, mockHTTPMCPServerOpts{non2xxStatus: http.StatusUnauthorized})
+	defer srv.Close()
+
+	conn := mcp.NewHTTPConnForTest("call-typed", srv.URL)
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := conn.CallTool(ctx, "anything", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error from 401 response, got nil")
+	}
+	if !errors.Is(err, mcp.ErrUnauthorized) {
+		t.Errorf("errors.Is(err, ErrUnauthorized) = false for error %q", err.Error())
+	}
+}
+
+// TestClientManager_HTTP_TypedAuthErrorSurfaced verifies that the typed 401
+// error survives the ClientManager's error wrapping so callers of
+// DiscoverTools/ExecuteTool can distinguish auth failures with errors.Is.
+func TestClientManager_HTTP_TypedAuthErrorSurfaced(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockMCPHTTPServer(t, mockHTTPMCPServerOpts{non2xxStatus: http.StatusUnauthorized})
+	defer srv.Close()
+
+	cm := mcp.NewClientManager()
+	defer cm.Close()
+
+	if err := cm.AddServer(mcp.ServerConfig{
+		Name:      "authed",
+		Transport: "http",
+		URL:       srv.URL,
+	}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cm.DiscoverTools(ctx, "authed")
+	if err == nil {
+		t.Fatal("expected error from 401 server, got nil")
+	}
+	if !errors.Is(err, mcp.ErrUnauthorized) {
+		t.Errorf("errors.Is(err, ErrUnauthorized) = false through ClientManager for error %q", err.Error())
+	}
+}
+
+// TestClientManager_HTTP_BearerGatedServer_ReachableViaConfig is the slice
+// acceptance test: a mock HTTP MCP server requiring "Authorization: Bearer x"
+// is reachable purely via ServerConfig headers — both DiscoverTools and
+// ExecuteTool succeed.
+func TestClientManager_HTTP_BearerGatedServer_ReachableViaConfig(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newHeaderRecordingServer(t, "Bearer x")
+	defer srv.Close()
+
+	cm := mcp.NewClientManager()
+	defer cm.Close()
+
+	if err := cm.AddServer(mcp.ServerConfig{
+		Name:      "gated",
+		Transport: "http",
+		URL:       srv.URL,
+		Headers:   map[string]string{"Authorization": "Bearer x"},
+	}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tools, err := cm.DiscoverTools(ctx, "gated")
+	if err != nil {
+		t.Fatalf("DiscoverTools against bearer-gated server: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "ping" {
+		t.Fatalf("unexpected tools from gated server: %v", tools)
+	}
+
+	result, err := cm.ExecuteTool(ctx, "gated", "ping", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("ExecuteTool against bearer-gated server: %v", err)
+	}
+	if !strings.Contains(result, "ok") {
+		t.Errorf("expected 'ok' in tool result, got %q", result)
+	}
+}
+
+// TestClientManager_HTTP_BearerGatedServer_WithoutHeaders_Unauthorized is the
+// negative companion: the same gated server without configured headers fails
+// with the typed ErrUnauthorized.
+func TestClientManager_HTTP_BearerGatedServer_WithoutHeaders_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv, _ := newHeaderRecordingServer(t, "Bearer x")
+	defer srv.Close()
+
+	cm := mcp.NewClientManager()
+	defer cm.Close()
+
+	if err := cm.AddServer(mcp.ServerConfig{
+		Name:      "gated-no-auth",
+		Transport: "http",
+		URL:       srv.URL,
+	}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := cm.DiscoverTools(ctx, "gated-no-auth")
+	if err == nil {
+		t.Fatal("expected error against bearer-gated server without headers, got nil")
+	}
+	if !errors.Is(err, mcp.ErrUnauthorized) {
+		t.Errorf("errors.Is(err, ErrUnauthorized) = false for error %q", err.Error())
 	}
 }

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -50,6 +50,12 @@ type ServerConfig struct {
 
 	// HTTP transport field.
 	URL string // HTTP endpoint, e.g. "http://localhost:3000/mcp"
+
+	// Headers are static HTTP headers sent with every request on the http
+	// transport (e.g. "Authorization": "Bearer <token>"). They are applied
+	// after the transport's own protocol headers, so an explicitly configured
+	// header wins on collision. Ignored on the stdio transport.
+	Headers map[string]string
 }
 
 // Conn represents an active connection to an MCP server.


### PR DESCRIPTION
Parent epic: #809. Part of #803.

## What

Slice 1 of epic #809 (OAuth login flow for remote MCP servers):

- `Headers map[string]string` added to `mcp.ServerConfig` (`internal/mcp/mcp.go`) and TOML `MCPServerConfig` (`internal/config/config.go`); passed through in `cmd/harnessd/mcp_setup.go`.
- `headers` key accepted in `HARNESS_MCP_SERVERS` JSON entries (`internal/mcp/config.go`).
- `httpConn.sendRequest` attaches configured headers to every request (applied after protocol headers so explicit config wins).
- HTTP 401/403 now return errors wrapping the exported sentinels `mcp.ErrUnauthorized` / `mcp.ErrForbidden` (`errors.Is`-compatible, preserved through `ClientManager` wrapping); other non-2xx handling unchanged.

## Tests (TDD — written first, verified failing, then implemented)

- Header attachment on initialize/tools-list/tools-call; zero-value behavior unchanged.
- Table-driven 401→`ErrUnauthorized`, 403→`ErrForbidden`, 400/500/503 stay generic; typed error surfaced through `ClientManager`.
- Acceptance: bearer-gated mock MCP server reachable purely via config (with and without headers).
- TOML `[mcp_servers.*.headers]` decode + layer override; env JSON `headers` round-trip + wrong-type skip; harnessd TOML pass-through.

## Verification

- `go test ./internal/mcp/... ./internal/config/... ./cmd/harnessd/... -count=1` — all ok.
- `go test ./internal/mcp/... ./cmd/harnessd/... ./internal/config/... -count=1 -race` — all ok.
- `gofmt`/`go vet` clean.
- `./scripts/test-regression.sh`: the three failures seen across two full runs (`TestGetProviders_ReflectsOverride`, `TestRunWithSignalsObservationalMemoryFallsBackToOpenAIAPIKey`, `TestWorkerPool_RunQueuedEventEmitted`, `TestRetryBudgetReturnsFinalResponse`) are timing flakes under full-suite load in packages this diff does not touch — each passes individually with `-race` in this worktree, and the worker-pool one is already documented as a full-suite flake in `docs/logs/engineering-log.md`.

Not merged; sibling slices build on this branch.