### PR TITLE
feat(harnesscli): steer client plumbing — steerRunCmd + harnesscli steer subcommand

### DIFF
--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -207,6 +207,8 @@ func dispatch(args []string) int {
 		return runList(args[1:])
 	case "cancel":
 		return runCancel(args[1:])
+	case "steer":
+		return runSteer(args[1:])
 	case "status":
 		return runStatus(args[1:])
 	case "show":

--- a/cmd/harnesscli/runctl.go
+++ b/cmd/harnesscli/runctl.go
@@ -169,6 +169,82 @@ func runCancel(args []string) int {
 	return 0
 }
 
+// runSteer implements "harnesscli steer <run-id> <prompt>".
+// Sends POST /v1/runs/{id}/steer to inject a steering message into the active
+// run. The server queues the message and the harness delivers it to the agent
+// as a user message at the next step boundary; the run keeps going. Empty or
+// whitespace-only prompts are rejected client-side before any request is sent.
+func runSteer(args []string) int {
+	fs := flag.NewFlagSet("steer", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "harnesscli steer: %v\n", err)
+		return 1
+	}
+
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "harnesscli steer: run ID is required")
+		return 1
+	}
+	if fs.NArg() < 2 {
+		fmt.Fprintln(stderr, "harnesscli steer: prompt is required")
+		return 1
+	}
+	runID := fs.Arg(0)
+	prompt := strings.TrimSpace(strings.Join(fs.Args()[1:], " "))
+	if prompt == "" {
+		fmt.Fprintln(stderr, "harnesscli steer: prompt is required")
+		return 1
+	}
+
+	body, err := json.Marshal(map[string]string{"prompt": prompt})
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli steer: encode request: %v\n", err)
+		return 1
+	}
+	endpoint := strings.TrimRight(*baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/steer"
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli steer: build request: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := requestHTTPClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli steer: request failed: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli steer: read response: %v\n", err)
+		return 1
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		fmt.Fprintf(stderr, "harnesscli steer: run %q not found\n", runID)
+		return 1
+	case http.StatusConflict:
+		fmt.Fprintf(stderr, "harnesscli steer: run %q is not active (already finished?)\n", runID)
+		return 1
+	case http.StatusTooManyRequests:
+		fmt.Fprintf(stderr, "harnesscli steer: steering buffer full for run %q — try again shortly\n", runID)
+		return 1
+	}
+	if resp.StatusCode >= 300 {
+		fmt.Fprintf(stderr, "harnesscli steer: %v\n", formatAPIError(resp.StatusCode, respBody))
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Run %s steering accepted\n", runID)
+	return 0
+}
+
 // runStatus implements "harnesscli status <run-id>".
 // Sends GET /v1/runs/{id} and prints run details.
 func runStatus(args []string) int {

--- a/cmd/harnesscli/runctl_test.go
+++ b/cmd/harnesscli/runctl_test.go
@@ -808,3 +808,212 @@ func TestDispatch_DailyAliasesRouted(t *testing.T) {
 		t.Fatalf("dispatch show returned %d", code)
 	}
 }
+
+// --- BT-010: steer posts prompt to /v1/runs/{id}/steer and confirms ---
+
+// TestRunSteer_Success verifies the one-shot steer path: POST to
+// /v1/runs/{id}/steer with JSON body {"prompt": ...}, and a confirmation on
+// stdout when the server answers 202.
+func TestRunSteer_Success(t *testing.T) {
+	var gotMethod, gotPath, gotPrompt, gotContentType string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		var body map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode steer body: %v", err)
+		}
+		gotPrompt = body["prompt"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(w, `{"status":"accepted"}`)
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runSteer([]string{"-base-url=" + ts.URL, "run_xyz", "focus on", "tests"})
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%s)", code, errBuf.String())
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/runs/run_xyz/steer" {
+		t.Errorf("path = %q, want /v1/runs/run_xyz/steer", gotPath)
+	}
+	if gotPrompt != "focus on tests" {
+		t.Errorf("prompt = %q, want %q (positional args joined with spaces)", gotPrompt, "focus on tests")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if !strings.Contains(outBuf.String(), "run_xyz") || !strings.Contains(outBuf.String(), "steer") {
+		t.Errorf("expected confirmation naming the run and steering, got: %s", outBuf.String())
+	}
+}
+
+// TestRunSteer_MissingArgs verifies usage errors: no run ID, and run ID with
+// no prompt, both exit 1 with a clear message and no HTTP request.
+func TestRunSteer_MissingArgs(t *testing.T) {
+	t.Run("no run id", func(t *testing.T) {
+		_, errBuf, restore := captureOutput(t)
+		defer restore()
+
+		code := runSteer([]string{})
+		if code != 1 {
+			t.Fatalf("expected exit code 1 for missing run ID, got %d", code)
+		}
+		if !strings.Contains(errBuf.String(), "run ID") {
+			t.Errorf("expected usage error about run ID, got: %s", errBuf.String())
+		}
+	})
+
+	t.Run("no prompt", func(t *testing.T) {
+		var calls int32
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		defer ts.Close()
+
+		_, errBuf, restore := captureOutput(t)
+		defer restore()
+
+		origClient := requestHTTPClient
+		requestHTTPClient = ts.Client()
+		defer func() { requestHTTPClient = origClient }()
+
+		code := runSteer([]string{"-base-url=" + ts.URL, "run_xyz"})
+		if code != 1 {
+			t.Fatalf("expected exit code 1 for missing prompt, got %d", code)
+		}
+		if !strings.Contains(errBuf.String(), "prompt") {
+			t.Errorf("expected usage error about prompt, got: %s", errBuf.String())
+		}
+		if calls != 0 {
+			t.Errorf("server received %d request(s); want 0 for missing prompt", calls)
+		}
+	})
+}
+
+// TestRunSteer_RejectsWhitespacePrompt verifies a whitespace-only prompt is
+// rejected client-side before any HTTP request is issued (the server contract
+// is 400 invalid_request; the client must not send it).
+func TestRunSteer_RejectsWhitespacePrompt(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer ts.Close()
+
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	code := runSteer([]string{"-base-url=" + ts.URL, "run_xyz", "   "})
+	if code != 1 {
+		t.Fatalf("expected exit code 1 for whitespace prompt, got %d", code)
+	}
+	if !strings.Contains(errBuf.String(), "prompt") {
+		t.Errorf("expected error about prompt, got: %s", errBuf.String())
+	}
+	if calls != 0 {
+		t.Errorf("server received %d request(s); want 0 for whitespace prompt", calls)
+	}
+}
+
+// TestRunSteer_ErrorStatuses verifies the documented steer failure statuses
+// surface as clear stderr messages with exit code 1.
+func TestRunSteer_ErrorStatuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantText string
+	}{
+		{"not found", http.StatusNotFound, `{"error":{"code":"not_found","message":"run \"run_nope\" not found"}}`, "not found"},
+		{"run not active", http.StatusConflict, `{"error":{"code":"run_not_active","message":"run \"run_done\" is not active"}}`, "not active"},
+		{"buffer full", http.StatusTooManyRequests, `{"error":{"code":"steering_buffer_full","message":"steering buffer full"}}`, "buffer full"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer ts.Close()
+
+			_, errBuf, restore := captureOutput(t)
+			defer restore()
+
+			origClient := requestHTTPClient
+			requestHTTPClient = ts.Client()
+			defer func() { requestHTTPClient = origClient }()
+
+			code := runSteer([]string{"-base-url=" + ts.URL, "run_xyz", "focus"})
+			if code != 1 {
+				t.Fatalf("expected exit code 1 for HTTP %d, got %d", tc.status, code)
+			}
+			if !strings.Contains(errBuf.String(), tc.wantText) {
+				t.Errorf("expected stderr to contain %q, got: %s", tc.wantText, errBuf.String())
+			}
+		})
+	}
+}
+
+// TestRunSteer_PathEscapesRunID mirrors the cancel path-traversal regression:
+// a "/" in the run ID must be percent-encoded on the wire.
+func TestRunSteer_PathEscapesRunID(t *testing.T) {
+	var capturedRawPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRawPath = r.URL.RawPath
+		if capturedRawPath == "" {
+			capturedRawPath = r.URL.Path
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = io.WriteString(w, `{"status":"accepted"}`)
+	}))
+	defer ts.Close()
+
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	origClient := requestHTTPClient
+	requestHTTPClient = ts.Client()
+	defer func() { requestHTTPClient = origClient }()
+
+	runSteer([]string{"-base-url=" + ts.URL, "../admin", "focus"})
+
+	if strings.Contains(capturedRawPath, "/admin") {
+		t.Errorf("path traversal not escaped: raw path %q contains literal /admin; run ID slash must be %%2F-encoded", capturedRawPath)
+	}
+}
+
+// TestDispatch_SteerRouted verifies dispatch routes "steer" to runSteer and
+// not to the default run() path (which would print "prompt is required" for
+// the TUI-less one-shot run path).
+func TestDispatch_SteerRouted(t *testing.T) {
+	_, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := dispatch([]string{"steer"})
+	if code != 1 {
+		t.Fatalf("dispatch steer with no args should return 1; got %d", code)
+	}
+	if strings.Contains(errBuf.String(), "prompt is required") && !strings.Contains(errBuf.String(), "harnesscli steer") {
+		t.Errorf("dispatch('steer') should route to runSteer, not run(); got: %s", errBuf.String())
+	}
+}

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -199,6 +199,53 @@ func cancelRunCmd(baseURL, runID, apiKey string) tea.Cmd {
 	}
 }
 
+// steerRunCmd POSTs a steering message to /v1/runs/{id}/steer for the active
+// run (server: internal/server/http_runs.go handleRunSteer). The server queues
+// the message and the harness injects it as a user message at the next step
+// boundary — the run is neither cancelled nor restarted. Empty/whitespace
+// prompts are rejected client-side (SteerErrorMsg Kind "invalid_prompt")
+// without issuing a request; 202 maps to SteerAcceptedMsg and the documented
+// failure statuses map to SteerErrorMsg kinds (see messages.go).
+func steerRunCmd(baseURL, runID, prompt, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(prompt) == "" {
+			return SteerErrorMsg{RunID: runID, Kind: "invalid_prompt", Err: "prompt is required"}
+		}
+		body, err := json.Marshal(map[string]string{"prompt": prompt})
+		if err != nil {
+			return SteerErrorMsg{RunID: runID, Kind: "transport", Err: "encode request: " + err.Error()}
+		}
+		endpoint := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/steer"
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body), apiKey)
+		if err != nil {
+			return SteerErrorMsg{RunID: runID, Kind: "transport", Err: "build request: " + err.Error()}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return SteerErrorMsg{RunID: runID, Kind: "transport", Err: "request failed: " + err.Error()}
+		}
+		defer resp.Body.Close()
+		responseBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return SteerErrorMsg{RunID: runID, Kind: "transport", Err: "read response: " + err.Error()}
+		}
+		if resp.StatusCode >= 300 {
+			kind := "http"
+			switch resp.StatusCode {
+			case http.StatusNotFound:
+				kind = "not_found"
+			case http.StatusConflict:
+				kind = "run_not_active"
+			case http.StatusTooManyRequests:
+				kind = "steering_buffer_full"
+			}
+			return SteerErrorMsg{RunID: runID, Kind: kind, Err: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(responseBody)))}
+		}
+		return SteerAcceptedMsg{RunID: runID}
+	}
+}
+
 func replayRunCmd(baseURL, target, apiKey string) tea.Cmd {
 	return func() tea.Msg {
 		body, err := json.Marshal(map[string]any{

--- a/cmd/harnesscli/tui/api_auth_test.go
+++ b/cmd/harnesscli/tui/api_auth_test.go
@@ -18,6 +18,7 @@ package tui
 //	api.go          startRunCmd                    harnessd    yes (newHarnessRequest)
 //	api.go          fetchRunsCmd                    harnessd    yes
 //	api.go          cancelRunCmd                    harnessd    yes
+//	api.go          steerRunCmd                     harnessd    yes
 //	api.go          replayRunCmd                    harnessd    yes
 //	api.go          continueRunCmd                  harnessd    yes
 //	api.go          fetchModelsCmd                  harnessd    yes
@@ -76,6 +77,12 @@ func harnessAuthCases() []harnessAuthCase {
 			name: "cancelRunCmd",
 			call: func(ts *httptest.Server, apiKey string) any {
 				return cancelRunCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "steerRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return steerRunCmd(ts.URL, "run-1", "focus on tests", apiKey)()
 			},
 		},
 		{

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -201,6 +201,26 @@ type RunControlResultMsg struct {
 	Err    string
 }
 
+// SteerAcceptedMsg signals the server accepted a steering message for a run
+// (HTTP 202 from POST /v1/runs/{id}/steer). The steered text is injected as a
+// user message at the next step boundary; the run keeps going.
+type SteerAcceptedMsg struct{ RunID string }
+
+// SteerErrorMsg carries a failed steering attempt. Kind is a stable machine
+// string the model maps to status-bar text:
+//   - "not_found"            — HTTP 404, unknown run
+//   - "run_not_active"       — HTTP 409, run already finished
+//   - "steering_buffer_full" — HTTP 429, steering queue is full; retry shortly
+//   - "invalid_prompt"       — client-side rejection of an empty/whitespace
+//     prompt; no HTTP request was issued
+//   - "http"                 — any other non-2xx status
+//   - "transport"            — request build/send/read failure
+type SteerErrorMsg struct {
+	RunID string
+	Kind  string
+	Err   string
+}
+
 // statusTickMsg is sent after statusMsgDuration to clear the transient status bar message.
 type statusTickMsg struct{}
 

--- a/cmd/harnesscli/tui/steer_command_test.go
+++ b/cmd/harnesscli/tui/steer_command_test.go
@@ -1,0 +1,177 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+// TestSteerRunCmd_PostsPromptToSteerEndpoint pins the wire contract of
+// POST /v1/runs/{id}/steer (internal/server/http_runs.go handleRunSteer):
+// POST method, path-escaped run ID, JSON body {"prompt": ...},
+// Content-Type: application/json, the harnessd API key on the Authorization
+// header, and HTTP 202 mapping to SteerAcceptedMsg carrying the run ID.
+func TestSteerRunCmd_PostsPromptToSteerEndpoint(t *testing.T) {
+	var gotMethod, gotPath, gotPrompt, gotContentType, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotAuth = r.Header.Get("Authorization")
+		var body struct {
+			Prompt string `json:"prompt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode steer body: %v", err)
+		}
+		gotPrompt = body.Prompt
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	}))
+	defer srv.Close()
+
+	msg := steerRunCmd(srv.URL, "run-x", "focus on X", "test-key")()
+
+	accepted, ok := msg.(SteerAcceptedMsg)
+	if !ok {
+		t.Fatalf("expected SteerAcceptedMsg, got %T: %+v", msg, msg)
+	}
+	if accepted.RunID != "run-x" {
+		t.Errorf("SteerAcceptedMsg.RunID = %q, want %q", accepted.RunID, "run-x")
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/runs/run-x/steer" {
+		t.Errorf("path = %q, want /v1/runs/run-x/steer", gotPath)
+	}
+	if gotPrompt != "focus on X" {
+		t.Errorf("prompt body = %q, want %q", gotPrompt, "focus on X")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer test-key")
+	}
+}
+
+// TestSteerRunCmd_PathEscapesRunID mirrors the cancel regression: a run ID
+// containing "/" must be percent-encoded so it cannot traverse the URL path.
+func TestSteerRunCmd_PathEscapesRunID(t *testing.T) {
+	var gotRawPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRawPath = r.URL.RawPath
+		if gotRawPath == "" {
+			gotRawPath = r.URL.Path
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	}))
+	defer srv.Close()
+
+	steerRunCmd(srv.URL, "../admin", "focus", "")()
+
+	if gotRawPath != "/v1/runs/..%2Fadmin/steer" {
+		t.Errorf("raw path = %q, want /v1/runs/..%%2Fadmin/steer (run ID slash percent-encoded)", gotRawPath)
+	}
+}
+
+// TestSteerRunCmd_MapsErrorStatuses verifies each documented steer failure
+// status maps to a SteerErrorMsg with a stable Kind the model can translate
+// into status-bar text (slice 3 consumes these kinds).
+func TestSteerRunCmd_MapsErrorStatuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		status   int
+		body     string
+		wantKind string
+	}{
+		{"not found", http.StatusNotFound, `{"error":{"code":"not_found","message":"run \"run-x\" not found"}}`, "not_found"},
+		{"run not active", http.StatusConflict, `{"error":{"code":"run_not_active","message":"run \"run-x\" is not active"}}`, "run_not_active"},
+		{"buffer full", http.StatusTooManyRequests, `{"error":{"code":"steering_buffer_full","message":"steering buffer full"}}`, "steering_buffer_full"},
+		{"unexpected status", http.StatusInternalServerError, `boom`, "http"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			msg := steerRunCmd(srv.URL, "run-x", "focus on X", "")()
+
+			steerErr, ok := msg.(SteerErrorMsg)
+			if !ok {
+				t.Fatalf("expected SteerErrorMsg, got %T: %+v", msg, msg)
+			}
+			if steerErr.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", steerErr.Kind, tc.wantKind)
+			}
+			if steerErr.RunID != "run-x" {
+				t.Errorf("RunID = %q, want %q", steerErr.RunID, "run-x")
+			}
+			if steerErr.Err == "" {
+				t.Error("expected non-empty error detail")
+			}
+		})
+	}
+}
+
+// TestSteerRunCmd_RejectsEmptyPromptClientSide verifies that an empty or
+// whitespace-only prompt is rejected before any HTTP request is issued — the
+// server would answer 400, but the client must not send it at all.
+func TestSteerRunCmd_RejectsEmptyPromptClientSide(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	for _, prompt := range []string{"", "   ", "\n\t "} {
+		msg := steerRunCmd(srv.URL, "run-x", prompt, "")()
+		steerErr, ok := msg.(SteerErrorMsg)
+		if !ok {
+			t.Fatalf("prompt %q: expected SteerErrorMsg, got %T: %+v", prompt, msg, msg)
+		}
+		if steerErr.Kind != "invalid_prompt" {
+			t.Errorf("prompt %q: Kind = %q, want %q", prompt, steerErr.Kind, "invalid_prompt")
+		}
+		if steerErr.RunID != "run-x" {
+			t.Errorf("prompt %q: RunID = %q, want %q", prompt, steerErr.RunID, "run-x")
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Fatalf("server received %d request(s) for empty prompts; want 0 (client-side rejection)", got)
+	}
+}
+
+// TestSteerRunCmd_TransportError verifies a connection failure surfaces as a
+// SteerErrorMsg (Kind "transport") rather than panicking or returning nil.
+func TestSteerRunCmd_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // refuse connections
+
+	msg := steerRunCmd(srv.URL, "run-x", "focus on X", "")()
+
+	steerErr, ok := msg.(SteerErrorMsg)
+	if !ok {
+		t.Fatalf("expected SteerErrorMsg, got %T: %+v", msg, msg)
+	}
+	if steerErr.Kind != "transport" {
+		t.Errorf("Kind = %q, want %q", steerErr.Kind, "transport")
+	}
+	if steerErr.RunID != "run-x" {
+		t.Errorf("RunID = %q, want %q", steerErr.RunID, "run-x")
+	}
+	if steerErr.Err == "" {
+		t.Error("expected non-empty error detail")
+	}
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -82,6 +82,16 @@
   land with their owning slices (3+); no pre-existing subagent design doc
   exists to update in this slice.
 
+## 2026-07-19 (Mid-Turn Steering — Epic #820, Slice 1)
+
+- Added the client plumbing for the existing `POST /v1/runs/{id}/steer` route, strict TDD:
+  - `cmd/harnesscli/tui/api.go`: `steerRunCmd(baseURL, runID, prompt, apiKey)` mirroring `cancelRunCmd`; routes through `newHarnessRequest` so harnessd auth is preserved (pinned by the `api_auth_test.go` audit table + static routing regression).
+  - `cmd/harnesscli/tui/messages.go`: `SteerAcceptedMsg` (202) and `SteerErrorMsg` with stable `Kind` strings (`not_found`, `run_not_active`, `steering_buffer_full`, `invalid_prompt`, `http`, `transport`) for slice 3's status-bar mapping.
+  - `cmd/harnesscli/runctl.go` + `auth.go` dispatch: `harnesscli steer <run-id> <prompt>` one-shot subcommand mirroring `runCancel` (`-base-url` only — the epic's `-api-key` parenthetical does not match `runCancel`, which has no such flag; noted in the PR).
+  - Empty/whitespace prompts are rejected client-side in both paths before any HTTP request (the server would 400).
+- Live-daemon smoke: `harnessd` with `HARNESS_PROVIDER=fake` + a scripted bash turn held active via `HARNESS_TOOL_APPROVAL_MODE=all`; `harnesscli steer <id> "focus on X"` printed `Run <id> steering accepted` (exit 0); unknown run → `not found` (exit 1); finished run → `not active` (exit 1).
+- Validation: `go test ./cmd/harnesscli/... -count=1` all ok; `go test ./internal/server/ ./internal/harness/ -count=1` ok; `go vet ./cmd/harnesscli/...` clean; gofmt clean on touched files (repo-wide gofmt drift on unrelated files pre-exists on main).
+
 ## 2026-07-19 (ACP Server Mode — Epic #746)
 
 - Added `cmd/harness-acp` and `internal/harnessacp`, using pinned

--- a/docs/plans/820-tui-steering.md
+++ b/docs/plans/820-tui-steering.md
@@ -1,0 +1,72 @@
+# Plan: epic #820 slice 1 — steer client plumbing (steerRunCmd + harnesscli steer)
+
+## Context
+
+- Problem: the server exposes `POST /v1/runs/{id}/steer` (202/404/409/429 contract,
+  `internal/server/http_runs.go` `handleRunSteer`) but no client path exists — the TUI
+  never calls it and the one-shot CLI has no `steer` subcommand.
+- User impact: users cannot inject corrective input into a running turn from any
+  go-code client (kimi-code parity gap).
+- Constraints: implement ONLY slice 1 of #820 (client plumbing). No keybinding, no
+  SSE `steering.received` rendering, no local echo — those are slices 2–4.
+  Strict TDD per `docs/runbooks/testing.md`. Server-side steering semantics are a
+  fixed contract.
+
+## Scope
+
+- In scope:
+  - `cmd/harnesscli/tui/api.go`: `steerRunCmd(baseURL, runID, prompt, apiKey) tea.Cmd`
+    mirroring `cancelRunCmd`; client-side rejection of empty/whitespace prompts.
+  - `cmd/harnesscli/tui/messages.go`: `SteerAcceptedMsg` + `SteerErrorMsg` (Kind:
+    `not_found`, `run_not_active`, `steering_buffer_full`, `invalid_prompt`, `http`,
+    `transport`).
+  - `cmd/harnesscli/runctl.go`: `runSteer(args)` — `harnesscli steer <run-id> <prompt>`,
+    `-base-url` flag mirroring `runCancel` (runCancel has no `-api-key` flag; "consistent
+    with runCancel" wins over the epic's parenthetical).
+  - `cmd/harnesscli/auth.go` `dispatch`: route `steer`.
+- Out of scope: slices 2–5 (SSE rendering, ctrl+g binding, local echo, e2e); any
+  server/harness change; help-dialog/keybinding docs (slice 3).
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none in this slice (CLI help text is the usage error output;
+  `website/docs/cli/tui.md` keybinding table belongs to slice 3).
+- Spec docs to update before code: none — server contract already documented in
+  `docs/implementation/issue-6-mid-run-steering.md`.
+- Implementation notes to add after code: engineering-log entry per repo convention.
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `cmd/harnesscli/tui/steer_command_test.go`: POST path + JSON body assertion,
+    202 → `SteerAcceptedMsg`, 404/409/429 → `SteerErrorMsg` kinds, empty prompt
+    rejected client-side without HTTP call, API key header sent.
+  - `cmd/harnesscli/runctl_test.go` (append, mirroring runCancel tests): happy path
+    202 + confirmation output, missing-args usage error, whitespace prompt rejected
+    without HTTP, 404/409/429 exit 1 with clear message, dispatch routing.
+  - `cmd/harnesscli/tui/api_auth_test.go`: add `steerRunCmd` to the auth audit table.
+- Existing tests to update: none.
+- Regression tests required: `go test ./cmd/harnesscli/... -count=1` green.
+
+## Cross-Surface Impact Map
+
+- Not a provider/model flow change — no impact map required. Surfaces touched:
+  TUI API client + one-shot CLI only.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above).
+- [x] Write failing tests first, watch them fail.
+- [x] Implement `steerRunCmd` + message types.
+- [x] Implement `runSteer` + dispatch routing.
+- [x] gofmt + go vet clean.
+- [x] `go test ./cmd/harnesscli/... -count=1` green.
+- [x] Engineering-log entry; `docs/plans/INDEX.md` updated for the new plan page.
+- [ ] Commit, push `epic/820-tui-steering`, open PR (do NOT merge).
+
+## Risks and Mitigations
+
+- Risk: epic parenthetical mentions an `-api-key` flag that `runCancel` does not have.
+- Mitigation: mirror `runCancel` exactly (`-base-url` only); note the deviation in the
+  PR body so slice reviewers can decide.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -9,6 +9,7 @@
 - `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
 - `809-mcp-oauth.md` — Epic #809 slice 1: static HTTP headers and typed auth errors for the MCP HTTP transport (in implementation).
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
+- `820-tui-steering.md` — Epic #820 slice 1 (in implementation): steer client plumbing (`steerRunCmd` + `harnesscli steer`).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.


### PR DESCRIPTION
Parent epic: #820. Part of #803.

## What

Slice 1 of #820 (mid-turn steering): a tested client path for the existing `POST /v1/runs/{id}/steer` route, usable from both the TUI and the one-shot CLI. No keybinding, SSE rendering, or local echo — those are slices 2–4.

- `cmd/harnesscli/tui/api.go` — `steerRunCmd(baseURL, runID, prompt, apiKey) tea.Cmd` mirroring `cancelRunCmd`; routes through `newHarnessRequest` (auth audit table + static routing regression updated). Maps 202 → `SteerAcceptedMsg`, 404/409/429 → `SteerErrorMsg` kinds (`not_found` / `run_not_active` / `steering_buffer_full`), other failures → `http` / `transport`.
- `cmd/harnesscli/tui/messages.go` — `SteerAcceptedMsg` + `SteerErrorMsg` with stable `Kind` strings for slice 3's status-bar mapping.
- `cmd/harnesscli/runctl.go` + `auth.go` dispatch — `harnesscli steer <run-id> <prompt>` one-shot subcommand mirroring `runCancel`.
- Empty/whitespace prompts rejected client-side in both paths before any HTTP request.

Note: the epic parenthetical mentions an `-api-key` flag, but `runCancel` has only `-base-url`; "consistent with runCancel" was taken as normative, so `runSteer` mirrors `runCancel` exactly.

## Tests (strict TDD — failing first)

- `cmd/harnesscli/tui/steer_command_test.go`: POST path/body/auth/content-type assertion, 202 mapping, 404/409/429/500 kind mapping, client-side empty-prompt rejection (zero HTTP calls), transport error, run-ID path-escape.
- `cmd/harnesscli/runctl_test.go`: happy path + confirmation output, missing-args usage errors, whitespace prompt (no HTTP), 404/409/429 messages, path-escape, dispatch routing.
- `cmd/harnesscli/tui/api_auth_test.go`: `steerRunCmd` added to the harnessd auth audit.

## Verification

- `go test ./cmd/harnesscli/... -count=1` — all packages ok
- `go test ./internal/server/ ./internal/harness/ -count=1` — ok (15.989s / 23.604s)
- `go vet ./cmd/harnesscli/...` — clean; gofmt clean on touched files
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — PASS (coveragegate 83.9%, zero zero-coverage functions). First run hit a load flake in `internal/watcher` `TestSubdirectoryCreated` (500ms fsnotify timing under -race with ~18 concurrent agent suites); passes 10/10 in isolation on both `main` and this branch, and the full-suite re-run is green.
- Live-daemon smoke: `harnessd` with `HARNESS_PROVIDER=fake` + scripted bash turn held active via `HARNESS_TOOL_APPROVAL_MODE=all`; `harnesscli steer <id> "focus on X"` → `Run <id> steering accepted` (exit 0); unknown run → `not found` (exit 1); finished run → `not active` (exit 1).