### PR TITLE
feat(tui): /title — name sessions and show the title in statusbar and picker

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -192,6 +192,14 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeSessionsCommand,
 		},
 		{
+			Name:        "title",
+			Description: "Set or show the current session title (/title clear to remove)",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeTitleCommand,
+		},
+		{
 			Name:        "rewind",
 			Description: "Choose and confirm a destructive session rewind",
 			Handler:     func(cmd Command) CommandResult { return CommandResult{Status: CmdOK} },

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -398,7 +398,7 @@ func TestTUI364_RegistryCompleteness(t *testing.T) {
 	knownCommands := []string{
 		"attach", "cancel", "clear", "config", "context", "cost", "dashboard", "doctor", "export", "help", "history", "hooks", "keys",
 		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
-		"sessions", "stats", "subagents", "rewind",
+		"sessions", "stats", "subagents", "rewind", "title",
 	}
 
 	r := tui.NewCommandRegistry()

--- a/cmd/harnesscli/tui/components/sessionpicker/model.go
+++ b/cmd/harnesscli/tui/components/sessionpicker/model.go
@@ -9,6 +9,7 @@ import (
 const (
 	maxVisibleRows = 10
 	lastMsgMaxLen  = 60
+	titleMaxLen    = 20
 )
 
 // SessionEntry holds display data for a single past session.
@@ -18,6 +19,7 @@ type SessionEntry struct {
 	Model     string    // LLM model used
 	TurnCount int       // number of turns
 	LastMsg   string    // first 60 chars of last user message
+	Title     string    // optional user-assigned label; shown instead of the ID when set
 }
 
 // Model is the session picker list state machine.

--- a/cmd/harnesscli/tui/components/sessionpicker/model_test.go
+++ b/cmd/harnesscli/tui/components/sessionpicker/model_test.go
@@ -485,3 +485,70 @@ func TestTUI053_VisualSnapshot_200x50(t *testing.T) {
 		t.Error("View() returned empty output at width 200")
 	}
 }
+
+// ─── Title rendering ─────────────────────────────────────────────────────────
+
+// TestTUI053_ViewPrefersTitleOverID verifies that when a session has a title,
+// the picker row shows the title instead of the truncated session ID.
+func TestTUI053_ViewPrefersTitleOverID(t *testing.T) {
+	entries := []sessionpicker.SessionEntry{
+		{
+			ID:        "abc12345-0000-0000-0000-000000000000",
+			StartedAt: testTime,
+			Model:     "gpt-4.1-mini",
+			TurnCount: 5,
+			LastMsg:   "some message",
+			Title:     "fix auth bug",
+		},
+	}
+	m := sessionpicker.New(entries).Open()
+	v := m.View(80)
+
+	if !strings.Contains(v, "fix auth bug") {
+		t.Errorf("View() should contain the session title:\n%s", v)
+	}
+	if strings.Contains(v, "abc12345") {
+		t.Errorf("View() should not show the truncated ID when a title is set:\n%s", v)
+	}
+}
+
+// TestTUI053_ViewFallsBackToIDWithoutTitle verifies that entries without a
+// title still render the 8-char ID prefix.
+func TestTUI053_ViewFallsBackToIDWithoutTitle(t *testing.T) {
+	entries := []sessionpicker.SessionEntry{
+		{
+			ID:        "abc12345-0000-0000-0000-000000000000",
+			StartedAt: testTime,
+			Model:     "gpt-4.1-mini",
+			TurnCount: 5,
+			LastMsg:   "some message",
+		},
+	}
+	m := sessionpicker.New(entries).Open()
+	v := m.View(80)
+
+	if !strings.Contains(v, "abc12345") {
+		t.Errorf("View() should contain the short ID %q when no title is set:\n%s", "abc12345", v)
+	}
+}
+
+// TestTUI053_ViewTruncatesLongTitle verifies a very long title is clipped so
+// the row stays within the picker width.
+func TestTUI053_ViewTruncatesLongTitle(t *testing.T) {
+	long := "this is an extremely long session title that must be clipped to fit the row"
+	entries := []sessionpicker.SessionEntry{
+		{
+			ID:        "abc12345-0000-0000-0000-000000000000",
+			StartedAt: testTime,
+			Model:     "gpt-4.1-mini",
+			TurnCount: 5,
+			Title:     long,
+		},
+	}
+	m := sessionpicker.New(entries).Open()
+	v := m.View(80)
+
+	if strings.Contains(v, long) {
+		t.Errorf("View() should truncate a long title, got full title in:\n%s", v)
+	}
+}

--- a/cmd/harnesscli/tui/components/sessionpicker/view.go
+++ b/cmd/harnesscli/tui/components/sessionpicker/view.go
@@ -64,9 +64,16 @@ func (m Model) View(width int) string {
 			isSelected := i == m.selected
 
 			// Build columns.
-			shortID := e.ID
-			if len(shortID) > 8 {
-				shortID = shortID[:8]
+			// Prefer the user-assigned title over the truncated session ID.
+			label := e.Title
+			if len([]rune(label)) > titleMaxLen {
+				label = string([]rune(label)[:titleMaxLen])
+			}
+			if label == "" {
+				label = e.ID
+				if len(label) > 8 {
+					label = label[:8]
+				}
 			}
 
 			dateStr := e.StartedAt.Format("Jan 2")
@@ -78,8 +85,8 @@ func (m Model) View(width int) string {
 				lastMsg = string(runes[:lastMsgMaxLen])
 			}
 
-			// Compose the row: ID  Date  Model  Turns  LastMsg
-			metaPart := fmt.Sprintf("  %s  %s  %s  %s  ", shortID, dateStr, e.Model, turnsStr)
+			// Compose the row: Label  Date  Model  Turns  LastMsg
+			metaPart := fmt.Sprintf("  %s  %s  %s  %s  ", label, dateStr, e.Model, turnsStr)
 			rowContent := metaPart + lastMsg
 
 			// Truncate to innerWidth.

--- a/cmd/harnesscli/tui/components/statusbar/model.go
+++ b/cmd/harnesscli/tui/components/statusbar/model.go
@@ -11,6 +11,7 @@ import (
 type Model struct {
 	width    int
 	model    string
+	title    string // optional session title (see /title)
 	workdir  string
 	branch   string
 	permMode string // "", "plan", "accept-edits", "auto-approve"
@@ -27,6 +28,7 @@ func New(width int) Model {
 }
 
 func (m *Model) SetModel(name string)    { m.model = name }
+func (m *Model) SetTitle(title string)   { m.title = title }
 func (m *Model) SetWorkdir(path string)  { m.workdir = path }
 func (m *Model) SetBranch(branch string) { m.branch = branch }
 func (m *Model) SetPermMode(mode string) { m.permMode = mode }
@@ -65,7 +67,7 @@ func (m Model) View() string {
 	sep := dimStyle.Render(" ~ ")
 	sepLen := 3 // plain rune width of " ~ "
 
-	// Segments in priority order: model > context > running > cost > perm > branch > workdir > mcpFails
+	// Segments in priority order: model > title > context > running > cost > perm > branch > workdir > mcpFails
 	type segment struct {
 		text     string
 		priority int // lower = higher priority (kept last when trimming)
@@ -75,6 +77,9 @@ func (m Model) View() string {
 	if m.model != "" {
 		segs = append(segs, segment{boldStyle.Render(truncate(m.model, 24)), 1})
 	}
+	if m.title != "" {
+		segs = append(segs, segment{boldStyle.Render(truncate(m.title, 24)), 2})
+	}
 	if m.ctxUsed > 0 && m.ctxTotal > 0 {
 		pct := int(float64(m.ctxUsed)/float64(m.ctxTotal)*100 + 0.5)
 		text := fmt.Sprintf("◫ %d%%/%s", pct, formatCompactTokens(m.ctxTotal))
@@ -82,26 +87,26 @@ func (m Model) View() string {
 		if pct >= 80 {
 			style = warnStyle
 		}
-		segs = append(segs, segment{style.Render(text), 2})
+		segs = append(segs, segment{style.Render(text), 3})
 	}
 	if m.running {
-		segs = append(segs, segment{dimStyle.Render("..."), 3})
+		segs = append(segs, segment{dimStyle.Render("..."), 4})
 	}
 	if m.costUSD > 0 {
-		segs = append(segs, segment{dimStyle.Render(fmt.Sprintf("$%.4f", m.costUSD)), 4})
+		segs = append(segs, segment{dimStyle.Render(fmt.Sprintf("$%.4f", m.costUSD)), 5})
 	}
 	if m.permMode != "" && m.permMode != "default" {
-		segs = append(segs, segment{warnStyle.Render("[" + m.permMode + "]"), 5})
+		segs = append(segs, segment{warnStyle.Render("[" + m.permMode + "]"), 6})
 	}
 	if m.branch != "" {
-		segs = append(segs, segment{dimStyle.Render("(" + m.branch + ")"), 6})
+		segs = append(segs, segment{dimStyle.Render("(" + m.branch + ")"), 7})
 	}
 	if m.workdir != "" {
 		dir := shortenPath(m.workdir, 20)
-		segs = append(segs, segment{dimStyle.Render(dir), 7})
+		segs = append(segs, segment{dimStyle.Render(dir), 8})
 	}
 	if m.mcpFails > 0 {
-		segs = append(segs, segment{warnStyle.Render(fmt.Sprintf("%d MCP fail", m.mcpFails)), 8})
+		segs = append(segs, segment{warnStyle.Render(fmt.Sprintf("%d MCP fail", m.mcpFails)), 9})
 	}
 
 	// Build line progressively, dropping lowest-priority segments when over width.

--- a/cmd/harnesscli/tui/components/statusbar/statusbar_test.go
+++ b/cmd/harnesscli/tui/components/statusbar/statusbar_test.go
@@ -199,3 +199,57 @@ func stripANSI(s string) string {
 	}
 	return result.String()
 }
+
+func TestStatusbarShowsTitle(t *testing.T) {
+	sb := statusbar.New(80)
+	sb.SetModel("gpt-4.1-mini")
+	sb.SetTitle("fix auth bug")
+	view := sb.View()
+	if !strings.Contains(view, "fix auth bug") {
+		t.Errorf("status bar missing session title: %q", view)
+	}
+}
+
+func TestStatusbarTitleOmittedWhenEmpty(t *testing.T) {
+	withEmpty := statusbar.New(80)
+	withEmpty.SetModel("gpt-4.1-mini")
+	withEmpty.SetTitle("")
+
+	unset := statusbar.New(80)
+	unset.SetModel("gpt-4.1-mini")
+
+	if withEmpty.View() != unset.View() {
+		t.Errorf("empty title must render identically to an unset title:\nwith-empty: %q\nunset:      %q", withEmpty.View(), unset.View())
+	}
+}
+
+func TestStatusbarTitleTruncated(t *testing.T) {
+	sb := statusbar.New(80)
+	sb.SetModel("gpt-4.1-mini")
+	long := "this is an extremely long session title that must be clipped"
+	sb.SetTitle(long)
+	view := sb.View()
+	if strings.Contains(view, long) {
+		t.Errorf("status bar must truncate long titles, got full title in: %q", view)
+	}
+	stripped := stripANSI(view)
+	if len([]rune(stripped)) > 82 { // width + small ANSI tolerance
+		t.Errorf("status bar overflowed width 80 with a long title: %d runes: %q", len([]rune(stripped)), stripped)
+	}
+}
+
+func TestStatusbarTitleClearRestoresBaseline(t *testing.T) {
+	sb := statusbar.New(80)
+	sb.SetModel("gpt-4.1-mini")
+	baseline := sb.View()
+
+	sb.SetTitle("temporary")
+	if sb.View() == baseline {
+		t.Fatal("setting a title must change the rendered bar")
+	}
+
+	sb.SetTitle("")
+	if sb.View() != baseline {
+		t.Errorf("clearing the title must restore the baseline bar:\nbaseline: %q\ncleared:  %q", baseline, sb.View())
+	}
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1560,6 +1560,60 @@ func executeSessionsCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return nil, false
 }
 
+// sessionTitle returns the stored title for the current conversation, or ""
+// when the session has no title (or no session is active).
+func (m Model) sessionTitle() string {
+	if m.sessionStore == nil || m.conversationID == "" {
+		return ""
+	}
+	if e, ok := m.sessionStore.Get(m.conversationID); ok {
+		return e.Title
+	}
+	return ""
+}
+
+// executeTitleCommand implements /title: with no args it shows the current
+// session's title, `/title <text>` names the session, and `/title clear`
+// removes the name. Titles persist in sessions.json and render in the
+// statusbar and /sessions picker.
+func executeTitleCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	if m.conversationID == "" {
+		return []tea.Cmd{m.setStatusMsg("No active session — start a run before setting a title")}, false
+	}
+	if m.sessionStore == nil {
+		return []tea.Cmd{m.setStatusMsg("Session store unavailable")}, false
+	}
+
+	// /title clear — remove the title (only when "clear" is the sole argument).
+	if len(cmd.Args) == 1 && cmd.Args[0] == "clear" {
+		m.sessionStore.SetTitle(m.conversationID, "")
+		if err := m.sessionStore.Save(); err != nil {
+			return []tea.Cmd{m.setStatusMsg("Could not save session title: " + err.Error())}, false
+		}
+		m.statusBar.SetTitle("")
+		return []tea.Cmd{m.setStatusMsg("Session title cleared")}, false
+	}
+
+	// /title — show the current title.
+	if len(cmd.Args) == 0 {
+		if title := m.sessionTitle(); title != "" {
+			return []tea.Cmd{m.setStatusMsg("Session title: " + title)}, false
+		}
+		return []tea.Cmd{m.setStatusMsg("No title set — use /title <text> to name this session")}, false
+	}
+
+	// /title <text> — set the title.
+	title := strings.Join(cmd.Args, " ")
+	if ok := m.sessionStore.SetTitle(m.conversationID, title); !ok {
+		return []tea.Cmd{m.setStatusMsg("Current session is not in the store yet — send a message first")}, false
+	}
+	if err := m.sessionStore.Save(); err != nil {
+		return []tea.Cmd{m.setStatusMsg("Could not save session title: " + err.Error())}, false
+	}
+	m.statusBar.SetTitle(title)
+	return []tea.Cmd{m.setStatusMsg("Session title set to: " + title)}, false
+}
+
 // executeRewindCommand intentionally requires an explicit point id and force
 // confirmation token. The server endpoint remains the authority for file
 // restore; this command never issues a destructive request implicitly.
@@ -1581,6 +1635,8 @@ func executeNewSessionCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	m.responseStarted = false
 	m.activeAssistantLineCount = 0
 	m.clearThinkingBar()
+	// A fresh session has no title; drop it from the status bar.
+	m.statusBar.SetTitle("")
 	return []tea.Cmd{m.setStatusMsg("New session started")}, false
 }
 
@@ -1814,6 +1870,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Initialize/resize components
 		m.statusBar = statusbar.New(msg.Width)
 		m.statusBar.SetModel(m.statusBarModelLabel())
+		m.statusBar.SetTitle(m.sessionTitle())
 		m.statusBar.SetCost(m.cumulativeCostUSD)
 		m.statusBar.SetContext(m.totalTokens, m.contextWindowTotal())
 		m.interruptBanner.Width = msg.Width
@@ -2856,6 +2913,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			_ = m.sessionStore.Save()
 		}
+		// Reflect the session's title (new sessions have none) in the status bar.
+		m.statusBar.SetTitle(m.sessionTitle())
 		// Clear pending message preview now that it has been recorded.
 		m.pendingLastMsg = ""
 		// Start the SSE bridge for this run only if no cancel func is already
@@ -3478,6 +3537,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sessionPicker = m.sessionPicker.Close()
 		m.overlayActive = false
 		m.activeOverlay = ""
+		// Show the picked session's title (if any) in the status bar.
+		m.statusBar.SetTitle(m.sessionTitle())
 		// Clear the viewport and transcript so stale messages from the previous
 		// conversation are not shown alongside the resumed session.
 		m.vp = viewport.New(m.width, m.layout.ViewportHeight)

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -566,8 +566,10 @@ func TestAPIKeySetMsg_DifferentProviders(t *testing.T) {
 // TestBuildCommandRegistry_FullBuiltinSet verifies that buildCommandRegistry
 // registers all expected built-in slash commands. We test this by observing which
 // commands appear in the /help overlay (which derives its list from the registry).
+// The window must be tall enough to fit every command row: the help dialog
+// renders (height-13) content lines and the registry holds ~28 commands.
 func TestBuildCommandRegistry_FullBuiltinSet(t *testing.T) {
-	m := initModel(t, 120, 40)
+	m := initModel(t, 120, 50)
 	m = sendSlashCommand(m, "/help")
 	v := m.View()
 

--- a/cmd/harnesscli/tui/sessionstore.go
+++ b/cmd/harnesscli/tui/sessionstore.go
@@ -27,6 +27,8 @@ type StoredSessionEntry struct {
 	Model     string    `json:"model,omitempty"`
 	TurnCount int       `json:"turn_count"`
 	LastMsg   string    `json:"last_msg,omitempty"`
+	// Title is an optional user-assigned label for the session (see /title).
+	Title string `json:"title,omitempty"`
 }
 
 // SessionStore manages a list of StoredSessionEntry values persisted to a
@@ -147,6 +149,19 @@ func (s *SessionStore) Update(id string, fn func(*StoredSessionEntry)) {
 	}
 }
 
+// SetTitle sets the title of the entry with the given ID. An empty title
+// clears it. It returns false when no entry with that ID exists.
+// Call Save() to persist the change.
+func (s *SessionStore) SetTitle(id, title string) bool {
+	for i := range s.entries {
+		if s.entries[i].ID == id {
+			s.entries[i].Title = title
+			return true
+		}
+	}
+	return false
+}
+
 // List returns a copy of all entries sorted by StartedAt descending (most
 // recent first). It is safe to call on a nil *SessionStore.
 func (s *SessionStore) List() []StoredSessionEntry {
@@ -178,6 +193,7 @@ func sessionEntriesToPicker(entries []StoredSessionEntry) []sessionpicker.Sessio
 			Model:     e.Model,
 			TurnCount: e.TurnCount,
 			LastMsg:   e.LastMsg,
+			Title:     e.Title,
 		}
 	}
 	return out

--- a/cmd/harnesscli/tui/sessionstore_test.go
+++ b/cmd/harnesscli/tui/sessionstore_test.go
@@ -3,6 +3,7 @@ package tui_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -272,5 +273,116 @@ func TestSS_SaveWriteFileError(t *testing.T) {
 	store.Add(tui.StoredSessionEntry{ID: "y", StartedAt: time.Now()})
 	if err := store.Save(); err == nil {
 		t.Fatal("Save must return an error when WriteFile fails on read-only dir")
+	}
+}
+
+// ─── Title: set + persisted round-trip ────────────────────────────────────────
+
+// TestSS_TitleRoundtrip verifies that a session title survives a Save/Load
+// cycle in sessions.json.
+func TestSS_TitleRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	store.Add(tui.StoredSessionEntry{
+		ID:        "titled-session",
+		StartedAt: time.Now(),
+		Title:     "fix auth bug",
+	})
+
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	store2 := tui.NewSessionStore(dir)
+	if err := store2.Load(); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	got, ok := store2.Get("titled-session")
+	if !ok {
+		t.Fatal("session missing after Load")
+	}
+	if got.Title != "fix auth bug" {
+		t.Errorf("Title after round-trip: want %q, got %q", "fix auth bug", got.Title)
+	}
+}
+
+// ─── Title: backward compatibility with pre-title sessions.json ───────────────
+
+// TestSS_LoadLegacyJSONWithoutTitle verifies that a sessions.json written
+// before the Title field existed loads cleanly with an empty Title.
+func TestSS_LoadLegacyJSONWithoutTitle(t *testing.T) {
+	dir := t.TempDir()
+	legacy := `[{"id":"old-1","started_at":"2026-01-02T03:04:05Z","model":"gpt-4o","turn_count":3,"last_msg":"hi"}]`
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte(legacy), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	store := tui.NewSessionStore(dir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("Load of legacy file failed: %v", err)
+	}
+	got, ok := store.Get("old-1")
+	if !ok {
+		t.Fatal("legacy entry missing after Load")
+	}
+	if got.Title != "" {
+		t.Errorf("legacy entry Title: want empty, got %q", got.Title)
+	}
+	if got.TurnCount != 3 || got.Model != "gpt-4o" || got.LastMsg != "hi" {
+		t.Errorf("legacy fields not preserved: %+v", got)
+	}
+}
+
+// TestSS_TitleOmittedFromJSONWhenEmpty verifies that an entry with no title
+// serializes without the "title" key, keeping sessions.json identical in shape
+// to what pre-title versions wrote.
+func TestSS_TitleOmittedFromJSONWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store := tui.NewSessionStore(dir)
+	store.Add(tui.StoredSessionEntry{ID: "no-title", StartedAt: time.Now(), TurnCount: 1})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "sessions.json"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(data), `"title":`) {
+		t.Errorf("sessions.json must omit the title key when empty, got: %s", data)
+	}
+}
+
+// ─── Title: SetTitle setter ───────────────────────────────────────────────────
+
+// TestSS_SetTitleUpdatesExistingEntry verifies SetTitle sets and clears the
+// title on a stored entry.
+func TestSS_SetTitleUpdatesExistingEntry(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+	store.Add(tui.StoredSessionEntry{ID: "s1", StartedAt: time.Now()})
+
+	if ok := store.SetTitle("s1", "rename me"); !ok {
+		t.Fatal("SetTitle returned false for an existing entry")
+	}
+	got, _ := store.Get("s1")
+	if got.Title != "rename me" {
+		t.Errorf("Title after SetTitle: want %q, got %q", "rename me", got.Title)
+	}
+
+	if ok := store.SetTitle("s1", ""); !ok {
+		t.Fatal("SetTitle(clear) returned false for an existing entry")
+	}
+	got, _ = store.Get("s1")
+	if got.Title != "" {
+		t.Errorf("Title after clearing SetTitle: want empty, got %q", got.Title)
+	}
+}
+
+// TestSS_SetTitleUnknownIDReturnsFalse verifies SetTitle reports failure for a
+// session ID that is not in the store.
+func TestSS_SetTitleUnknownIDReturnsFalse(t *testing.T) {
+	store := tui.NewSessionStore(t.TempDir())
+	if ok := store.SetTitle("missing", "x"); ok {
+		t.Error("SetTitle must return false for an unknown session ID")
 	}
 }

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -27,3 +27,4 @@ Command Registry - 120x40
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes
+/title — Set or show the current session title (/title clear to remove)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -27,3 +27,4 @@ Command Registry - 200x50
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes
+/title — Set or show the current session title (/title clear to remove)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -27,3 +27,4 @@ Command Registry - 80x24
 /sessions — Browse and switch between past sessions
 /stats — Show cost and token statistics
 /subagents — View active subagent processes
+/title — Set or show the current session title (/title clear to remove)

--- a/cmd/harnesscli/tui/title_test.go
+++ b/cmd/harnesscli/tui/title_test.go
@@ -1,0 +1,259 @@
+package tui_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// initModelForTitle creates a Model with an isolated HOME so the session store
+// writes to a temp dir, then starts a session so a conversation ID exists.
+func initModelForTitle(t *testing.T) tui.Model {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 80, 24)
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-1"})
+	return m2.(tui.Model)
+}
+
+// TestTitleCommand_SetPersistsAndShowsInStatusbar verifies that
+// `/title fix auth bug` stores the title on the current session and renders it
+// in the status bar.
+func TestTitleCommand_SetPersistsAndShowsInStatusbar(t *testing.T) {
+	m := initModelForTitle(t)
+
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	entry, ok := m.SessionStore().Get("run-1")
+	if !ok {
+		t.Fatal("session entry missing from store after RunStartedMsg")
+	}
+	if entry.Title != "fix auth bug" {
+		t.Errorf("stored Title: want %q, got %q", "fix auth bug", entry.Title)
+	}
+	if got := m.StatusMsg(); !strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusMsg() = %q, want it to confirm the new title", got)
+	}
+	if got := m.StatusBarView(); !strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusBarView() = %q, want it to contain the session title", got)
+	}
+}
+
+// TestTitleCommand_NoArgsPrintsCurrentTitle verifies that `/title` with no
+// arguments reports the current title.
+func TestTitleCommand_NoArgsPrintsCurrentTitle(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	m = sendSlashCommand(m, "/title")
+
+	if got := m.StatusMsg(); !strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusMsg() = %q, want it to show the current title", got)
+	}
+}
+
+// TestTitleCommand_NoArgsWithoutTitle verifies that `/title` with no title set
+// explains how to set one.
+func TestTitleCommand_NoArgsWithoutTitle(t *testing.T) {
+	m := initModelForTitle(t)
+
+	m = sendSlashCommand(m, "/title")
+
+	if got := m.StatusMsg(); !strings.Contains(got, "No title set") {
+		t.Errorf("StatusMsg() = %q, want a 'No title set' hint", got)
+	}
+}
+
+// TestTitleCommand_ClearRemovesTitle verifies that `/title clear` removes the
+// title from the store and the status bar.
+func TestTitleCommand_ClearRemovesTitle(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	m = sendSlashCommand(m, "/title clear")
+
+	entry, _ := m.SessionStore().Get("run-1")
+	if entry.Title != "" {
+		t.Errorf("stored Title after /title clear: want empty, got %q", entry.Title)
+	}
+	if got := m.StatusBarView(); strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusBarView() = %q, must not show the cleared title", got)
+	}
+}
+
+// TestTitleCommand_ClearOnlyWhenSoleArgument documents that `clear` only
+// clears when it is the entire argument list; `/title clear screen` sets a
+// literal title.
+func TestTitleCommand_ClearOnlyWhenSoleArgument(t *testing.T) {
+	m := initModelForTitle(t)
+
+	m = sendSlashCommand(m, "/title clear screen")
+
+	entry, _ := m.SessionStore().Get("run-1")
+	if entry.Title != "clear screen" {
+		t.Errorf("stored Title: want %q, got %q", "clear screen", entry.Title)
+	}
+}
+
+// TestTitleCommand_RequiresActiveSession verifies that `/title` before any
+// session exists explains that a session is required and stores nothing.
+func TestTitleCommand_RequiresActiveSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 80, 24) // no RunStartedMsg: no active session
+
+	m = sendSlashCommand(m, "/title foo")
+
+	if got := m.StatusMsg(); !strings.Contains(got, "No active session") {
+		t.Errorf("StatusMsg() = %q, want a 'No active session' explanation", got)
+	}
+	if n := len(m.SessionStore().List()); n != 0 {
+		t.Errorf("store must stay empty when there is no active session, got %d entries", n)
+	}
+}
+
+// TestTitleCommand_PersistsAcrossReload simulates a TUI restart: a new
+// SessionStore reading the same sessions.json must see the title.
+func TestTitleCommand_PersistsAcrossReload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	m := initModel(t, 80, 24)
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-1"})
+	m = m2.(tui.Model)
+
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	reloaded := tui.NewSessionStore(filepath.Join(home, ".config", "harnesscli"))
+	if err := reloaded.Load(); err != nil {
+		t.Fatalf("Load after simulated restart: %v", err)
+	}
+	entry, ok := reloaded.Get("run-1")
+	if !ok {
+		t.Fatal("session missing after simulated restart")
+	}
+	if entry.Title != "fix auth bug" {
+		t.Errorf("Title after restart: want %q, got %q", "fix auth bug", entry.Title)
+	}
+}
+
+// TestTitleCommand_SessionPickerShowsTitle verifies that /sessions renders the
+// title instead of the session ID for titled sessions.
+func TestTitleCommand_SessionPickerShowsTitle(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	m = sendSlashCommand(m, "/sessions")
+	v := m.View()
+
+	if !strings.Contains(v, "fix auth bug") {
+		t.Errorf("/sessions view must contain the session title:\n%s", v)
+	}
+	if strings.Contains(v, "run-1") {
+		t.Errorf("/sessions view must not show the bare session ID when a title is set:\n%s", v)
+	}
+}
+
+// TestTitleCommand_SwitchingSessionLoadsItsTitle verifies that picking a
+// titled session in /sessions updates the status bar to that session's title.
+func TestTitleCommand_SwitchingSessionLoadsItsTitle(t *testing.T) {
+	m := initModelForTitle(t)
+	m.SessionStore().Add(tui.StoredSessionEntry{
+		ID:        "sess-b",
+		StartedAt: time.Now(),
+		Title:     "second session",
+	})
+
+	m2, _ := m.Update(tui.SessionPickerSelectedMsg{SessionID: "sess-b"})
+	m = m2.(tui.Model)
+
+	if got := m.StatusBarView(); !strings.Contains(got, "second session") {
+		t.Errorf("StatusBarView() = %q, want the switched session's title", got)
+	}
+}
+
+// TestTitleCommand_SwitchingToUntitledSessionClearsStatusbar verifies that
+// switching from a titled session to an untitled one removes the title from
+// the status bar.
+func TestTitleCommand_SwitchingToUntitledSessionClearsStatusbar(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+	m.SessionStore().Add(tui.StoredSessionEntry{ID: "sess-plain", StartedAt: time.Now()})
+
+	m2, _ := m.Update(tui.SessionPickerSelectedMsg{SessionID: "sess-plain"})
+	m = m2.(tui.Model)
+
+	if got := m.StatusBarView(); strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusBarView() = %q, must not keep the previous session's title", got)
+	}
+}
+
+// TestTitleCommand_NewSessionClearsStatusbar verifies that /new drops the
+// title from the status bar.
+func TestTitleCommand_NewSessionClearsStatusbar(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	m = sendSlashCommand(m, "/new")
+
+	if got := m.StatusBarView(); strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusBarView() = %q after /new, must not show the old session's title", got)
+	}
+}
+
+// TestTitleCommand_TitleSurvivesWindowResize verifies the status bar title is
+// re-applied when the status bar is rebuilt on a WindowSizeMsg.
+func TestTitleCommand_TitleSurvivesWindowResize(t *testing.T) {
+	m := initModelForTitle(t)
+	m = sendSlashCommand(m, "/title fix auth bug")
+
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = m2.(tui.Model)
+
+	if got := m.StatusBarView(); !strings.Contains(got, "fix auth bug") {
+		t.Errorf("StatusBarView() = %q after resize, want the title re-applied", got)
+	}
+}
+
+// TestTitleCommand_Registered verifies the title command is registered and
+// dispatchable in the built-in registry.
+func TestTitleCommand_Registered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("title") {
+		t.Fatal("built-in registry must register the title command")
+	}
+	entry, ok := r.Lookup("title")
+	if !ok {
+		t.Fatal("Lookup(title) returned false")
+	}
+	if entry.Description == "" {
+		t.Error("title command must have a description for /help and autocomplete")
+	}
+}
+
+// TestTitleCommand_InSlashComplete verifies /title appears in the autocomplete
+// dropdown when typing "/ti".
+func TestTitleCommand_InSlashComplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 120, 40)
+	m = typeIntoModel(m, "/ti")
+	v := m.View()
+	if !strings.Contains(v, "title") {
+		t.Errorf("slash-complete must contain 'title' when typing '/ti'; got:\n%s", v)
+	}
+}
+
+// TestTitleCommand_InHelpDialog verifies /title is listed in the /help overlay.
+// The window must be tall enough to show every registered command: the help
+// dialog renders height-13 content lines and the registry has ~28 commands.
+func TestTitleCommand_InHelpDialog(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 120, 50)
+	m = sendSlashCommand(m, "/help")
+	if v := m.View(); !strings.Contains(v, "title") {
+		t.Errorf("/help overlay must list the title command; got:\n%s", v)
+	}
+}

--- a/docs/plans/822-qol-commands.md
+++ b/docs/plans/822-qol-commands.md
@@ -1,0 +1,57 @@
+# Plan: /title — name sessions and show the title in statusbar and picker
+
+Epic: #822 (slice 1 of 5). Parent: #803. Branch: `epic/822-qol-commands`.
+
+## Context
+
+- Problem: sessions are identified only by a bare conversation ID; users cannot label them.
+- User impact: `/title fix auth bug` names a session; the name survives restarts and shows in the statusbar and `/sessions` picker.
+- Constraints: title stays client-side (`sessions.json`); no server store changes; strict TDD.
+
+## Scope
+
+- In scope:
+  - `Title string \`json:"title,omitempty"\`` on `StoredSessionEntry` + `SetTitle(id, title) bool` setter (`cmd/harnesscli/tui/sessionstore.go`).
+  - `title` command in `builtinCommandEntries()` (`cmd_parser.go`): no args shows current title; args set it (`Save()`); `/title clear` removes it.
+  - Optional title segment in `components/statusbar` (`SetTitle`), rendered after the model segment.
+  - `Title` on `sessionpicker.SessionEntry`; picker row prefers title over the 8-char ID.
+  - Wiring: statusbar title refreshed on WindowSizeMsg, `/title`, session switch, `/new`, and RunStartedMsg.
+  - Docs: one row in `website/docs/cli/tui.md`, one row in `docs/ux-paths.md`, plans index entry.
+- Out of scope: server-side title columns, other epic slices (`/init`, `/add-dir`, `/feedback`, `/upgrade`).
+
+## Documentation Contract
+
+- Feature status: `implemented`
+- Public docs affected: `website/docs/cli/tui.md` (slash-command table), `docs/ux-paths.md` (command table)
+- Spec docs to update before code: none (epic #822 body is the contract)
+- Implementation notes to add after code: none required for this slice
+
+## Test Plan (TDD)
+
+- New failing tests to add first:
+  - `sessionstore_test.go`: title round-trip; legacy JSON without `title` loads with empty Title; empty title omitted from saved JSON; `SetTitle` found/not-found.
+  - `title_test.go` (new): `/title` set + show + clear via the model; no-session error path; persistence across store reload; statusbar shows title; session switch loads the titled session's title; `/new` clears it; picker shows title; registry/slash-complete contains `title`.
+  - `components/statusbar/statusbar_test.go`: title rendered when set; unchanged when empty; long title truncated.
+  - `components/sessionpicker/model_test.go`: row prefers title over short ID; falls back to ID when empty.
+- Existing tests to update: none expected (additive change).
+- Regression tests required: legacy `sessions.json` without `title` key loads unchanged.
+
+## Cross-Surface Impact Map
+
+- None required: no provider/model flow, gateway routing, model catalog, API-key, or server plumbing changes. All state is client-side in the TUI.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above; acceptance from epic: `/title fix auth bug`, restart, `/sessions` shows title, statusbar shows it in session).
+- [x] Write failing tests first (store, command, statusbar, picker).
+- [x] Implement minimal code changes.
+- [x] Update docs (`tui.md`, `ux-paths.md`, plans index).
+- [x] Run `go test ./cmd/harnesscli/... -count=1` (27 packages ok); gofmt + go vet clean on touched files.
+- [ ] Push branch, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: `/title clear` collides with a literal one-word title "clear".
+  - Mitigation: `clear` clears only when it is the sole argument; `/title clear screen` still sets the literal title "clear screen". Documented in the command description.
+- Risk: tests writing to the developer's real `~/.config/harnesscli/sessions.json`.
+  - Mitigation: every new model-level test sets `t.Setenv("HOME", t.TempDir())` before `initModel` (existing repo pattern).

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,6 +5,7 @@
 - `2026-07-19-issue-818-clipboard-image-plan.md` — Epic #818 slice 1: read images from the system clipboard into a temp file (in implementation).
 - `2026-07-19-issue-818-clipboard-image-impact-map.md` — One-page provider/model impact map for epic #818 slice 1.
 - `810-theme-system.md` — Theme system epic #810, slice 1: token schema + JSON loader with base-palette fallback (in implementation).
+- `822-qol-commands.md` — Epic #822 slice 1: `/title` command for naming sessions, shown in statusbar and session picker (in implementation).
 
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.

--- a/docs/ux-paths.md
+++ b/docs/ux-paths.md
@@ -336,6 +336,9 @@ Registry (`cmd_parser.go:79-194`): clear, context, export, help, keys, model, qu
 | `/profiles` | profile picker | OK | `model.go:1026-1033`; model_init_test.go |
 | `/sessions` | session picker | OK | `model.go:1035-1042`; `TestSS006_SessionsCommandOpensOverlay` |
 | `/new` | reset conversationID | OK | `model.go:1044-1053`; `TestSS005_NewCommandResetsConversationID` |
+| `/title <text>` | set session title; persists; shown in statusbar + picker | OK | `model.go` (`executeTitleCommand`); title_test.go |
+| `/title` (no args) | show current title / "No title set" hint | OK | title_test.go |
+| `/title clear` | remove session title | OK | title_test.go |
 | `/search <q>` | search transcript | OK | `model.go:1055-1068`; search_test.go (12+) |
 | `/search` (no args) | usage hint | OK | `model.go:1056-1058`; `TestSearch_BT002_EmptyQueryStatusMessage` |
 | `/history <q>` | search session meta | OK | `model.go:1070-1083`; `TestSearch_BT006_HistorySearchOpensOverlay` |

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -138,6 +138,7 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/model` | Open the model picker |
 | `/profiles` | View and select a capability profile |
 | `/sessions` | Browse and resume past sessions |
+| `/title [text]` | Set or show the current session's title (`/title clear` removes it). Shown in the status bar and the `/sessions` picker, persisted across restarts |
 | `/new` | Start a fresh conversation (resets conversation ID) |
 | `/search <query>` | Search the current session transcript |
 | `/history <query>` | Search across stored session metadata |


### PR DESCRIPTION
Parent epic: #822. Part of #803.

## What

Adds the `/title` slash command (slice 1 of #822):

- `StoredSessionEntry.Title` (`json:"title,omitempty"`) + `SessionStore.SetTitle(id, title)` — legacy `sessions.json` files load unchanged.
- `/title` shows the current title; `/title <text>` sets it and persists via `Save()`; `/title clear` removes it.
- New optional title segment in the statusbar (after the model segment), refreshed on window resize, run start, session switch, and `/new`.
- `/sessions` picker rows prefer the title over the truncated 8-char session ID (titles clipped to 20 runes).
- Registered in `builtinCommandEntries()`, so it appears in the `/` autocomplete dropdown and `/help` automatically.

## Tests (TDD — tests written first, watched fail, then implemented)

- sessionstore: title round-trip, legacy JSON without `title` loads with empty Title, empty title omitted from saved JSON, SetTitle found/not-found.
- model dispatch: set/show/clear/no-session paths through the real `CommandSubmittedMsg` dispatch, persistence across store reload (simulated restart), session switch loads/clears the title, `/new` clears it, title survives window resize, registry + slash-complete + /help registration.
- statusbar: title rendered when set, unchanged when empty, long titles truncated, clear restores baseline.
- sessionpicker: prefers title over ID, falls back to ID, truncates long titles.

`go test ./cmd/harnesscli/... -count=1` — 27 packages ok. Regression note on the PR check: `./scripts/test-regression.sh` stage `go test ./... -race` hit a pre-existing timing flake in `cmd/harnessd` (`TestRunWithSignalsMemoryProviderModeFromProjectConfig`: server health check > 3s under concurrent load); it passes in isolation on `main` and in this worktree, and `cmd/harnessd` does not import the TUI package.

## Docs

- `website/docs/cli/tui.md`: slash-command table row.
- `docs/ux-paths.md`: /title rows in the command table.
- Plan: `docs/plans/822-qol-commands.md` (+ plans index).