### PR TITLE
test(acp): cover drainLine and rpcError.Error to restore coverage gate

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,11 @@
 # Engineering Log
 
+## 2026-07-19 (Coverage-Gate Fix — `internal/acp` Zero-Coverage Functions)
+
+- Post-merge regression gate (`scripts/test-regression.sh`) failed after epic #806 slice 1 landed: `coveragegate` flagged `(*Conn).drainLine` (conn.go) and `(*rpcError).Error` (jsonrpc.go) at 0.0%.
+- Cause: the existing oversized-line tests only exercised the path where the over-cap fragment already contains the newline (no drain needed); the drain path (fragment ends mid-line, `ErrBufferFull`) and the `error`-interface method were never called.
+- Fix (test-only): added a `ReadLine` subtest that shrinks `maxMessageSize` below the bufio buffer size so the crossing fragment lacks the terminator (covers `drainLine` and stream realignment), plus a direct `rpcError.Error` test. Both functions now report 100%.
+
 ## 2026-07-19 (Plugin Home Decision + Manifest v1 Contract — Epic #821 Slice 1)
 
 - Extended `docs/design/installable-plugin-bundles.md` into the stable v1 authoring contract: full `plugin.json` field reference with validation rules, install layout (`<name>/<version>` under `$HARNESS_GLOBAL_DIR/plugins`, default `~/.go-harness/plugins`), and the enabled-vs-trusted gating table grounded in the current loader wiring.

--- a/internal/acp/conn_test.go
+++ b/internal/acp/conn_test.go
@@ -87,6 +87,29 @@ func TestConnReadLine(t *testing.T) {
 		}
 	})
 
+	t.Run("oversized line with unconsumed terminator drains remainder", func(t *testing.T) {
+		// When the fragment that pushes the buffer over maxMessageSize does
+		// not contain the line's newline, ReadLine must drain through the
+		// terminator so the stream stays aligned. Shrink the cap below the
+		// bufio buffer size so the crossing fragment ends mid-line.
+		old := maxMessageSize
+		maxMessageSize = 5000
+		defer func() { maxMessageSize = old }()
+
+		big := strings.Repeat("x", 9000)
+		c := NewConn(strings.NewReader(big+"\n{\"ok\":true}\n"), io.Discard)
+		if _, err := c.ReadLine(); !errors.Is(err, ErrMessageTooLarge) {
+			t.Fatalf("expected ErrMessageTooLarge, got %v", err)
+		}
+		line, err := c.ReadLine()
+		if err != nil {
+			t.Fatalf("ReadLine after oversized: %v", err)
+		}
+		if string(line) != `{"ok":true}` {
+			t.Fatalf("stream misaligned after drain, got %q", line[:min(len(line), 40)])
+		}
+	})
+
 	t.Run("final line without trailing newline is delivered", func(t *testing.T) {
 		c := NewConn(strings.NewReader(`{"a":1}`), io.Discard)
 		line, err := c.ReadLine()

--- a/internal/acp/jsonrpc_test.go
+++ b/internal/acp/jsonrpc_test.go
@@ -1,0 +1,10 @@
+package acp
+
+import "testing"
+
+func TestRPCErrorError(t *testing.T) {
+	e := &rpcError{Code: CodeParseError, Message: "parse error"}
+	if e.Error() != "parse error" {
+		t.Fatalf("Error() = %q, want %q", e.Error(), "parse error")
+	}
+}


### PR DESCRIPTION
The post-merge regression gate (`scripts/test-regression.sh`) failed on main after #835 landed: `coveragegate` flagged two zero-coverage functions in the new `internal/acp` package.

- `(*Conn).drainLine` (conn.go:74) — existing oversized-line tests only cover the path where the over-cap fragment already contains the newline, so the drain branch never ran. The new subtest shrinks `maxMessageSize` below the bufio buffer size (the var exists for exactly this) so the crossing fragment ends mid-line with `ErrBufferFull`, forcing `drainLine` and asserting the stream stays aligned for the next message.
- `(*rpcError).Error` (jsonrpc.go:59) — the error-interface method was never called; added a direct unit test.

Test-only change, no production code touched. Verified: `go test -count=1 ./internal/acp/` green; both functions now report 100% coverage.