### PR TITLE
refactor(catalog): generalize live model discovery to all providers — epic #849

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,7 @@ the SQLite conversation store persists the latest plan content per conversation.
 ACP session lifecycle, streamed updates, cancellation, and approvals to the
 existing harnessd HTTP/SSE API. See `docs/runbooks/acp.md` for setup and the
 manual Zed verification checklist.
+
+## 2026-07-20 — Live model discovery (Epic #849)
+
+- Live model discovery is provider-agnostic: configured OpenRouter, OpenAI, Anthropic, and DeepSeek entries refresh on a five-minute TTL. Discovery failures never remove static models; cached results are served stale after a failed refresh, and static metadata wins on ID conflicts.

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -118,7 +118,7 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 
 	if bootstrap.providerRegistry != nil {
 		if _, ok := bootstrap.modelCatalog.Providers["openrouter"]; ok {
-			bootstrap.providerRegistry.SetOpenRouterDiscovery(catalog.NewDiscovery(catalog.DiscoveryOptions{
+			bootstrap.providerRegistry.SetDiscovery("openrouter", catalog.NewDiscovery(catalog.DiscoveryOptions{
 				TTL: 5 * time.Minute,
 			}))
 		}

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -117,11 +117,7 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 	}
 
 	if bootstrap.providerRegistry != nil {
-		if _, ok := bootstrap.modelCatalog.Providers["openrouter"]; ok {
-			bootstrap.providerRegistry.SetDiscovery("openrouter", catalog.NewDiscovery(catalog.DiscoveryOptions{
-				TTL: 5 * time.Minute,
-			}))
-		}
+		registerModelDiscoverers(bootstrap.providerRegistry)
 		bootstrap.providerRegistry.SetClientFactory(func(apiKey, baseURL, providerName string) (catalog.ProviderClient, error) {
 			if providerName == "anthropic" {
 				return anthropic.NewClient(anthropic.Config{
@@ -174,6 +170,28 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 	}
 
 	return bootstrap, nil
+}
+
+func registerModelDiscoverers(registry *catalog.ProviderRegistry) {
+	for _, providerName := range []string{"openrouter", "openai", "anthropic", "deepseek"} {
+		if !registry.IsConfigured(providerName) {
+			continue
+		}
+		apiKey, baseURL, ok := registry.DiscoveryCredentials(providerName)
+		if !ok {
+			continue
+		}
+		switch providerName {
+		case "openrouter":
+			registry.SetDiscovery(providerName, catalog.NewDiscovery(catalog.DiscoveryOptions{TTL: 5 * time.Minute}))
+		case "openai":
+			registry.SetDiscovery(providerName, openai.NewModelDiscovery(openai.Config{APIKey: apiKey, BaseURL: baseURL}))
+		case "anthropic":
+			registry.SetDiscovery(providerName, anthropic.NewModelDiscovery(anthropic.Config{APIKey: apiKey, BaseURL: baseURL}))
+		case "deepseek":
+			registry.SetDiscovery(providerName, openai.NewDeepSeekModelDiscovery(openai.Config{APIKey: apiKey, BaseURL: baseURL, ProviderName: providerName}))
+		}
+	}
 }
 
 type cronBootstrap struct {

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -118,7 +118,7 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 
 	if bootstrap.providerRegistry != nil {
 		if _, ok := bootstrap.modelCatalog.Providers["openrouter"]; ok {
-			bootstrap.providerRegistry.SetOpenRouterDiscovery(catalog.NewOpenRouterDiscovery(catalog.OpenRouterDiscoveryOptions{
+			bootstrap.providerRegistry.SetOpenRouterDiscovery(catalog.NewDiscovery(catalog.DiscoveryOptions{
 				TTL: 5 * time.Minute,
 			}))
 		}

--- a/cmd/harnessd/bootstrap_helpers_test.go
+++ b/cmd/harnessd/bootstrap_helpers_test.go
@@ -73,6 +73,37 @@ func TestBuildCatalogBootstrapFallsBackToWorkspaceCatalog(t *testing.T) {
 	}
 }
 
+func TestBuildCatalogBootstrapRegistersDiscoverersOnlyForConfiguredProviders(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(workspace+"/catalog", 0o755); err != nil {
+		t.Fatalf("mkdir catalog: %v", err)
+	}
+	if err := os.WriteFile(workspace+"/catalog/models.json", []byte(`{"catalog_version":"1.0","providers":{"openai":{"display_name":"OpenAI","base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_API_KEY","protocol":"openai_compat","models":{"gpt":{"display_name":"GPT","context_window":1}}},"anthropic":{"display_name":"Anthropic","base_url":"https://api.anthropic.com/v1","api_key_env":"ANTHROPIC_API_KEY","protocol":"anthropic","models":{"claude":{"display_name":"Claude","context_window":1}}},"deepseek":{"display_name":"DeepSeek","base_url":"https://api.deepseek.com/v1","api_key_env":"DEEPSEEK_API_KEY","protocol":"openai_compat","models":{"deepseek":{"display_name":"DeepSeek","context_window":1}}}}}`), 0o644); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+	bootstrap, err := buildCatalogBootstrap(catalogBootstrapOptions{
+		workspace: workspace,
+		getenv: func(key string) string {
+			if key == "OPENAI_API_KEY" || key == "DEEPSEEK_API_KEY" {
+				return "test-key"
+			}
+			return ""
+		},
+		newProvider: func(openai.Config) (harness.Provider, error) { return &noopProvider{}, nil },
+	})
+	if err != nil {
+		t.Fatalf("buildCatalogBootstrap: %v", err)
+	}
+	if !bootstrap.providerRegistry.HasDiscovery("openai") || !bootstrap.providerRegistry.HasDiscovery("deepseek") {
+		t.Fatal("expected discoverers for configured providers")
+	}
+	if bootstrap.providerRegistry.HasDiscovery("anthropic") {
+		t.Fatal("did not expect a discoverer for unconfigured anthropic")
+	}
+}
+
 // TestBuildCatalogBootstrapAnthropicFactoryUsesCatalogMaxTokens is a BUG2(a)
 // regression guard: the anthropic client the registry's ClientFactory builds
 // must be constructed with the loaded model catalog wired in, so that

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1607,3 +1607,9 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
 
 - Added validated, versioned installable bundles with explicit enabled versus trusted lifecycle state, CLI/TUI management, marketplace indexes, and runtime reuse of the existing skills, profiles, MCP, and hooks paths.
 - Remote installs default untrusted; hook and MCP execution are unreachable until explicit trust.
+
+## 2026-07-20 (Epic #849 Live Model Discovery)
+
+- Generalized the catalog's OpenRouter-only cache into provider-agnostic live model discovery.
+- OpenRouter, OpenAI, Anthropic, and DeepSeek now have five-minute cached listings when configured; failures retain stale cached results when present and otherwise leave the static catalog untouched.
+- Live listings add models while curated catalog metadata remains authoritative on matching IDs.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -557,7 +557,13 @@ Use this file to document systems, interfaces, and interactions as they are buil
   - workflow or network execution failures are persisted as terminal failed runs with step-level error text
 - Operational notes:
   - workflow and network routes are now real but remain intentionally conservative in v1
-  - sequential network execution is implemented; parallel fan-out remains deferred
+- sequential network execution is implemented; parallel fan-out remains deferred
+
+## 2026-07-20 (Live model discovery — Epic #849)
+
+- System/component: `internal/provider/catalog`, OpenAI/Anthropic provider clients, and `harnessd` startup.
+- Configured OpenRouter, OpenAI, Anthropic, and DeepSeek providers refresh their model lists on a five-minute in-memory TTL using their existing credentials.
+- A failed initial refresh preserves static catalog models; a failed later refresh serves stale cached models. Static metadata, including pricing and model guidance, wins over sparse live records.
 # 2026-07-19 — Plugin bundle subsystem
 
 - `internal/plugins` owns bundle validation, safe staged installation, persisted lifecycle state, marketplace index parsing, and discovery. `harnessd` loads enabled skills/commands and gates agents/MCP/hooks on trust.

--- a/docs/plans/2026-07-20-live-model-discovery-849-plan.md
+++ b/docs/plans/2026-07-20-live-model-discovery-849-plan.md
@@ -1,0 +1,56 @@
+# Live Model Discovery — Epic #849 Plan
+
+## Context
+
+The static model catalog is useful for curated metadata but cannot keep pace with
+provider releases. This epic generalizes OpenRouter's existing five-minute live
+discovery cache so configured providers can add their live model listings without
+ever removing static models when discovery is unavailable.
+
+## Scope
+
+- Generalize OpenRouter discovery types and preserve its cache/fallback behavior.
+- Replace the single registry discoverer with provider-keyed registration and
+  additive, metadata-preserving merging.
+- Add OpenAI, Anthropic, and DeepSeek live discoverers using their configured
+  credentials; DeepSeek is the confirmed OpenAI-compatible provider selected for
+  this epic.
+- Wire configured discoverers in `harnessd` and document the behavior.
+
+Out of scope: changing credential resolution, removing static catalog metadata,
+and discovery for unconfigured or subscription-only providers.
+
+## Documentation Contract
+
+- Append the mechanism, providers, five-minute TTL, and static/stale fallback
+  policy to `docs/logs/engineering-log.md`, `docs/logs/system-log.md`, and
+  `CLAUDE.md` after implementation.
+- Keep this plan checklist current and keep the existing catalog as the durable
+  curated metadata source.
+
+## Test Plan (TDD)
+
+For every checklist slice, add the behavior test first, run it red, implement
+only what makes it pass, then run the affected package suite before committing.
+Use realistic fake HTTP responses for the three provider APIs. Finish with
+`gofmt -l .`, `go vet ./...`, provider/harnessd tests, and the full regression
+script.
+
+## Cross-Surface Impact Map
+
+| Surface | Impact |
+| --- | --- |
+| Config | Existing provider API keys and base URLs remain the only inputs; discovery is registered only when `IsConfigured` is true. |
+| Server API | Existing merged catalog consumers (`/models`, model resolution, context lookup) gain live provider models; no route contract changes. |
+| TUI state | TUI and `/keys` receive the existing server model list with additive live entries; no client state or protocol change. |
+| Regression tests | Catalog cache/merge/fallback tests plus realistic OpenAI, Anthropic, and DeepSeek fake-server tests; harnessd startup coverage. |
+
+## Implementation Checklist
+
+- [x] refactor(catalog): generalize OpenRouterModelDiscoverer/Discovery/OpenRouterModel to provider-agnostic ModelDiscoverer/Discovery/DiscoveredModel, OpenRouter behavior unchanged (regression-tested)
+- [ ] refactor(catalog): ProviderRegistry.discoverers map + SetDiscovery, effectiveCatalog/merge logic generalized across every registered discoverer
+- [ ] feat(provider/openai): live model discovery via GET /v1/models
+- [ ] feat(provider/anthropic): live model discovery via GET /v1/models
+- [ ] feat(provider): live model discovery for one additional OpenAI-compatible provider from the existing catalog (confirm which during implementation)
+- [ ] feat(harnessd): wire discoverers at startup for every configured provider
+- [ ] docs(provider): document the discovery mechanism, TTL, and fallback policy

--- a/docs/plans/2026-07-20-live-model-discovery-849-plan.md
+++ b/docs/plans/2026-07-20-live-model-discovery-849-plan.md
@@ -48,9 +48,9 @@ script.
 ## Implementation Checklist
 
 - [x] refactor(catalog): generalize OpenRouterModelDiscoverer/Discovery/OpenRouterModel to provider-agnostic ModelDiscoverer/Discovery/DiscoveredModel, OpenRouter behavior unchanged (regression-tested)
-- [ ] refactor(catalog): ProviderRegistry.discoverers map + SetDiscovery, effectiveCatalog/merge logic generalized across every registered discoverer
-- [ ] feat(provider/openai): live model discovery via GET /v1/models
-- [ ] feat(provider/anthropic): live model discovery via GET /v1/models
-- [ ] feat(provider): live model discovery for one additional OpenAI-compatible provider from the existing catalog (confirm which during implementation)
-- [ ] feat(harnessd): wire discoverers at startup for every configured provider
-- [ ] docs(provider): document the discovery mechanism, TTL, and fallback policy
+- [x] refactor(catalog): ProviderRegistry.discoverers map + SetDiscovery, effectiveCatalog/merge logic generalized across every registered discoverer
+- [x] feat(provider/openai): live model discovery via GET /v1/models
+- [x] feat(provider/anthropic): live model discovery via GET /v1/models
+- [x] feat(provider): live model discovery for one additional OpenAI-compatible provider from the existing catalog (confirm which during implementation)
+- [x] feat(harnessd): wire discoverers at startup for every configured provider
+- [x] docs(provider): document the discovery mechanism, TTL, and fallback policy

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -7,6 +7,7 @@
 - `806-acp-server.md` — ACP server mode epic #806, slice 1: stdio JSON-RPC framing and initialize handshake in the stdlib-only `internal/acp` package plus the `harness acp` subcommand (in implementation).
 - `805-undo-prompts.md` — Epic #805 Slice 1 plan: `ConversationStore.UndoPrompts` with compaction-boundary guard (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
+- `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.
 
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1386,7 +1386,7 @@ func TestRunnerRoutesDynamicOpenRouterSlugViaRegistry(t *testing.T) {
 		}
 		return ""
 	})
-	reg.SetOpenRouterDiscovery(runnerTestOpenRouterDiscovery{
+	reg.SetDiscovery("openrouter", runnerTestOpenRouterDiscovery{
 		models: []catalog.DiscoveredModel{
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1387,7 +1387,7 @@ func TestRunnerRoutesDynamicOpenRouterSlugViaRegistry(t *testing.T) {
 		return ""
 	})
 	reg.SetOpenRouterDiscovery(runnerTestOpenRouterDiscovery{
-		models: []catalog.OpenRouterModel{
+		models: []catalog.DiscoveredModel{
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},
 	})
@@ -1451,12 +1451,12 @@ func TestRunnerRoutesDynamicOpenRouterSlugViaRegistry(t *testing.T) {
 }
 
 type runnerTestOpenRouterDiscovery struct {
-	models []catalog.OpenRouterModel
+	models []catalog.DiscoveredModel
 	err    error
 }
 
-func (d runnerTestOpenRouterDiscovery) Models(context.Context) ([]catalog.OpenRouterModel, error) {
-	out := make([]catalog.OpenRouterModel, len(d.models))
+func (d runnerTestOpenRouterDiscovery) Models(context.Context) ([]catalog.DiscoveredModel, error) {
+	out := make([]catalog.DiscoveredModel, len(d.models))
 	copy(out, d.models)
 	return out, d.err
 }

--- a/internal/provider/anthropic/discovery.go
+++ b/internal/provider/anthropic/discovery.go
@@ -1,0 +1,72 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/provider/catalog"
+)
+
+// NewModelDiscovery returns a cached discoverer for Anthropic's GET /v1/models
+// endpoint. It uses the configured Anthropic API key and version header.
+func NewModelDiscovery(config Config) catalog.ModelDiscoverer {
+	baseURL := strings.TrimRight(strings.TrimSpace(config.BaseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	return catalog.NewDiscovery(catalog.DiscoveryOptions{
+		Endpoint: baseURL + "/models",
+		Client:   config.Client,
+		TTL:      5 * time.Minute,
+		Fetch: func(ctx context.Context, client *http.Client, endpoint string) ([]catalog.DiscoveredModel, error) {
+			return fetchModels(ctx, client, endpoint, config.APIKey)
+		},
+	})
+}
+
+func fetchModels(ctx context.Context, client *http.Client, endpoint, apiKey string) ([]catalog.DiscoveredModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create anthropic model-list request: %w", err)
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch anthropic models: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch anthropic models: status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode anthropic models: %w", err)
+	}
+	models := make([]catalog.DiscoveredModel, 0, len(payload.Data))
+	for _, entry := range payload.Data {
+		id := strings.TrimSpace(entry.ID)
+		if id != "" {
+			models = append(models, catalog.DiscoveredModel{ID: id, Name: firstNonEmpty(strings.TrimSpace(entry.DisplayName), id)})
+		}
+	}
+	return models, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/provider/anthropic/discovery_test.go
+++ b/internal/provider/anthropic/discovery_test.go
@@ -1,0 +1,40 @@
+package anthropic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-agent-harness/internal/provider/catalog"
+)
+
+func TestNewModelDiscoveryListsAnthropicModels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("expected /v1/models, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("x-api-key"); got != "test-key" {
+			t.Fatalf("expected x-api-key authentication, got %q", got)
+		}
+		if got := r.Header.Get("anthropic-version"); got != anthropicVersion {
+			t.Fatalf("expected anthropic version %q, got %q", anthropicVersion, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"data":[{"type":"model","id":"claude-sonnet-4-6","display_name":"Claude Sonnet 4.6","created_at":"2026-02-17T00:00:00Z"}],"has_more":false,"first_id":"claude-sonnet-4-6","last_id":"claude-sonnet-4-6"}`)
+	}))
+	defer srv.Close()
+
+	discovery := NewModelDiscovery(Config{APIKey: "test-key", BaseURL: srv.URL + "/v1", Client: srv.Client()})
+	models, err := discovery.Models(context.Background())
+	if err != nil {
+		t.Fatalf("Models() error: %v", err)
+	}
+	want := []catalog.DiscoveredModel{{ID: "claude-sonnet-4-6", Name: "Claude Sonnet 4.6"}}
+	if fmt.Sprint(models) != fmt.Sprint(want) {
+		t.Fatalf("models = %+v, want %+v", models, want)
+	}
+}

--- a/internal/provider/catalog/discovery.go
+++ b/internal/provider/catalog/discovery.go
@@ -10,41 +10,44 @@ import (
 	"time"
 )
 
-// OpenRouterModel is the minimal live metadata needed from OpenRouter's
-// public model listing endpoint.
-type OpenRouterModel struct {
+// DiscoveredModel is the minimal live metadata needed from a provider's model
+// listing endpoint.
+type DiscoveredModel struct {
 	ID            string
 	Name          string
 	ContextWindow int
 }
 
-// OpenRouterModelDiscoverer exposes cached live model lookup for OpenRouter.
-type OpenRouterModelDiscoverer interface {
-	Models(ctx context.Context) ([]OpenRouterModel, error)
+// ModelDiscoverer exposes cached live model lookup for a provider.
+type ModelDiscoverer interface {
+	Models(ctx context.Context) ([]DiscoveredModel, error)
 }
 
-// OpenRouterDiscoveryOptions configures OpenRouter live model discovery.
-type OpenRouterDiscoveryOptions struct {
+// DiscoveryOptions configures a provider's live model discovery.
+type DiscoveryOptions struct {
 	Endpoint string
 	Client   *http.Client
 	TTL      time.Duration
 	Now      func() time.Time
+	Fetch    func(ctx context.Context, client *http.Client, endpoint string) ([]DiscoveredModel, error)
 }
 
-// OpenRouterDiscovery fetches and caches live model data from OpenRouter.
-type OpenRouterDiscovery struct {
+// Discovery fetches and caches live model data from a provider.
+type Discovery struct {
 	endpoint string
 	client   *http.Client
 	ttl      time.Duration
 	now      func() time.Time
 
 	mu        sync.Mutex
-	cached    []OpenRouterModel
+	cached    []DiscoveredModel
 	expiresAt time.Time
+	fetchFn   func(ctx context.Context, client *http.Client, endpoint string) ([]DiscoveredModel, error)
 }
 
-// NewOpenRouterDiscovery creates an OpenRouter discovery client with in-memory TTL caching.
-func NewOpenRouterDiscovery(opts OpenRouterDiscoveryOptions) *OpenRouterDiscovery {
+// NewDiscovery creates a provider discovery client with in-memory TTL caching.
+// If Fetch is omitted, it decodes OpenRouter's public model-list response.
+func NewDiscovery(opts DiscoveryOptions) *Discovery {
 	client := opts.Client
 	if client == nil {
 		client = &http.Client{Timeout: 10 * time.Second}
@@ -61,28 +64,33 @@ func NewOpenRouterDiscovery(opts OpenRouterDiscoveryOptions) *OpenRouterDiscover
 	if endpoint == "" {
 		endpoint = "https://openrouter.ai/api/v1/models"
 	}
-	return &OpenRouterDiscovery{
+	fetchFn := opts.Fetch
+	if fetchFn == nil {
+		fetchFn = FetchOpenRouterModels
+	}
+	return &Discovery{
 		endpoint: endpoint,
 		client:   client,
 		ttl:      ttl,
 		now:      now,
+		fetchFn:  fetchFn,
 	}
 }
 
-// Models returns cached live OpenRouter models when fresh, refreshes stale
+// Models returns cached live provider models when fresh, refreshes stale
 // cache entries, and returns stale cached data if a refresh attempt fails.
-func (d *OpenRouterDiscovery) Models(ctx context.Context) ([]OpenRouterModel, error) {
+func (d *Discovery) Models(ctx context.Context) ([]DiscoveredModel, error) {
 	if d == nil {
-		return nil, fmt.Errorf("openrouter discovery is nil")
+		return nil, fmt.Errorf("model discovery is nil")
 	}
 
 	d.mu.Lock()
 	if len(d.cached) > 0 && d.now().Before(d.expiresAt) {
-		models := cloneOpenRouterModels(d.cached)
+		models := cloneDiscoveredModels(d.cached)
 		d.mu.Unlock()
 		return models, nil
 	}
-	cached := cloneOpenRouterModels(d.cached)
+	cached := cloneDiscoveredModels(d.cached)
 	d.mu.Unlock()
 
 	models, err := d.fetch(ctx)
@@ -94,20 +102,25 @@ func (d *OpenRouterDiscovery) Models(ctx context.Context) ([]OpenRouterModel, er
 	}
 
 	d.mu.Lock()
-	d.cached = cloneOpenRouterModels(models)
+	d.cached = cloneDiscoveredModels(models)
 	d.expiresAt = d.now().Add(d.ttl)
-	fresh := cloneOpenRouterModels(d.cached)
+	fresh := cloneDiscoveredModels(d.cached)
 	d.mu.Unlock()
 	return fresh, nil
 }
 
-func (d *OpenRouterDiscovery) fetch(ctx context.Context) ([]OpenRouterModel, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.endpoint, nil)
+func (d *Discovery) fetch(ctx context.Context) ([]DiscoveredModel, error) {
+	return d.fetchFn(ctx, d.client, d.endpoint)
+}
+
+// FetchOpenRouterModels decodes OpenRouter's public model-list response.
+func FetchOpenRouterModels(ctx context.Context, client *http.Client, endpoint string) ([]DiscoveredModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create openrouter request: %w", err)
 	}
 
-	resp, err := d.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch openrouter models: %w", err)
 	}
@@ -128,13 +141,13 @@ func (d *OpenRouterDiscovery) fetch(ctx context.Context) ([]OpenRouterModel, err
 		return nil, fmt.Errorf("decode openrouter models: %w", err)
 	}
 
-	models := make([]OpenRouterModel, 0, len(payload.Data))
+	models := make([]DiscoveredModel, 0, len(payload.Data))
 	for _, entry := range payload.Data {
 		id := strings.TrimSpace(entry.ID)
 		if id == "" {
 			continue
 		}
-		models = append(models, OpenRouterModel{
+		models = append(models, DiscoveredModel{
 			ID:            id,
 			Name:          strings.TrimSpace(entry.Name),
 			ContextWindow: entry.ContextLength,
@@ -143,11 +156,11 @@ func (d *OpenRouterDiscovery) fetch(ctx context.Context) ([]OpenRouterModel, err
 	return models, nil
 }
 
-func cloneOpenRouterModels(in []OpenRouterModel) []OpenRouterModel {
+func cloneDiscoveredModels(in []DiscoveredModel) []DiscoveredModel {
 	if len(in) == 0 {
 		return nil
 	}
-	out := make([]OpenRouterModel, len(in))
+	out := make([]DiscoveredModel, len(in))
 	copy(out, in)
 	return out
 }

--- a/internal/provider/catalog/discovery_docs_test.go
+++ b/internal/provider/catalog/discovery_docs_test.go
@@ -1,0 +1,26 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLiveModelDiscoveryIsDocumentedForOperators(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		filepath.Join("..", "..", "..", "docs", "logs", "engineering-log.md"),
+		filepath.Join("..", "..", "..", "docs", "logs", "system-log.md"),
+		filepath.Join("..", "..", "..", "CLAUDE.md"),
+	} {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(strings.ToLower(string(contents)), "live model discovery") {
+			t.Fatalf("%s does not document live model discovery", path)
+		}
+	}
+}

--- a/internal/provider/catalog/discovery_registry_test.go
+++ b/internal/provider/catalog/discovery_registry_test.go
@@ -35,7 +35,7 @@ func TestProviderRegistryResolveProviderUsesOpenRouterDiscovery(t *testing.T) {
 	}
 
 	reg := NewProviderRegistry(cat)
-	reg.SetOpenRouterDiscovery(stubOpenRouterDiscovery{
+	reg.SetDiscovery("openrouter", stubOpenRouterDiscovery{
 		models: []DiscoveredModel{
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},
@@ -88,7 +88,7 @@ func TestProviderRegistryListModelsMergesStaticAndOpenRouterDiscovery(t *testing
 	}
 
 	reg := NewProviderRegistry(cat)
-	reg.SetOpenRouterDiscovery(stubOpenRouterDiscovery{
+	reg.SetDiscovery("openrouter", stubOpenRouterDiscovery{
 		models: []DiscoveredModel{
 			{ID: "openai/gpt-4.1-mini", Name: "Live GPT-4.1 Mini", ContextWindow: 999999},
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
@@ -154,7 +154,7 @@ func TestProviderRegistryListModelsFallsBackToStaticWhenDiscoveryFails(t *testin
 	}
 
 	reg := NewProviderRegistry(cat)
-	reg.SetOpenRouterDiscovery(stubOpenRouterDiscovery{err: context.DeadlineExceeded})
+	reg.SetDiscovery("openrouter", stubOpenRouterDiscovery{err: context.DeadlineExceeded})
 
 	models := reg.ListModelsContext(context.Background())
 	if len(models) != 1 {
@@ -162,5 +162,45 @@ func TestProviderRegistryListModelsFallsBackToStaticWhenDiscoveryFails(t *testin
 	}
 	if models[0].ModelID != "openai/gpt-4.1-mini" {
 		t.Fatalf("expected static openrouter model, got %q", models[0].ModelID)
+	}
+}
+
+func TestProviderRegistrySetDiscoveryMergesNonOpenRouterAndFallsBackToStatic(t *testing.T) {
+	t.Parallel()
+
+	cat := &Catalog{CatalogVersion: "1.0", Providers: map[string]ProviderEntry{
+		"openai": {
+			DisplayName: "OpenAI", Models: map[string]Model{
+				"gpt-curated": {
+					DisplayName: "Curated GPT", ContextWindow: 128000, CostTier: "premium",
+					BestFor: []string{"coding"}, Pricing: &ModelPricing{InputPer1MTokensUSD: 1},
+				},
+			},
+		},
+	}}
+
+	reg := NewProviderRegistry(cat)
+	reg.SetDiscovery("openai", stubOpenRouterDiscovery{models: []DiscoveredModel{
+		{ID: "gpt-curated", Name: "Live GPT", ContextWindow: 1},
+		{ID: "gpt-live", Name: "Live GPT", ContextWindow: 256000},
+	}})
+	reg.SetDiscovery("missing", stubOpenRouterDiscovery{models: []DiscoveredModel{{ID: "ignored"}}})
+
+	byID := make(map[string]ModelResult)
+	for _, result := range reg.ListModelsContext(context.Background()) {
+		byID[result.ModelID] = result
+	}
+	curated := byID["gpt-curated"].Model
+	if curated.DisplayName != "Curated GPT" || curated.ContextWindow != 128000 || curated.Pricing == nil || curated.CostTier != "premium" || len(curated.BestFor) != 1 {
+		t.Fatalf("expected curated metadata to win, got %+v", curated)
+	}
+	if got := byID["gpt-live"].Model.ContextWindow; got != 256000 {
+		t.Fatalf("expected live-only model to be merged, got context %d", got)
+	}
+
+	reg.SetDiscovery("openai", stubOpenRouterDiscovery{err: context.DeadlineExceeded})
+	models := reg.ListModelsContext(context.Background())
+	if len(models) != 1 || models[0].ModelID != "gpt-curated" {
+		t.Fatalf("expected first-attempt discovery failure to retain static models, got %+v", models)
 	}
 }

--- a/internal/provider/catalog/discovery_registry_test.go
+++ b/internal/provider/catalog/discovery_registry_test.go
@@ -6,12 +6,12 @@ import (
 )
 
 type stubOpenRouterDiscovery struct {
-	models []OpenRouterModel
+	models []DiscoveredModel
 	err    error
 }
 
-func (s stubOpenRouterDiscovery) Models(context.Context) ([]OpenRouterModel, error) {
-	out := make([]OpenRouterModel, len(s.models))
+func (s stubOpenRouterDiscovery) Models(context.Context) ([]DiscoveredModel, error) {
+	out := make([]DiscoveredModel, len(s.models))
 	copy(out, s.models)
 	return out, s.err
 }
@@ -36,7 +36,7 @@ func TestProviderRegistryResolveProviderUsesOpenRouterDiscovery(t *testing.T) {
 
 	reg := NewProviderRegistry(cat)
 	reg.SetOpenRouterDiscovery(stubOpenRouterDiscovery{
-		models: []OpenRouterModel{
+		models: []DiscoveredModel{
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},
 	})
@@ -89,7 +89,7 @@ func TestProviderRegistryListModelsMergesStaticAndOpenRouterDiscovery(t *testing
 
 	reg := NewProviderRegistry(cat)
 	reg.SetOpenRouterDiscovery(stubOpenRouterDiscovery{
-		models: []OpenRouterModel{
+		models: []DiscoveredModel{
 			{ID: "openai/gpt-4.1-mini", Name: "Live GPT-4.1 Mini", ContextWindow: 999999},
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},

--- a/internal/provider/catalog/discovery_test.go
+++ b/internal/provider/catalog/discovery_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestOpenRouterDiscoveryDecode(t *testing.T) {
+func TestDiscoveryDecodeOpenRouterResponse(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -32,7 +32,7 @@ func TestOpenRouterDiscoveryDecode(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	discovery := NewOpenRouterDiscovery(OpenRouterDiscoveryOptions{
+	discovery := NewDiscovery(DiscoveryOptions{
 		Endpoint: srv.URL,
 		Client:   srv.Client(),
 		TTL:      time.Minute,
@@ -56,7 +56,7 @@ func TestOpenRouterDiscoveryDecode(t *testing.T) {
 	}
 }
 
-func TestOpenRouterDiscoveryTTLCache(t *testing.T) {
+func TestDiscoveryTTLCache(t *testing.T) {
 	t.Parallel()
 
 	var hits atomic.Int32
@@ -68,7 +68,7 @@ func TestOpenRouterDiscoveryTTLCache(t *testing.T) {
 	defer srv.Close()
 
 	now := time.Date(2026, 3, 25, 10, 0, 0, 0, time.UTC)
-	discovery := NewOpenRouterDiscovery(OpenRouterDiscoveryOptions{
+	discovery := NewDiscovery(DiscoveryOptions{
 		Endpoint: srv.URL,
 		Client:   srv.Client(),
 		TTL:      time.Minute,
@@ -106,7 +106,7 @@ func TestOpenRouterDiscoveryTTLCache(t *testing.T) {
 	}
 }
 
-func TestOpenRouterDiscoveryReturnsCachedDataWhenRefreshFails(t *testing.T) {
+func TestDiscoveryReturnsCachedDataWhenRefreshFails(t *testing.T) {
 	t.Parallel()
 
 	var calls atomic.Int32
@@ -122,7 +122,7 @@ func TestOpenRouterDiscoveryReturnsCachedDataWhenRefreshFails(t *testing.T) {
 	defer srv.Close()
 
 	now := time.Date(2026, 3, 25, 10, 0, 0, 0, time.UTC)
-	discovery := NewOpenRouterDiscovery(OpenRouterDiscoveryOptions{
+	discovery := NewDiscovery(DiscoveryOptions{
 		Endpoint: srv.URL,
 		Client:   srv.Client(),
 		TTL:      time.Minute,
@@ -144,5 +144,14 @@ func TestOpenRouterDiscoveryReturnsCachedDataWhenRefreshFails(t *testing.T) {
 	}
 	if len(second) != 1 || second[0].ID != first[0].ID {
 		t.Fatalf("expected cached model %q, got %+v", first[0].ID, second)
+	}
+}
+
+func TestDiscoveryNilReturnsError(t *testing.T) {
+	t.Parallel()
+
+	var discovery *Discovery
+	if _, err := discovery.Models(context.Background()); err == nil {
+		t.Fatal("expected nil generic discovery to return an error")
 	}
 }

--- a/internal/provider/catalog/registry.go
+++ b/internal/provider/catalog/registry.go
@@ -79,6 +79,37 @@ func (r *ProviderRegistry) SetDiscovery(providerName string, discoverer ModelDis
 	r.discoverers[providerName] = discoverer
 }
 
+// HasDiscovery reports whether providerName has a registered live discoverer.
+func (r *ProviderRegistry) HasDiscovery(providerName string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.discoverers[providerName]
+	return ok
+}
+
+// DiscoveryCredentials returns the already-configured credentials and base URL
+// for providerName. It follows the same runtime-override/environment precedence
+// as GetClient without constructing a completion client.
+func (r *ProviderRegistry) DiscoveryCredentials(providerName string) (apiKey, baseURL string, ok bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, found := r.catalog.Providers[providerName]
+	if !found {
+		return "", "", false
+	}
+	apiKey = r.overrideKeys[providerName]
+	if apiKey == "" {
+		apiKey = r.getenv(entry.APIKeyEnv)
+	}
+	if apiKey == "" && !entry.APIKeyOptional {
+		return "", "", false
+	}
+	if apiKey == "" {
+		apiKey = providerName
+	}
+	return apiKey, entry.BaseURL, true
+}
+
 // SetAPIKey stores a runtime API key override for the named provider.
 // When set, GetClient uses this key instead of the environment variable.
 func (r *ProviderRegistry) SetAPIKey(provider, key string) {

--- a/internal/provider/catalog/registry.go
+++ b/internal/provider/catalog/registry.go
@@ -26,15 +26,16 @@ type ProviderRegistry struct {
 	overrideKeys  map[string]string
 	getenv        func(string) string
 	clientFactory ClientFactory
-	openRouter    ModelDiscoverer
+	discoverers   map[string]ModelDiscoverer
 }
 
 // NewProviderRegistry creates a registry that uses os.Getenv for API key lookup.
 func NewProviderRegistry(catalog *Catalog) *ProviderRegistry {
 	return &ProviderRegistry{
-		catalog: catalog,
-		clients: make(map[string]ProviderClient),
-		getenv:  os.Getenv,
+		catalog:     catalog,
+		clients:     make(map[string]ProviderClient),
+		discoverers: make(map[string]ModelDiscoverer),
+		getenv:      os.Getenv,
 	}
 }
 
@@ -44,9 +45,10 @@ func NewProviderRegistryWithEnv(catalog *Catalog, getenv func(string) string) *P
 		getenv = os.Getenv
 	}
 	return &ProviderRegistry{
-		catalog: catalog,
-		clients: make(map[string]ProviderClient),
-		getenv:  getenv,
+		catalog:     catalog,
+		clients:     make(map[string]ProviderClient),
+		discoverers: make(map[string]ModelDiscoverer),
+		getenv:      getenv,
 	}
 }
 
@@ -58,12 +60,23 @@ func (r *ProviderRegistry) SetClientFactory(factory ClientFactory) {
 	r.clientFactory = factory
 }
 
-// SetOpenRouterDiscovery sets the live OpenRouter model discoverer used for
-// additive model resolution and merged model listing.
-func (r *ProviderRegistry) SetOpenRouterDiscovery(discoverer ModelDiscoverer) {
+// SetDiscovery sets the live model discoverer used for additive model
+// resolution and merged model listing for providerName.
+func (r *ProviderRegistry) SetDiscovery(providerName string, discoverer ModelDiscoverer) {
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.openRouter = discoverer
+	if discoverer == nil {
+		delete(r.discoverers, providerName)
+		return
+	}
+	if r.discoverers == nil {
+		r.discoverers = make(map[string]ModelDiscoverer)
+	}
+	r.discoverers[providerName] = discoverer
 }
 
 // SetAPIKey stores a runtime API key override for the named provider.
@@ -175,7 +188,7 @@ func (r *ProviderRegistry) ResolveProvider(modelID string) (string, bool) {
 }
 
 // ResolveProviderContext searches all providers to find which one has the given
-// model, including live OpenRouter discovery when configured.
+// model, including live discovery when configured.
 func (r *ProviderRegistry) ResolveProviderContext(ctx context.Context, modelID string) (string, bool) {
 	if r.catalog == nil {
 		return "", false
@@ -184,8 +197,8 @@ func (r *ProviderRegistry) ResolveProviderContext(ctx context.Context, modelID s
 	if providerName, found := r.resolveProviderFromCatalog(modelID); found {
 		return providerName, true
 	}
-	if r.hasOpenRouterDiscoveredModel(ctx, modelID) {
-		return "openrouter", true
+	if providerName, found := r.hasDiscoveredModel(ctx, modelID); found {
+		return providerName, true
 	}
 	// OpenRouter exposes a very large dynamic slug space (for example
 	// "moonshotai/kimi-k2.5"), so startup and run-time routing cannot depend on
@@ -272,27 +285,29 @@ func (r *ProviderRegistry) MaxContextTokensContext(ctx context.Context, modelID 
 	return m.ContextWindow, true
 }
 
-func (r *ProviderRegistry) hasOpenRouterDiscoveredModel(ctx context.Context, modelID string) bool {
+func (r *ProviderRegistry) hasDiscoveredModel(ctx context.Context, modelID string) (string, bool) {
 	modelID = strings.TrimSpace(modelID)
 	if modelID == "" {
-		return false
+		return "", false
 	}
-	if r == nil || r.catalog == nil || r.openRouter == nil {
-		return false
+	if r == nil || r.catalog == nil {
+		return "", false
 	}
-	if _, ok := r.catalog.Providers["openrouter"]; !ok {
-		return false
-	}
-	models, err := r.openRouter.Models(ctx)
-	if err != nil {
-		return false
-	}
-	for _, model := range models {
-		if strings.TrimSpace(model.ID) == modelID {
-			return true
+	for providerName, discoverer := range r.discoverySnapshot() {
+		if _, ok := r.catalog.Providers[providerName]; !ok {
+			continue
+		}
+		models, err := discoverer.Models(ctx)
+		if err != nil {
+			continue
+		}
+		for _, model := range models {
+			if strings.TrimSpace(model.ID) == modelID {
+				return providerName, true
+			}
 		}
 	}
-	return false
+	return "", false
 }
 
 func (r *ProviderRegistry) effectiveCatalog(ctx context.Context) *Catalog {
@@ -300,23 +315,34 @@ func (r *ProviderRegistry) effectiveCatalog(ctx context.Context) *Catalog {
 	if clone == nil {
 		return nil
 	}
-	if r == nil || r.openRouter == nil {
+	if r == nil {
 		return clone
 	}
-	entry, ok := clone.Providers["openrouter"]
-	if !ok {
-		return clone
+	for providerName, discoverer := range r.discoverySnapshot() {
+		entry, ok := clone.Providers[providerName]
+		if !ok {
+			continue
+		}
+		models, err := discoverer.Models(ctx)
+		if err != nil {
+			continue
+		}
+		clone.Providers[providerName] = mergeDiscoveredProvider(entry, models)
 	}
-	models, err := r.openRouter.Models(ctx)
-	if err != nil {
-		return clone
-	}
-	entry = mergeOpenRouterProvider(entry, models)
-	clone.Providers["openrouter"] = entry
 	return clone
 }
 
-func mergeOpenRouterProvider(static ProviderEntry, discovered []DiscoveredModel) ProviderEntry {
+func (r *ProviderRegistry) discoverySnapshot() map[string]ModelDiscoverer {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	discoverers := make(map[string]ModelDiscoverer, len(r.discoverers))
+	for providerName, discoverer := range r.discoverers {
+		discoverers[providerName] = discoverer
+	}
+	return discoverers
+}
+
+func mergeDiscoveredProvider(static ProviderEntry, discovered []DiscoveredModel) ProviderEntry {
 	merged := cloneProviderEntry(static)
 	if merged.Models == nil {
 		merged.Models = make(map[string]Model, len(discovered))

--- a/internal/provider/catalog/registry.go
+++ b/internal/provider/catalog/registry.go
@@ -26,7 +26,7 @@ type ProviderRegistry struct {
 	overrideKeys  map[string]string
 	getenv        func(string) string
 	clientFactory ClientFactory
-	openRouter    OpenRouterModelDiscoverer
+	openRouter    ModelDiscoverer
 }
 
 // NewProviderRegistry creates a registry that uses os.Getenv for API key lookup.
@@ -60,7 +60,7 @@ func (r *ProviderRegistry) SetClientFactory(factory ClientFactory) {
 
 // SetOpenRouterDiscovery sets the live OpenRouter model discoverer used for
 // additive model resolution and merged model listing.
-func (r *ProviderRegistry) SetOpenRouterDiscovery(discoverer OpenRouterModelDiscoverer) {
+func (r *ProviderRegistry) SetOpenRouterDiscovery(discoverer ModelDiscoverer) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.openRouter = discoverer
@@ -316,7 +316,7 @@ func (r *ProviderRegistry) effectiveCatalog(ctx context.Context) *Catalog {
 	return clone
 }
 
-func mergeOpenRouterProvider(static ProviderEntry, discovered []OpenRouterModel) ProviderEntry {
+func mergeOpenRouterProvider(static ProviderEntry, discovered []DiscoveredModel) ProviderEntry {
 	merged := cloneProviderEntry(static)
 	if merged.Models == nil {
 		merged.Models = make(map[string]Model, len(discovered))
@@ -529,7 +529,7 @@ func matchesProviderPrefix(prefix, provider string) bool {
 	// Known OpenRouter prefix aliases for common providers.
 	knownAliases := map[string]string{
 		"x-ai":       "xai",
-		"meta-llama": "groq",    // meta-llama models are often routed via groq
+		"meta-llama": "groq", // meta-llama models are often routed via groq
 		"moonshotai": "kimi",
 		"google":     "gemini",
 	}

--- a/internal/provider/openai/discovery.go
+++ b/internal/provider/openai/discovery.go
@@ -1,0 +1,61 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/provider/catalog"
+)
+
+// NewModelDiscovery returns a cached discoverer for an OpenAI-compatible
+// provider's GET /v1/models endpoint. It uses the configured provider key.
+func NewModelDiscovery(config Config) catalog.ModelDiscoverer {
+	baseURL := strings.TrimRight(strings.TrimSpace(config.BaseURL), "/")
+	if baseURL == "" {
+		baseURL = "https://api.openai.com/v1"
+	}
+	return catalog.NewDiscovery(catalog.DiscoveryOptions{
+		Endpoint: baseURL + "/models",
+		Client:   config.Client,
+		TTL:      5 * time.Minute,
+		Fetch: func(ctx context.Context, client *http.Client, endpoint string) ([]catalog.DiscoveredModel, error) {
+			return fetchModels(ctx, client, endpoint, config.APIKey)
+		},
+	})
+}
+
+func fetchModels(ctx context.Context, client *http.Client, endpoint, apiKey string) ([]catalog.DiscoveredModel, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create openai model-list request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch openai models: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch openai models: status %d", resp.StatusCode)
+	}
+	var payload struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode openai models: %w", err)
+	}
+	models := make([]catalog.DiscoveredModel, 0, len(payload.Data))
+	for _, entry := range payload.Data {
+		id := strings.TrimSpace(entry.ID)
+		if id != "" {
+			models = append(models, catalog.DiscoveredModel{ID: id, Name: id})
+		}
+	}
+	return models, nil
+}

--- a/internal/provider/openai/discovery.go
+++ b/internal/provider/openai/discovery.go
@@ -28,6 +28,12 @@ func NewModelDiscovery(config Config) catalog.ModelDiscoverer {
 	})
 }
 
+// NewDeepSeekModelDiscovery returns a cached discoverer for DeepSeek's
+// OpenAI-compatible GET /v1/models endpoint.
+func NewDeepSeekModelDiscovery(config Config) catalog.ModelDiscoverer {
+	return NewModelDiscovery(config)
+}
+
 func fetchModels(ctx context.Context, client *http.Client, endpoint, apiKey string) ([]catalog.DiscoveredModel, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {

--- a/internal/provider/openai/discovery_test.go
+++ b/internal/provider/openai/discovery_test.go
@@ -35,3 +35,23 @@ func TestNewModelDiscoveryListsOpenAIModels(t *testing.T) {
 		t.Fatalf("models = %+v, want %+v", models, want)
 	}
 }
+
+func TestNewDeepSeekModelDiscoveryListsOpenAICompatibleModels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" || r.Header.Get("Authorization") != "Bearer deepseek-key" {
+			t.Fatalf("unexpected DeepSeek discovery request: %s auth=%q", r.URL.Path, r.Header.Get("Authorization"))
+		}
+		_, _ = fmt.Fprint(w, `{"object":"list","data":[{"id":"deepseek-chat","object":"model","owned_by":"deepseek"}]}`)
+	}))
+	defer srv.Close()
+
+	models, err := NewDeepSeekModelDiscovery(Config{APIKey: "deepseek-key", BaseURL: srv.URL + "/v1", Client: srv.Client(), ProviderName: "deepseek"}).Models(context.Background())
+	if err != nil {
+		t.Fatalf("Models() error: %v", err)
+	}
+	if len(models) != 1 || models[0].ID != "deepseek-chat" {
+		t.Fatalf("expected DeepSeek's live model, got %+v", models)
+	}
+}

--- a/internal/provider/openai/discovery_test.go
+++ b/internal/provider/openai/discovery_test.go
@@ -1,0 +1,37 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go-agent-harness/internal/provider/catalog"
+)
+
+func TestNewModelDiscoveryListsOpenAIModels(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("expected /v1/models, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("expected bearer authentication, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"object":"list","data":[{"id":"gpt-4.1","object":"model","created":1740000000,"owned_by":"openai"}]}`)
+	}))
+	defer srv.Close()
+
+	discovery := NewModelDiscovery(Config{APIKey: "test-key", BaseURL: srv.URL + "/v1", Client: srv.Client()})
+	models, err := discovery.Models(context.Background())
+	if err != nil {
+		t.Fatalf("Models() error: %v", err)
+	}
+	want := []catalog.DiscoveredModel{{ID: "gpt-4.1", Name: "gpt-4.1"}}
+	if fmt.Sprint(models) != fmt.Sprint(want) {
+		t.Fatalf("models = %+v, want %+v", models, want)
+	}
+}

--- a/internal/server/http_models_test.go
+++ b/internal/server/http_models_test.go
@@ -248,7 +248,7 @@ func TestModelsEndpointIncludesDiscoveredOpenRouterModels(t *testing.T) {
 		},
 	}
 	reg := catalog.NewProviderRegistry(cat)
-	reg.SetOpenRouterDiscovery(testOpenRouterDiscovery{
+	reg.SetDiscovery("openrouter", testOpenRouterDiscovery{
 		models: []catalog.DiscoveredModel{
 			{ID: "openai/gpt-4.1-mini", Name: "Live GPT-4.1 Mini", ContextWindow: 999999},
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},

--- a/internal/server/http_models_test.go
+++ b/internal/server/http_models_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 type testOpenRouterDiscovery struct {
-	models []catalog.OpenRouterModel
+	models []catalog.DiscoveredModel
 	err    error
 }
 
-func (d testOpenRouterDiscovery) Models(context.Context) ([]catalog.OpenRouterModel, error) {
-	out := make([]catalog.OpenRouterModel, len(d.models))
+func (d testOpenRouterDiscovery) Models(context.Context) ([]catalog.DiscoveredModel, error) {
+	out := make([]catalog.DiscoveredModel, len(d.models))
 	copy(out, d.models)
 	return out, d.err
 }
@@ -249,7 +249,7 @@ func TestModelsEndpointIncludesDiscoveredOpenRouterModels(t *testing.T) {
 	}
 	reg := catalog.NewProviderRegistry(cat)
 	reg.SetOpenRouterDiscovery(testOpenRouterDiscovery{
-		models: []catalog.OpenRouterModel{
+		models: []catalog.DiscoveredModel{
 			{ID: "openai/gpt-4.1-mini", Name: "Live GPT-4.1 Mini", ContextWindow: 999999},
 			{ID: "moonshotai/kimi-k2.5", Name: "Kimi K2.5", ContextWindow: 262144},
 		},


### PR DESCRIPTION
## Summary

- Generalizes cached live model discovery from OpenRouter-only types and wiring into provider-keyed registry discoverers.
- Adds documented live `/v1/models` discovery for configured OpenAI, Anthropic, and DeepSeek providers; OpenRouter remains supported.
- Preserves five-minute TTL caching, stale-cache-on-refresh-error behavior, static fallback on first discovery failure, and curated metadata precedence.

## Tests

- Added realistic fake-server coverage for OpenAI, Anthropic, and DeepSeek response/auth shapes.
- Added non-OpenRouter registry merge and first-attempt failure fallback coverage, startup configured-provider wiring coverage, and operator documentation coverage.
- `go test ./internal/provider/... ./cmd/harnessd/...`
- `go vet ./...`
- `./scripts/test-regression.sh`

Closes #849