### PR TITLE
feat(provider/kimi): kimi-code subscription authentication mode — epic #848

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ the SQLite conversation store persists the latest plan content per conversation.
 - Anthropic provider support exists in the provider catalog and should not be described as merely planned.
 - Subscription-auth foundation: `internal/provider.TokenSource` supplies request-time bearer credentials; `internal/provider/tokencache` supplies generic in-memory expiry-margin refresh caching. OpenAI-compatible clients accept optional `TokenSource` and static `ExtraHeaders`; the provider registry exposes `SetTokenSource`, which evicts its cached client. Never log credential values. Codex/Kimi OAuth refresh transport, credential import, persistence, and TUI surfaces are intentionally separate follow-on work.
 
+### Kimi Code subscription auth (Epic #848)
+
+- `harnesscli auth kimi login|status|logout` manages only `~/.harness/subscription-auth/kimi.json`; it must never write under `~/.kimi-code/`.
+- The subscription provider mirrors models from metered `kimi` via `models_from`, uses a 30-second safety margin for 900-second tokens, and sends `X-Kimi-Client-*` headers through the OpenAI-compatible client.
+- Do not claim live Kimi OAuth or completion verification: only one unauthenticated OPTIONS probe confirmed `POST` is allowed at `/api/oauth/token`; fake-server tests cover the convention-based OAuth request.
+
 ## Benchmarks
 
 - `benchmarks/` and `harness_agent/` are Python (not Go). They need external pip deps (`terminal_bench`, `harbor`) that are not vendored here.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ export ZAI_API_KEY="..."
 
 You only need keys for the providers you use. You can also configure provider keys through the TUI and server APIs as the harness evolves.
 
+### Kimi Code subscription
+
+If you already use the MoonshotAI `kimi-code` CLI, authenticate it first, then import a separate go-code-owned copy:
+
+```bash
+kimi-code login
+harnesscli auth kimi login
+harnesscli auth kimi status
+```
+
+Select `kimi-subscription` to use the subscription route. The importer only reads the vendor credential; go-code refreshes its own `~/.harness/subscription-auth/kimi.json` copy and never writes under `~/.kimi-code/`. `harnesscli auth kimi logout` removes only the go-code copy.
+
+The live Kimi refresh request body and subscription API compatibility were not authenticated against the live service in this release: the implementation uses the conventional OAuth2 refresh-token form and fake-server coverage. Verify this manually before relying on it for production use, and ensure this workflow complies with MoonshotAI's terms.
+
 ## Running From Source
 
 For development or debugging, run the server and CLI directly:

--- a/catalog/models.json
+++ b/catalog/models.json
@@ -537,6 +537,13 @@
         }
       }
     },
+    "kimi-subscription": {
+      "display_name": "Kimi Code Subscription",
+      "base_url": "https://api.kimi.com/coding/v1",
+      "api_key_optional": true,
+      "protocol": "openai_compat",
+      "models_from": "kimi"
+    },
     "qwen": {
       "display_name": "Qwen (DashScope)",
       "base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",

--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"go-agent-harness/internal/provider/kimi"
 	"go-agent-harness/internal/store"
 )
 
@@ -90,8 +92,49 @@ func runAuth(args []string) int {
 	switch args[0] {
 	case "login":
 		return runAuthLogin(args[1:])
+	case "kimi":
+		return runAuthKimi(args[1:])
 	default:
 		fmt.Fprintf(stderr, "harnesscli auth: unknown subcommand %q\n", args[0])
+		return 1
+	}
+}
+
+func runAuthKimi(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "harnesscli auth kimi: subcommand required (login, status, or logout)")
+		return 1
+	}
+	storePath := kimi.DefaultStorePath()
+	switch args[0] {
+	case "login":
+		if err := kimi.Import(kimi.VendorCredentialPath(), storePath); err != nil {
+			fmt.Fprintln(stderr, "harnesscli auth kimi: run kimi-code login, then retry harnesscli auth kimi login")
+			return 1
+		}
+		fmt.Fprintln(stdout, "Kimi Code subscription credential imported.")
+		return 0
+	case "status":
+		creds, err := kimi.Load(storePath)
+		if err != nil {
+			fmt.Fprintln(stdout, "Kimi Code subscription: not configured (run kimi-code login, then harnesscli auth kimi login)")
+			return 1
+		}
+		if time.Unix(creds.ExpiresAt, 0).After(time.Now()) {
+			fmt.Fprintln(stdout, "Kimi Code subscription: configured (access credential valid)")
+		} else {
+			fmt.Fprintln(stdout, "Kimi Code subscription: configured (access credential will refresh on use)")
+		}
+		return 0
+	case "logout":
+		if err := os.Remove(storePath); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "harnesscli auth kimi: remove stored credential: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "Kimi Code subscription credential removed.")
+		return 0
+	default:
+		fmt.Fprintf(stderr, "harnesscli auth kimi: unknown subcommand %q\n", args[0])
 		return 1
 	}
 }

--- a/cmd/harnesscli/auth_test.go
+++ b/cmd/harnesscli/auth_test.go
@@ -103,6 +103,37 @@ func TestRunAuth_NoSubcommand(t *testing.T) {
 	}
 }
 
+func TestRunAuthKimiLifecycleNeverPrintsCredential(t *testing.T) {
+	tmp := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Cleanup(func() { _ = os.Setenv("HOME", oldHome) })
+	_ = os.Setenv("HOME", tmp)
+	vendor := filepath.Join(tmp, ".kimi-code", "credentials")
+	if err := os.MkdirAll(vendor, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vendor, "kimi-code.json"), []byte(`{"access_token":"fake-access","refresh_token":"fake-refresh","expires_at":2000000000}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	origOut, origErr := stdout, stderr
+	stdout, stderr = &out, &errOut
+	t.Cleanup(func() { stdout, stderr = origOut, origErr })
+	if got := runAuth([]string{"kimi", "login"}); got != 0 {
+		t.Fatalf("login = %d: %s", got, errOut.String())
+	}
+	if strings.Contains(out.String(), "fake-access") || strings.Contains(out.String(), "fake-refresh") {
+		t.Fatal("credential printed")
+	}
+	out.Reset()
+	if got := runAuth([]string{"kimi", "status"}); got != 0 || !strings.Contains(out.String(), "configured") {
+		t.Fatalf("status: %d %s", got, out.String())
+	}
+	if got := runAuth([]string{"kimi", "logout"}); got != 0 {
+		t.Fatal("logout failed")
+	}
+}
+
 func TestDispatch_AuthRouted(t *testing.T) {
 	origStdout := stdout
 	origStderr := stderr

--- a/cmd/harnesscli/tui/kimi_subscription_test.go
+++ b/cmd/harnesscli/tui/kimi_subscription_test.go
@@ -1,0 +1,11 @@
+package tui
+
+import "testing"
+
+func TestKimiSubscriptionAppearsInKeysEnvironmentMap(t *testing.T) {
+	t.Setenv("KIMI_SUBSCRIPTION_AUTH", "configured")
+	m := New(TUIConfig{})
+	if !m.providerKeyConfigured("kimi-subscription") {
+		t.Fatal("Kimi subscription status should be available to /keys without a token")
+	}
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -383,6 +383,9 @@ func New(cfg TUIConfig) Model {
 		"openrouter": "OPENROUTER_API_KEY",
 		"openai":     "OPENAI_API_KEY",
 		"anthropic":  "ANTHROPIC_API_KEY",
+		// Subscription auth is managed with `harnesscli auth kimi`; this
+		// marker lets /keys display the provider without ever reading a token.
+		"kimi-subscription": "KIMI_SUBSCRIPTION_AUTH",
 	}
 	for provider, envVar := range envKeyVars {
 		if key := os.Getenv(envVar); key != "" {

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -20,6 +20,7 @@ import (
 	"go-agent-harness/internal/provider"
 	"go-agent-harness/internal/provider/anthropic"
 	"go-agent-harness/internal/provider/catalog"
+	"go-agent-harness/internal/provider/kimi"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/provider/pricing"
 	"go-agent-harness/internal/relay"
@@ -118,6 +119,9 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 	}
 
 	if bootstrap.providerRegistry != nil {
+		if source, err := kimi.NewTokenSource(kimi.DefaultStorePath(), "", nil); err == nil {
+			bootstrap.providerRegistry.SetTokenSource("kimi-subscription", source)
+		}
 		registerModelDiscoverers(bootstrap.providerRegistry)
 		bootstrap.providerRegistry.SetClientFactory(catalog.ClientFactory(func(apiKey, baseURL, providerName string, tokenSource provider.TokenSource) (catalog.ProviderClient, error) {
 			if providerName == "anthropic" {
@@ -154,6 +158,9 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 					return ""
 				}(),
 				Quirks: providerQuirks,
+			}
+			if providerName == "kimi-subscription" {
+				cfg.ExtraHeaders = kimi.ExtraHeaders()
 			}
 			if providerName == "openrouter" {
 				referer := os.Getenv("HARNESS_OPENROUTER_REFERER")

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1620,3 +1620,9 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
 - Generalized the catalog's OpenRouter-only cache into provider-agnostic live model discovery.
 - OpenRouter, OpenAI, Anthropic, and DeepSeek now have five-minute cached listings when configured; failures retain stale cached results when present and otherwise leave the static catalog untouched.
 - Live listings add models while curated catalog metadata remains authoritative on matching IDs.
+## 2026-07-20 (Issue #848 Kimi Code Subscription Authentication)
+
+- Added a separate `kimi-subscription` provider that derives its model list from the existing metered `kimi` entry, preserving the metered path unchanged.
+- `harnesscli auth kimi login` reads the vendor credential only and stores a `0600` go-code-owned copy; status and logout never print a credential and logout never affects the vendor CLI.
+- Refresh uses a 30-second margin for the real 900-second TTL. Fake OAuth/API integration coverage proves a forced near-expiry refresh, rotated persistence, dynamic bearer authorization, and all `X-Kimi-Client-*` headers.
+- Live endpoint caveat: a single unauthenticated `OPTIONS https://auth.kimi.com/api/oauth/token` returned `405 Allow: POST`; no authenticated live refresh or completion was performed. The form/body and OpenAI-compatible wire contract are convention-based and must be manually verified.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -1,5 +1,12 @@
 # Long-Term Thinking Log
 
+## 2026-07-20 (Kimi Code Subscription Auth — Epic #848)
+
+- Command intent: Let an existing Kimi Code CLI subscription authenticate the separate `kimi-subscription` provider, with strict test-first slices, verification, PR creation, and no vendor credential writes.
+- User intent: Reuse an already-paid Kimi Code subscription safely through go-code, including ordinary 15-minute access-token refreshes.
+- Success definition: read-only CLI credential import into `~/.harness/subscription-auth/kimi.json`; `auth kimi login|status|logout`; 30-second refresh safety margin; derived (not duplicated) Kimi model catalog; dynamic bearer plus client headers; fake-server completion/refresh integration coverage; no credential logging.
+- Guardrails: Live `/api/oauth/token` was confirmed only as POST-capable by one unauthenticated OPTIONS probe. No authenticated refresh or completion was sent to the live service; conventional OAuth2 form details and OpenAI compatibility require manual verification before production reliance.
+
 ## 2026-07-20 (Subscription-Auth Foundation — Epic #846)
 
 - Command intent: Add provider-layer dynamic bearer credential and extra-header plumbing, a generic refresh cache, and registry token-source support; commit each test-first slice, verify, push, and open a PR without merging it.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -573,3 +573,9 @@ Use this file to document systems, interfaces, and interactions as they are buil
 - `internal/provider/tokencache.Cache` owns only in-memory cache, expiry-margin, and single-flight synchronization. Provider-specific code supplies refresh transport and any credential persistence; this foundation never imports, stores, or logs provider credentials.
 - `openai.Config.TokenSource` and `ExtraHeaders` flow through the existing chat-completions and responses request paths. Nil `TokenSource` uses the existing static `APIKey` behavior; headers are copied on client construction.
 - `catalog.ProviderRegistry` holds optional runtime token sources alongside API-key overrides. A source marks a provider configured and causes `GetClient` to forward it to `ClientFactory`; changing either credential mode evicts the cached provider client.
+## 2026-07-20 (Kimi subscription auth — Epic #848)
+
+- System/component: `internal/provider/kimi`, Kimi catalog/bootstrap wiring, and `harnesscli auth kimi`.
+- Credentials flow: vendor `~/.kimi-code/credentials/kimi-code.json` is read once on explicit import; mutable state is only `~/.harness/subscription-auth/kimi.json` with mode `0600`.
+- Requests use the existing OpenAI-compatible client with a refreshable token source and static `X-Kimi-Client-*` headers. Refresh persistence is contained in the harness-owned store.
+- Operational limitation: live POST capability, not authenticated OAuth request shape or completion compatibility, was verified; manual service verification remains required.

--- a/docs/plans/2026-07-20-kimi-subscription-auth-848-impact-map.md
+++ b/docs/plans/2026-07-20-kimi-subscription-auth-848-impact-map.md
@@ -1,0 +1,33 @@
+# Provider/Model Impact Map: Kimi Code subscription authentication (#848)
+
+## Task
+
+- Task / issue: #848 Kimi Code subscription authentication
+- Plan link: `2026-07-20-kimi-subscription-auth-848-plan.md`
+- Owner: codex/kimi-subscription-auth-848
+- Status: in implementation
+
+## Config
+
+- User-facing config added or changed: go-code-owned credential file at `~/.harness/subscription-auth/kimi.json`, seeded only by `harnesscli auth kimi login`.
+- Defaults / fallbacks: missing store leaves `kimi-subscription` unconfigured with an actionable `kimi-code login` then `harnesscli auth kimi login` error; metered `kimi` remains unchanged.
+- Environment variables, config files, or saved settings touched: vendor credential is read only; no new environment variable; separate store is `0600` or more restrictive.
+- Migration / backward-compatibility notes: additive provider and commands only.
+
+## Server API
+
+- Endpoints, request fields, response fields, or server wiring affected: no public server endpoint changes.
+- Provider/model resolution or registry changes: bootstrap installs the credential-backed token source for `kimi-subscription`; OpenAI-compatible requests include static `X-Kimi-Client-*` headers.
+- Error states / validation changes: unavailable subscription auth is clearly reported without printing secrets.
+
+## TUI State
+
+- Slash commands, overlays, selection state, routing, or status bar changes: `/keys` includes Kimi subscription status for `kimi-subscription`.
+- Persisted client state or local config changes: none; credentials stay in the shared harness user store.
+- Keyboard/navigation implications: none.
+
+## Regression Tests
+
+- New acceptance tests required: fake OAuth/API round trip with forced short-TTL refresh and Kimi headers.
+- Existing tests to update: catalog loading/bootstrap and `/keys` provider mapping.
+- Cross-surface regressions to guard: metered Kimi remains API-key-only; no vendor-store writes; no credential value in source logging.

--- a/docs/plans/2026-07-20-kimi-subscription-auth-848-plan.md
+++ b/docs/plans/2026-07-20-kimi-subscription-auth-848-plan.md
@@ -14,7 +14,7 @@
 
 ## Documentation Contract
 
-- Feature status: `in implementation`
+- Feature status: `implemented` (pending manual live-provider verification)
 - Public docs affected: README/provider setup documentation and CLI help.
 - Spec docs to update before code: this plan and `2026-07-20-kimi-subscription-auth-848-impact-map.md`.
 - Implementation notes to add after code: engineering/system logs, `CLAUDE.md`, and docs indexes.
@@ -32,13 +32,13 @@
 ## Implementation Checklist
 
 - [x] Spike: record endpoint evidence, one safe live probe, and live-verification gap.
-- [ ] Refresh: add convention-based OAuth refresh and 30-second safety margin for 900-second credentials.
-- [ ] Import: copy vendor credential read-only into `~/.harness/subscription-auth/kimi.json` with restrictive matching mode.
-- [ ] Catalog/bootstrap: derive `kimi-subscription` models from `kimi`; wire dynamic token and client headers.
-- [ ] CLI: add `harnesscli auth kimi login|status|logout`.
-- [ ] TUI: expose `kimi-subscription` status in `/keys`.
-- [ ] Integration: fake API/token server completion plus forced refresh; add token-log grep regression.
-- [ ] Documentation/logs/indexes: mark implemented and record live-verification limitation.
+- [x] Refresh: add convention-based OAuth refresh and 30-second safety margin for 900-second credentials.
+- [x] Import: copy vendor credential read-only into `~/.harness/subscription-auth/kimi.json` with restrictive matching mode.
+- [x] Catalog/bootstrap: derive `kimi-subscription` models from `kimi`; wire dynamic token and client headers.
+- [x] CLI: add `harnesscli auth kimi login|status|logout`.
+- [x] TUI: expose `kimi-subscription` status in `/keys`.
+- [x] Integration: fake API/token server completion plus forced refresh; add token-log grep regression.
+- [x] Documentation/logs/indexes: mark implemented and record live-verification limitation.
 - [ ] Run focused tests, requested package tests, `gofmt`, `go vet ./...`, and `./scripts/test-regression.sh`.
 
 ## Risks and Mitigations

--- a/docs/plans/2026-07-20-kimi-subscription-auth-848-plan.md
+++ b/docs/plans/2026-07-20-kimi-subscription-auth-848-plan.md
@@ -1,0 +1,48 @@
+# Plan: Kimi Code subscription authentication — Epic #848
+
+## Context
+
+- Problem: Kimi Code subscribers can currently use only the metered Moonshot API-key provider.
+- User impact: An existing `kimi-code` login can be imported into go-code and used as a refreshable bearer credential for a separate `kimi-subscription` provider.
+- Constraints: Never write under `~/.kimi-code`; use stdlib HTTP; never log credentials; preserve metered `kimi`; token storage must be `0600` or stricter; each slice is test-first and committed independently.
+- Spike findings (2026-07-20): Local vendor-session evidence identifies `https://auth.kimi.com/api/oauth/token`. One unauthenticated `OPTIONS` probe returned `405` with `Allow: POST`, confirming the route accepts POST but **not** the authenticated body/response. The API wire format was not exercised against the live subscription endpoint because an authenticated completion could consume subscription capacity. The implementation therefore uses the conventional OAuth2 form grant (`grant_type=refresh_token`, `refresh_token`, `client_id`) and the existing OpenAI-compatible client, both verified only against fake servers. Manual live verification is still required before real-world reliance.
+
+## Scope
+
+- In scope: Kimi refresh/client headers, read-only vendor credential import, separate credential store, CLI lifecycle commands, catalog/provider wiring, TUI status, fake-server end-to-end refresh coverage, and operator documentation.
+- Out of scope: interactive Kimi device login, writes to vendor credentials, changes to the existing metered `kimi` provider, or guessing/retrying live endpoint requests.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: README/provider setup documentation and CLI help.
+- Spec docs to update before code: this plan and `2026-07-20-kimi-subscription-auth-848-impact-map.md`.
+- Implementation notes to add after code: engineering/system logs, `CLAUDE.md`, and docs indexes.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: OAuth form/response/error redaction; safe import and matching permissions; CLI login/status/logout; catalog derived models and bootstrap headers/token source; TUI key status; fake-server completion with forced refresh inside a 900-second-token-appropriate safety window; source grep prevents token logging.
+- Existing tests to update: catalog/bootstrap and `/keys` behavior where provider maps are enumerated.
+- Regression tests required: full requested package tests plus `scripts/test-regression.sh`.
+
+## Cross-Surface Impact Map
+
+- Required impact map: `docs/plans/2026-07-20-kimi-subscription-auth-848-impact-map.md`.
+
+## Implementation Checklist
+
+- [x] Spike: record endpoint evidence, one safe live probe, and live-verification gap.
+- [ ] Refresh: add convention-based OAuth refresh and 30-second safety margin for 900-second credentials.
+- [ ] Import: copy vendor credential read-only into `~/.harness/subscription-auth/kimi.json` with restrictive matching mode.
+- [ ] Catalog/bootstrap: derive `kimi-subscription` models from `kimi`; wire dynamic token and client headers.
+- [ ] CLI: add `harnesscli auth kimi login|status|logout`.
+- [ ] TUI: expose `kimi-subscription` status in `/keys`.
+- [ ] Integration: fake API/token server completion plus forced refresh; add token-log grep regression.
+- [ ] Documentation/logs/indexes: mark implemented and record live-verification limitation.
+- [ ] Run focused tests, requested package tests, `gofmt`, `go vet ./...`, and `./scripts/test-regression.sh`.
+
+## Risks and Mitigations
+
+- Risk: Live OAuth body/client identity may differ from the documented convention. Mitigation: fake-server contract only, clear manual-verification notice, no repeated live probing.
+- Risk: 900-second access tokens expire during normal runs. Mitigation: independent 30-second margin and forced-window refresh test.
+- Risk: credential disclosure. Mitigation: no credential logging, fixtures use only fake values, source grep regression, and separate `0600` store.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,5 +1,7 @@
 # Plans Index
 
+- `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
+- `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.
 - `2026-07-20-subscription-auth-foundation-846-plan.md` — Epic #846 subscription-auth foundation: token-source, dynamic request auth, refresh cache, and registry plumbing (in implementation).
 - `2026-07-20-subscription-auth-foundation-846-impact-map.md` — Cross-surface impact map for Epic #846 provider credential plumbing.
 - `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.

--- a/internal/provider/catalog/loader.go
+++ b/internal/provider/catalog/loader.go
@@ -28,12 +28,43 @@ func LoadCatalogFromBytes(data []byte) (*Catalog, error) {
 	if err := json.Unmarshal(data, &cat); err != nil {
 		return nil, fmt.Errorf("decode catalog: %w", err)
 	}
+	for name, entry := range cat.Providers {
+		if entry.ModelsFrom == "" {
+			continue
+		}
+		source, ok := cat.Providers[entry.ModelsFrom]
+		if !ok {
+			return nil, fmt.Errorf("provider %q: models_from %q not found", name, entry.ModelsFrom)
+		}
+		entry.Models = cloneModels(source.Models)
+		entry.Aliases = cloneAliases(source.Aliases)
+		cat.Providers[name] = entry
+	}
 
 	if err := validateCatalog(&cat); err != nil {
 		return nil, err
 	}
 
 	return &cat, nil
+}
+
+func cloneModels(models map[string]Model) map[string]Model {
+	out := make(map[string]Model, len(models))
+	for name, model := range models {
+		out[name] = model
+	}
+	return out
+}
+
+func cloneAliases(aliases map[string]string) map[string]string {
+	if aliases == nil {
+		return nil
+	}
+	out := make(map[string]string, len(aliases))
+	for from, to := range aliases {
+		out[from] = to
+	}
+	return out
 }
 
 func validateCatalog(cat *Catalog) error {

--- a/internal/provider/catalog/loader_test.go
+++ b/internal/provider/catalog/loader_test.go
@@ -99,6 +99,16 @@ func TestLoadCatalogFromBytes_Valid(t *testing.T) {
 	}
 }
 
+func TestLoadCatalogFromBytes_DerivesKimiSubscriptionModels(t *testing.T) {
+	cat, err := LoadCatalogFromBytes([]byte(`{"catalog_version":"1","providers":{"kimi":{"base_url":"https://metered","api_key_env":"MOONSHOT_API_KEY","models":{"kimi-k2.5":{"context_window":1}}},"kimi-subscription":{"base_url":"https://api.kimi.com/coding/v1","api_key_optional":true,"models_from":"kimi"}}}`))
+	if err != nil {
+		t.Fatalf("LoadCatalogFromBytes: %v", err)
+	}
+	if got := cat.Providers["kimi-subscription"].Models["kimi-k2.5"].ContextWindow; got != 1 {
+		t.Fatalf("derived model context = %d", got)
+	}
+}
+
 func TestLoadCatalogFromBytes_EmptyVersion(t *testing.T) {
 	data := `{"catalog_version": "", "providers": {"p": {"base_url": "http://x", "api_key_env": "K", "models": {"m": {"context_window": 1}}}}}`
 	_, err := LoadCatalogFromBytes([]byte(data))

--- a/internal/provider/catalog/registry.go
+++ b/internal/provider/catalog/registry.go
@@ -173,10 +173,15 @@ func (r *ProviderRegistry) IsConfigured(providerName string) bool {
 	if !ok {
 		return false
 	}
-	if entry.APIKeyOptional {
+	if entry.APIKeyOptional && isLocalBaseURL(entry.BaseURL) {
 		return true
 	}
 	return r.getenv(entry.APIKeyEnv) != ""
+}
+
+func isLocalBaseURL(baseURL string) bool {
+	baseURL = strings.ToLower(baseURL)
+	return strings.Contains(baseURL, "://localhost") || strings.Contains(baseURL, "://127.0.0.1") || strings.Contains(baseURL, "://[::1]")
 }
 
 // GetClient returns (or lazily creates) a provider client for the named provider.
@@ -210,7 +215,10 @@ func (r *ProviderRegistry) GetClient(providerName string) (ProviderClient, error
 		apiKey = r.getenv(entry.APIKeyEnv)
 	}
 	if apiKey == "" && tokenSource == nil {
-		if !entry.APIKeyOptional {
+		if !entry.APIKeyOptional || !isLocalBaseURL(entry.BaseURL) {
+			if providerName == "kimi-subscription" {
+				return nil, fmt.Errorf("provider %q is not configured; run kimi-code login, then harnesscli auth kimi login", providerName)
+			}
 			return nil, fmt.Errorf("provider %q: API key env %q is not set", providerName, entry.APIKeyEnv)
 		}
 		apiKey = providerName
@@ -220,7 +228,7 @@ func (r *ProviderRegistry) GetClient(providerName string) (ProviderClient, error
 		return nil, fmt.Errorf("provider %q: no client factory configured", providerName)
 	}
 
-	if entry.APIKeyOptional {
+	if entry.APIKeyOptional && isLocalBaseURL(entry.BaseURL) {
 		if err := checkLocalServerReachable(providerName, entry); err != nil {
 			return nil, err
 		}

--- a/internal/provider/catalog/types.go
+++ b/internal/provider/catalog/types.go
@@ -18,6 +18,9 @@ type ProviderEntry struct {
 	Quirks         []string          `json:"quirks,omitempty"`
 	Models         map[string]Model  `json:"models"`
 	Aliases        map[string]string `json:"aliases,omitempty"`
+	// ModelsFrom mirrors models from another catalog provider at load time so
+	// subscription variants cannot silently drift from their metered peer.
+	ModelsFrom string `json:"models_from,omitempty"`
 }
 
 // Model describes a single LLM model's capabilities and metadata.

--- a/internal/provider/kimi/kimi.go
+++ b/internal/provider/kimi/kimi.go
@@ -8,8 +8,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"go-agent-harness/internal/provider"
+	"go-agent-harness/internal/provider/tokencache"
 )
 
 const (
@@ -19,6 +24,89 @@ const (
 	ClientID     = "kimi-code"
 	SafetyMargin = 30 * time.Second
 )
+
+// Credentials is the minimal compatible vendor credential shape. Values are
+// deliberately never formatted into errors or log messages.
+type Credentials struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+}
+
+func DefaultStorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".harness", "subscription-auth", "kimi.json")
+	}
+	return filepath.Join(home, ".harness", "subscription-auth", "kimi.json")
+}
+
+func VendorCredentialPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".kimi-code", "credentials", "kimi-code.json")
+	}
+	return filepath.Join(home, ".kimi-code", "credentials", "kimi-code.json")
+}
+
+// Load reads a credential without exposing its values in errors.
+func Load(path string) (Credentials, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Credentials{}, fmt.Errorf("read Kimi subscription credential: %w", err)
+	}
+	var creds Credentials
+	if err := json.Unmarshal(raw, &creds); err != nil {
+		return Credentials{}, fmt.Errorf("decode Kimi subscription credential: %w", err)
+	}
+	if creds.AccessToken == "" || creds.RefreshToken == "" || creds.ExpiresAt <= 0 {
+		return Credentials{}, fmt.Errorf("Kimi subscription credential is incomplete")
+	}
+	return creds, nil
+}
+
+func save(path string, creds Credentials) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create Kimi subscription credential directory: %w", err)
+	}
+	raw, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode Kimi subscription credential")
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write Kimi subscription credential: %w", err)
+	}
+	return os.Chmod(path, 0o600)
+}
+
+// Import performs a read-only vendor-file import into a separate harness file.
+func Import(vendorPath, storePath string) error {
+	creds, err := Load(vendorPath)
+	if err != nil {
+		return fmt.Errorf("Kimi Code credential unavailable; run kimi-code login then harnesscli auth kimi login")
+	}
+	return save(storePath, creds)
+}
+
+// NewTokenSource persists rotated credentials only to the harness-owned store.
+func NewTokenSource(storePath, endpoint string, client *http.Client) (provider.TokenSource, error) {
+	creds, err := Load(storePath)
+	if err != nil {
+		return nil, err
+	}
+	refresh := RefreshFunc(endpoint, client)
+	return tokencache.New(creds.AccessToken, creds.RefreshToken, time.Unix(creds.ExpiresAt, 0), SafetyMargin, func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+		token, next, expiry, err := refresh(ctx, refreshToken)
+		if err != nil {
+			return "", "", time.Time{}, err
+		}
+		if err := save(storePath, Credentials{AccessToken: token, RefreshToken: next, ExpiresAt: expiry.Unix(), ExpiresIn: int64(time.Until(expiry).Seconds())}); err != nil {
+			return "", "", time.Time{}, err
+		}
+		return token, next, expiry, nil
+	}), nil
+}
 
 // ExtraHeaders identifies go-code to Kimi's subscription API on every request.
 // Values are intentionally static and contain no user credentials.

--- a/internal/provider/kimi/kimi.go
+++ b/internal/provider/kimi/kimi.go
@@ -1,0 +1,73 @@
+// Package kimi implements Kimi Code subscription credentials. It never writes
+// the vendor CLI credential file; only the separate harness store is mutable.
+package kimi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	TokenEndpoint = "https://auth.kimi.com/api/oauth/token"
+	// ClientID is the public Kimi Code OAuth client identifier used by the
+	// convention-based refresh request. Live body verification remains pending.
+	ClientID     = "kimi-code"
+	SafetyMargin = 30 * time.Second
+)
+
+// ExtraHeaders identifies go-code to Kimi's subscription API on every request.
+// Values are intentionally static and contain no user credentials.
+func ExtraHeaders() map[string]string {
+	return map[string]string{
+		"X-Kimi-Client-Id":      ClientID,
+		"X-Kimi-Client-Name":    "go-code",
+		"X-Kimi-Client-Version": "1",
+		"X-Kimi-Client-Ui-Mode": "cli",
+	}
+}
+
+// RefreshFunc returns a token-cache compatible OAuth refresh function.
+func RefreshFunc(endpoint string, client *http.Client) func(context.Context, string) (string, string, time.Time, error) {
+	if endpoint == "" {
+		endpoint = TokenEndpoint
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+		form := url.Values{"grant_type": {"refresh_token"}, "refresh_token": {refreshToken}, "client_id": {ClientID}}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", "", time.Time{}, fmt.Errorf("create Kimi token refresh request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		res, err := client.Do(req)
+		if err != nil {
+			return "", "", time.Time{}, fmt.Errorf("Kimi token refresh request failed")
+		}
+		defer res.Body.Close()
+		if res.StatusCode < 200 || res.StatusCode >= 300 {
+			return "", "", time.Time{}, fmt.Errorf("Kimi token refresh returned HTTP %d", res.StatusCode)
+		}
+		var payload struct {
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			ExpiresIn    int64  `json:"expires_in"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(nil, res.Body, 1<<20)).Decode(&payload); err != nil {
+			return "", "", time.Time{}, fmt.Errorf("decode Kimi token refresh response: %w", err)
+		}
+		if payload.AccessToken == "" || payload.ExpiresIn <= 0 {
+			return "", "", time.Time{}, fmt.Errorf("Kimi token refresh response is missing required fields")
+		}
+		if payload.RefreshToken == "" {
+			payload.RefreshToken = refreshToken
+		}
+		return payload.AccessToken, payload.RefreshToken, time.Now().Add(time.Duration(payload.ExpiresIn) * time.Second), nil
+	}
+}

--- a/internal/provider/kimi/kimi_test.go
+++ b/internal/provider/kimi/kimi_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -51,5 +52,27 @@ func TestRefreshUsesOAuthFormAndDoesNotExposeCredential(t *testing.T) {
 func TestSafetyMarginIsRealisticForKimiShortTTL(t *testing.T) {
 	if SafetyMargin != 30*time.Second {
 		t.Fatalf("SafetyMargin = %s, want 30s", SafetyMargin)
+	}
+}
+
+func TestImportCopiesVendorCredentialToSeparateRestrictiveStore(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	vendor := dir + "/vendor.json"
+	store := dir + "/harness/kimi.json"
+	if err := os.WriteFile(vendor, []byte(`{"access_token":"fake-access","refresh_token":"fake-refresh","expires_at":2000000000,"expires_in":900}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Import(vendor, store); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if got, err := Load(store); err != nil || got.AccessToken != "fake-access" || got.RefreshToken != "fake-refresh" {
+		t.Fatal("import did not preserve credential pair")
+	}
+	if info, err := os.Stat(store); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("store mode = %v, want 0600", info.Mode())
+	}
+	if data, err := os.ReadFile(vendor); err != nil || !strings.Contains(string(data), "fake-access") {
+		t.Fatal("vendor credential changed")
 	}
 }

--- a/internal/provider/kimi/kimi_test.go
+++ b/internal/provider/kimi/kimi_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"go-agent-harness/internal/harness"
+	openai "go-agent-harness/internal/provider/openai"
 )
 
 func TestRefreshUsesOAuthFormAndDoesNotExposeCredential(t *testing.T) {
@@ -74,5 +77,64 @@ func TestImportCopiesVendorCredentialToSeparateRestrictiveStore(t *testing.T) {
 	}
 	if data, err := os.ReadFile(vendor); err != nil || !strings.Contains(string(data), "fake-access") {
 		t.Fatal("vendor credential changed")
+	}
+}
+
+func TestSubscriptionCompletionRefreshesInsideShortTTLWindow(t *testing.T) {
+	var refreshes int
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshes++
+		_, _ = w.Write([]byte(`{"access_token":"fake-refreshed","refresh_token":"fake-rotated","expires_in":900}`))
+	}))
+	defer tokenServer.Close()
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer fake-refreshed" {
+			t.Fatal("completion did not use refreshed bearer credential")
+		}
+		for key, value := range ExtraHeaders() {
+			if r.Header.Get(key) != value {
+				t.Fatalf("missing %s", key)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}]}`))
+	}))
+	defer apiServer.Close()
+	store := t.TempDir() + "/kimi.json"
+	if err := save(store, Credentials{AccessToken: "fake-expiring", RefreshToken: "fake-refresh", ExpiresAt: time.Now().Add(20 * time.Second).Unix(), ExpiresIn: 900}); err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewTokenSource(store, tokenServer.URL, tokenServer.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := openai.NewClient(openai.Config{BaseURL: apiServer.URL, TokenSource: source, ExtraHeaders: ExtraHeaders(), ProviderName: "kimi-subscription"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Complete(context.Background(), harness.CompletionRequest{Messages: []harness.Message{{Role: "user", Content: "hello"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if refreshes != 1 {
+		t.Fatalf("refreshes = %d, want 1", refreshes)
+	}
+	updated, err := Load(store)
+	if err != nil || updated.AccessToken != "fake-refreshed" {
+		t.Fatal("rotated pair was not persisted to harness store")
+	}
+}
+
+func TestCredentialCodeHasNoLoggingCalls(t *testing.T) {
+	data, err := os.ReadFile("kimi.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"log.", "slog.", "fmt.Print"} {
+		if strings.Contains(string(data), forbidden) {
+			t.Fatalf("credential code must not log: %s", forbidden)
+		}
 	}
 }

--- a/internal/provider/kimi/kimi_test.go
+++ b/internal/provider/kimi/kimi_test.go
@@ -1,0 +1,55 @@
+package kimi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshUsesOAuthFormAndDoesNotExposeCredential(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/api/oauth/token" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if form.Get("grant_type") != "refresh_token" || form.Get("refresh_token") != "fake-refresh" || form.Get("client_id") != ClientID {
+			t.Fatal("unexpected OAuth refresh form")
+		}
+		_, _ = w.Write([]byte(`{"access_token":"fake-next","refresh_token":"fake-next-refresh","expires_in":900}`))
+	}))
+	defer server.Close()
+
+	token, next, expires, err := RefreshFunc(server.URL+"/api/oauth/token", server.Client())(context.Background(), "fake-refresh")
+	if err != nil {
+		t.Fatalf("RefreshFunc: %v", err)
+	}
+	until := time.Until(expires)
+	if token != "fake-next" || next != "fake-next-refresh" || until < 14*time.Minute || until > 16*time.Minute {
+		t.Fatal("unexpected refresh result")
+	}
+
+	_, _, _, err = RefreshFunc(server.URL, server.Client())(context.Background(), "fake-secret")
+	if err == nil || strings.Contains(err.Error(), "fake-secret") {
+		t.Fatalf("credential leaked in error: %v", err)
+	}
+}
+
+func TestSafetyMarginIsRealisticForKimiShortTTL(t *testing.T) {
+	if SafetyMargin != 30*time.Second {
+		t.Fatalf("SafetyMargin = %s, want 30s", SafetyMargin)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a separate `kimi-subscription` provider whose models are derived from the existing metered Kimi catalog entry.
- Imports Kimi Code credentials read-only into `~/.harness/subscription-auth/kimi.json` (0600), refreshes them with a 30-second safety margin, and wires dynamic bearer credentials plus `X-Kimi-Client-*` headers through the existing OpenAI-compatible client.
- Adds `harnesscli auth kimi login|status|logout`, `/keys` subscription status, fake-server OAuth/API integration coverage, and a credential-logging source regression.

## Verification

- `go test ./internal/provider/... ./cmd/harnesscli/... ./internal/server/...`
- `go vet ./...`
- `./scripts/test-regression.sh` (PASS; 83.9% total coverage, zero uncovered functions)

## Live verification caveat

The exact live `auth.kimi.com` authenticated refresh body/response was **not** confirmed against a real server. I made one safe unauthenticated `OPTIONS https://auth.kimi.com/api/oauth/token` probe; it returned `405 Allow: POST`. Local vendor-session evidence identifies the path, but I did not submit credentials or a live completion because that could consume subscription capacity. The refresh implementation therefore follows the conventional OAuth2 form (`grant_type=refresh_token`, `refresh_token`, `client_id`) and is verified only against fake servers. Manual live verification is required before production reliance.

Closes #848