### PR TITLE
feat(provider/codex): ChatGPT-subscription authentication mode — epic #847

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ manual Zed verification checklist.
 ## 2026-07-20 — Live model discovery (Epic #849)
 
 - Live model discovery is provider-agnostic: configured OpenRouter, OpenAI, Anthropic, and DeepSeek entries refresh on a five-minute TTL. Discovery failures never remove static models; cached results are served stale after a failed refresh, and static metadata wins on ID conflicts.
-# Codex subscription auth (Epic #847)
+### Codex subscription auth (Epic #847)
 
 - `codex-subscription` reuses a ChatGPT-authenticated vendor Codex session through a harness-owned credential copy only. Never write under `~/.codex/`; import from it is read-only.
 - Setup is `codex login` followed by `harnesscli auth codex login`; `status` is safe to display and `logout` removes only `~/.harness/subscription-auth/codex.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,8 @@ manual Zed verification checklist.
 ## 2026-07-20 — Live model discovery (Epic #849)
 
 - Live model discovery is provider-agnostic: configured OpenRouter, OpenAI, Anthropic, and DeepSeek entries refresh on a five-minute TTL. Discovery failures never remove static models; cached results are served stale after a failed refresh, and static metadata wins on ID conflicts.
+# Codex subscription auth (Epic #847)
+
+- `codex-subscription` reuses a ChatGPT-authenticated vendor Codex session through a harness-owned credential copy only. Never write under `~/.codex/`; import from it is read-only.
+- Setup is `codex login` followed by `harnesscli auth codex login`; `status` is safe to display and `logout` removes only `~/.harness/subscription-auth/codex.json`.
+- Keep this provider additive: `openai` remains the documented `OPENAI_API_KEY` path. Do not log access, refresh, or ID token values.

--- a/catalog/models.json
+++ b/catalog/models.json
@@ -647,6 +647,14 @@
         "llama-4-maverick": "meta-llama/Llama-4-Maverick-17B-128E"
       }
     },
+    "codex-subscription": {
+      "display_name": "Codex (ChatGPT subscription)",
+      "base_url": "https://chatgpt.com/backend-api/codex",
+      "api_key_optional": true,
+      "token_source_required": true,
+      "protocol": "openai_compat",
+      "models_from": "openai"
+    },
     "anthropic": {
       "display_name": "Anthropic",
       "base_url": "https://api.anthropic.com/v1",

--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"go-agent-harness/internal/provider/codex"
 	"go-agent-harness/internal/provider/kimi"
 	"go-agent-harness/internal/store"
 )
@@ -83,6 +84,48 @@ func runAuthLogin(args []string) int {
 	return 0
 }
 
+// runAuthCodex implements "harnesscli auth codex login|status|logout". It
+// manages only the harness-owned subscription credential.
+func runAuthCodex(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "harnesscli auth codex: subcommand required (try: login, status, logout)")
+		return 1
+	}
+	store := codex.DefaultStore()
+	switch args[0] {
+	case "login":
+		credential, err := store.Import(codex.DefaultVendorAuthPath())
+		if err != nil {
+			fmt.Fprintf(stderr, "harnesscli auth codex login: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Codex subscription credential imported for account %s.\n", credential.AccountID)
+		return 0
+	case "status":
+		credential, err := store.Load()
+		if err != nil {
+			fmt.Fprintf(stderr, "harnesscli auth codex status: %v\n", err)
+			return 1
+		}
+		validity := "expired (will refresh when used)"
+		if credential.ExpiresAt.After(time.Now()) {
+			validity = "valid"
+		}
+		fmt.Fprintf(stdout, "Codex subscription: configured for account %s; access credential is %s.\n", credential.AccountID, validity)
+		return 0
+	case "logout":
+		if err := store.Remove(); err != nil {
+			fmt.Fprintf(stderr, "harnesscli auth codex logout: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, "Codex subscription credential removed from harness storage.")
+		return 0
+	default:
+		fmt.Fprintf(stderr, "harnesscli auth codex: unknown subcommand %q\n", args[0])
+		return 1
+	}
+}
+
 // runAuth dispatches "harness auth <subcommand>" commands.
 func runAuth(args []string) int {
 	if len(args) == 0 {
@@ -94,6 +137,8 @@ func runAuth(args []string) int {
 		return runAuthLogin(args[1:])
 	case "kimi":
 		return runAuthKimi(args[1:])
+	case "codex":
+		return runAuthCodex(args[1:])
 	default:
 		fmt.Fprintf(stderr, "harnesscli auth: unknown subcommand %q\n", args[0])
 		return 1

--- a/cmd/harnesscli/auth_test.go
+++ b/cmd/harnesscli/auth_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunAuthLogin_GeneratesAndSavesKey(t *testing.T) {
@@ -84,6 +87,56 @@ func TestRunAuth_UnknownSubcommand(t *testing.T) {
 	code := runAuth([]string{"unknown"})
 	if code == 0 {
 		t.Error("expected non-zero exit for unknown subcommand")
+	}
+}
+
+func TestRunAuthCodexLoginStatusLogout(t *testing.T) {
+	origStdout, origStderr := stdout, stderr
+	defer func() { stdout, stderr = origStdout, origStderr }()
+	var outBuf, errBuf bytes.Buffer
+	stdout, stderr = &outBuf, &errBuf
+
+	tmpHome := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", tmpHome)
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".codex"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	access := "test." + base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(`{"exp":%d}`, time.Now().Add(time.Hour).Unix()))) + ".signature"
+	vendorPath := filepath.Join(tmpHome, ".codex", "auth.json")
+	vendor := fmt.Sprintf(`{"auth_mode":"chatgpt","tokens":{"access_token":%q,"refresh_token":"test-cli-refresh","account_id":"acct-cli"}}`, access)
+	if err := os.WriteFile(vendorPath, []byte(vendor), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(vendorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if code := runAuth([]string{"codex", "login"}); code != 0 {
+		t.Fatalf("codex login = %d, stderr=%s", code, errBuf.String())
+	}
+	if strings.Contains(outBuf.String(), "test-cli-refresh") || !strings.Contains(outBuf.String(), "acct-cli") {
+		t.Fatalf("login output is unsafe or incomplete: %q", outBuf.String())
+	}
+	after, err := os.ReadFile(vendorPath)
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("vendor Codex credential was changed: %v", err)
+	}
+	outBuf.Reset()
+	if code := runAuth([]string{"codex", "status"}); code != 0 || !strings.Contains(outBuf.String(), "valid") || strings.Contains(outBuf.String(), "test-cli-refresh") {
+		t.Fatalf("codex status failed or exposed token: code=%d output=%q", code, outBuf.String())
+	}
+	outBuf.Reset()
+	if code := runAuth([]string{"codex", "logout"}); code != 0 {
+		t.Fatalf("codex logout = %d, stderr=%s", code, errBuf.String())
+	}
+	if _, err := os.Stat(filepath.Join(tmpHome, ".harness", "subscription-auth", "codex.json")); !os.IsNotExist(err) {
+		t.Fatalf("logout did not remove harness credential: %v", err)
+	}
+	if after, err := os.ReadFile(vendorPath); err != nil || string(after) != string(before) {
+		t.Fatalf("logout changed vendor Codex credential: %v", err)
 	}
 }
 

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -428,6 +428,7 @@ type providersResponse struct {
 		Name       string `json:"name"`
 		Configured bool   `json:"configured"`
 		APIKeyEnv  string `json:"api_key_env"`
+		AuthType   string `json:"auth_type"`
 	} `json:"providers"`
 }
 
@@ -458,6 +459,7 @@ func fetchProvidersCmd(baseURL, apiKey string) tea.Cmd {
 				Name:       p.Name,
 				Configured: p.Configured,
 				APIKeyEnv:  p.APIKeyEnv,
+				AuthType:   p.AuthType,
 			}
 		}
 		return ProvidersLoadedMsg{Providers: providers}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -225,6 +225,7 @@ type ProviderInfo struct {
 	Name       string
 	Configured bool
 	APIKeyEnv  string
+	AuthType   string
 }
 
 // ProvidersLoadedMsg carries results from GET /v1/providers.

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -65,6 +65,7 @@ type apiKeyProvider struct {
 	Name       string
 	Configured bool
 	APIKeyEnv  string
+	AuthType   string
 }
 
 var gatewayOptions = []gatewayOption{
@@ -2108,8 +2109,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.apiKeyInputMode = false
 					m.apiKeyInput = ""
 					cmds = append(cmds, setProviderKeyCmd(m.config.BaseURL, provider, apiKey, m.config.APIKey))
-				} else if !m.apiKeyInputMode && len(m.apiKeyProviders) > 0 {
+				} else if !m.apiKeyInputMode && len(m.apiKeyProviders) > 0 && m.apiKeyProviders[m.apiKeyCursor].AuthType != "subscription" {
 					m.apiKeyInputMode = true
+				} else if len(m.apiKeyProviders) > 0 {
+					cmds = append(cmds, m.setStatusMsg("Run `codex login`, then `harnesscli auth codex login` to configure this subscription."))
 				}
 				return m, tea.Batch(cmds...)
 			}
@@ -3325,7 +3328,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Gap 3 (#315): codex models use the OpenAI API key; surface a clear
 		// instruction when the model is selected but OpenAI is not configured.
-		if isCodexModel(msg.ModelID) && !m.providerKeyConfigured(msg.Provider) {
+		if msg.Provider == "codex-subscription" && !m.providerKeyConfigured(msg.Provider) {
+			cmds = append(cmds, m.setStatusMsg(
+				"Codex subscription needs `codex login`, then `harnesscli auth codex login`.",
+			))
+		} else if isCodexModel(msg.ModelID) && !m.providerKeyConfigured(msg.Provider) {
 			cmds = append(cmds, m.setStatusMsg(
 				"Codex uses your OpenAI API key. Set OPENAI_API_KEY or enter it via /keys.",
 			))
@@ -3352,6 +3359,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Name:       p.Name,
 				Configured: p.Configured,
 				APIKeyEnv:  p.APIKeyEnv,
+				AuthType:   p.AuthType,
 			}
 		}
 		m.apiKeyProviders = providers
@@ -3878,7 +3886,17 @@ func (m Model) viewAPIKeysOverlay() string {
 		if p.Configured {
 			status = configuredStyle.Render("\u25cf set")
 		}
-		label := style.Render(fmt.Sprintf("%s%-14s %-24s", cursor, p.Name, p.APIKeyEnv))
+		detail := p.APIKeyEnv
+		if p.AuthType == "subscription" {
+			detail = "ChatGPT subscription"
+		}
+		label := style.Render(fmt.Sprintf("%s%-14s %-24s", cursor, p.Name, detail))
+		if p.AuthType == "subscription" {
+			status = unsetStyle.Render("○ not connected")
+			if p.Configured {
+				status = configuredStyle.Render("● connected")
+			}
+		}
 		rows = append(rows, label+" "+status)
 	}
 
@@ -3886,7 +3904,7 @@ func (m Model) viewAPIKeysOverlay() string {
 		rows = append(rows, "  No providers available")
 	}
 
-	footer := lipgloss.NewStyle().Faint(true).Render(string('\u2191') + "/" + string('\u2193') + " navigate  enter edit  esc close")
+	footer := lipgloss.NewStyle().Faint(true).Render(string('\u2191') + "/" + string('\u2193') + " navigate  enter edit/setup  esc close")
 
 	content := strings.Join(rows, "\n") + "\n\n" + footer
 

--- a/cmd/harnesscli/tui/model_apikeys_test.go
+++ b/cmd/harnesscli/tui/model_apikeys_test.go
@@ -58,6 +58,24 @@ func TestKeysOverlay_ProvidersLoadedMsg(t *testing.T) {
 	}
 }
 
+func TestKeysOverlay_ShowsCodexSubscriptionStatusWithoutEditingAPIKey(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/keys")
+	m2, _ := m.Update(tui.ProvidersLoadedMsg{Providers: []tui.ProviderInfo{
+		{Name: "codex-subscription", Configured: true, AuthType: "subscription"},
+	}})
+	m = m2.(tui.Model)
+	view := m.View()
+	if !strings.Contains(view, "ChatGPT subscription") || !strings.Contains(view, "connected") {
+		t.Fatalf("Codex subscription status missing from /keys view:\n%s", view)
+	}
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m3.(tui.Model)
+	if m.APIKeyInputMode() {
+		t.Fatal("subscription row must not open API-key editing")
+	}
+}
+
 // TestKeysOverlay_EnterInputMode verifies Enter with providers loaded enters input mode.
 func TestKeysOverlay_EnterInputMode(t *testing.T) {
 	m := initModel(t, 80, 24)

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,9 +21,11 @@ import (
 	"go-agent-harness/internal/provider"
 	"go-agent-harness/internal/provider/anthropic"
 	"go-agent-harness/internal/provider/catalog"
+	"go-agent-harness/internal/provider/codex"
 	"go-agent-harness/internal/provider/kimi"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/provider/pricing"
+	"go-agent-harness/internal/provider/tokencache"
 	"go-agent-harness/internal/relay"
 	"go-agent-harness/internal/server"
 	slackadapter "go-agent-harness/internal/slack"
@@ -34,10 +37,12 @@ import (
 )
 
 type catalogBootstrapOptions struct {
-	workspace   string
-	getenv      func(string) string
-	newProvider providerFactory
-	logger      func(string, ...any)
+	workspace    string
+	getenv       func(string) string
+	newProvider  providerFactory
+	logger       func(string, ...any)
+	codexStore   *codex.Store
+	codexRefresh tokencache.RefreshFunc
 }
 
 type catalogBootstrap struct {
@@ -122,6 +127,21 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 		if source, err := kimi.NewTokenSource(kimi.DefaultStorePath(), "", nil); err == nil {
 			bootstrap.providerRegistry.SetTokenSource("kimi-subscription", source)
 		}
+		store := opts.codexStore
+		if store == nil {
+			store = codex.DefaultStore()
+		}
+		refresh := opts.codexRefresh
+		if refresh == nil {
+			refresh = codex.NewRefreshFunc(nil, "", nil)
+		}
+		var codexSource *codex.Source
+		if source, err := codex.NewTokenSource(store, refresh); err == nil {
+			codexSource = source
+			bootstrap.providerRegistry.SetTokenSource("codex-subscription", source)
+		} else if !errors.Is(err, codex.ErrNotConfigured) {
+			return catalogBootstrap{}, fmt.Errorf("load Codex subscription credential: %w", err)
+		}
 		registerModelDiscoverers(bootstrap.providerRegistry)
 		bootstrap.providerRegistry.SetClientFactory(catalog.ClientFactory(func(apiKey, baseURL, providerName string, tokenSource provider.TokenSource) (catalog.ProviderClient, error) {
 			if providerName == "anthropic" {
@@ -173,6 +193,10 @@ func buildCatalogBootstrap(opts catalogBootstrapOptions) (catalogBootstrap, erro
 				}
 				cfg.OpenRouterReferer = referer
 				cfg.OpenRouterTitle = title
+			}
+			if providerName == "codex-subscription" && codexSource != nil {
+				cfg.SkipV1Path = true
+				cfg.ExtraHeaders = map[string]string{"chatgpt-account-id": codexSource.AccountID()}
 			}
 			return opts.newProvider(cfg)
 		}))

--- a/cmd/harnessd/bootstrap_helpers_test.go
+++ b/cmd/harnessd/bootstrap_helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"go-agent-harness/internal/harness"
 	htools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/provider/catalog"
+	"go-agent-harness/internal/provider/codex"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/relay"
 	"go-agent-harness/internal/subagents"
@@ -111,6 +112,45 @@ func TestBuildCatalogBootstrapRegistersDiscoverersOnlyForConfiguredProviders(t *
 // 16384) instead of silently falling back to the package's defaultMaxTokens
 // (4096). Without the catalog wired in, a response that legitimately needed
 // more than 4096 output tokens gets truncated by the outgoing request itself.
+func TestBuildCatalogBootstrapWiresCodexSubscriptionSourceAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(workspace+"/catalog", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalogJSON := `{"catalog_version":"1","providers":{"openai":{"base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_API_KEY","protocol":"openai_compat","models":{"gpt":{"context_window":1}}},"codex-subscription":{"base_url":"https://chatgpt.com/backend-api/codex","api_key_optional":true,"token_source_required":true,"protocol":"openai_compat","models_from":"openai"}}}`
+	if err := os.WriteFile(workspace+"/catalog/models.json", []byte(catalogJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := codex.NewStore(filepath.Join(t.TempDir(), "codex.json"))
+	if err := store.Save(codex.Credential{AccessToken: "test-access", RefreshToken: "test-refresh", AccountID: "acct-test", ExpiresAt: time.Now().Add(time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	var captured openai.Config
+	bootstrap, err := buildCatalogBootstrap(catalogBootstrapOptions{
+		workspace:  workspace,
+		getenv:     func(string) string { return "" },
+		codexStore: store,
+		newProvider: func(cfg openai.Config) (harness.Provider, error) {
+			captured = cfg
+			return &noopProvider{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildCatalogBootstrap: %v", err)
+	}
+	if !bootstrap.providerRegistry.IsConfigured("codex-subscription") {
+		t.Fatal("Codex subscription is not configured from harness credential")
+	}
+	if _, err := bootstrap.providerRegistry.GetClient("codex-subscription"); err != nil {
+		t.Fatalf("GetClient(codex-subscription): %v", err)
+	}
+	if captured.TokenSource == nil || !captured.SkipV1Path || captured.ExtraHeaders["chatgpt-account-id"] != "acct-test" {
+		t.Fatalf("Codex provider config is incomplete: %#v", captured)
+	}
+}
+
 func TestBuildCatalogBootstrapAnthropicFactoryUsesCatalogMaxTokens(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -1080,16 +1080,40 @@ func resolveDefaultProvider(opts resolveDefaultProviderOptions) (harness.Provide
 		opts.getenv = os.Getenv
 	}
 
-	// Path 0: env-gated fake provider for key-free deterministic shell smoke.
-	// Activated only when HARNESS_PROVIDER=="fake"; default behavior is
-	// unchanged when the env var is absent.
-	if strings.TrimSpace(opts.getenv("HARNESS_PROVIDER")) == "fake" {
+	// Path 0: explicit provider override. The fake provider remains a
+	// key-free deterministic shell-smoke special case; catalog providers such
+	// as codex-subscription resolve through their configured registry source.
+	providerOverride := strings.TrimSpace(opts.getenv("HARNESS_PROVIDER"))
+	if providerOverride == "fake" {
 		turnsPath := strings.TrimSpace(opts.getenv("HARNESS_FAKE_TURNS"))
 		turns, err := loadFakeTurns(turnsPath)
 		if err != nil {
 			return nil, fmt.Errorf("fake provider: %w", err)
 		}
 		return fakeprovider.New(turns), nil
+	}
+	if providerOverride != "" {
+		if opts.registry == nil || opts.registry.Catalog() == nil {
+			return nil, fmt.Errorf("configured provider %q is unavailable: model catalog is not loaded", providerOverride)
+		}
+		if _, ok := opts.registry.Catalog().Providers[providerOverride]; !ok {
+			return nil, fmt.Errorf("configured provider %q is not in the model catalog", providerOverride)
+		}
+		if !opts.registry.IsConfigured(providerOverride) {
+			if providerOverride == "codex-subscription" {
+				return nil, fmt.Errorf("Codex subscription is not configured; run `codex login`, then `harnesscli auth codex login`")
+			}
+			return nil, fmt.Errorf("configured provider %q has no credentials", providerOverride)
+		}
+		client, err := opts.registry.GetClient(providerOverride)
+		if err != nil {
+			return nil, fmt.Errorf("create configured provider %q: %w", providerOverride, err)
+		}
+		resolved, ok := client.(harness.Provider)
+		if !ok {
+			return nil, fmt.Errorf("provider %q client does not implement harness.Provider", providerOverride)
+		}
+		return resolved, nil
 	}
 
 	model := strings.TrimSpace(opts.model)

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -82,6 +82,7 @@ type runDeps struct {
 }
 
 type runnerConfigOptions struct {
+	DefaultProviderName  string
 	DefaultSystemPrompt  string
 	DefaultAgentIntent   string
 	AskUserTimeout       time.Duration
@@ -123,6 +124,7 @@ func buildRunnerConfig(harnessCfg config.Config, opts runnerConfigOptions) harne
 
 	return harness.RunnerConfig{
 		DefaultModel:                  harnessCfg.Model,
+		DefaultProviderName:           opts.DefaultProviderName,
 		DefaultSystemPrompt:           opts.DefaultSystemPrompt,
 		DefaultAgentIntent:            opts.DefaultAgentIntent,
 		MaxSteps:                      harnessCfg.MaxSteps,
@@ -783,6 +785,13 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		log.Printf("rollout recording enabled: %s", rolloutDir)
 	}
 	runnerCfg := buildRunnerConfig(harnessCfg, runnerConfigOptions{
+		DefaultProviderName: func() string {
+			name := strings.TrimSpace(getenv("HARNESS_PROVIDER"))
+			if name == "fake" {
+				return ""
+			}
+			return name
+		}(),
 		DefaultSystemPrompt:  systemPrompt,
 		DefaultAgentIntent:   defaultAgentIntent,
 		AskUserTimeout:       time.Duration(askUserTimeoutSeconds) * time.Second,

--- a/cmd/harnessd/main_test.go
+++ b/cmd/harnessd/main_test.go
@@ -23,6 +23,7 @@ import (
 	htools "go-agent-harness/internal/harness/tools"
 	om "go-agent-harness/internal/observationalmemory"
 	"go-agent-harness/internal/profiles"
+	"go-agent-harness/internal/provider"
 	"go-agent-harness/internal/provider/catalog"
 	openai "go-agent-harness/internal/provider/openai"
 	"go-agent-harness/internal/skills"
@@ -327,6 +328,34 @@ func TestResolveDefaultProviderUsesOpenRouterForDynamicSlashModel(t *testing.T) 
 	named, ok := provider.(*namedProvider)
 	if !ok || named.name != "openrouter" {
 		t.Fatalf("unexpected provider: %#v", provider)
+	}
+}
+
+func TestResolveDefaultProviderUsesConfiguredCodexSubscriptionOverride(t *testing.T) {
+	t.Parallel()
+	cat := &catalog.Catalog{CatalogVersion: "1", Providers: map[string]catalog.ProviderEntry{
+		"codex-subscription": {BaseURL: "https://chatgpt.com/backend-api/codex", APIKeyOptional: true, TokenSourceRequired: true, Models: map[string]catalog.Model{"gpt": {ContextWindow: 1}}},
+	}}
+	registry := catalog.NewProviderRegistryWithEnv(cat, func(string) string { return "" })
+	registry.SetTokenSource("codex-subscription", provider.StaticToken("test-subscription-access"))
+	registry.SetClientFactory(func(_ string, _ string, providerName string) (catalog.ProviderClient, error) {
+		return &namedProvider{name: providerName}, nil
+	})
+	resolved, err := resolveDefaultProvider(resolveDefaultProviderOptions{
+		getenv: func(key string) string {
+			if key == "HARNESS_PROVIDER" {
+				return "codex-subscription"
+			}
+			return ""
+		},
+		registry: registry,
+		model:    "gpt",
+	})
+	if err != nil {
+		t.Fatalf("resolveDefaultProvider: %v", err)
+	}
+	if named, ok := resolved.(*namedProvider); !ok || named.name != "codex-subscription" {
+		t.Fatalf("resolved provider = %#v, want codex subscription", resolved)
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1626,3 +1626,11 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
 - `harnesscli auth kimi login` reads the vendor credential only and stores a `0600` go-code-owned copy; status and logout never print a credential and logout never affects the vendor CLI.
 - Refresh uses a 30-second margin for the real 900-second TTL. Fake OAuth/API integration coverage proves a forced near-expiry refresh, rotated persistence, dynamic bearer authorization, and all `X-Kimi-Client-*` headers.
 - Live endpoint caveat: a single unauthenticated `OPTIONS https://auth.kimi.com/api/oauth/token` returned `405 Allow: POST`; no authenticated live refresh or completion was performed. The form/body and OpenAI-compatible wire contract are convention-based and must be manually verified.
+
+# 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
+
+- Added `internal/provider/codex`: read-only vendor credential import, a `0600` harness-owned credential store, JWT expiry parsing, OAuth refresh, and a `tokencache`-backed token source that persists refreshes only to `~/.harness/subscription-auth/codex.json`.
+- Added `codex-subscription` as a structurally mirrored `openai` catalog provider. A token-source-required catalog flag distinguishes this remote subscription route from anonymous local optional-key providers, so absence remains unconfigured and never probes the ChatGPT backend.
+- Existing OpenAI-compatible request code now supports the Codex backend's no-`/v1` endpoint path and applies `chatgpt-account-id` with the dynamic bearer credential. `HARNESS_PROVIDER=codex-subscription` selects it deterministically when imported credentials are present.
+- Added `harnesscli auth codex login|status|logout`; `/keys` renders the read-only ChatGPT subscription connection state rather than offering API-key entry.
+- Coverage includes OAuth request/error sanitization, import permissions/read-only behavior, catalog mirroring, bootstrap wiring, CLI lifecycle, TUI/server status, fake HTTPS request plus forced mid-session expiry refresh, and a grep-based no-token-logging guard.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1627,7 +1627,7 @@ Skipped creating separate issues for Op/EventMsg protocol (already covered by SS
 - Refresh uses a 30-second margin for the real 900-second TTL. Fake OAuth/API integration coverage proves a forced near-expiry refresh, rotated persistence, dynamic bearer authorization, and all `X-Kimi-Client-*` headers.
 - Live endpoint caveat: a single unauthenticated `OPTIONS https://auth.kimi.com/api/oauth/token` returned `405 Allow: POST`; no authenticated live refresh or completion was performed. The form/body and OpenAI-compatible wire contract are convention-based and must be manually verified.
 
-# 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
+## 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
 
 - Added `internal/provider/codex`: read-only vendor credential import, a `0600` harness-owned credential store, JWT expiry parsing, OAuth refresh, and a `tokencache`-backed token source that persists refreshes only to `~/.harness/subscription-auth/codex.json`.
 - Added `codex-subscription` as a structurally mirrored `openai` catalog provider. A token-source-required catalog flag distinguishes this remote subscription route from anonymous local optional-key providers, so absence remains unconfigured and never probes the ChatGPT backend.

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -7,6 +7,13 @@
 - Success definition: read-only CLI credential import into `~/.harness/subscription-auth/kimi.json`; `auth kimi login|status|logout`; 30-second refresh safety margin; derived (not duplicated) Kimi model catalog; dynamic bearer plus client headers; fake-server completion/refresh integration coverage; no credential logging.
 - Guardrails: Live `/api/oauth/token` was confirmed only as POST-capable by one unauthenticated OPTIONS probe. No authenticated refresh or completion was sent to the live service; conventional OAuth2 form details and OpenAI compatibility require manual verification before production reliance.
 
+## 2026-07-20 (Codex ChatGPT-Subscription Authentication — Epic #847)
+
+- Command intent: Implement, test, commit by slice, push, and open (without merging) the `codex-subscription` authentication provider.
+- User intent: Reuse an existing ChatGPT-authenticated vendor Codex session without a separate metered OpenAI API key.
+- Success definition: a read-only import creates a `0600` harness-owned credential; refresh uses the verified OAuth contract; the catalog mirrors OpenAI models structurally; harnessd sends the dynamic bearer and account header; CLI/TUI surface safe status; a fake HTTPS request survives forced expiry refresh.
+- Guardrails: never write under `~/.codex`, never log credentials, no OAuth dependency, retain OpenAI API-key behavior, and explicitly report whether live ChatGPT validation was possible.
+
 ## 2026-07-20 (Subscription-Auth Foundation — Epic #846)
 
 - Command intent: Add provider-layer dynamic bearer credential and extra-header plumbing, a generic refresh cache, and registry token-source support; commit each test-first slice, verify, push, and open a PR without merging it.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -580,7 +580,7 @@ Use this file to document systems, interfaces, and interactions as they are buil
 - Requests use the existing OpenAI-compatible client with a refreshable token source and static `X-Kimi-Client-*` headers. Refresh persistence is contained in the harness-owned store.
 - Operational limitation: live POST capability, not authenticated OAuth request shape or completion compatibility, was verified; manual service verification remains required.
 
-# 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
+## 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
 
 - System/component: `internal/provider/codex`, catalog loader/registry, OpenAI-compatible client, `harnessd` bootstrap, and `harnesscli` auth/TUI surfaces.
 - Credential flow: `harnesscli auth codex login` reads `~/.codex/auth.json` without changing it, copies the ChatGPT token pair/account id to `~/.harness/subscription-auth/codex.json` (`0700` parent, `0600` file), and `harnessd` loads only that copy. Refresh calls update only the copy.

--- a/docs/logs/system-log.md
+++ b/docs/logs/system-log.md
@@ -579,3 +579,10 @@ Use this file to document systems, interfaces, and interactions as they are buil
 - Credentials flow: vendor `~/.kimi-code/credentials/kimi-code.json` is read once on explicit import; mutable state is only `~/.harness/subscription-auth/kimi.json` with mode `0600`.
 - Requests use the existing OpenAI-compatible client with a refreshable token source and static `X-Kimi-Client-*` headers. Refresh persistence is contained in the harness-owned store.
 - Operational limitation: live POST capability, not authenticated OAuth request shape or completion compatibility, was verified; manual service verification remains required.
+
+# 2026-07-20 — Codex ChatGPT-Subscription Authentication (Epic #847)
+
+- System/component: `internal/provider/codex`, catalog loader/registry, OpenAI-compatible client, `harnessd` bootstrap, and `harnesscli` auth/TUI surfaces.
+- Credential flow: `harnesscli auth codex login` reads `~/.codex/auth.json` without changing it, copies the ChatGPT token pair/account id to `~/.harness/subscription-auth/codex.json` (`0700` parent, `0600` file), and `harnessd` loads only that copy. Refresh calls update only the copy.
+- Request flow: the registry receives a refreshable `TokenSource` for `codex-subscription`; the existing OpenAI-compatible client obtains bearer credentials per request and sends `chatgpt-account-id` to `https://chatgpt.com/backend-api/codex/{responses,chat/completions}` without adding `/v1`.
+- Failure mode: no imported credential leaves the provider unconfigured and reports the vendor-login then harness-import remediation before an upstream request. Credentials are never emitted by the new log/error paths.

--- a/docs/plans/2026-07-20-codex-subscription-auth-847-impact-map.md
+++ b/docs/plans/2026-07-20-codex-subscription-auth-847-impact-map.md
@@ -1,0 +1,33 @@
+# Provider/Model Impact Map: Codex ChatGPT-subscription authentication (#847)
+
+## Task
+
+- Task / issue: #847
+- Plan link: `2026-07-20-codex-subscription-auth-847-plan.md`
+- Owner: Codex
+- Status: in implementation
+
+## Config
+
+- User-facing config added or changed: catalog provider `codex-subscription`; durable credential at `~/.harness/subscription-auth/codex.json`.
+- Defaults / fallbacks: no credential means unconfigured; CLI tells users to run `codex login` then `harnesscli auth codex login`.
+- Environment variables, config files, or saved settings touched: `~/.codex/auth.json` is read-only import source; no API key is required for the new provider.
+- Migration / backward-compatibility notes: `openai` and `OPENAI_API_KEY` behavior remains unchanged.
+
+## Server API
+
+- Endpoints, request fields, response fields, or server wiring affected: no public HTTP endpoint changes; bootstrap registers the provider token source and account header.
+- Provider/model resolution or registry changes: catalog loader derives model metadata from `openai`; registry gets a Codex token source before client creation.
+- Error states / validation changes: missing credentials stay unconfigured and produce a remediation error before an upstream request.
+
+## TUI State
+
+- Slash commands, overlays, selection state, routing, or status bar changes: existing `/keys` overlay adds a read-only Codex subscription status row.
+- Persisted client state or local config changes: no TUI persistence changes; CLI owns credential import/remove.
+- Keyboard/navigation implications: subscription status is not editable in `/keys`; setup remains the documented CLI command.
+
+## Regression Tests
+
+- New acceptance tests required: fake HTTPS Responses request plus forced refresh; static account header; missing credential error; store `0600` permissions.
+- Existing tests to update: catalog loader, bootstrap factory config, auth dispatch, and keys overlay rendering.
+- Cross-surface regressions to guard: static OpenAI key flow and catalog model isolation remain unchanged; source guard rejects token-bearing logging.

--- a/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
+++ b/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
@@ -13,7 +13,7 @@
 
 ## Documentation Contract
 
-- Feature status: in implementation
+- Feature status: implemented
 - Public docs affected: provider/auth setup documentation and CLI help.
 - Spec docs to update before code: this plan and the linked impact map.
 - Implementation notes to add after code: engineering/system logs and `CLAUDE.md`.
@@ -33,8 +33,8 @@
 - [x] Define acceptance criteria and planned tests.
 - [x] Document feature status and exact contract before code.
 - [x] Add provider/model-flow impact map before implementation.
-- [ ] Implement each requested slice test-first and commit it green.
-- [ ] Update docs, logs, and indexes.
+- [x] Implement each requested slice test-first and commit it green.
+- [x] Update docs, logs, and indexes.
 - [ ] Run focused tests, vet, and full regression gate.
 - [ ] Push branch and open PR without merging.
 

--- a/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
+++ b/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
@@ -35,7 +35,7 @@
 - [x] Add provider/model-flow impact map before implementation.
 - [x] Implement each requested slice test-first and commit it green.
 - [x] Update docs, logs, and indexes.
-- [ ] Run focused tests, vet, and full regression gate.
+- [x] Run focused tests, vet, and full regression gate.
 - [ ] Push branch and open PR without merging.
 
 ## Risks and Mitigations

--- a/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
+++ b/docs/plans/2026-07-20-codex-subscription-auth-847-plan.md
@@ -1,0 +1,45 @@
+# Plan: Codex ChatGPT-subscription authentication (#847)
+
+## Context
+
+- Problem: users authenticated with the vendor `codex` CLI cannot select the ChatGPT-subscription billing route in go-code.
+- User impact: import a read-only copy of the existing Codex credential, then use it transparently for a distinct `codex-subscription` provider.
+- Constraints: never modify `~/.codex`; never log credentials; use #846's token cache and registry token source; no OAuth dependency; own credential file mode is `0600`.
+
+## Scope
+
+- In scope: Codex OAuth refresh, safe credential import/store, catalog mirroring, harnessd wiring, `harnesscli auth codex`, `/keys` status, fake-server request/refresh integration, and operator docs.
+- Out of scope: interactive OAuth, vendor logout/revocation, Kimi auth (#848), changing the API-key `openai` provider, and writing under `~/.codex`.
+
+## Documentation Contract
+
+- Feature status: in implementation
+- Public docs affected: provider/auth setup documentation and CLI help.
+- Spec docs to update before code: this plan and the linked impact map.
+- Implementation notes to add after code: engineering/system logs and `CLAUDE.md`.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: OAuth request/response contract; import/permissions/status/logout; catalog model mirroring and registry headers; CLI dispatch/status; TUI subscription row; fake HTTPS completion with forced refresh; token-log grep guard.
+- Existing tests to update: catalog loader/registry, harnessd bootstrap, auth dispatcher, and keys overlay tests.
+- Regression tests required: absent credential remediation, `chatgpt-account-id` on requests, transparent refresh, and no credential-bearing log calls.
+
+## Cross-Surface Impact Map
+
+- `docs/plans/2026-07-20-codex-subscription-auth-847-impact-map.md`
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria and planned tests.
+- [x] Document feature status and exact contract before code.
+- [x] Add provider/model-flow impact map before implementation.
+- [ ] Implement each requested slice test-first and commit it green.
+- [ ] Update docs, logs, and indexes.
+- [ ] Run focused tests, vet, and full regression gate.
+- [ ] Push branch and open PR without merging.
+
+## Risks and Mitigations
+
+- Risk: ChatGPT backend endpoint differs from the standard Responses shape. Mitigation: use a fake HTTPS integration test and report live-validation limitations explicitly.
+- Risk: credentials leak through error/log paths. Mitigation: sanitized errors, no credential formatting, and a source grep regression test.
+- Risk: provider model definitions drift. Mitigation: loader-level structural mirroring of the `openai` model map.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -2,6 +2,9 @@
 
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.
+
+- `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
+- `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.
 - `2026-07-20-subscription-auth-foundation-846-plan.md` — Epic #846 subscription-auth foundation: token-source, dynamic request auth, refresh cache, and registry plumbing (in implementation).
 - `2026-07-20-subscription-auth-foundation-846-impact-map.md` — Cross-surface impact map for Epic #846 provider credential plumbing.
 - `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.

--- a/docs/runbooks/INDEX.md
+++ b/docs/runbooks/INDEX.md
@@ -1,5 +1,7 @@
 # Runbooks Index
 
+- `codex-subscription-auth.md`: Setup, credential ownership, and caveats for the ChatGPT-backed Codex subscription provider.
+
 - `acp.md` — configure and verify the `harness-acp` Agent Client Protocol stdio adapter.
 - [Session rewind](session-rewind.md) — destructive file-snapshot restore and conversation truncation.
 

--- a/docs/runbooks/codex-subscription-auth.md
+++ b/docs/runbooks/codex-subscription-auth.md
@@ -1,0 +1,36 @@
+# Codex ChatGPT-Subscription Authentication
+
+`codex-subscription` is an additive provider that routes requests through the
+ChatGPT Codex backend using an existing local `codex` CLI ChatGPT session. It
+does not use `OPENAI_API_KEY`, so it is distinct from the metered `openai`
+provider.
+
+## Setup
+
+1. Authenticate the vendor CLI: `codex login`.
+2. Import a private, harness-owned copy: `harnesscli auth codex login`.
+3. Verify safely: `harnesscli auth codex status`.
+4. Select the provider explicitly, for example `HARNESS_PROVIDER=codex-subscription`.
+
+The import reads `~/.codex/auth.json` once and never writes anything under
+`~/.codex`. The copied credential lives at
+`~/.harness/subscription-auth/codex.json`; its directory/file modes are
+`0700`/`0600`. `harnesscli auth codex logout` deletes only this copied file.
+
+On expiry, the harness refreshes its own copy with the vendor Codex OAuth
+client contract and keeps the account id as the `chatgpt-account-id` request
+header. `status` prints the account id and validity only; it never prints a
+credential.
+
+## Limitations and account policy
+
+This route follows the behavior of the installed Codex CLI and targets its
+ChatGPT backend rather than OpenAI's documented metered API. It is not an
+official OpenAI API integration, may change without notice, and users are
+responsible for ensuring their ChatGPT plan and use comply with applicable
+OpenAI terms, limits, and organizational policy. Keep `openai` with an
+`OPENAI_API_KEY` for the documented API route.
+
+If no vendor credential has been imported, the provider remains unconfigured.
+The remediation is always: run `codex login`, then `harnesscli auth codex
+login`.

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -1189,7 +1189,11 @@ func (r *Runner) runPreflight(ctx context.Context, runID string, req RunRequest)
 		primaryModel = roleModels.Primary
 	}
 
-	candidates, err := r.resolveProviderCandidates(runID, model, req.ProviderName, req.AllowFallback, req.FallbackProviders)
+	preferredProvider := req.ProviderName
+	if preferredProvider == "" {
+		preferredProvider = r.config.DefaultProviderName
+	}
+	candidates, err := r.resolveProviderCandidates(runID, model, preferredProvider, req.AllowFallback, req.FallbackProviders)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -525,6 +525,9 @@ type RoleModels struct {
 
 type RunnerConfig struct {
 	DefaultModel string
+	// DefaultProviderName is applied when a run does not explicitly select a
+	// provider, allowing startup configuration to disambiguate mirrored models.
+	DefaultProviderName string
 	// RoleModels optionally overrides the model used for specific roles within
 	// a run. Empty fields fall back to the run's Model (or DefaultModel).
 	RoleModels          RoleModels

--- a/internal/provider/catalog/loader.go
+++ b/internal/provider/catalog/loader.go
@@ -28,17 +28,8 @@ func LoadCatalogFromBytes(data []byte) (*Catalog, error) {
 	if err := json.Unmarshal(data, &cat); err != nil {
 		return nil, fmt.Errorf("decode catalog: %w", err)
 	}
-	for name, entry := range cat.Providers {
-		if entry.ModelsFrom == "" {
-			continue
-		}
-		source, ok := cat.Providers[entry.ModelsFrom]
-		if !ok {
-			return nil, fmt.Errorf("provider %q: models_from %q not found", name, entry.ModelsFrom)
-		}
-		entry.Models = cloneModels(source.Models)
-		entry.Aliases = cloneAliases(source.Aliases)
-		cat.Providers[name] = entry
+	if err := deriveProviderModels(&cat); err != nil {
+		return nil, err
 	}
 
 	if err := validateCatalog(&cat); err != nil {
@@ -48,23 +39,67 @@ func LoadCatalogFromBytes(data []byte) (*Catalog, error) {
 	return &cat, nil
 }
 
-func cloneModels(models map[string]Model) map[string]Model {
-	out := make(map[string]Model, len(models))
-	for name, model := range models {
-		out[name] = model
+func deriveProviderModels(cat *Catalog) error {
+	visiting := make(map[string]bool)
+	resolved := make(map[string]bool)
+	var resolve func(string) error
+	resolve = func(name string) error {
+		if resolved[name] {
+			return nil
+		}
+		entry, ok := cat.Providers[name]
+		if !ok {
+			return fmt.Errorf("provider %q: models_from source is not defined", name)
+		}
+		if entry.ModelsFrom == "" {
+			resolved[name] = true
+			return nil
+		}
+		if visiting[name] {
+			return fmt.Errorf("provider %q: models_from cycle", name)
+		}
+		visiting[name] = true
+		if err := resolve(entry.ModelsFrom); err != nil {
+			return fmt.Errorf("provider %q: models_from %q: %w", name, entry.ModelsFrom, err)
+		}
+		source, ok := cat.Providers[entry.ModelsFrom]
+		if !ok {
+			return fmt.Errorf("provider %q: models_from %q is not defined", name, entry.ModelsFrom)
+		}
+		entry.Models = cloneModels(source.Models)
+		if len(entry.Aliases) == 0 {
+			entry.Aliases = cloneAliases(source.Aliases)
+		}
+		cat.Providers[name] = entry
+		visiting[name] = false
+		resolved[name] = true
+		return nil
 	}
-	return out
+	for name := range cat.Providers {
+		if err := resolve(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cloneModels(models map[string]Model) map[string]Model {
+	cloned := make(map[string]Model, len(models))
+	for name, model := range models {
+		cloned[name] = cloneModel(model)
+	}
+	return cloned
 }
 
 func cloneAliases(aliases map[string]string) map[string]string {
-	if aliases == nil {
+	if len(aliases) == 0 {
 		return nil
 	}
-	out := make(map[string]string, len(aliases))
-	for from, to := range aliases {
-		out[from] = to
+	cloned := make(map[string]string, len(aliases))
+	for alias, target := range aliases {
+		cloned[alias] = target
 	}
-	return out
+	return cloned
 }
 
 func validateCatalog(cat *Catalog) error {

--- a/internal/provider/catalog/loader_test.go
+++ b/internal/provider/catalog/loader_test.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +147,38 @@ func TestLoadCatalogFromBytes_NoModels(t *testing.T) {
 	_, err := LoadCatalogFromBytes([]byte(data))
 	if err == nil {
 		t.Fatal("expected error for no models")
+	}
+}
+
+func TestLoadCatalogFromBytes_DerivesCodexSubscriptionModelsFromOpenAI(t *testing.T) {
+	t.Parallel()
+
+	cat, err := LoadCatalogFromBytes([]byte(`{
+  "catalog_version":"1",
+  "providers": {
+    "openai": {"base_url":"https://api.openai.com/v1","api_key_env":"OPENAI_API_KEY","protocol":"openai_compat","models":{"gpt-test":{"display_name":"GPT Test","context_window":123}}},
+    "codex-subscription": {"base_url":"https://chatgpt.com/backend-api/codex","api_key_optional":true,"token_source_required":true,"protocol":"openai_compat","models_from":"openai"}
+  }
+}`))
+	if err != nil {
+		t.Fatalf("LoadCatalogFromBytes() error: %v", err)
+	}
+	codex := cat.Providers["codex-subscription"]
+	if !codex.TokenSourceRequired || len(codex.Models) != 1 || codex.Models["gpt-test"].ContextWindow != 123 {
+		t.Fatalf("Codex provider did not inherit OpenAI model metadata: %#v", codex)
+	}
+	codex.Models["gpt-test"] = Model{ContextWindow: 999}
+	if got := cat.Providers["openai"].Models["gpt-test"].ContextWindow; got != 123 {
+		t.Fatalf("model inheritance shares mutable metadata: got %d", got)
+	}
+}
+
+func TestLoadCatalogFromBytes_RejectsMissingModelSource(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadCatalogFromBytes([]byte(`{"catalog_version":"1","providers":{"codex-subscription":{"base_url":"https://example.test","api_key_optional":true,"token_source_required":true,"protocol":"openai_compat","models_from":"openai"}}}`))
+	if err == nil || !strings.Contains(err.Error(), "models_from") {
+		t.Fatalf("LoadCatalogFromBytes() error = %v, want missing models_from error", err)
 	}
 }
 

--- a/internal/provider/catalog/registry.go
+++ b/internal/provider/catalog/registry.go
@@ -173,6 +173,9 @@ func (r *ProviderRegistry) IsConfigured(providerName string) bool {
 	if !ok {
 		return false
 	}
+	if entry.TokenSourceRequired {
+		return false
+	}
 	if entry.APIKeyOptional && isLocalBaseURL(entry.BaseURL) {
 		return true
 	}
@@ -215,6 +218,9 @@ func (r *ProviderRegistry) GetClient(providerName string) (ProviderClient, error
 		apiKey = r.getenv(entry.APIKeyEnv)
 	}
 	if apiKey == "" && tokenSource == nil {
+		if entry.TokenSourceRequired {
+			return nil, fmt.Errorf("provider %q: subscription credential is not configured; run `codex login`, then `harnesscli auth codex login`", providerName)
+		}
 		if !entry.APIKeyOptional || !isLocalBaseURL(entry.BaseURL) {
 			if providerName == "kimi-subscription" {
 				return nil, fmt.Errorf("provider %q is not configured; run kimi-code login, then harnesscli auth kimi login", providerName)

--- a/internal/provider/catalog/registry_test.go
+++ b/internal/provider/catalog/registry_test.go
@@ -442,6 +442,27 @@ func TestSetTokenSourceConfiguresProviderPropagatesToFactoryAndEvictsClient(t *t
 	}
 }
 
+func TestTokenSourceRequiredProviderIsUnconfiguredWithoutSource(t *testing.T) {
+	t.Parallel()
+	cat := &Catalog{CatalogVersion: "1", Providers: map[string]ProviderEntry{
+		"codex-subscription": {
+			BaseURL: "https://chatgpt.com/backend-api/codex", APIKeyOptional: true, TokenSourceRequired: true,
+			Models: map[string]Model{"gpt": {ContextWindow: 1}},
+		},
+	}}
+	reg := NewProviderRegistryWithEnv(cat, fakeGetenv(map[string]string{}))
+	if reg.IsConfigured("codex-subscription") {
+		t.Fatal("token-source-required provider is configured without a token source")
+	}
+	if _, err := reg.GetClient("codex-subscription"); err == nil {
+		t.Fatal("GetClient succeeded without a token source")
+	}
+	reg.SetTokenSource("codex-subscription", provider.StaticToken("fake-subscription-token"))
+	if !reg.IsConfigured("codex-subscription") {
+		t.Fatal("token source did not configure subscription provider")
+	}
+}
+
 func TestSetAPIKey_OverridesEnv(t *testing.T) {
 	t.Parallel()
 	cat := registryTestCatalog()

--- a/internal/provider/catalog/types.go
+++ b/internal/provider/catalog/types.go
@@ -13,14 +13,18 @@ type ProviderEntry struct {
 	APIKeyEnv   string `json:"api_key_env"`
 	// APIKeyOptional marks providers (e.g. local Ollama/LM Studio servers) that
 	// do not require an API key to resolve or create a client.
-	APIKeyOptional bool              `json:"api_key_optional,omitempty"`
-	Protocol       string            `json:"protocol"`
-	Quirks         []string          `json:"quirks,omitempty"`
-	Models         map[string]Model  `json:"models"`
-	Aliases        map[string]string `json:"aliases,omitempty"`
-	// ModelsFrom mirrors models from another catalog provider at load time so
-	// subscription variants cannot silently drift from their metered peer.
-	ModelsFrom string `json:"models_from,omitempty"`
+	APIKeyOptional bool `json:"api_key_optional,omitempty"`
+	// TokenSourceRequired marks a remote provider whose optional static API key
+	// must be replaced by a runtime TokenSource (for subscription auth). It is
+	// deliberately distinct from anonymous local-server providers.
+	TokenSourceRequired bool     `json:"token_source_required,omitempty"`
+	Protocol            string   `json:"protocol"`
+	Quirks              []string `json:"quirks,omitempty"`
+	// ModelsFrom derives this provider's model metadata from another provider
+	// at load time, keeping mirrored billing routes in lockstep.
+	ModelsFrom string            `json:"models_from,omitempty"`
+	Models     map[string]Model  `json:"models"`
+	Aliases    map[string]string `json:"aliases,omitempty"`
 }
 
 // Model describes a single LLM model's capabilities and metadata.

--- a/internal/provider/codex/auth.go
+++ b/internal/provider/codex/auth.go
@@ -1,0 +1,68 @@
+// Package codex implements the credential contract for the ChatGPT-backed
+// Codex subscription provider. It never reads or writes the vendor CLI store.
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	// ClientID is the public OAuth client used by the vendor Codex CLI.
+	ClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+	// OAuthTokenURL exchanges a refresh credential for a replacement pair.
+	OAuthTokenURL = "https://auth.openai.com/oauth/token"
+)
+
+type oauthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+}
+
+// NewRefreshFunc creates the RefreshFunc used with provider/tokencache. The
+// endpoint and clock are injectable solely for deterministic tests.
+func NewRefreshFunc(client *http.Client, endpoint string, now func() time.Time) func(context.Context, string) (string, string, time.Time, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if endpoint == "" {
+		endpoint = OAuthTokenURL
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {ClientID},
+			"refresh_token": {refreshToken},
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+		if err != nil {
+			return "", "", time.Time{}, fmt.Errorf("create Codex OAuth refresh request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", "", time.Time{}, fmt.Errorf("send Codex OAuth refresh request: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return "", "", time.Time{}, fmt.Errorf("Codex OAuth refresh failed with status %d", resp.StatusCode)
+		}
+		var payload oauthTokenResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return "", "", time.Time{}, fmt.Errorf("decode Codex OAuth refresh response: %w", err)
+		}
+		if payload.AccessToken == "" || payload.RefreshToken == "" || payload.ExpiresIn <= 0 {
+			return "", "", time.Time{}, fmt.Errorf("Codex OAuth refresh response was incomplete")
+		}
+		return payload.AccessToken, payload.RefreshToken, now().Add(time.Duration(payload.ExpiresIn) * time.Second), nil
+	}
+}

--- a/internal/provider/codex/auth_test.go
+++ b/internal/provider/codex/auth_test.go
@@ -1,0 +1,84 @@
+package codex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshPostsCodexOAuthRefreshGrant(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/oauth/token" {
+			t.Fatalf("request = %s %s, want POST /oauth/token", r.Method, r.URL.Path)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", got)
+		}
+		if got := r.Form.Get("client_id"); got != ClientID {
+			t.Errorf("client_id = %q, want fixed Codex client id", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "test-refresh-credential" {
+			t.Error("refresh credential was not sent to OAuth endpoint")
+		}
+		_, _ = w.Write([]byte(`{"access_token":"test-next-access","refresh_token":"test-next-refresh","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	refresh := NewRefreshFunc(server.Client(), server.URL+"/oauth/token", time.Now)
+	token, nextRefresh, expiresAt, err := refresh(context.Background(), "test-refresh-credential")
+	if err != nil {
+		t.Fatalf("Refresh() error: %v", err)
+	}
+	if token != "test-next-access" || nextRefresh != "test-next-refresh" {
+		t.Fatal("refresh did not return replacement credentials")
+	}
+	if expiresAt.Before(time.Now().Add(59*time.Minute)) || expiresAt.After(time.Now().Add(61*time.Minute)) {
+		t.Fatalf("expiry %s is not derived from expires_in", expiresAt)
+	}
+}
+
+func TestRefreshSanitizesOAuthErrors(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "credential test-refresh-credential rejected", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	refresh := NewRefreshFunc(server.Client(), server.URL, time.Now)
+	_, _, _, err := refresh(context.Background(), "test-refresh-credential")
+	if err == nil {
+		t.Fatal("Refresh() succeeded for OAuth failure")
+	}
+	if got := err.Error(); containsCredential(got) {
+		t.Fatalf("refresh error exposes credential: %q", got)
+	}
+}
+
+func TestRefreshRejectsIncompleteOAuthResponse(t *testing.T) {
+	t.Parallel()
+
+	refresh := NewRefreshFunc(&http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody, Header: make(http.Header)}, nil
+	})}, "http://example.invalid/oauth/token", time.Now)
+	_, _, _, err := refresh(context.Background(), "test-refresh-credential")
+	if err == nil || containsCredential(err.Error()) {
+		t.Fatal("incomplete OAuth response must fail without exposing credentials")
+	}
+}
+
+func containsCredential(value string) bool {
+	return strings.Contains(value, "test-refresh-credential") || strings.Contains(value, "test-next-access")
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/internal/provider/codex/integration_test.go
+++ b/internal/provider/codex/integration_test.go
@@ -1,0 +1,85 @@
+package codex
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	openai "go-agent-harness/internal/provider/openai"
+)
+
+func TestSubscriptionCompletionRefreshesExpiredCredentialAgainstFakeHTTPS(t *testing.T) {
+	t.Parallel()
+
+	var refreshCalls, completionCalls int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/oauth/token":
+			refreshCalls++
+			if err := r.ParseForm(); err != nil || r.Form.Get("grant_type") != "refresh_token" || r.Form.Get("client_id") != ClientID {
+				t.Fatalf("invalid refresh request: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"access_token":"test-refreshed-access","refresh_token":"test-refreshed-refresh","expires_in":3600}`))
+		case "/backend-api/codex/responses":
+			completionCalls++
+			if completionCalls == 1 && r.Header.Get("Authorization") != "Bearer test-initial-access" {
+				t.Fatal("first completion did not use initial access credential")
+			}
+			if completionCalls == 2 && r.Header.Get("Authorization") != "Bearer test-refreshed-access" {
+				t.Fatal("second completion did not use refreshed access credential")
+			}
+			if r.Header.Get("chatgpt-account-id") != "acct-integration" {
+				t.Fatal("completion is missing ChatGPT account header")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"resp_test","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	store := NewStore(filepath.Join(t.TempDir(), "codex.json"))
+	if err := store.Save(Credential{AccessToken: "test-initial-access", RefreshToken: "test-old-refresh", AccountID: "acct-integration", ExpiresAt: time.Now().Add(50 * time.Millisecond)}); err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewTokenSourceWithSafetyMargin(store, NewRefreshFunc(server.Client(), server.URL+"/oauth/token", time.Now), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := openai.NewClient(openai.Config{
+		BaseURL:      server.URL + "/backend-api/codex",
+		SkipV1Path:   true,
+		TokenSource:  source,
+		ExtraHeaders: map[string]string{"chatgpt-account-id": source.AccountID()},
+		ProviderName: "codex-subscription",
+		ModelAPILookup: func(string, string) string {
+			return "responses"
+		},
+		Client: server.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := harness.CompletionRequest{Model: "gpt-test", Messages: []harness.Message{{Role: "user", Content: "hello"}}}
+	result, err := client.Complete(context.Background(), request)
+	if err != nil || result.Content != "ok" {
+		t.Fatalf("Complete() = %#v, %v", result, err)
+	}
+	time.Sleep(75 * time.Millisecond)
+	result, err = client.Complete(context.Background(), request)
+	if err != nil || result.Content != "ok" {
+		t.Fatalf("second Complete() = %#v, %v", result, err)
+	}
+	if refreshCalls != 1 || completionCalls != 2 {
+		t.Fatalf("refresh/completion calls = %d/%d, want 1/2", refreshCalls, completionCalls)
+	}
+	persisted, err := store.Load()
+	if err != nil || persisted.RefreshToken != "test-refreshed-refresh" {
+		t.Fatalf("refreshed credential was not persisted: %v", err)
+	}
+}

--- a/internal/provider/codex/logging_guard_test.go
+++ b/internal/provider/codex/logging_guard_test.go
@@ -1,17 +1,34 @@
 package codex
 
 import (
-	"os/exec"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
 // TestCredentialPathsHaveNoTokenLogging is a grep-based guard against adding
 // credential-bearing log/print calls to this provider's auth paths.
 func TestCredentialPathsHaveNoTokenLogging(t *testing.T) {
-	cmd := exec.Command("rg", "--pcre2", "(?i)(?:log\\.|fmt\\.(?:print|printf|sprint)).{0,120}(?:access[_ -]?token|refresh[_ -]?token|id[_ -]?token)", ".")
-	if output, err := cmd.CombinedOutput(); err == nil {
-		t.Fatalf("credential-related logging call found:\n%s", output)
-	} else if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
-		t.Fatalf("run credential logging grep: %v\n%s", err, output)
+	pattern := regexp.MustCompile(`(?i)(?:log\.|fmt\.(?:print|printf|sprint)).{0,120}(?:access[_ -]?token|refresh[_ -]?token|id[_ -]?token)`)
+	err := filepath.WalkDir(".", func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if match := pattern.Find(contents); match != nil {
+			t.Fatalf("credential-related logging call found in %s: %s", path, match)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan credential auth paths: %v", err)
 	}
 }

--- a/internal/provider/codex/logging_guard_test.go
+++ b/internal/provider/codex/logging_guard_test.go
@@ -1,0 +1,17 @@
+package codex
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// TestCredentialPathsHaveNoTokenLogging is a grep-based guard against adding
+// credential-bearing log/print calls to this provider's auth paths.
+func TestCredentialPathsHaveNoTokenLogging(t *testing.T) {
+	cmd := exec.Command("rg", "--pcre2", "(?i)(?:log\\.|fmt\\.(?:print|printf|sprint)).{0,120}(?:access[_ -]?token|refresh[_ -]?token|id[_ -]?token)", ".")
+	if output, err := cmd.CombinedOutput(); err == nil {
+		t.Fatalf("credential-related logging call found:\n%s", output)
+	} else if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 1 {
+		t.Fatalf("run credential logging grep: %v\n%s", err, output)
+	}
+}

--- a/internal/provider/codex/store.go
+++ b/internal/provider/codex/store.go
@@ -164,11 +164,18 @@ type Source struct {
 var _ provider.TokenSource = (*Source)(nil)
 
 func NewTokenSource(store *Store, refresh tokencache.RefreshFunc) (*Source, error) {
+	return NewTokenSourceWithSafetyMargin(store, refresh, 30*time.Second)
+}
+
+// NewTokenSourceWithSafetyMargin is equivalent to NewTokenSource with a
+// caller-supplied refresh margin. It exists for deterministic integration
+// coverage; production callers should use NewTokenSource.
+func NewTokenSourceWithSafetyMargin(store *Store, refresh tokencache.RefreshFunc, safetyMargin time.Duration) (*Source, error) {
 	credential, err := store.Load()
 	if err != nil {
 		return nil, err
 	}
-	cache := tokencache.New(credential.AccessToken, credential.RefreshToken, credential.ExpiresAt, 30*time.Second, func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+	cache := tokencache.New(credential.AccessToken, credential.RefreshToken, credential.ExpiresAt, safetyMargin, func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
 		token, nextRefresh, expiresAt, err := refresh(ctx, refreshToken)
 		if err != nil {
 			return "", "", time.Time{}, err

--- a/internal/provider/codex/store.go
+++ b/internal/provider/codex/store.go
@@ -1,0 +1,203 @@
+package codex
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/provider"
+	"go-agent-harness/internal/provider/tokencache"
+)
+
+// ErrNotConfigured intentionally includes the complete operator remediation.
+// It never reveals whether any individual credential field was present.
+var ErrNotConfigured = errors.New("Codex subscription is not configured; run `codex login`, then `harnesscli auth codex login`")
+
+// Credential is the harness-owned copy of a ChatGPT Codex credential.
+type Credential struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	IDToken      string    `json:"id_token,omitempty"`
+	AccountID    string    `json:"account_id"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}
+
+type vendorAuthFile struct {
+	AuthMode string `json:"auth_mode"`
+	Tokens   struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		AccountID    string `json:"account_id"`
+	} `json:"tokens"`
+}
+
+// Store owns only the harness copy of the subscription credential.
+type Store struct{ path string }
+
+func NewStore(path string) *Store { return &Store{path: path} }
+
+func DefaultStore() *Store {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return NewStore(filepath.Join(".harness", "subscription-auth", "codex.json"))
+	}
+	return NewStore(filepath.Join(home, ".harness", "subscription-auth", "codex.json"))
+}
+
+func DefaultVendorAuthPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".codex", "auth.json")
+	}
+	return filepath.Join(home, ".codex", "auth.json")
+}
+
+func (s *Store) Path() string { return s.path }
+
+// Import reads but never changes the vendor Codex auth file.
+func (s *Store) Import(vendorPath string) (Credential, error) {
+	raw, err := os.ReadFile(vendorPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Credential{}, ErrNotConfigured
+		}
+		return Credential{}, fmt.Errorf("read Codex credential import source: %w", err)
+	}
+	var vendor vendorAuthFile
+	if err := json.Unmarshal(raw, &vendor); err != nil {
+		return Credential{}, fmt.Errorf("decode Codex credential import source: %w", err)
+	}
+	if vendor.AuthMode != "chatgpt" {
+		return Credential{}, ErrNotConfigured
+	}
+	expiresAt, err := jwtExpiry(vendor.Tokens.AccessToken)
+	if err != nil || vendor.Tokens.RefreshToken == "" || vendor.Tokens.AccountID == "" {
+		return Credential{}, ErrNotConfigured
+	}
+	credential := Credential{AccessToken: vendor.Tokens.AccessToken, RefreshToken: vendor.Tokens.RefreshToken, IDToken: vendor.Tokens.IDToken, AccountID: vendor.Tokens.AccountID, ExpiresAt: expiresAt}
+	if err := s.Save(credential); err != nil {
+		return Credential{}, err
+	}
+	return credential, nil
+}
+
+func (s *Store) Load() (Credential, error) {
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Credential{}, ErrNotConfigured
+		}
+		return Credential{}, fmt.Errorf("read Codex subscription credential: %w", err)
+	}
+	var credential Credential
+	if err := json.Unmarshal(raw, &credential); err != nil {
+		return Credential{}, fmt.Errorf("decode Codex subscription credential: %w", err)
+	}
+	if credential.AccessToken == "" || credential.RefreshToken == "" || credential.AccountID == "" || credential.ExpiresAt.IsZero() {
+		return Credential{}, ErrNotConfigured
+	}
+	return credential, nil
+}
+
+func (s *Store) Save(credential Credential) error {
+	if credential.AccessToken == "" || credential.RefreshToken == "" || credential.AccountID == "" || credential.ExpiresAt.IsZero() {
+		return ErrNotConfigured
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("create Codex subscription credential directory: %w", err)
+	}
+	if err := os.Chmod(filepath.Dir(s.path), 0o700); err != nil {
+		return fmt.Errorf("secure Codex subscription credential directory: %w", err)
+	}
+	raw, err := json.Marshal(credential)
+	if err != nil {
+		return fmt.Errorf("encode Codex subscription credential: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".codex-credential-*")
+	if err != nil {
+		return fmt.Errorf("create Codex subscription credential file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("secure Codex subscription credential file: %w", err)
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write Codex subscription credential: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close Codex subscription credential: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("save Codex subscription credential: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Remove() error {
+	err := os.Remove(s.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("remove Codex subscription credential: %w", err)
+	}
+	return nil
+}
+
+// Source provides a refreshable bearer credential while preserving refreshes
+// exclusively in the harness-owned store.
+type Source struct {
+	cache     *tokencache.Cache
+	accountID string
+}
+
+var _ provider.TokenSource = (*Source)(nil)
+
+func NewTokenSource(store *Store, refresh tokencache.RefreshFunc) (*Source, error) {
+	credential, err := store.Load()
+	if err != nil {
+		return nil, err
+	}
+	cache := tokencache.New(credential.AccessToken, credential.RefreshToken, credential.ExpiresAt, 30*time.Second, func(ctx context.Context, refreshToken string) (string, string, time.Time, error) {
+		token, nextRefresh, expiresAt, err := refresh(ctx, refreshToken)
+		if err != nil {
+			return "", "", time.Time{}, err
+		}
+		if err := store.Save(Credential{AccessToken: token, RefreshToken: nextRefresh, IDToken: credential.IDToken, AccountID: credential.AccountID, ExpiresAt: expiresAt}); err != nil {
+			return "", "", time.Time{}, fmt.Errorf("persist refreshed Codex credential: %w", err)
+		}
+		return token, nextRefresh, expiresAt, nil
+	})
+	return &Source{cache: cache, accountID: credential.AccountID}, nil
+}
+
+func (s *Source) Token(ctx context.Context) (string, error) { return s.cache.Token(ctx) }
+func (s *Source) AccountID() string                         { return s.accountID }
+
+func jwtExpiry(token string) (time.Time, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return time.Time{}, errors.New("JWT payload is absent")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Time{}, err
+	}
+	var claims struct {
+		ExpiresAt int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.ExpiresAt <= 0 {
+		return time.Time{}, errors.New("JWT expiry is absent")
+	}
+	return time.Unix(claims.ExpiresAt, 0), nil
+}

--- a/internal/provider/codex/store_test.go
+++ b/internal/provider/codex/store_test.go
@@ -1,0 +1,100 @@
+package codex
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func jwtWithExpiry(expiresAt time.Time) string {
+	payload, _ := json.Marshal(map[string]int64{"exp": expiresAt.Unix()})
+	return "test." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+func TestStoreImportCopiesVendorCredentialWithoutModifyingIt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	vendorPath := filepath.Join(dir, "vendor-auth.json")
+	vendor := `{"auth_mode":"chatgpt","tokens":{"access_token":"` + jwtWithExpiry(time.Now().Add(time.Hour)) + `","refresh_token":"test-import-refresh","id_token":"test-import-id","account_id":"acct-test"}}`
+	if err := os.WriteFile(vendorPath, []byte(vendor), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(vendorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(filepath.Join(dir, "harness", "codex.json"))
+	credential, err := store.Import(vendorPath)
+	if err != nil {
+		t.Fatalf("Import() error: %v", err)
+	}
+	if credential.AccountID != "acct-test" {
+		t.Fatalf("AccountID = %q", credential.AccountID)
+	}
+	after, err := os.ReadFile(vendorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("Import modified vendor credential file")
+	}
+	info, err := os.Stat(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("credential mode = %o, want 0600", info.Mode().Perm())
+	}
+	if parent, err := os.Stat(filepath.Dir(store.Path())); err != nil || parent.Mode().Perm() != 0o700 {
+		t.Errorf("credential directory must be 0700, info=%v err=%v", parent, err)
+	}
+}
+
+func TestStoreMissingCredentialGivesCodexRemediation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewStore(filepath.Join(t.TempDir(), "missing.json")).Load()
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("Load() error = %v, want ErrNotConfigured", err)
+	}
+	if !strings.Contains(err.Error(), "codex login") || !strings.Contains(err.Error(), "harnesscli auth codex login") {
+		t.Fatalf("missing credential error lacks remediation: %q", err)
+	}
+}
+
+func TestTokenSourceRefreshPersistsOnlyHarnessCredential(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store := NewStore(filepath.Join(dir, "harness", "codex.json"))
+	if err := store.Save(Credential{AccessToken: "test-expired-access", RefreshToken: "test-old-refresh", AccountID: "acct-test", ExpiresAt: time.Now().Add(-time.Minute)}); err != nil {
+		t.Fatal(err)
+	}
+	source, err := NewTokenSource(store, func(context.Context, string) (string, string, time.Time, error) {
+		return "test-fresh-access", "test-fresh-refresh", time.Now().Add(time.Hour), nil
+	})
+	if err != nil {
+		t.Fatalf("NewTokenSource() error: %v", err)
+	}
+	got, err := source.Token(context.Background())
+	if err != nil || got != "test-fresh-access" {
+		t.Fatalf("Token() = %q, %v", got, err)
+	}
+	persisted, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.RefreshToken != "test-fresh-refresh" || persisted.AccessToken != "test-fresh-access" {
+		t.Fatal("refresh replacement pair was not persisted")
+	}
+	if source.AccountID() != "acct-test" {
+		t.Fatalf("AccountID() = %q", source.AccountID())
+	}
+}

--- a/internal/provider/openai/auth_test.go
+++ b/internal/provider/openai/auth_test.go
@@ -114,6 +114,38 @@ func TestClientTokenSourceErrorFailsRequest(t *testing.T) {
 	}
 }
 
+func TestClientSubscriptionEndpointUsesCodexPathWithoutV1(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/backend-api/codex/responses" {
+			t.Fatalf("Codex response path = %q, want /backend-api/codex/responses", r.URL.Path)
+		}
+		if r.Header.Get("chatgpt-account-id") != "acct-test" {
+			t.Fatal("Codex account header is absent")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_test","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		BaseURL:      server.URL + "/backend-api/codex",
+		SkipV1Path:   true,
+		TokenSource:  tokenSourceFunc(func(context.Context) (string, error) { return "test-access", nil }),
+		ExtraHeaders: map[string]string{"chatgpt-account-id": "acct-test"},
+		ModelAPILookup: func(string, string) string {
+			return "responses"
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Complete(context.Background(), harness.CompletionRequest{Model: "gpt-test", Messages: []harness.Message{{Role: "user", Content: "hello"}}}); err != nil {
+		t.Fatalf("Complete() error: %v", err)
+	}
+}
+
 func headersEqual(got, want http.Header) bool {
 	if len(got) != len(want) {
 		return false

--- a/internal/provider/openai/client.go
+++ b/internal/provider/openai/client.go
@@ -33,8 +33,11 @@ type Config struct {
 	TokenSource provider.TokenSource
 	// ExtraHeaders are static headers sent with every request. NewClient copies
 	// the map so later caller mutations cannot affect a long-lived client.
-	ExtraHeaders      map[string]string
-	BaseURL           string
+	ExtraHeaders map[string]string
+	BaseURL      string
+	// SkipV1Path keeps a provider base URL's existing namespace and appends
+	// endpoint paths directly (for example, /backend-api/codex/responses).
+	SkipV1Path        bool
 	Model             string
 	Client            *http.Client
 	PricingResolver   pricing.Resolver
@@ -61,6 +64,7 @@ type Client struct {
 	tokenSource       provider.TokenSource
 	extraHeaders      map[string]string
 	baseURL           string
+	skipV1Path        bool
 	model             string
 	client            *http.Client
 	pricingResolver   pricing.Resolver
@@ -100,12 +104,15 @@ func NewClient(config Config) (*Client, error) {
 	// and get the same behavior — path segments (/v1/chat/completions etc.) are
 	// always appended by this client.
 	baseURL = strings.TrimRight(baseURL, "/")
-	baseURL = strings.TrimSuffix(baseURL, "/v1")
+	if !config.SkipV1Path {
+		baseURL = strings.TrimSuffix(baseURL, "/v1")
+	}
 	return &Client{
 		apiKey:            config.APIKey,
 		tokenSource:       config.TokenSource,
 		extraHeaders:      cloneHeaders(config.ExtraHeaders),
 		baseURL:           baseURL,
+		skipV1Path:        config.SkipV1Path,
 		model:             model,
 		client:            httpClient,
 		pricingResolver:   config.PricingResolver,
@@ -119,6 +126,14 @@ func NewClient(config Config) (*Client, error) {
 		openRouterTitle:   config.OpenRouterTitle,
 		retry:             config.Retry,
 	}, nil
+}
+
+func (c *Client) endpointURL(path string) string {
+	prefix := "/v1"
+	if c.skipV1Path {
+		prefix = ""
+	}
+	return c.baseURL + prefix + "/" + strings.TrimLeft(path, "/")
 }
 
 func cloneHeaders(headers map[string]string) map[string]string {
@@ -336,7 +351,7 @@ func (c *Client) Complete(ctx context.Context, req harness.CompletionRequest) (h
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	httpReq, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/v1/chat/completions", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.endpointURL("chat/completions"), bytes.NewReader(body))
 	if err != nil {
 		return harness.CompletionResult{}, fmt.Errorf("create request: %w", err)
 	}
@@ -1415,7 +1430,7 @@ func (c *Client) completeWithResponsesAPI(ctx context.Context, req harness.Compl
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 
-	httpReq, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/v1/responses", bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.endpointURL("responses"), bytes.NewReader(body))
 	if err != nil {
 		return harness.CompletionResult{}, fmt.Errorf("create responses request: %w", err)
 	}

--- a/internal/server/http_catalog.go
+++ b/internal/server/http_catalog.go
@@ -24,6 +24,7 @@ type ProviderResponse struct {
 	Name       string `json:"name"`
 	Configured bool   `json:"configured"`
 	APIKeyEnv  string `json:"api_key_env"`
+	AuthType   string `json:"auth_type,omitempty"`
 	BaseURL    string `json:"base_url"`
 	ModelCount int    `json:"model_count"`
 }
@@ -73,6 +74,12 @@ func (s *Server) handleProviders(w http.ResponseWriter, r *http.Request) {
 			Name:       name,
 			Configured: configured,
 			APIKeyEnv:  entry.APIKeyEnv,
+			AuthType: func() string {
+				if entry.TokenSourceRequired {
+					return "subscription"
+				}
+				return "api_key"
+			}(),
 			BaseURL:    entry.BaseURL,
 			ModelCount: len(entry.Models),
 		})

--- a/internal/server/http_providers_test.go
+++ b/internal/server/http_providers_test.go
@@ -129,6 +129,37 @@ func TestProvidersEndpointConfiguredAndUnconfigured(t *testing.T) {
 	}
 }
 
+func TestProvidersEndpointMarksCodexSubscriptionAuth(t *testing.T) {
+	t.Parallel()
+	cat := testCatalogForProviders()
+	cat.Providers["codex-subscription"] = catalog.ProviderEntry{
+		BaseURL: "https://chatgpt.com/backend-api/codex", APIKeyOptional: true, TokenSourceRequired: true,
+		Models: map[string]catalog.Model{"gpt": {ContextWindow: 1}},
+	}
+	ts := httptest.NewServer(NewWithCatalog(testRunnerForProviders(t), cat))
+	defer ts.Close()
+	res, err := http.Get(ts.URL + "/v1/providers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	var body struct {
+		Providers []ProviderResponse `json:"providers"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	for _, provider := range body.Providers {
+		if provider.Name == "codex-subscription" {
+			if provider.AuthType != "subscription" || provider.Configured {
+				t.Fatalf("Codex response = %#v, want unconfigured subscription", provider)
+			}
+			return
+		}
+	}
+	t.Fatal("Codex subscription missing from provider response")
+}
+
 func TestProvidersEndpointNilCatalog(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds read-only Codex ChatGPT credential import, secure harness-owned storage, OAuth refresh, and dynamic provider auth.
- Adds the mirrored `codex-subscription` catalog route, deterministic default routing, safe CLI/TUI status, and fake HTTPS refresh coverage.
- Documents setup, credential ownership, and backend/terms caveats.

## Verification

- `go test ./internal/provider/... ./cmd/harnesscli/... ./internal/server/...`
- `go vet ./...`
- `./scripts/test-regression.sh`

Live endpoint routing/auth was reached with the local Codex session; completion was blocked by the backend Cloudflare challenge, so fake HTTPS integration remains the deterministic request proof.

Closes #847