### PR TITLE
feat(mcp): file-backed OAuth token store under ~/.harness/mcp/

### DIFF
--- a/docs/plans/809-mcp-oauth.md
+++ b/docs/plans/809-mcp-oauth.md
@@ -1,4 +1,15 @@
-# Plan: MCP HTTP static headers and typed auth errors (epic #809, slice 1)
+# Plan: MCP OAuth login flow for remote servers (epic #809)
+
+## Slice 2: file-backed OAuth token store under `~/.harness/mcp/` (in implementation)
+
+- Goal: safe persistence for OAuth tokens, reusable by the flow (slice 3) and the transport (slice 4).
+- Changes: new `internal/mcp/tokens.go` — `Token` (issuer, access/refresh tokens, type, expiry, scopes), `TokenStore` with `Get(server)` / `Put(server, token)` / `Delete(server)`; one JSON file per server under `~/.harness/mcp/`, 0600 file / 0700 dir perms and atomic temp+rename writes mirroring `internal/provider/codex/store.go`; filename derived from the server name with `url.PathEscape` (traversal-safe, injective), recorded server name verified on read.
+- Expiry classification: `Get` returns the token (refresh token included) with an error wrapping `ErrTokenExpired` when expired, so callers refresh instead of failing; `ErrTokenNotFound` when absent; `ErrTokenCorrupt` for unreadable/mismatched files. Delete is idempotent.
+- Concurrency: store is mutex-guarded, safe for concurrent use.
+- Tests (TDD, temp-dir only, no writes outside injected dir): round-trip save/load, missing file, corrupt file (garbage/missing fields/server mismatch), permission bits via `os.Stat` (including pre-existing loose dir hardened to 0700), expiry classification (expired/future/zero/boundary via injected clock), overwrite, server-name sanitization, concurrent access under `-race`.
+- Acceptance: `go test ./internal/mcp/... -count=1` green.
+
+## Slice 1: MCP HTTP static headers and typed auth errors (implemented, PR #840)
 
 ## Context
 
@@ -45,7 +56,7 @@
 - [x] gofmt + go vet clean.
 - [x] Run `go test ./internal/mcp/... ./internal/config/... ./cmd/harnessd/... -count=1`.
 - [x] Update `docs/plans/INDEX.md`.
-- [ ] Commit, push `epic/809-mcp-oauth`, open PR (no merge).
+- [x] Commit, push `epic/809-mcp-oauth`, open PR (no merge). — PR #840, merged.
 
 ## Risks and Mitigations
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -14,7 +14,7 @@
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
-- `809-mcp-oauth.md` — Epic #809 slice 1: static HTTP headers and typed auth errors for the MCP HTTP transport (in implementation).
+- `809-mcp-oauth.md` — Epic #809: slice 1 (static HTTP headers + typed auth errors, merged PR #840) and slice 2 (file-backed OAuth token store, in implementation).
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 slice 1 (in implementation): steer client plumbing (`steerRunCmd` + `harnesscli steer`).
 

--- a/internal/mcp/tokens.go
+++ b/internal/mcp/tokens.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Sentinel errors for the MCP OAuth token store. They are wrapped (%w) in
+// returned errors so callers can classify failures with errors.Is.
+var (
+	// ErrTokenNotFound is returned by TokenStore.Get when no token is stored
+	// for the named server.
+	ErrTokenNotFound = errors.New("mcp: no stored token for server")
+	// ErrTokenExpired is returned by TokenStore.Get when the stored token's
+	// expiry has passed. The token is still returned so the caller can use
+	// its refresh token instead of failing.
+	ErrTokenExpired = errors.New("mcp: stored token is expired")
+	// ErrTokenCorrupt is returned by TokenStore.Get when the token file
+	// exists but cannot be decoded or fails consistency checks.
+	ErrTokenCorrupt = errors.New("mcp: stored token file is corrupt")
+)
+
+// Token is an OAuth 2.1 token set issued for one MCP server. The zero Expiry
+// means the access token does not expire.
+type Token struct {
+	// Issuer identifies the authorization server that issued the token. It
+	// is stored alongside the token so callers can detect an issuer change
+	// (tokens are keyed by server name and issuer).
+	Issuer string `json:"issuer,omitempty"`
+	// AccessToken is the bearer credential attached to MCP HTTP requests.
+	AccessToken string `json:"access_token"`
+	// RefreshToken is used to renew the access token when it expires.
+	RefreshToken string `json:"refresh_token,omitempty"`
+	// TokenType is the token type from the OAuth response, typically "Bearer".
+	TokenType string `json:"token_type,omitempty"`
+	// Expiry is the access token's expiration time; zero means never.
+	Expiry time.Time `json:"expiry,omitempty"`
+	// Scopes are the granted OAuth scopes, if any.
+	Scopes []string `json:"scopes,omitempty"`
+}
+
+// tokenFile is the on-disk JSON envelope for one server's token. The server
+// name is recorded so reads can detect a mismatch between the file name and
+// its contents.
+type tokenFile struct {
+	Server string `json:"server"`
+	Token  Token  `json:"token"`
+}
+
+// tokenFileName maps a server name to a safe, unique file name inside the
+// store directory. url.PathEscape is injective and escapes path separators,
+// so distinct server names never collide and cannot traverse the directory.
+func tokenFileName(server string) string {
+	return url.PathEscape(server) + ".json"
+}
+
+// TokenStore persists OAuth tokens as one JSON file per server under a
+// single directory (by default ~/.harness/mcp). Files are written atomically
+// (temp file + rename) with 0600 permissions; the directory is enforced to
+// 0700, mirroring the credential-store practice in
+// internal/provider/codex/store.go.
+//
+// TokenStore is safe for concurrent use.
+type TokenStore struct {
+	dir string
+
+	mu  sync.Mutex
+	now func() time.Time
+}
+
+// NewTokenStore returns a TokenStore rooted at dir. The directory is created
+// (with 0700 permissions) on the first Put.
+func NewTokenStore(dir string) *TokenStore {
+	return &TokenStore{dir: dir, now: time.Now}
+}
+
+// DefaultTokenStore returns a TokenStore under ~/.harness/mcp, falling back
+// to a relative .harness/mcp when the home directory cannot be determined —
+// the same fallback pattern as codex.DefaultStore.
+func DefaultTokenStore() *TokenStore {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return NewTokenStore(filepath.Join(".harness", "mcp"))
+	}
+	return NewTokenStore(filepath.Join(home, ".harness", "mcp"))
+}
+
+// Dir returns the directory the store persists tokens in.
+func (s *TokenStore) Dir() string { return s.dir }
+
+// Get returns the token stored for server.
+//
+//   - No token stored: zero Token and an error wrapping ErrTokenNotFound.
+//   - Token file corrupt or inconsistent: zero Token and an error wrapping
+//     ErrTokenCorrupt.
+//   - Token expired (non-zero Expiry at or before now): the token and an
+//     error wrapping ErrTokenExpired — the caller is expected to refresh
+//     using the returned token's refresh token rather than fail.
+//   - Otherwise: the token and nil.
+func (s *TokenStore) Get(server string) (Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raw, err := os.ReadFile(s.pathFor(server))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Token{}, fmt.Errorf("mcp: token for server %q: %w", server, ErrTokenNotFound)
+		}
+		return Token{}, fmt.Errorf("mcp: read token for server %q: %w", server, err)
+	}
+
+	var f tokenFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return Token{}, fmt.Errorf("mcp: decode token for server %q: %v: %w", server, err, ErrTokenCorrupt)
+	}
+	if f.Server != server || f.Token.AccessToken == "" {
+		return Token{}, fmt.Errorf("mcp: token file for server %q is inconsistent: %w", server, ErrTokenCorrupt)
+	}
+
+	if !f.Token.Expiry.IsZero() && !s.now().Before(f.Token.Expiry) {
+		return f.Token, fmt.Errorf("mcp: token for server %q: %w", server, ErrTokenExpired)
+	}
+	return f.Token, nil
+}
+
+// Put stores tok for server, replacing any previously stored token. The
+// server name must be non-empty and the token must carry an access token.
+func (s *TokenStore) Put(server string, tok Token) error {
+	if server == "" {
+		return fmt.Errorf("mcp: server name must not be empty")
+	}
+	if tok.AccessToken == "" {
+		return fmt.Errorf("mcp: token for server %q has no access token", server)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return fmt.Errorf("mcp: create token directory: %w", err)
+	}
+	// Harden the directory even if it pre-existed with loose permissions.
+	if err := os.Chmod(s.dir, 0o700); err != nil {
+		return fmt.Errorf("mcp: secure token directory: %w", err)
+	}
+
+	raw, err := json.Marshal(tokenFile{Server: server, Token: tok})
+	if err != nil {
+		return fmt.Errorf("mcp: encode token for server %q: %w", server, err)
+	}
+
+	tmp, err := os.CreateTemp(s.dir, ".mcp-token-*")
+	if err != nil {
+		return fmt.Errorf("mcp: create token file for server %q: %w", server, err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("mcp: secure token file for server %q: %w", server, err)
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		tmp.Close()
+		return fmt.Errorf("mcp: write token file for server %q: %w", server, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("mcp: close token file for server %q: %w", server, err)
+	}
+	if err := os.Rename(tmpName, s.pathFor(server)); err != nil {
+		return fmt.Errorf("mcp: save token file for server %q: %w", server, err)
+	}
+	return nil
+}
+
+// Delete removes the token stored for server. Deleting a token that does not
+// exist is not an error, so logout flows are idempotent.
+func (s *TokenStore) Delete(server string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := os.Remove(s.pathFor(server))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("mcp: remove token for server %q: %w", server, err)
+	}
+	return nil
+}
+
+// pathFor returns the token file path for a server name.
+func (s *TokenStore) pathFor(server string) string {
+	return filepath.Join(s.dir, tokenFileName(server))
+}

--- a/internal/mcp/tokens_test.go
+++ b/internal/mcp/tokens_test.go
@@ -1,0 +1,438 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fixedClock returns a clock function pinned at t0.
+func fixedClock(t0 time.Time) func() time.Time { return func() time.Time { return t0 } }
+
+func fullToken(issuer string, expiry time.Time) Token {
+	return Token{
+		Issuer:       issuer,
+		AccessToken:  "access-" + issuer,
+		RefreshToken: "refresh-" + issuer,
+		TokenType:    "Bearer",
+		Expiry:       expiry,
+		Scopes:       []string{"mcp", "offline_access"},
+	}
+}
+
+// TestTokenStore_PutGet_RoundTrip verifies that a token written with Put is
+// returned by Get with every field intact, and that the on-disk file lives
+// under the store directory.
+func TestTokenStore_PutGet_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTokenStore(dir)
+
+	want := fullToken("https://as.example.com", time.Now().Add(time.Hour).UTC().Truncate(time.Second))
+	if err := store.Put("demo", want); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.Get("demo")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Issuer != want.Issuer {
+		t.Errorf("Issuer = %q, want %q", got.Issuer, want.Issuer)
+	}
+	if got.AccessToken != want.AccessToken {
+		t.Errorf("AccessToken = %q, want %q", got.AccessToken, want.AccessToken)
+	}
+	if got.RefreshToken != want.RefreshToken {
+		t.Errorf("RefreshToken = %q, want %q", got.RefreshToken, want.RefreshToken)
+	}
+	if got.TokenType != want.TokenType {
+		t.Errorf("TokenType = %q, want %q", got.TokenType, want.TokenType)
+	}
+	if !got.Expiry.Equal(want.Expiry) {
+		t.Errorf("Expiry = %v, want %v", got.Expiry, want.Expiry)
+	}
+	if len(got.Scopes) != len(want.Scopes) || got.Scopes[0] != "mcp" || got.Scopes[1] != "offline_access" {
+		t.Errorf("Scopes = %v, want %v", got.Scopes, want.Scopes)
+	}
+
+	// The file must exist inside the injected directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 token file in %s, got %d", dir, len(entries))
+	}
+
+	// The on-disk JSON must carry the server name and token fields.
+	raw, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var onDisk struct {
+		Server string `json:"server"`
+		Token  Token  `json:"token"`
+	}
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("on-disk file is not valid JSON: %v", err)
+	}
+	if onDisk.Server != "demo" {
+		t.Errorf("on-disk server = %q, want %q", onDisk.Server, "demo")
+	}
+	if onDisk.Token.AccessToken != want.AccessToken {
+		t.Errorf("on-disk access token = %q, want %q", onDisk.Token.AccessToken, want.AccessToken)
+	}
+}
+
+// TestTokenStore_Get_NotFound verifies the distinct not-found error.
+func TestTokenStore_Get_NotFound(t *testing.T) {
+	store := NewTokenStore(t.TempDir())
+
+	tok, err := store.Get("missing")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("Get error = %v, want errors.Is ErrTokenNotFound", err)
+	}
+	if tok.AccessToken != "" {
+		t.Errorf("expected zero token on not-found, got %+v", tok)
+	}
+}
+
+// TestTokenStore_Get_CorruptFile verifies that unreadable or inconsistent
+// files are reported distinctly from a missing token.
+func TestTokenStore_Get_CorruptFile(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"not JSON at all", `{"server":`},
+		{"valid JSON wrong shape", `["an","array"]`},
+		{"missing access token", `{"server":"demo","token":{"issuer":"https://as.example.com"}}`},
+		{"server name mismatch", `{"server":"other","token":{"access_token":"x"}}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store := NewTokenStore(dir)
+
+			path := filepath.Join(dir, tokenFileName("demo"))
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := store.Get("demo")
+			if !errors.Is(err, ErrTokenCorrupt) {
+				t.Fatalf("Get error = %v, want errors.Is ErrTokenCorrupt", err)
+			}
+			if errors.Is(err, ErrTokenNotFound) {
+				t.Fatalf("corrupt file must not be reported as not-found: %v", err)
+			}
+		})
+	}
+}
+
+// TestTokenStore_Permissions verifies 0700 on the directory and 0600 on the
+// token file, including when the directory pre-existed with loose perms.
+func TestTokenStore_Permissions(t *testing.T) {
+	t.Run("fresh dir", func(t *testing.T) {
+		base := t.TempDir()
+		dir := filepath.Join(base, "mcp")
+		store := NewTokenStore(dir)
+
+		if err := store.Put("demo", fullToken("https://as.example.com", time.Time{})); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+
+		di, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat dir: %v", err)
+		}
+		if got := di.Mode().Perm(); got != 0o700 {
+			t.Errorf("dir perms = %o, want 700", got)
+		}
+
+		fi, err := os.Stat(filepath.Join(dir, tokenFileName("demo")))
+		if err != nil {
+			t.Fatalf("stat file: %v", err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("file perms = %o, want 600", got)
+		}
+	})
+
+	t.Run("pre-existing loose dir is hardened", func(t *testing.T) {
+		dir := t.TempDir() // t.TempDir creates 0700 already; loosen it.
+		if err := os.Chmod(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		store := NewTokenStore(dir)
+
+		if err := store.Put("demo", fullToken("https://as.example.com", time.Time{})); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+
+		di, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat dir: %v", err)
+		}
+		if got := di.Mode().Perm(); got != 0o700 {
+			t.Errorf("dir perms = %o, want 700 after Put", got)
+		}
+	})
+
+	t.Run("overwrite keeps 0600", func(t *testing.T) {
+		dir := t.TempDir()
+		store := NewTokenStore(dir)
+		if err := store.Put("demo", fullToken("https://as1.example.com", time.Time{})); err != nil {
+			t.Fatalf("Put 1: %v", err)
+		}
+		if err := store.Put("demo", fullToken("https://as2.example.com", time.Time{})); err != nil {
+			t.Fatalf("Put 2: %v", err)
+		}
+		fi, err := os.Stat(filepath.Join(dir, tokenFileName("demo")))
+		if err != nil {
+			t.Fatalf("stat file: %v", err)
+		}
+		if got := fi.Mode().Perm(); got != 0o600 {
+			t.Errorf("file perms after overwrite = %o, want 600", got)
+		}
+	})
+}
+
+// TestTokenStore_Get_ExpiryClassification verifies the distinct expiry
+// behavior: expired tokens are returned (so the caller can use the refresh
+// token) together with an ErrTokenExpired-wrapping error; tokens without an
+// expiry never expire; a token whose expiry equals now is expired.
+func TestTokenStore_Get_ExpiryClassification(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name      string
+		expiry    time.Time
+		wantErr   error // nil means valid token
+		wantToken bool
+	}{
+		{"expired in the past", now.Add(-time.Minute), ErrTokenExpired, true},
+		{"expiry equals now", now, ErrTokenExpired, true},
+		{"valid in the future", now.Add(time.Hour), nil, true},
+		{"zero expiry never expires", time.Time{}, nil, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewTokenStore(t.TempDir())
+			store.now = fixedClock(now)
+
+			tok := fullToken("https://as.example.com", tc.expiry)
+			if err := store.Put("demo", tok); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+
+			got, err := store.Get("demo")
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("Get error = %v, want nil", err)
+				}
+			} else {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Get error = %v, want errors.Is %v", err, tc.wantErr)
+				}
+			}
+			if tc.wantToken {
+				if got.AccessToken != tok.AccessToken {
+					t.Errorf("returned token AccessToken = %q, want %q", got.AccessToken, tok.AccessToken)
+				}
+				if got.RefreshToken != tok.RefreshToken {
+					t.Errorf("expired path must still return the refresh token: got %q, want %q", got.RefreshToken, tok.RefreshToken)
+				}
+			}
+		})
+	}
+}
+
+// TestTokenStore_Delete verifies delete removes the token and is idempotent.
+func TestTokenStore_Delete(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTokenStore(dir)
+
+	if err := store.Put("demo", fullToken("https://as.example.com", time.Time{})); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Delete("demo"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get("demo"); !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("Get after Delete error = %v, want errors.Is ErrTokenNotFound", err)
+	}
+
+	// Deleting a missing token is not an error (logout is idempotent).
+	if err := store.Delete("demo"); err != nil {
+		t.Fatalf("Delete of missing token: %v", err)
+	}
+	// Deleting from a store whose directory does not exist yet is also fine.
+	fresh := NewTokenStore(filepath.Join(t.TempDir(), "not-created-yet"))
+	if err := fresh.Delete("ghost"); err != nil {
+		t.Fatalf("Delete with absent store dir: %v", err)
+	}
+}
+
+// TestTokenStore_PutOverwrite verifies a second Put replaces the stored token
+// (e.g. re-login against a different issuer).
+func TestTokenStore_PutOverwrite(t *testing.T) {
+	store := NewTokenStore(t.TempDir())
+
+	if err := store.Put("demo", fullToken("https://old.example.com", time.Time{})); err != nil {
+		t.Fatalf("Put old: %v", err)
+	}
+	want := fullToken("https://new.example.com", time.Time{})
+	if err := store.Put("demo", want); err != nil {
+		t.Fatalf("Put new: %v", err)
+	}
+
+	got, err := store.Get("demo")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Issuer != want.Issuer || got.AccessToken != want.AccessToken {
+		t.Errorf("Get = %+v, want issuer/access from %q", got, want.Issuer)
+	}
+}
+
+// TestTokenStore_PutValidation verifies invalid inputs are rejected without
+// writing anything.
+func TestTokenStore_PutValidation(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTokenStore(dir)
+
+	if err := store.Put("", fullToken("https://as.example.com", time.Time{})); err == nil {
+		t.Error("Put with empty server name: expected error, got nil")
+	}
+	if err := store.Put("demo", Token{Issuer: "https://as.example.com"}); err == nil {
+		t.Error("Put with empty access token: expected error, got nil")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("invalid Puts must not write files, found %d entries", len(entries))
+	}
+}
+
+// TestTokenStore_ServerNameSanitization verifies that server names containing
+// path separators or other special characters are stored inside the store
+// directory (no traversal) and round-trip correctly.
+func TestTokenStore_ServerNameSanitization(t *testing.T) {
+	dir := t.TempDir()
+	store := NewTokenStore(dir)
+
+	names := []string{"org/server", "a b", "dots..here", `back\slash`, "percent%20"}
+	for i, name := range names {
+		tok := fullToken(fmt.Sprintf("https://as%d.example.com", i), time.Time{})
+		if err := store.Put(name, tok); err != nil {
+			t.Fatalf("Put(%q): %v", name, err)
+		}
+	}
+	for i, name := range names {
+		got, err := store.Get(name)
+		if err != nil {
+			t.Fatalf("Get(%q): %v", name, err)
+		}
+		if want := fmt.Sprintf("https://as%d.example.com", i); got.Issuer != want {
+			t.Errorf("Get(%q).Issuer = %q, want %q", name, got.Issuer, want)
+		}
+	}
+
+	// Every file must be directly inside the store directory — no escapes.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != len(names) {
+		t.Fatalf("expected %d files in store dir, got %d", len(names), len(entries))
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("unexpected subdirectory created by sanitization: %q", e.Name())
+		}
+		if strings.Contains(e.Name(), "/") || strings.Contains(e.Name(), `\`) {
+			t.Errorf("file name contains a path separator: %q", e.Name())
+		}
+	}
+}
+
+// TestTokenStore_ConcurrentAccess hammers the store from many goroutines and
+// verifies consistency. Run with -race for the race-detector guarantee.
+func TestTokenStore_ConcurrentAccess(t *testing.T) {
+	store := NewTokenStore(t.TempDir())
+
+	const workers = 16
+	const opsPerWorker = 25
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*opsPerWorker)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			server := fmt.Sprintf("server-%d", w%4) // force contention on shared keys
+			for i := 0; i < opsPerWorker; i++ {
+				tok := fullToken(fmt.Sprintf("https://as-%d-%d.example.com", w, i), time.Time{})
+				if err := store.Put(server, tok); err != nil {
+					errs <- fmt.Errorf("Put(%q): %w", server, err)
+					return
+				}
+				if _, err := store.Get(server); err != nil && !errors.Is(err, ErrTokenNotFound) && !errors.Is(err, ErrTokenExpired) {
+					errs <- fmt.Errorf("Get(%q): %w", server, err)
+					return
+				}
+				if i%5 == 0 {
+					if err := store.Delete(server); err != nil {
+						errs <- fmt.Errorf("Delete(%q): %w", server, err)
+						return
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// Final write must be readable and complete — a torn write would fail to
+	// decode and surface as ErrTokenCorrupt.
+	final := fullToken("https://final.example.com", time.Time{})
+	if err := store.Put("server-0", final); err != nil {
+		t.Fatalf("final Put: %v", err)
+	}
+	got, err := store.Get("server-0")
+	if err != nil {
+		t.Fatalf("final Get: %v", err)
+	}
+	if got.AccessToken != final.AccessToken || got.Issuer != final.Issuer {
+		t.Errorf("final Get = %+v, want token from %q", got, final.Issuer)
+	}
+}
+
+// TestDefaultTokenStore_Path verifies the default store resolves under
+// ~/.harness/mcp using the process home, without writing anything.
+func TestDefaultTokenStore_Path(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := DefaultTokenStore()
+	want := filepath.Join(home, ".harness", "mcp")
+	if store.Dir() != want {
+		t.Errorf("DefaultTokenStore dir = %q, want %q", store.Dir(), want)
+	}
+}


### PR DESCRIPTION
Parent epic: #809. Part of #803.

## What

Slice 2 of epic #809 — safe persistence for OAuth tokens, reusable by the flow (slice 3) and the transport (slice 4):

- New `internal/mcp/tokens.go`: `Token` (issuer, access/refresh tokens, token type, expiry, scopes) and `TokenStore` with `Get(server)` / `Put(server, token)` / `Delete(server)`.
- One JSON file per server under `~/.harness/mcp/`; atomic writes (temp file + rename), 0600 file / enforced 0700 directory permissions, mirroring `internal/provider/codex/store.go`.
- File names are `url.PathEscape`'d server names (injective, traversal-safe) with the server name re-verified from the file on read.
- Expiry handling: `Get` classifies distinctly via `errors.Is`-compatible sentinels — `ErrTokenNotFound`, `ErrTokenCorrupt`, `ErrTokenExpired` (expired still returns the token so callers refresh instead of failing). `Delete` is idempotent. Mutex-guarded for concurrent use.

## Tests (TDD — written first, verified failing, then implemented)

Temp-dir based; no writes outside the injected dir: round-trip save/load incl. on-disk JSON shape, missing file, corrupt file (garbage / wrong shape / missing access token / server-name mismatch), permission bits via `os.Stat` (fresh dir, pre-existing loose dir hardened to 0700, overwrite keeps 0600), expiry classification (past / boundary equal-to-now / future / zero, injected clock), overwrite, Put validation, server-name sanitization (separators, spaces, dots, percent), concurrent access under `-race`, `DefaultTokenStore` path under a test `HOME`.

## Verification

- `go test ./internal/mcp/... -count=1` — ok
- `go test ./internal/mcp/... -count=1 -race` — ok
- `gofmt` / `go vet` clean

Not merged; slice 3 (OAuth flow) builds on this branch.