### PR TITLE
feat(harnesscli): add viz subcommand that prints/opens the visualizer URL

### DIFF
--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -213,6 +213,8 @@ func dispatch(args []string) int {
 		return runStatus(args[1:])
 	case "show":
 		return runStatus(args[1:])
+	case "viz":
+		return runViz(args[1:])
 	case "continue":
 		return runContinue(args[1:])
 	case "replay":

--- a/cmd/harnesscli/viz.go
+++ b/cmd/harnesscli/viz.go
@@ -1,0 +1,74 @@
+package main
+
+// viz.go — "harnesscli viz [--open]" (epic #812, slice 2).
+//
+// Prints the session visualizer URL (<base>/viz/) for a configured daemon
+// and, with --open, launches it in the OS browser. The visualizer itself is
+// the embedded static shell served by harnessd under /viz (slice 1); this
+// subcommand is only the one-command path into it.
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// vizPlatform selects the browser opener command. It is a var (not
+// runtime.GOOS inline) so tests can exercise either platform path — same
+// precedent as servicePlatform in service.go.
+var vizPlatform = runtime.GOOS
+
+// vizOpenURL launches the OS default browser at url. It is a var so tests
+// can substitute a recording fake — unit tests must never exec a real
+// browser (same precedent as serviceRunLifecycle in service.go).
+var vizOpenURL = func(url string) error {
+	return exec.Command(vizOpenerName(vizPlatform), url).Start()
+}
+
+// vizOpenerName returns the platform's browser-launch command: open on
+// macOS, xdg-open on Linux and other Unixes.
+func vizOpenerName(platform string) string {
+	if platform == "darwin" {
+		return "open"
+	}
+	return "xdg-open"
+}
+
+// vizURL returns the visualizer URL for a daemon base URL, trimming any
+// trailing slash the way runStatus/runList build their endpoints.
+func vizURL(baseURL string) string {
+	return strings.TrimRight(baseURL, "/") + "/viz/"
+}
+
+// runViz implements "harnesscli viz [--open]". It always prints the
+// visualizer URL; with --open it also tries to launch the browser, falling
+// back to the already-printed URL when the launch fails.
+func runViz(args []string) int {
+	fs := flag.NewFlagSet("viz", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL")
+	open := fs.Bool("open", false, "open the visualizer URL in the default browser")
+
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "harnesscli viz: %v\n", err)
+		return 1
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "harnesscli viz: unexpected argument %q (usage: harnesscli viz [--open] [-base-url URL])\n", fs.Arg(0))
+		return 1
+	}
+
+	url := vizURL(*baseURL)
+	fmt.Fprintln(stdout, url)
+
+	if !*open {
+		return 0
+	}
+	if err := vizOpenURL(url); err != nil {
+		fmt.Fprintf(stderr, "harnesscli viz: open browser: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/harnesscli/viz_test.go
+++ b/cmd/harnesscli/viz_test.go
@@ -1,0 +1,150 @@
+package main
+
+// viz_test.go — tests for "harnesscli viz [--open]" (epic #812, slice 2).
+//
+// Behavior under test:
+//   - viz prints the visualizer URL (<base>/viz/) for the configured daemon.
+//   - -base-url resolves the daemon address the same way runStatus/runList do,
+//     with trailing slashes trimmed.
+//   - --open launches the OS browser via an injected opener (tests never exec
+//     a real browser); on opener failure the URL is still printed as fallback.
+//   - The opener command is selected by platform: open on darwin, xdg-open
+//     elsewhere.
+//   - dispatch routes the "viz" subcommand.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRunVizPrintsDefaultURL(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runViz(nil)
+	if code != 0 {
+		t.Fatalf("runViz returned %d, stderr=%s", code, errBuf.String())
+	}
+	got := strings.TrimSpace(outBuf.String())
+	if got != "http://localhost:8080/viz/" {
+		t.Fatalf("runViz printed %q, want %q", got, "http://localhost:8080/viz/")
+	}
+}
+
+func TestRunVizTrimsTrailingSlashOnBaseURL(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runViz([]string{"-base-url", "http://example.com:9000/"})
+	if code != 0 {
+		t.Fatalf("runViz returned %d, stderr=%s", code, errBuf.String())
+	}
+	got := strings.TrimSpace(outBuf.String())
+	if got != "http://example.com:9000/viz/" {
+		t.Fatalf("runViz printed %q, want %q", got, "http://example.com:9000/viz/")
+	}
+}
+
+func TestRunVizRejectsPositionalArgs(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := runViz([]string{"extra"})
+	if code == 0 {
+		t.Fatalf("runViz with positional arg returned 0, want non-zero; stdout=%s", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "harnesscli viz") {
+		t.Fatalf("stderr missing command prefix: %q", errBuf.String())
+	}
+}
+
+func TestRunVizOpenInvokesOpener(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	var opened []string
+	origOpen := vizOpenURL
+	vizOpenURL = func(url string) error {
+		opened = append(opened, url)
+		return nil
+	}
+	defer func() { vizOpenURL = origOpen }()
+
+	code := runViz([]string{"--open", "-base-url", "http://example.com:1234"})
+	if code != 0 {
+		t.Fatalf("runViz --open returned %d, stderr=%s", code, errBuf.String())
+	}
+	if len(opened) != 1 || opened[0] != "http://example.com:1234/viz/" {
+		t.Fatalf("opener invoked with %v, want [http://example.com:1234/viz/]", opened)
+	}
+	if !strings.Contains(outBuf.String(), "http://example.com:1234/viz/") {
+		t.Fatalf("stdout missing URL even on successful open: %q", outBuf.String())
+	}
+}
+
+func TestRunVizOpenFailureFallsBackToPrintingURL(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origOpen := vizOpenURL
+	vizOpenURL = func(url string) error {
+		return errors.New("no browser available")
+	}
+	defer func() { vizOpenURL = origOpen }()
+
+	code := runViz([]string{"--open"})
+	if code == 0 {
+		t.Fatalf("runViz --open with failing opener returned 0, want non-zero")
+	}
+	if !strings.Contains(outBuf.String(), "http://localhost:8080/viz/") {
+		t.Fatalf("stdout missing fallback URL after opener failure: %q", outBuf.String())
+	}
+	if !strings.Contains(errBuf.String(), "no browser available") {
+		t.Fatalf("stderr missing opener error: %q", errBuf.String())
+	}
+}
+
+func TestRunVizWithoutOpenDoesNotInvokeOpener(t *testing.T) {
+	_, _, restore := captureOutput(t)
+	defer restore()
+
+	called := false
+	origOpen := vizOpenURL
+	vizOpenURL = func(url string) error {
+		called = true
+		return nil
+	}
+	defer func() { vizOpenURL = origOpen }()
+
+	if code := runViz(nil); code != 0 {
+		t.Fatalf("runViz returned %d", code)
+	}
+	if called {
+		t.Fatal("opener invoked without --open")
+	}
+}
+
+func TestVizOpenerNameSelectsPlatformCommand(t *testing.T) {
+	if got := vizOpenerName("darwin"); got != "open" {
+		t.Errorf("vizOpenerName(darwin) = %q, want %q", got, "open")
+	}
+	for _, platform := range []string{"linux", "freebsd"} {
+		if got := vizOpenerName(platform); got != "xdg-open" {
+			t.Errorf("vizOpenerName(%s) = %q, want %q", platform, got, "xdg-open")
+		}
+	}
+}
+
+func TestDispatchRoutesViz(t *testing.T) {
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	code := dispatch([]string{"viz", "-base-url", "http://example.com:5555"})
+	if code != 0 {
+		t.Fatalf("dispatch viz returned %d, stderr=%s", code, errBuf.String())
+	}
+	if !strings.Contains(outBuf.String(), "http://example.com:5555/viz/") {
+		t.Fatalf("dispatch viz output missing URL: %q", outBuf.String())
+	}
+}

--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -1,6 +1,8 @@
-# Plan: Session Visualizer — Slice 1: embedded /viz static shell behind Bearer auth
+# Plan: Session Visualizer — Slices 1–2
 
-Epic: #812 (parent #803). This plan covers **Slice 1 only**.
+Epic: #812 (parent #803).
+
+## Slice 1 (merged, PR #829): embedded /viz static shell behind Bearer auth
 
 ## Context
 
@@ -51,9 +53,49 @@ Epic: #812 (parent #803). This plan covers **Slice 1 only**.
 - [x] Tests green; gofmt/go vet clean.
 - [x] Update `docs/plans/INDEX.md`.
 - [x] Run touched-package tests.
-- [ ] Commit, push `epic/812-session-visualizer`, open PR against repo.
+- [x] Commit, push `epic/812-session-visualizer`, open PR against repo.
 
 ## Risks and Mitigations
 
 - Risk: issue text says runs:write-only key → 403, but `hasScope` grants runs:write → runs:read (superscope, tested in `auth_scope_test.go`).
 - Mitigation: assert 200 for runs:write and 403 for a scope-less key; document the deviation in the PR body.
+
+---
+
+## Slice 2 (this branch): `feat(harnesscli): add viz subcommand that prints/opens the visualizer URL`
+
+### Context
+
+- Problem: users must know the `/viz/` URL exists to use the shell from slice 1.
+- User impact: one-command path into the UI: `harnesscli viz` / `harnesscli viz --open`.
+- Constraints: no real browser launch in tests (inject the opener); base URL resolved the same way `runStatus`/`runList` do (`-base-url` flag, default `http://localhost:8080`); no token in the printed URL.
+
+### Scope
+
+- In scope:
+  - `cmd/harnesscli/auth.go` `dispatch`: add `case "viz": return runViz(args[1:])`.
+  - New `cmd/harnesscli/viz.go`: `runViz` prints `<base>/viz/`; `--open` launches the OS browser (`open` on darwin, `xdg-open` elsewhere) via an injectable package var (precedent: `servicePlatform`/`serviceRunLifecycle` in `service.go`), falling back to the already-printed URL on failure.
+- Out of scope: slices 3–6; embedding tokens in the URL; probing the daemon's reachability.
+
+### Test Plan (TDD)
+
+- New failing tests (`cmd/harnesscli/viz_test.go`):
+  - `viz` prints `http://localhost:8080/viz/` by default.
+  - `viz -base-url http://host:9000/` trims the trailing slash and prints `http://host:9000/viz/`.
+  - positional args → exit 1 with usage on stderr.
+  - `viz --open` invokes the injected opener with the URL; success → exit 0.
+  - opener failure → exit 1, stderr diagnostic, URL still printed (fallback).
+  - `vizOpenerName`: darwin → `open`, linux → `xdg-open`.
+  - dispatch routes `viz` to `runViz`.
+- Existing tests to update: none.
+- Regression tests required: `go test ./cmd/harnesscli/... -count=1`.
+
+### Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Write failing tests first; watch them fail (undefined symbols).
+- [x] Implement `cmd/harnesscli/viz.go` and the dispatch case.
+- [x] Tests green; gofmt/go vet clean.
+- [x] Update this plan.
+- [x] Run touched-package tests.
+- [ ] Commit, push `epic/812-session-visualizer-s2`, open PR against repo.


### PR DESCRIPTION
Parent epic: #812. Part of #803.

## What

Slice 2 of #812: `harnesscli viz [--open]` — a one-command path into the embedded session visualizer shell that landed in slice 1 (PR #829, merged).

- **`cmd/harnesscli/viz.go`** (new): `runViz` prints `<base>/viz/`; `-base-url` resolves the daemon address the same way `runStatus`/`runList` do (default `http://localhost:8080`, trailing slash trimmed). `--open` launches the OS browser — `open` on darwin, `xdg-open` on Linux/other Unix — via injectable package vars (`vizPlatform`, `vizOpenURL`), following the `servicePlatform`/`serviceRunLifecycle` precedent in `service.go`. On launcher failure the URL is already printed (fallback) and the command exits 1 with a stderr diagnostic.
- **`cmd/harnesscli/auth.go`**: `dispatch` gains `case "viz": return runViz(args[1:])` alongside `status`/`show`.

No token is embedded in the printed URL — the browser landing form / client-side `?token=` handoff from slice 1 remains the auth story.

## Tests (TDD: undefined-symbol failure first, then implementation)

`cmd/harnesscli/viz_test.go` (8 tests):
- default URL print (`http://localhost:8080/viz/`), custom `-base-url` with trailing-slash trimming
- positional-arg rejection with usage on stderr
- `--open` invokes the injected opener with the URL; success exits 0; no opener call without `--open`
- opener failure → exit 1, stderr diagnostic, URL still printed (fallback)
- `vizOpenerName`: darwin → `open`, linux/freebsd → `xdg-open`
- `dispatch` routes `viz`

## Verification actually run

- `go test ./cmd/harnesscli/ -run 'TestRunViz|TestVizOpenerName|TestDispatchRoutesViz' -count=1 -v` → 8/8 PASS
- `go test ./cmd/harnesscli/... -count=1` → all 27 packages ok (incl. TUI)
- `go vet ./cmd/harnesscli/` → clean; `gofmt -l` on touched files → clean
- Real binary: built `harnesscli`; `viz` printed `http://localhost:8080/viz/`; `viz -base-url http://myhost:9999/` printed `http://myhost:9999/viz/`; `viz --open` with a PATH-shimmed fake `open` invoked the shim with the URL (no real browser launched)

Regression note from slice 1 still applies: `internal/provider/anthropic` retry tests (`TestClientRetriesOn503`/`429`) are load-flaky under full-suite parallelism and unrelated to this CLI-only diff.

## Out of scope (later slices)

Runs list/detail views (3), event timeline (4), search view (5), operations doc (6).