### PR TITLE
feat(tui): render steering.received events in the transcript

### DIFF
--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -864,6 +864,26 @@ func (m *Model) appendMessageBubble(role messagebubble.Role, content string) {
 	m.vp.AppendLines(lines)
 }
 
+// steeringMarkerPrefix labels input that was steered into a running turn
+// (POST /v1/runs/{id}/steer, confirmed by the steering.received SSE event) so
+// it reads distinctly from a typed prompt both in the viewport and in
+// exported transcripts.
+const steeringMarkerPrefix = "steered ⟂ "
+
+// appendSteeringMarker renders a server-confirmed steering injection as a
+// user bubble and records it in the transcript as a role "user" entry, both
+// carrying the steering marker. Slice 4 reuses this for the local echo of
+// TUI-originated steers.
+func (m *Model) appendSteeringMarker(message string) {
+	marked := steeringMarkerPrefix + message
+	m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
+		Role:      "user",
+		Content:   marked,
+		Timestamp: time.Now(),
+	})
+	m.appendMessageBubble(messagebubble.RoleUser, marked)
+}
+
 func (m *Model) appendToolUseView(view tooluse.Model) {
 	view.Width = m.width
 	lines := renderedBlockLines(view.View())
@@ -3286,6 +3306,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "run.resumed":
 			// Dismiss the ask-user overlay when the run resumes.
 			m.askUser = askUserState{}
+		case "steering.received":
+			// Server-confirmed steering injection (harness drainSteering): the
+			// steered text was appended to the run as a user message at the last
+			// step boundary. Show it marked as steered input so it is not
+			// mistaken for a typed prompt. Malformed/empty payloads are dropped.
+			var p struct {
+				Message string `json:"message"`
+			}
+			if err := json.Unmarshal(msg.Raw, &p); err == nil && strings.TrimSpace(p.Message) != "" {
+				m.appendSteeringMarker(p.Message)
+			}
 		}
 		// Continue polling the SSE channel.
 		if m.sseCh != nil {

--- a/cmd/harnesscli/tui/steer_events_test.go
+++ b/cmd/harnesscli/tui/steer_events_test.go
@@ -1,0 +1,159 @@
+package tui_test
+
+// steer_events_test.go — epic #820 slice 2
+// The TUI must not drop steering.received SSE events: a server-confirmed
+// steering injection (payload {"message": "..."}) is rendered as a user bubble
+// carrying a "steered ⟂" marker — visually distinct from a typed prompt — and
+// recorded in the transcript (role "user") so exports include it. Malformed or
+// empty payloads are ignored without panic.
+
+import (
+	"strings"
+	"testing"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/cmd/harnesscli/tui/components/inputarea"
+)
+
+func TestSteeringReceived_RendersMarkerBubbleAndTranscript(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = m.WithCancelRun(func() {})
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-steer-1"})
+	model := m2.(tui.Model)
+
+	transcriptBefore := len(model.Transcript())
+
+	m3, _ := model.Update(tui.SSEEventMsg{
+		EventType: "steering.received",
+		Raw:       []byte(`{"message":"focus on X"}`),
+		ID:        "run-steer-1:7",
+	})
+	model = m3.(tui.Model)
+
+	view := model.View()
+	if !strings.Contains(view, "focus on X") {
+		t.Fatalf("expected steered message in viewport; view=\n%s", view)
+	}
+	if !strings.Contains(view, "steered") {
+		t.Fatalf("expected steering marker in viewport; view=\n%s", view)
+	}
+	// The marker must sit on the same rendered line as the steered message so
+	// the bubble reads as steered input, not as a typed prompt.
+	markerOnMessageLine := false
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "focus on X") && strings.Contains(line, "steered") {
+			markerOnMessageLine = true
+		}
+	}
+	if !markerOnMessageLine {
+		t.Errorf("no viewport line carries both the marker and the steered message; view=\n%s", view)
+	}
+
+	entries := model.Transcript()
+	if len(entries) != transcriptBefore+1 {
+		t.Fatalf("transcript should gain exactly one entry, before=%d after=%d", transcriptBefore, len(entries))
+	}
+	last := entries[len(entries)-1]
+	if last.Role != "user" {
+		t.Errorf("transcript entry role = %q, want %q", last.Role, "user")
+	}
+	if !strings.Contains(last.Content, "focus on X") {
+		t.Errorf("transcript entry missing steered message: %+v", last)
+	}
+	if !strings.Contains(last.Content, "steered") {
+		t.Errorf("transcript entry missing steering marker (exports must show it was steered): %+v", last)
+	}
+
+	if !model.RunActive() {
+		t.Error("run must stay active after steering.received")
+	}
+}
+
+func TestSteeringReceived_MarkerDistinctFromTypedPrompt(t *testing.T) {
+	m := initModel(t, 80, 24)
+	m = m.WithCancelRun(func() {})
+
+	// A typed prompt renders as a normal user bubble...
+	m1, _ := m.Update(inputarea.CommandSubmittedMsg{Value: "write the tests"})
+	model := m1.(tui.Model)
+
+	// ...and a server-confirmed steer renders with the marker.
+	m2, _ := model.Update(tui.SSEEventMsg{
+		EventType: "steering.received",
+		Raw:       []byte(`{"message":"switch to approach B"}`),
+	})
+	model = m2.(tui.Model)
+
+	view := model.View()
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "write the tests") && strings.Contains(line, "steered") {
+			t.Errorf("typed prompt must NOT carry the steering marker: %q", line)
+		}
+		if strings.Contains(line, "switch to approach B") && !strings.Contains(line, "steered") {
+			t.Errorf("steered message MUST carry the steering marker: %q", line)
+		}
+	}
+
+	// Transcript: typed prompt entry is unmarked; steered entry is marked.
+	var typedEntry, steeredEntry *struct{ role, content string }
+	for _, e := range model.Transcript() {
+		e := e
+		if strings.Contains(e.Content, "write the tests") {
+			typedEntry = &struct{ role, content string }{e.Role, e.Content}
+		}
+		if strings.Contains(e.Content, "switch to approach B") {
+			steeredEntry = &struct{ role, content string }{e.Role, e.Content}
+		}
+	}
+	if typedEntry == nil || steeredEntry == nil {
+		t.Fatalf("expected both transcript entries, got %+v", model.Transcript())
+	}
+	if strings.Contains(typedEntry.content, "steered") {
+		t.Errorf("typed prompt transcript entry must NOT carry the marker: %+v", *typedEntry)
+	}
+	if !strings.Contains(steeredEntry.content, "steered") {
+		t.Errorf("steered transcript entry MUST carry the marker: %+v", *steeredEntry)
+	}
+}
+
+func TestSteeringReceived_MalformedPayload_NoPanicNoMarker(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"not json", `not-json`},
+		{"empty object", `{}`},
+		{"wrong type", `{"message":42}`},
+		{"whitespace message", `{"message":"   "}`},
+		{"empty message", `{"message":""}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := initModel(t, 80, 24)
+			m = m.WithCancelRun(func() {})
+			m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-steer-bad"})
+			model := m2.(tui.Model)
+
+			transcriptBefore := len(model.Transcript())
+
+			m3, _ := model.Update(tui.SSEEventMsg{
+				EventType: "steering.received",
+				Raw:       []byte(tc.raw),
+			})
+			if m3 == nil {
+				t.Fatal("Update returned nil model for malformed steering.received")
+			}
+			model = m3.(tui.Model)
+
+			if got := len(model.Transcript()); got != transcriptBefore {
+				t.Errorf("malformed payload must not append transcript entries: before=%d after=%d", transcriptBefore, got)
+			}
+			if strings.Contains(model.View(), "steered") {
+				t.Errorf("malformed payload must not render a steering marker; view=\n%s", model.View())
+			}
+			if !model.RunActive() {
+				t.Error("run must stay active after malformed steering.received")
+			}
+		})
+	}
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -66,6 +66,13 @@
 - `plugin update` re-stages from the recorded source, and for remote bundles re-prints surfaces and re-requires confirmation only when the declared surfaces changed; unchanged remote updates skip confirmation and preserve trust (pinned by tests).
 - TDD: failing-first tests cover Stage/Promote/Discard residue discipline, trust/untrust round-trip with `plugins.TrustedBundles` gating proof, declined/non-TTY/`--yes`/prompt-accept install paths, and update trust preservation on both unchanged and changed surfaces. Remote fixtures use local `file://` git remotes (no network).
 
+## 2026-07-20 (Mid-Turn Steering — Epic #820, Slice 2)
+
+- The TUI no longer drops `steering.received` SSE events: `cmd/harnesscli/tui/model.go`'s dispatch switch gained a `case "steering.received"` that parses the fixed `{"message": "..."}` payload (harness `drainSteering` contract) and appends a user bubble + transcript entry (role `user`) via a new `appendSteeringMarker` helper.
+- Both viewport and transcript/export carry a `steered ⟂ ` marker prefix so steered input reads distinctly from a typed prompt; the helper is the rendering slice 4's local echo will reuse. Malformed/empty payloads are dropped without panic; `m.lastEventID` bookkeeping is untouched (the case sits after ID tracking in the existing switch).
+- Strict TDD: `cmd/harnesscli/tui/steer_events_test.go` (package `tui_test`, `sse_events_test.go` pattern) drives scripted `SSEEventMsg`s — marker+message in viewport, exactly one role-`user` transcript entry, distinction from a typed prompt, five malformed-payload shapes (no panic, no marker, transcript unchanged, run stays active).
+- Validation: `go test ./cmd/harnesscli/... -count=1` all ok (incl. `sse_events_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `keys_test.go` guards); `go test ./internal/server/ ./internal/harness/ -count=1` ok; gofmt/vet clean.
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/820-tui-steering.md
+++ b/docs/plans/820-tui-steering.md
@@ -1,6 +1,8 @@
-# Plan: epic #820 slice 1 — steer client plumbing (steerRunCmd + harnesscli steer)
+# Plan: epic #820 — mid-turn steering from the TUI (per-slice sections)
 
-## Context
+## Slice 1 — steer client plumbing (steerRunCmd + harnesscli steer)
+
+### Context
 
 - Problem: the server exposes `POST /v1/runs/{id}/steer` (202/404/409/429 contract,
   `internal/server/http_runs.go` `handleRunSteer`) but no client path exists — the TUI
@@ -63,10 +65,68 @@
 - [x] gofmt + go vet clean.
 - [x] `go test ./cmd/harnesscli/... -count=1` green.
 - [x] Engineering-log entry; `docs/plans/INDEX.md` updated for the new plan page.
-- [ ] Commit, push `epic/820-tui-steering`, open PR (do NOT merge).
+- [x] Commit, push `epic/820-tui-steering`, open PR (do NOT merge). — merged as PR #841.
 
 ## Risks and Mitigations
 
 - Risk: epic parenthetical mentions an `-api-key` flag that `runCancel` does not have.
 - Mitigation: mirror `runCancel` exactly (`-base-url` only); note the deviation in the
   PR body so slice reviewers can decide.
+
+---
+
+## Slice 2 — render steering.received events in the transcript
+
+## Context
+
+- Problem: the TUI drops `steering.received` SSE events — there is no case for them in
+  the dispatch switch — so a server-confirmed steering injection is invisible to the
+  user even though the agent now sees the message.
+- User impact: after steering (from any client — this TUI, the one-shot CLI, or a
+  webhook), the transcript never shows the steered input, so the user cannot tell what
+  the agent was told.
+- Constraints: implement ONLY slice 2 of #820. No keybinding (slice 3), no local echo
+  or dedupe (slice 4). Server event payload `{"message": "..."}` is a fixed contract
+  (`internal/harness/runner.go` `drainSteering`). Strict TDD.
+
+## Scope
+
+- In scope:
+  - `cmd/harnesscli/tui/model.go`: `case "steering.received"` in the SSE dispatch
+    switch; parse `{"message": "..."}`; append a transcript entry (role `user`) and a
+    user bubble, both carrying a `steered ⟂ ` marker prefix, via a small
+    `appendSteeringMarker` helper (reused by slice 4's local echo). Malformed or empty
+    payloads are ignored without panic. `m.lastEventID` bookkeeping untouched (the
+    case sits inside the existing type switch, after ID tracking).
+- Out of scope: slices 3–5; any server/harness change; help/keybinding docs.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: none (`website/docs/cli/tui.md` belongs to slice 3).
+- Implementation notes to add after code: engineering-log entry.
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`cmd/harnesscli/tui/steer_events_test.go`, package
+  `tui_test`, pattern from `sse_events_test.go`):
+  - scripted `SSEEventMsg{EventType: "steering.received"}` → marker + message visible
+    in rendered viewport; transcript gains a role `user` entry carrying the marker;
+    run stays active.
+  - marker is visually distinct from a normal user prompt (steered line carries
+    `steered ⟂`; a typed prompt does not).
+  - malformed payload (`not-json`, `{}`, whitespace-only message) → no panic, no
+    marker, transcript unchanged.
+- Regression tests required: `go test ./cmd/harnesscli/... -count=1` green, esp.
+  `sse_events_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`,
+  `clipboard_test.go`, `keys_test.go`.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above).
+- [x] Write failing tests first, watch them fail.
+- [x] Implement `steering.received` case + `appendSteeringMarker`.
+- [x] gofmt + go vet clean.
+- [x] `go test ./cmd/harnesscli/... -count=1` green.
+- [x] Engineering-log entry.
+- [ ] Commit, push `epic/820-tui-steering-s2`, open PR (do NOT merge).

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -16,7 +16,7 @@
 - `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator (merged), Slice 2 resume via resume_agent_ids (in implementation).
 - `809-mcp-oauth.md` — Epic #809: slice 1 (static HTTP headers + typed auth errors, merged PR #840) and slice 2 (file-backed OAuth token store, in implementation).
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
-- `820-tui-steering.md` — Epic #820 slice 1 (in implementation): steer client plumbing (`steerRunCmd` + `harnesscli steer`).
+- `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slice 1 client plumbing merged; slice 2 transcript rendering in review).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.


### PR DESCRIPTION
Parent epic: #820. Part of #803.

## What

Slice 2 of #820 (mid-turn steering): the TUI stops dropping `steering.received` SSE events and shows a server-confirmed marker in the transcript.

- `cmd/harnesscli/tui/model.go` — `case "steering.received"` in the SSE dispatch switch parses the fixed `{"message": "..."}` payload (harness `drainSteering` contract) and appends a user bubble + role-`user` transcript entry via a new `appendSteeringMarker` helper. Both carry a `steered ⟂ ` marker prefix so steered input reads distinctly from a typed prompt in the viewport and in exported transcripts. Malformed/empty payloads are dropped without panic; `m.lastEventID` bookkeeping is untouched (the case sits after ID tracking in the existing switch). The helper is the rendering slice 4's local echo will reuse.

## Tests (strict TDD — failing first)

- `cmd/harnesscli/tui/steer_events_test.go` (package `tui_test`, `sse_events_test.go` pattern): scripted `SSEEventMsg{EventType: "steering.received"}` → marker+message in rendered viewport, exactly one role-`user` transcript entry carrying the marker, run stays active; marker distinct from a typed prompt (typed prompt line/entry unmarked, steered line/entry marked); five malformed-payload shapes (`not-json`, `{}`, wrong type, whitespace, empty) → no panic, no marker, transcript unchanged.

## Verification

- `go test ./cmd/harnesscli/... -count=1` — all packages ok
- `go test ./cmd/harnesscli/tui/ -count=1 -run 'Steer|TestTUI049|Escape|Cancel|CtrlC|Clipboard|Keys|SSE'` — ok (epic regression guards incl. `sse_events_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `keys_test.go`)
- `go test ./internal/server/ ./internal/harness/ -count=1` — ok (8.725s / 2.756s)
- gofmt / `go vet ./cmd/harnesscli/...` — clean