### PR TITLE
feat(harness): return the compaction summary from the compact endpoint

### DIFF
--- a/docs/plans/817-compact-cmd.md
+++ b/docs/plans/817-compact-cmd.md
@@ -1,7 +1,11 @@
-# Plan: epic #817 slice 1 — preserve-instruction in CompactRun and the compact endpoint
+# Plan: epic #817 — /compact preserve-instruction + compaction summary
 
 Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part of #803.
-This plan covers ONLY slice 1: `feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint`.
+
+- Slice 1 (`feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint`): **implemented**, merged via PR #836.
+- Slice 2 (`feat(harness): return the compaction summary from the compact endpoint`): **in implementation** (branch `epic/817-compact-cmd-s2`).
+
+## Slice 1 (done)
 
 ## Context
 
@@ -20,7 +24,7 @@ This plan covers ONLY slice 1: `feat(harness): accept a preserve-instruction in 
 
 ## Documentation Contract
 
-- Feature status: `in implementation`
+- Feature status: `implemented` (merged via PR #836)
 - Public docs affected: none (internal API additive field only).
 - Spec docs to update before code: none.
 - Implementation notes to add after code: none beyond this plan + folder index.
@@ -61,3 +65,38 @@ This plan covers ONLY slice 1: `feat(harness): accept a preserve-instruction in 
   - Mitigation: carry the instruction on the runner-side `runnerMessageSummarizer` wrapper; interface untouched.
 - Risk: empty/whitespace instruction altering today's prompt.
   - Mitigation: trim; when empty use the exact existing prompt string; pinned by the no-op test.
+
+---
+
+## Slice 2 (in implementation): return the compaction summary from the compact endpoint
+
+### Context
+
+- Problem: `CompactRunResult` and the compact endpoint report only `messages_removed` — clients (TUI slice 4) cannot render what was distilled.
+- Constraints: additive response fields only (`ok`/`messages_removed` unchanged); no SSE changes; strip mode returns an empty summary; existing `internal/server/http_compact_test.go` and `http_context_compact_test.go` pass unmodified.
+
+### Scope
+
+- In scope:
+  - `CompactRunResult.Mode` (resolved mode) and `CompactRunResult.Summary` (`internal/harness/runner.go`).
+  - `compactMessagesHTTP` returns the summary produced by `compactSummarizeHTTP`/`compactHybridHTTP` (previously discarded); strip and no-op paths return "".
+  - `autoCompactMessages` discards the summary — behavior unchanged.
+  - Endpoint response gains `mode` and `summary` keys (`internal/server/http_runs.go`).
+  - Mechanical signature updates at existing `compactMessagesHTTP` test call sites.
+- Out of scope: slices 3–4 (TUI command, transcript block); auto-compact SSE payloads; persisting summaries.
+
+### Test Plan (TDD)
+
+- New failing tests first:
+  - `internal/harness/runner_compact_summary_test.go`: summarize returns the scripted summary + mode; hybrid returns the summary; strip (and default-mode-resolves-to-strip) returns empty summary with `MessagesRemoved > 0` and the resolved mode.
+  - `internal/server/http_run_compact_instruction_test.go`: summarize endpoint returns `{ok, messages_removed>0, mode:"summarize", summary:"..."}`; strip endpoint returns `mode:"strip"`, `summary` key present and empty.
+- Existing tests to update: `compactMessagesHTTP` call sites in `runner_context_compact_test.go` (mechanical, 3-value return).
+- Regression: all pre-existing harness/server compaction tests pass.
+
+### Implementation Checklist
+
+- [x] Write failing tests first (watched red: runner build failure on missing fields; server missing `mode`/`summary` keys).
+- [x] Implement minimal code changes.
+- [ ] gofmt + go vet clean.
+- [ ] `go test ./internal/harness/ ./internal/server/ -count=1` green.
+- [ ] Commit, push `epic/817-compact-cmd-s2`, open PR (no merge).

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -4104,6 +4104,11 @@ type CompactRunRequest struct {
 // CompactRunResult holds the result of a CompactRun call.
 type CompactRunResult struct {
 	MessagesRemoved int `json:"messages_removed"`
+	// Mode is the resolved compaction mode that ran (strip/summarize/hybrid).
+	Mode string `json:"mode"`
+	// Summary is the text produced by the summarizer in summarize/hybrid
+	// modes. Empty for strip mode or when nothing was summarized.
+	Summary string `json:"summary"`
 }
 
 // CompactRun triggers in-memory context compaction on an active run.
@@ -4148,7 +4153,7 @@ func (r *Runner) CompactRun(ctx context.Context, runID string, req CompactRunReq
 	// Convert messages to TranscriptMessages for the compaction logic.
 	snap := messagesAsTranscriptSnapshot(messages)
 	if len(snap) == 0 {
-		return CompactRunResult{}, nil
+		return CompactRunResult{Mode: mode}, nil
 	}
 
 	// Snapshot the per-request Summarizer model from runState so that manual
@@ -4165,7 +4170,7 @@ func (r *Runner) CompactRun(ctx context.Context, runID string, req CompactRunReq
 		// strip never invokes the summarizer, so it ignores the instruction).
 		summarizer = r.newMessageSummarizerWithInstruction(summarizerModel, inst)
 	}
-	compacted, err := compactMessagesHTTP(ctx, snap, mode, keepLast, summarizer)
+	compacted, summary, err := compactMessagesHTTP(ctx, snap, mode, keepLast, summarizer)
 	if err != nil {
 		return CompactRunResult{}, fmt.Errorf("compaction failed: %w", err)
 	}
@@ -4178,7 +4183,7 @@ func (r *Runner) CompactRun(ctx context.Context, runID string, req CompactRunReq
 	if removed < 0 {
 		removed = 0
 	}
-	return CompactRunResult{MessagesRemoved: removed}, nil
+	return CompactRunResult{MessagesRemoved: removed, Mode: mode, Summary: summary}, nil
 }
 
 // messagesForStep returns a fresh snapshot of the canonical state.messages
@@ -4219,10 +4224,10 @@ func (r *Runner) autoCompactMessages(ctx context.Context, runID string, messages
 	// override is empty, preserving existing behaviour.
 	summarizer := r.newMessageSummarizerWithModel(state.resolvedRoleModels.Summarizer)
 
-	compacted, err := compactMessagesHTTP(ctx, snap, mode, keepLast, summarizer)
+	compacted, _, err := compactMessagesHTTP(ctx, snap, mode, keepLast, summarizer)
 	if err != nil && mode != "strip" {
 		// Fallback to strip mode if hybrid/summarize fails.
-		compacted, err = compactMessagesHTTP(ctx, snap, "strip", keepLast, nil)
+		compacted, _, err = compactMessagesHTTP(ctx, snap, "strip", keepLast, nil)
 	}
 	if err != nil {
 		return nil, err
@@ -4287,35 +4292,36 @@ func transcriptMessagesToHarness(msgs []htools.TranscriptMessage) []Message {
 // compactMessagesHTTP applies the compaction strategy to transcript messages.
 // It mirrors the logic inside the compact_history tool handler but operates
 // directly on slices without a context-based reader/replacer.
+// It also returns the summary produced by the summarizer in summarize/hybrid
+// modes ("" for strip mode, when nothing was compacted, or when the
+// summarizer produced no text).
 func compactMessagesHTTP(
 	ctx context.Context,
 	msgs []htools.TranscriptMessage,
 	mode string,
 	keepLast int,
 	summarizer htools.MessageSummarizer,
-) ([]htools.TranscriptMessage, error) {
+) ([]htools.TranscriptMessage, string, error) {
 	turns := parseTurnsHTTP(msgs)
 	prefixEnd, compactEnd := findCompactionBoundsHTTP(turns, keepLast)
 
 	if compactEnd <= prefixEnd {
 		// Nothing to compact — return the original slice.
-		return msgs, nil
+		return msgs, "", nil
 	}
 
 	switch mode {
 	case "strip":
-		return compactStripHTTP(turns, prefixEnd, compactEnd), nil
+		return compactStripHTTP(turns, prefixEnd, compactEnd), "", nil
 	case "summarize":
 		if summarizer == nil {
-			return nil, fmt.Errorf("summarize mode requires a message summarizer (not configured)")
+			return nil, "", fmt.Errorf("summarize mode requires a message summarizer (not configured)")
 		}
-		result, _, err := compactSummarizeHTTP(ctx, turns, prefixEnd, compactEnd, summarizer)
-		return result, err
+		return compactSummarizeHTTP(ctx, turns, prefixEnd, compactEnd, summarizer)
 	case "hybrid":
-		result, _, err := compactHybridHTTP(ctx, turns, prefixEnd, compactEnd, summarizer)
-		return result, err
+		return compactHybridHTTP(ctx, turns, prefixEnd, compactEnd, summarizer)
 	default:
-		return nil, fmt.Errorf("unknown mode: %s", mode)
+		return nil, "", fmt.Errorf("unknown mode: %s", mode)
 	}
 }
 

--- a/internal/harness/runner_compact_summary_test.go
+++ b/internal/harness/runner_compact_summary_test.go
@@ -1,0 +1,109 @@
+package harness
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Tests in this file cover epic #817 slice 2: CompactRunResult carries the
+// compaction mode and (for summarize/hybrid) the produced summary.
+// Helpers (compactInstructionProvider, startThreeStepGatedRun,
+// newGatedInstructionProvider, threeStepToolCallResults) live in
+// runner_compact_instruction_test.go.
+
+// TestCompactRun_SummarizeModeReturnsSummary verifies that summarize mode
+// returns the summary text produced by the summarizer along with the mode.
+func TestCompactRun_SummarizeModeReturnsSummary(t *testing.T) {
+	t.Parallel()
+
+	gateRelease := make(chan struct{})
+	prov := newGatedInstructionProvider(gateRelease)
+	runner, runID := startThreeStepGatedRun(t, prov, `{"echo":"ok"}`, gateRelease)
+
+	result, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+		Mode:     "summarize",
+		KeepLast: 1,
+	})
+	if err != nil {
+		t.Fatalf("CompactRun summarize: %v", err)
+	}
+	close(gateRelease)
+
+	if result.Mode != "summarize" {
+		t.Errorf("expected Mode=%q, got %q", "summarize", result.Mode)
+	}
+	// threeStepToolCallResults scripts the summarization response.
+	if result.Summary != "a compact summary" {
+		t.Errorf("expected Summary=%q, got %q", "a compact summary", result.Summary)
+	}
+	if result.MessagesRemoved <= 0 {
+		t.Errorf("expected MessagesRemoved > 0, got %d", result.MessagesRemoved)
+	}
+}
+
+// TestCompactRun_HybridModeReturnsSummary verifies that hybrid mode surfaces
+// the summary of the removed large tool outputs.
+func TestCompactRun_HybridModeReturnsSummary(t *testing.T) {
+	t.Parallel()
+
+	gateRelease := make(chan struct{})
+	prov := newGatedInstructionProvider(gateRelease)
+
+	// Tool output above the 500-token hybrid threshold (~2000 runes).
+	largeOutput := strings.Repeat("x", 2400)
+	runner, runID := startThreeStepGatedRun(t, prov, largeOutput, gateRelease)
+
+	result, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+		Mode:     "hybrid",
+		KeepLast: 1,
+	})
+	if err != nil {
+		t.Fatalf("CompactRun hybrid: %v", err)
+	}
+	close(gateRelease)
+
+	if result.Mode != "hybrid" {
+		t.Errorf("expected Mode=%q, got %q", "hybrid", result.Mode)
+	}
+	if result.Summary != "a compact summary" {
+		t.Errorf("expected Summary=%q, got %q", "a compact summary", result.Summary)
+	}
+}
+
+// TestCompactRun_StripModeReturnsEmptySummary verifies strip mode returns an
+// empty summary (nothing is summarized) while MessagesRemoved is populated.
+// An omitted mode resolves to "strip" and must report the resolved mode.
+func TestCompactRun_StripModeReturnsEmptySummary(t *testing.T) {
+	t.Parallel()
+
+	for _, reqMode := range []string{"strip", ""} {
+		reqMode := reqMode
+		t.Run("mode="+reqMode, func(t *testing.T) {
+			t.Parallel()
+
+			gateRelease := make(chan struct{})
+			prov := newGatedInstructionProvider(gateRelease)
+			runner, runID := startThreeStepGatedRun(t, prov, `{"echo":"ok"}`, gateRelease)
+
+			result, err := runner.CompactRun(context.Background(), runID, CompactRunRequest{
+				Mode:     reqMode,
+				KeepLast: 1,
+			})
+			if err != nil {
+				t.Fatalf("CompactRun strip: %v", err)
+			}
+			close(gateRelease)
+
+			if result.Mode != "strip" {
+				t.Errorf("expected resolved Mode=%q, got %q", "strip", result.Mode)
+			}
+			if result.Summary != "" {
+				t.Errorf("strip mode must return an empty summary, got %q", result.Summary)
+			}
+			if result.MessagesRemoved <= 0 {
+				t.Errorf("expected MessagesRemoved > 0, got %d", result.MessagesRemoved)
+			}
+		})
+	}
+}

--- a/internal/harness/runner_context_compact_test.go
+++ b/internal/harness/runner_context_compact_test.go
@@ -311,7 +311,7 @@ func TestCompactStripHTTP(t *testing.T) {
 		{Index: 4, Role: "assistant", Content: "done"},
 	}
 
-	result, err := compactMessagesHTTP(context.Background(), msgs, "strip", 2, nil)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "strip", 2, nil)
 	if err != nil {
 		t.Fatalf("compactMessagesHTTP strip: %v", err)
 	}
@@ -335,7 +335,7 @@ func TestCompactSummarizeHTTP(t *testing.T) {
 	}
 
 	summarizer := &fixedSummarizer{summary: "a summary"}
-	result, err := compactMessagesHTTP(context.Background(), msgs, "summarize", 2, summarizer)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "summarize", 2, summarizer)
 	if err != nil {
 		t.Fatalf("compactMessagesHTTP summarize: %v", err)
 	}
@@ -370,7 +370,7 @@ func TestCompactHybridHTTP(t *testing.T) {
 	}
 
 	summarizer := &fixedSummarizer{summary: "hybrid summary"}
-	result, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 2, summarizer)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 2, summarizer)
 	if err != nil {
 		t.Fatalf("compactMessagesHTTP hybrid: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestCompactMessagesHTTP_NoOp(t *testing.T) {
 		{Index: 1, Role: "assistant", Content: "done"},
 	}
 
-	result, err := compactMessagesHTTP(context.Background(), msgs, "strip", 4, nil)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "strip", 4, nil)
 	if err != nil {
 		t.Fatalf("compactMessagesHTTP: %v", err)
 	}
@@ -1161,7 +1161,7 @@ func TestCompactMessagesHTTP_SummarizeNilSummarizer(t *testing.T) {
 		{Index: 3, Role: "assistant", Content: "d"},
 	}
 
-	_, err := compactMessagesHTTP(context.Background(), msgs, "summarize", 1, nil)
+	_, _, err := compactMessagesHTTP(context.Background(), msgs, "summarize", 1, nil)
 	if err == nil {
 		t.Fatal("expected error when summarizer is nil in summarize mode")
 	}
@@ -1181,7 +1181,7 @@ func TestCompactMessagesHTTP_StripPreservesAssistantText(t *testing.T) {
 		{Index: 4, Role: "assistant", Content: "final"},
 	}
 
-	result, err := compactMessagesHTTP(context.Background(), msgs, "strip", 1, nil)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "strip", 1, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1219,7 +1219,7 @@ func TestCompactMessagesHTTP_HybridNilSummarizer(t *testing.T) {
 		{Index: 4, Role: "assistant", Content: "done"},
 	}
 
-	result, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 1, nil)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 1, nil)
 	if err != nil {
 		t.Fatalf("hybrid with nil summarizer should not error: %v", err)
 	}
@@ -1249,7 +1249,7 @@ func TestCompactMessagesHTTP_HybridSummarizerError(t *testing.T) {
 	}
 
 	errorSummarizer := &errorSummarizer{}
-	result, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 1, errorSummarizer)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "hybrid", 1, errorSummarizer)
 	// hybrid does not propagate summarizer errors; it falls back to a marker.
 	if err != nil {
 		t.Fatalf("hybrid should not propagate summarizer error: %v", err)
@@ -1274,7 +1274,7 @@ func TestCompactMessagesHTTP_StripCompactSummaryInPrefix(t *testing.T) {
 		{Index: 5, Role: "assistant", Content: "final"},
 	}
 
-	result, err := compactMessagesHTTP(context.Background(), msgs, "strip", 1, nil)
+	result, _, err := compactMessagesHTTP(context.Background(), msgs, "strip", 1, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1302,7 +1302,7 @@ func TestCompactMessagesHTTP_UnknownMode(t *testing.T) {
 		{Index: 3, Role: "assistant", Content: "d"},
 	}
 
-	_, err := compactMessagesHTTP(context.Background(), msgs, "bogusmode", 1, nil)
+	_, _, err := compactMessagesHTTP(context.Background(), msgs, "bogusmode", 1, nil)
 	if err == nil {
 		t.Fatal("expected error for unknown mode")
 	}

--- a/internal/server/http_run_compact_instruction_test.go
+++ b/internal/server/http_run_compact_instruction_test.go
@@ -286,3 +286,197 @@ func TestCompactEndpointWithoutInstructionUnchanged(t *testing.T) {
 
 	close(releaseCh)
 }
+
+// TestCompactEndpointReturnsSummaryForSummarizeMode verifies the compact
+// endpoint response carries mode and the produced summary for summarize mode
+// (epic #817 slice 2): {"ok":true,"messages_removed":N,"mode":"summarize","summary":"..."}.
+func TestCompactEndpointReturnsSummaryForSummarizeMode(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	provider := &compactInstructionCaptureProvider{
+		results: []harness.CompletionResult{
+			{ToolCalls: []harness.ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{"message":"s2"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-3", Name: "echo_json", Arguments: `{"message":"s3"}`}}},
+			{Content: "done"},
+			{Content: "a compact summary"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+
+	registry := harness.NewRegistry()
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     6,
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	<-blockCh
+
+	compactRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/compact",
+		"application/json",
+		bytes.NewBufferString(`{"mode":"summarize","keep_last":1}`),
+	)
+	if err != nil {
+		t.Fatalf("compact request: %v", err)
+	}
+	defer compactRes.Body.Close()
+
+	if compactRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(compactRes.Body)
+		t.Fatalf("expected 200, got %d: %s", compactRes.StatusCode, string(body))
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(compactRes.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode compact response: %v", err)
+	}
+
+	if resp["ok"] != true {
+		t.Errorf("expected ok=true, got %v", resp["ok"])
+	}
+	removed, ok := resp["messages_removed"].(float64)
+	if !ok || removed <= 0 {
+		t.Errorf("expected messages_removed > 0, got %v", resp["messages_removed"])
+	}
+	if resp["mode"] != "summarize" {
+		t.Errorf("expected mode=%q, got %v", "summarize", resp["mode"])
+	}
+	if resp["summary"] != "a compact summary" {
+		t.Errorf("expected summary=%q, got %v", "a compact summary", resp["summary"])
+	}
+
+	close(releaseCh)
+}
+
+// TestCompactEndpointStripModeReturnsEmptySummary verifies strip mode returns
+// mode="strip" and an empty summary while messages_removed stays populated,
+// and that the response remains additive-only (ok/messages_removed intact).
+func TestCompactEndpointStripModeReturnsEmptySummary(t *testing.T) {
+	t.Parallel()
+
+	blockCh := make(chan struct{})
+	releaseCh := make(chan struct{})
+
+	provider := &compactInstructionCaptureProvider{
+		results: []harness.CompletionResult{
+			{ToolCalls: []harness.ToolCall{{ID: "call-1", Name: "echo_json", Arguments: `{"message":"s1"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-2", Name: "echo_json", Arguments: `{"message":"s2"}`}}},
+			{ToolCalls: []harness.ToolCall{{ID: "call-3", Name: "echo_json", Arguments: `{"message":"s3"}`}}},
+			{Content: "done"},
+		},
+		beforeCall: func(idx int) {
+			if idx == 3 {
+				close(blockCh)
+				<-releaseCh
+			}
+		},
+	}
+
+	registry := harness.NewRegistry()
+	if err := registry.Register(harness.ToolDefinition{
+		Name:        "echo_json",
+		Description: "echoes payload",
+		Parameters:  map[string]any{"type": "object"},
+	}, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return `{"echo":"ok"}`, nil
+	}); err != nil {
+		t.Fatalf("register tool: %v", err)
+	}
+
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     6,
+	})
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json",
+		bytes.NewBufferString(`{"prompt":"hello"}`))
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+	defer res.Body.Close()
+
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	<-blockCh
+
+	compactRes, err := http.Post(
+		ts.URL+"/v1/runs/"+created.RunID+"/compact",
+		"application/json",
+		bytes.NewBufferString(`{"mode":"strip","keep_last":1}`),
+	)
+	if err != nil {
+		t.Fatalf("compact request: %v", err)
+	}
+	defer compactRes.Body.Close()
+
+	if compactRes.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(compactRes.Body)
+		t.Fatalf("expected 200, got %d: %s", compactRes.StatusCode, string(body))
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(compactRes.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode compact response: %v", err)
+	}
+
+	if resp["ok"] != true {
+		t.Errorf("expected ok=true, got %v", resp["ok"])
+	}
+	removed, ok := resp["messages_removed"].(float64)
+	if !ok || removed <= 0 {
+		t.Errorf("expected messages_removed > 0, got %v", resp["messages_removed"])
+	}
+	if resp["mode"] != "strip" {
+		t.Errorf("expected mode=%q, got %v", "strip", resp["mode"])
+	}
+	summaryVal, present := resp["summary"]
+	if !present {
+		t.Error("expected summary key to be present (additive field), got missing")
+	} else if summaryVal != "" {
+		t.Errorf("strip mode must return an empty summary, got %v", summaryVal)
+	}
+
+	close(releaseCh)
+}

--- a/internal/server/http_runs.go
+++ b/internal/server/http_runs.go
@@ -637,6 +637,8 @@ func (s *Server) handleRunCompact(w http.ResponseWriter, r *http.Request, runID 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"ok":               true,
 		"messages_removed": result.MessagesRemoved,
+		"mode":             result.Mode,
+		"summary":          result.Summary,
 	})
 }
 


### PR DESCRIPTION
Parent epic: #817. Part of #803.

## What

Epic #817 slice 2 (of 4), stacked on merged slice 1 (PR #836). Surfaces what compaction distilled so clients can render it:

- `CompactRunResult` gains `Mode` (resolved mode: strip/summarize/hybrid) and `Summary` (empty for strip) — `internal/harness/runner.go`.
- `compactMessagesHTTP` returns the summary that `compactSummarizeHTTP`/`compactHybridHTTP` already produced but discarded; strip/no-op paths return `""`. `autoCompactMessages` ignores it — auto-compaction behavior unchanged; no SSE changes.
- `POST /v1/runs/{id}/compact` response gains additive `mode` and `summary` fields; `ok`/`messages_removed` unchanged — `internal/server/http_runs.go`.

## Tests (strict TDD — failing tests written first, watched red)

- `internal/harness/runner_compact_summary_test.go` (new):
  - summarize returns the produced summary + `Mode="summarize"`
  - hybrid returns the summary of removed large tool outputs
  - strip and omitted-mode (resolves to strip) return empty `Summary`, `MessagesRemoved > 0`, resolved `Mode="strip"`
- `internal/server/http_run_compact_instruction_test.go` (extended):
  - summarize endpoint returns `{"ok":true,"messages_removed":N,"mode":"summarize","summary":"..."}`
  - strip endpoint returns `mode="strip"` with `summary` key present and empty; `ok`/`messages_removed` intact (additive only)
- Mechanical 3-value signature updates at existing `compactMessagesHTTP` call sites in `runner_context_compact_test.go`.

## Verification (actually run)

- Red phase: runner tests failed to build (`result.Mode undefined`); server tests failed on missing `mode`/`summary` keys.
- `go test ./internal/harness/ -run 'TestCompactRun_SummarizeModeReturnsSummary|TestCompactRun_HybridModeReturnsSummary|TestCompactRun_StripModeReturnsEmptySummary' -count=1 -v` — PASS
- `go test ./internal/server/ -run 'TestCompactEndpoint' -count=1 -v` — PASS (all 9, incl. pre-existing unmodified tests)
- `go test ./internal/harness/ ./internal/server/ -count=1` — ok (4.5s, 10.8s)
- `go test ./internal/harness/ -race -run 'Compact|Summarize' -count=1` — ok (3.8s)
- `gofmt` / `go vet` clean on touched packages

## Acceptance (from epic)

`curl -X POST localhost:PORT/v1/runs/<id>/compact -d '{"mode":"summarize","instruction":"keep the SQL schema"}'` now returns `{"ok":true,"messages_removed":N,"mode":"summarize","summary":"..."}` — covered by `TestCompactEndpointReturnsSummaryForSummarizeMode`; existing `http_compact_test.go`/`http_context_compact_test.go` pass unmodified.

Later slices (#817): TUI `/compact` command, transcript compaction block — not in this PR.