### PR TITLE
feat(cli): map run terminal events to exit codes in one-shot and continue

### DIFF
--- a/cmd/harnesscli/exitcodes.go
+++ b/cmd/harnesscli/exitcodes.go
@@ -1,0 +1,45 @@
+package main
+
+import "go-agent-harness/internal/harness"
+
+// Exit codes for headless (streaming) harnesscli usage. These constants are
+// the single source of truth for the contract documented in
+// website/docs/reference/exit-codes.md (epic #823): the literal values are a
+// public compatibility surface for shell scripts and CI, aligned with
+// kimi-code's headless codes (0 = completed, 3 = blocked, 6 = paused).
+const (
+	// exitSuccess: the run terminated with run.completed.
+	exitSuccess = 0
+	// exitClientError: bad flags, missing prompt, connection/HTTP failure,
+	// stream transport error — the failure is client-side, not a run outcome.
+	exitClientError = 1
+	// exitRunFailed: the run terminated with run.failed.
+	exitRunFailed = 2
+	// exitBlocked: the run cannot proceed without input a headless caller
+	// will never provide (run.waiting_for_user, tool.approval_required, or
+	// plan.approval_required observed while stdin is non-interactive).
+	exitBlocked = 3
+	// exitCancelled: the run terminated with run.cancelled; work is
+	// interrupted but resumable via "harnesscli continue".
+	exitCancelled = 6
+	// exitInterrupted: SIGINT/SIGTERM while streaming (128 + SIGINT, the
+	// conventional shell code).
+	exitInterrupted = 130
+)
+
+// exitCodeForTerminalEvent maps a run terminal event to its contracted exit
+// code. Unknown, non-terminal, or empty event types map to exitClientError as
+// a defensive default, so a scripting caller never mistakes an unrecognized
+// outcome for success.
+func exitCodeForTerminalEvent(et harness.EventType) int {
+	switch et {
+	case harness.EventRunCompleted:
+		return exitSuccess
+	case harness.EventRunFailed:
+		return exitRunFailed
+	case harness.EventRunCancelled:
+		return exitCancelled
+	default:
+		return exitClientError
+	}
+}

--- a/cmd/harnesscli/exitcodes_test.go
+++ b/cmd/harnesscli/exitcodes_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+)
+
+// The exit codes below are the public headless contract documented in
+// website/docs/reference/exit-codes.md (epic #823). The literal values are
+// the contract: changing them breaks scripting callers.
+
+func TestExitCodeConstantsMatchContract(t *testing.T) {
+	constants := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"exitSuccess", exitSuccess, 0},
+		{"exitClientError", exitClientError, 1},
+		{"exitRunFailed", exitRunFailed, 2},
+		{"exitBlocked", exitBlocked, 3},
+		{"exitCancelled", exitCancelled, 6},
+		{"exitInterrupted", exitInterrupted, 130},
+	}
+	for _, tc := range constants {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d (contract value)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestExitCodeForTerminalEvent(t *testing.T) {
+	cases := []struct {
+		name  string
+		event harness.EventType
+		want  int
+	}{
+		{"run.completed exits 0", harness.EventRunCompleted, 0},
+		{"run.failed exits 2", harness.EventRunFailed, 2},
+		{"run.cancelled exits 6", harness.EventRunCancelled, 6},
+		// Defensive default: anything that is not a known terminal event maps
+		// to the non-zero client-error code so a scripting caller never
+		// mistakes an unrecognized outcome for success.
+		{"non-terminal run.started exits 1", harness.EventRunStarted, 1},
+		{"non-terminal max_turns.exhausted exits 1", harness.EventMaxTurnsExhausted, 1},
+		{"non-terminal run.waiting_for_user exits 1", harness.EventRunWaitingForUser, 1},
+		{"unknown event exits 1", harness.EventType("run.bogus"), 1},
+		{"empty event exits 1", harness.EventType(""), 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitCodeForTerminalEvent(tc.event); got != tc.want {
+				t.Fatalf("exitCodeForTerminalEvent(%q) = %d, want %d", tc.event, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunExitCodeMatchesTerminalEvent drives the one-shot streaming path
+// against a scripted SSE server and asserts both the process exit code and
+// that the stdout contract (run_id= / terminal_event= lines) is preserved.
+func TestRunExitCodeMatchesTerminalEvent(t *testing.T) {
+	cases := []struct {
+		name          string
+		terminalEvent string
+		wantCode      int
+	}{
+		{"run.completed exits 0", "run.completed", 0},
+		{"run.failed exits 2", "run.failed", 2},
+		{"run.cancelled exits 6", "run.cancelled", 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/v1/runs", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("unexpected method: %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(w, `{"run_id":"run_abc","status":"queued"}`)
+			})
+			mux.HandleFunc("/v1/runs/run_abc/events", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+				_, _ = io.WriteString(w, "event: run.started\n")
+				_, _ = io.WriteString(w, "data: {\"id\":\"e1\",\"run_id\":\"run_abc\",\"type\":\"run.started\"}\n\n")
+				_, _ = io.WriteString(w, "event: "+tc.terminalEvent+"\n")
+				_, _ = io.WriteString(w, "data: {\"id\":\"e2\",\"run_id\":\"run_abc\",\"type\":\""+tc.terminalEvent+"\"}\n\n")
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			outBuf, errBuf, restore := captureOutput(t)
+			defer restore()
+
+			origRequestClient := requestHTTPClient
+			origStreamClient := streamHTTPClient
+			requestHTTPClient = ts.Client()
+			streamHTTPClient = ts.Client()
+			defer func() {
+				requestHTTPClient = origRequestClient
+				streamHTTPClient = origStreamClient
+			}()
+
+			code := run([]string{"-base-url=" + ts.URL, "-prompt=test prompt"})
+			if code != tc.wantCode {
+				t.Fatalf("run() exit code = %d, want %d (stderr=%s)", code, tc.wantCode, errBuf.String())
+			}
+			output := outBuf.String()
+			for _, want := range []string{"run_id=run_abc", "terminal_event=" + tc.terminalEvent} {
+				if !strings.Contains(output, want) {
+					t.Errorf("stdout missing %q (stdout contract must be preserved):\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+// TestRunContinueExitCodeMatchesTerminalEvent applies the same terminal-event
+// mapping to the streaming continue path.
+func TestRunContinueExitCodeMatchesTerminalEvent(t *testing.T) {
+	cases := []struct {
+		name          string
+		terminalEvent string
+		wantCode      int
+	}{
+		{"run.completed exits 0", "run.completed", 0},
+		{"run.failed exits 2", "run.failed", 2},
+		{"run.cancelled exits 6", "run.cancelled", 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_prev/continue":
+					var body map[string]string
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("decode continue body: %v", err)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusAccepted)
+					_, _ = io.WriteString(w, `{"run_id":"run_next","status":"queued"}`)
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_next/events":
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = io.WriteString(w, "event: "+tc.terminalEvent+"\n")
+					_, _ = io.WriteString(w, "data: {\"id\":\"run_next:0\",\"run_id\":\"run_next\",\"type\":\""+tc.terminalEvent+"\"}\n\n")
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					http.Error(w, "unexpected", http.StatusNotFound)
+				}
+			}))
+			defer ts.Close()
+
+			outBuf, errBuf, restore := captureOutput(t)
+			defer restore()
+
+			origRequestClient := requestHTTPClient
+			origStreamClient := streamHTTPClient
+			requestHTTPClient = ts.Client()
+			streamHTTPClient = ts.Client()
+			defer func() {
+				requestHTTPClient = origRequestClient
+				streamHTTPClient = origStreamClient
+			}()
+
+			code := runContinue([]string{"-base-url=" + ts.URL, "run_prev", "follow up"})
+			if code != tc.wantCode {
+				t.Fatalf("runContinue() exit code = %d, want %d (stderr=%s)", code, tc.wantCode, errBuf.String())
+			}
+			output := outBuf.String()
+			for _, want := range []string{"run_id=run_next", "terminal_event=" + tc.terminalEvent} {
+				if !strings.Contains(output, want) {
+					t.Errorf("stdout missing %q (stdout contract must be preserved):\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+// TestRunContinueNoStreamDoesNotObserveEvents pins the contract that
+// -no-stream exits 0 on creation without ever opening the event stream, so
+// no terminal-event mapping applies.
+func TestRunContinueNoStreamDoesNotObserveEvents(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_prev/continue":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"run_id":"run_next","status":"queued"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_next/events":
+			t.Errorf("event stream must not be requested with -no-stream")
+			http.Error(w, "unexpected", http.StatusNotFound)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origRequestClient := requestHTTPClient
+	origStreamClient := streamHTTPClient
+	requestHTTPClient = ts.Client()
+	streamHTTPClient = ts.Client()
+	defer func() {
+		requestHTTPClient = origRequestClient
+		streamHTTPClient = origStreamClient
+	}()
+
+	code := runContinue([]string{"-base-url=" + ts.URL, "-no-stream", "run_prev", "follow up"})
+	if code != 0 {
+		t.Fatalf("runContinue(-no-stream) exit code = %d, want 0 (stderr=%s)", code, errBuf.String())
+	}
+	if !strings.Contains(outBuf.String(), "run_id=run_next") {
+		t.Errorf("stdout missing run_id line:\n%s", outBuf.String())
+	}
+}

--- a/cmd/harnesscli/main.go
+++ b/cmd/harnesscli/main.go
@@ -161,7 +161,7 @@ func run(args []string) int {
 
 	if err := flags.Parse(args); err != nil {
 		fmt.Fprintf(stderr, "harnesscli: parse failed: %v\n", err)
-		return 1
+		return exitClientError
 	}
 
 	if *listProfiles {
@@ -173,14 +173,14 @@ func run(args []string) int {
 	if *enableTUI {
 		if err := runTUI(*baseURL, workspacePath, *resume); err != nil {
 			fmt.Fprintf(stderr, "harnesscli: tui: %v\n", err)
-			return 1
+			return exitClientError
 		}
-		return 0
+		return exitSuccess
 	}
 
 	if strings.TrimSpace(*prompt) == "" {
 		fmt.Fprintln(stderr, "harnesscli: prompt is required")
-		return 1
+		return exitClientError
 	}
 
 	var extensions *runCreatePromptSettings
@@ -208,7 +208,7 @@ func run(args []string) int {
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "harnesscli: start run: %v\n", err)
-		return 1
+		return exitClientError
 	}
 
 	fmt.Fprintf(stdout, "run_id=%s\n", runID)
@@ -217,7 +217,7 @@ func run(args []string) int {
 		return handleStreamError(ctx, requestHTTPClient, *baseURL, runID, err)
 	}
 	fmt.Fprintf(stdout, "terminal_event=%s\n", terminalEvent)
-	return 0
+	return exitCodeForTerminalEvent(harness.EventType(terminalEvent))
 }
 
 // handleStreamError decides how to report a streamRunEvents failure. If ctx
@@ -230,10 +230,10 @@ func handleStreamError(ctx context.Context, client *http.Client, baseURL, runID 
 		fmt.Fprintln(stderr, "harnesscli: interrupted, cancelling run...")
 		cancelRunOnInterrupt(client, baseURL, runID)
 		fmt.Fprintf(stdout, "run %s cancelled\n", runID)
-		return 130
+		return exitInterrupted
 	}
 	fmt.Fprintf(stderr, "harnesscli: stream events: %v\n", streamErr)
-	return 1
+	return exitClientError
 }
 
 // cancelRunOnInterrupt best-effort POSTs /v1/runs/{id}/cancel using a fresh,

--- a/cmd/harnesscli/runctl.go
+++ b/cmd/harnesscli/runctl.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"go-agent-harness/internal/harness"
 )
 
 // runListResponse is the JSON shape returned by GET /v1/runs.
@@ -400,10 +402,10 @@ func runContinue(args []string) int {
 	terminalEvent, err := streamRunEvents(context.Background(), streamHTTPClient, *baseURL, created.RunID, stdout)
 	if err != nil {
 		fmt.Fprintf(stderr, "harnesscli continue: stream events: %v\n", err)
-		return 1
+		return exitClientError
 	}
 	fmt.Fprintf(stdout, "terminal_event=%s\n", terminalEvent)
-	return 0
+	return exitCodeForTerminalEvent(harness.EventType(terminalEvent))
 }
 
 // runReplay implements "harnesscli replay <run-id-or-rollout-path>".

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -51,6 +51,12 @@
 - Server: `GET /v1/tasks` unions `bash_job` entries (label = command, cancel action while running) with the same tenant filtering as callbacks; new `POST /v1/jobs/{id}/kill` (runs:write, 404 unknown/cross-tenant, 501 unconfigured) reuses `JobManager.Kill`.
 - harnessd: one `JobTracker` created in `main.go`, threaded via `baseRegistryOptions` and `runtime_container`/`bootstrap_helpers` into `ServerOptions.JobTracker`.
 - Validation: failing-first tests — `bash_manager_list_test.go` (7 tests incl. race-checked concurrency), `job_tracker_test.go` (6 tests incl. registry-wiring integration through the real `bash` tool and `job_output`), and 8 new `http_tasks_test.go` tests. `go test ./internal/server/ ./internal/harness/ ./internal/harness/tools/ ./cmd/harnessd/ -count=1` all pass; the pre-existing flaky `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly` passed in this run.
+## 2026-07-20 (Headless Exit Codes — Epic #823, Slice 2)
+
+- `harnesscli -prompt ...` and streaming `harnesscli continue` no longer exit 0 for every terminal run state: the terminal event now maps through `exitCodeForTerminalEvent` (`cmd/harnesscli/exitcodes.go`) — `run.completed` → 0, `run.failed` → 2, `run.cancelled` → 6, unknown/empty → 1 (defensive non-zero default). stdout is unchanged (`run_id=` / `terminal_event=` lines preserved); only the process exit code changed.
+- New `cmd/harnesscli/exitcodes.go` holds all six contract codes (`exitSuccess`/`exitClientError`/`exitRunFailed`/`exitBlocked`/`exitCancelled`/`exitInterrupted`) as the single source of truth; literal `1`/`130` returns in `run()` and `handleStreamError()` were replaced with the named constants. `exitBlocked` (3) is wired in Slice 3.
+- TDD: failing-first tests in `cmd/harnesscli/exitcodes_test.go` — mapping table (all terminal events + non-terminal/unknown/empty), contract-value pins, and `httptest` SSE end-to-end assertions that `run()`/`runContinue()` return 0/2/6 for completed/failed/cancelled streams while preserving the stdout lines; `-no-stream` proven to exit 0 without opening the event stream.
+- Validation: `go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1` green; gofmt/vet clean; no existing test relied on the old failed/cancelled-exits-0 behavior.
 
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 

--- a/docs/plans/823-exit-codes.md
+++ b/docs/plans/823-exit-codes.md
@@ -1,46 +1,34 @@
-# Plan: headless exit-code contract — epic #823, Slice 1 (docs)
+# Plan: headless exit-code contract — epic #823
 
-## Context
+## Slice status
 
-- Problem: `harnesscli -prompt ...` exits 0 for every terminal run state (including `run.failed` and `run.cancelled`), so shell scripts and CI cannot branch on run outcomes without parsing stdout.
-- User impact: headless automation (CI, wrapper scripts) gets no reliable success/failure signal.
-- Constraints: Slice 1 is docs-only — ratify and document the exit-code table; no behavior changes (Slices 2–4 implement). Worktree-only flow; no merge to main from this branch.
+- Slice 1 (docs contract): **merged** (PR #824, branch `epic/823-exit-codes`).
+- Slice 2 (map terminal events to exit codes): **this branch** (`epic/823-exit-codes-s2`), branched from `origin/main` after the Slice 1 merge.
+- Slices 3–4 (blocked detection; e2e + per-command docs): future branches.
 
-## Scope
+## Slice 2 scope
 
-- In scope:
-  - New `website/docs/reference/exit-codes.md`: full exit-code table (run terminal events, waiting/blocked states, client errors, interrupt), kimi-code 0/3/6 alignment rationale, reserved goal-status mapping, `max_turns.exhausted` and `run.cost_limit_reached` semantics, precise blocked signals, current-vs-contracted table.
-  - Cross-links from `website/docs/cli/harnesscli.md` and `website/docs/reference/events-catalog.md`.
-  - `docs/plans/INDEX.md` entry for this plan.
-- Out of scope: implementing the mapping (Slice 2), blocked detection (Slice 3), e2e assertions and per-command doc updates (Slice 4). No Go code changes.
+- New `cmd/harnesscli/exitcodes.go`: constants `exitSuccess`(0) / `exitClientError`(1) / `exitRunFailed`(2) / `exitBlocked`(3) / `exitCancelled`(6) / `exitInterrupted`(130) and `exitCodeForTerminalEvent(harness.EventType) int`; unknown/empty/non-terminal events map to 1 (defensive non-zero default). `exitBlocked` is defined here and wired in Slice 3.
+- `cmd/harnesscli/main.go` `run()`: terminal return becomes `exitCodeForTerminalEvent(...)`; literal `1` returns in `run()` and `1`/`130` in `handleStreamError()` replaced with the named constants (one source of truth). `terminal_event=` stdout line and interrupt-cancel behavior untouched.
+- `cmd/harnesscli/runctl.go` `runContinue()`: same terminal-event mapping; `-no-stream` stays 0/1 and never opens the event stream.
+- Docs: contract page status table updated (failed 0→2 and cancelled 0→6 now implemented; blocked→3 still slice 3); engineering-log entry.
 
-## Documentation Contract
+## Slice 2 test plan (TDD)
 
-- Feature status: `planned` (contract ratified by this slice; implementation in later slices — the page states this explicitly per `docs/runbooks/documentation-maintenance.md` "public docs describe implemented behavior only", so the page clearly separates current behavior from contracted behavior).
-- Public docs affected: `website/docs/reference/exit-codes.md` (new), `website/docs/cli/harnesscli.md`, `website/docs/reference/events-catalog.md`.
-- Spec docs to update before code: this plan.
-- Implementation notes to add after code: none for Slice 1 (docs-only).
+- Failing-first (`cmd/harnesscli/exitcodes_test.go`): `exitCodeForTerminalEvent` table (all three terminal events + non-terminal/unknown/empty → 1); constant-value pins (0/1/2/3/6/130); `run()` against `httptest` SSE streams ending completed/failed/cancelled → 0/2/6 with `run_id=`/`terminal_event=` stdout preserved; `runContinue()` same; `-no-stream` exits 0 without requesting `/events`.
+- Regression guard: existing happy-path tests (`TestRunCreatesAndStreamsToCompletion`, `TestRunContinue_PostsPromptAndStreamsNewRun`, …) must pass unchanged; nothing may rely on "failed run exits 0".
+- Verification: `go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1`, gofmt, go vet.
 
-## Test Plan (TDD)
+## Slice 1 record (completed)
 
-- New failing tests to add first: none — epic designates Slice 1 as docs-only ("no behavior tests apply; reviewer validates the table against the event constants in `internal/harness/events.go`").
-- Existing tests to update: none.
-- Regression tests required: none for this slice. Validation = website build (Docusaurus broken-link check) + manual trace of every documented code to an event constant, run status, or current CLI behavior.
+- Problem: `harnesscli -prompt ...` exited 0 for every terminal run state (including `run.failed` and `run.cancelled`), so shell scripts and CI could not branch on run outcomes without parsing stdout.
+- Delivered: `website/docs/reference/exit-codes.md` contract page (full table, kimi 0/3/6 rationale, blocked signals, `max_turns.exhausted`/`run.cost_limit_reached` semantics, reserved goal mapping, current-vs-contracted table, traceability), cross-links from `website/docs/cli/harnesscli.md` and `website/docs/reference/events-catalog.md`, validated by `npm run build` (`onBrokenLinks: 'throw'`).
 
 ## Cross-Surface Impact Map
 
-- None — docs-only slice; no provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing touched.
-
-## Implementation Checklist
-
-- [x] Verify every epic citation against the source (event constants, run statuses, CLI return paths, wrapper propagation).
-- [x] Write `website/docs/reference/exit-codes.md`.
-- [x] Cross-link from `website/docs/cli/harnesscli.md` and `website/docs/reference/events-catalog.md`.
-- [x] Update `docs/plans/INDEX.md`.
-- [x] Build the website to validate links (`npm run build` green with `onBrokenLinks: 'throw'`); no Go packages touched, so no Go tests apply.
-- [ ] Commit, push `epic/823-exit-codes`, open PR against the repo (no merge).
+- None — CLI exit-path only; no provider/model flows, gateway routing, model catalogs, API-key management, or server/TUI provider plumbing touched.
 
 ## Risks and Mitigations
 
-- Risk: contract page drifts from code reality (documents behavior that does not exist yet).
-- Mitigation: explicit "current vs. contracted behavior" table and a traceability table mapping every code to its source constant/status/CLI path; page is labeled as the contract target for Slices 2–4.
+- Risk: a caller scripts against the old always-0 behavior.
+- Mitigation: intentional breaking fix per the ratified contract; stdout lines unchanged so log parsers keep working; contract page and engineering log record the behavior change.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -22,7 +22,7 @@
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.
 - `2026-07-20-subscription-auth-foundation-846-plan.md` — Epic #846 subscription-auth foundation: token-source, dynamic request auth, refresh cache, and registry plumbing (in implementation).
 - `2026-07-20-subscription-auth-foundation-846-impact-map.md` — Cross-surface impact map for Epic #846 provider credential plumbing.
-- `823-exit-codes.md` — Epic #823 Slice 1 (docs-only): ratify the headless CLI exit-code contract page for runs and goals.
+- `823-exit-codes.md` — Epic #823 headless CLI exit-code contract: Slice 1 (docs contract) merged; Slice 2 (terminal-event→exit-code mapping) in implementation.
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).

--- a/website/docs/reference/exit-codes.md
+++ b/website/docs/reference/exit-codes.md
@@ -8,8 +8,8 @@ import { Callout } from '@site/src/components/ui';
 
 This page is the **exit-code contract for headless `harnesscli` usage** — the one-shot streaming mode (`harnesscli -prompt ...`) and the streaming `continue` subcommand. It exists so shell scripts and CI pipelines can branch on a run's outcome via `$?` instead of parsing stdout.
 
-<Callout type="warning">
-**Contract status.** This page ratifies the target contract (tracking issue: epic #823, part of the kimi-code parity program #803). The implementation lands in later slices of that epic — see the [current vs. contracted behavior](#current-vs-contracted-behavior) table below for exactly which process outcomes change and which are already in effect. Until the implementation slices merge, treat the **Current** column as ground truth.
+<Callout type="info">
+**Contract status.** Tracking issue: epic #823 (part of the kimi-code parity program #803). The run terminal-event mapping (`0`/`1`/`2`/`6`/`130`) is **implemented and in effect**; the blocked exit `3` is ratified here and lands with slice 3 of the epic — until then a blocked headless run keeps streaming. See the [current vs. contracted behavior](#current-vs-contracted-behavior) table below for the per-outcome status. The single source of truth in code is `cmd/harnesscli/exitcodes.go`.
 </Callout>
 
 The contract adopts [kimi-code](https://github.com/MoonshotAI/kimi-code)'s headless codes where semantics align: kimi's `kimi -p` exits `0` when a goal completes, `3` when it blocks, `6` when it pauses, and non-zero on turn failure. Aligning on the same numbers means scripts written against one CLI keep working against the other.
@@ -113,16 +113,16 @@ This goal mapping is **documentation-only in this epic**. There is no goal-scope
 
 ## Current vs. contracted behavior
 
-This table is the reviewer-facing diff of process outcomes. Rows marked **unchanged** are already in effect; rows marked **changes** land with the implementation slices of epic #823.
+This table is the reviewer-facing diff of process outcomes. Rows marked **implemented** are in effect today; rows marked **changes** land with the remaining implementation slices of epic #823.
 
-| Outcome | Current exit code | Contracted exit code | Status |
+| Outcome | Pre-epic exit code | Contracted exit code | Status |
 |---|---|---|---|
-| `run.completed` (success) | `0` | `0` | Unchanged |
-| Client/usage/transport error | `1` | `1` | Unchanged |
-| SIGINT/SIGTERM interrupt | `130` | `130` | Unchanged |
-| `run.failed` | `0` | `2` | **Changes** — today every terminal event exits `0` (`cmd/harnesscli/main.go:219-220`, `cmd/harnesscli/runctl.go:324-330`) |
-| `run.cancelled` | `0` | `6` | **Changes** — same unconditional-`0` paths |
-| Blocked, stdin non-interactive | (streams forever) | `3` | **Changes** — today the CLI waits on the SSE stream indefinitely |
+| `run.completed` (success) | `0` | `0` | Implemented (unchanged) |
+| Client/usage/transport error | `1` | `1` | Implemented (unchanged) |
+| SIGINT/SIGTERM interrupt | `130` | `130` | Implemented (unchanged) |
+| `run.failed` | `0` | `2` | **Implemented** (epic #823 slice 2) — was an unconditional `0` at the old `cmd/harnesscli/main.go:219-220` and `cmd/harnesscli/runctl.go:324-330` paths |
+| `run.cancelled` | `0` | `6` | **Implemented** (epic #823 slice 2) — same former unconditional-`0` paths |
+| Blocked, stdin non-interactive | (streams forever) | `3` | **Changes** (epic #823 slice 3) — today the CLI waits on the SSE stream indefinitely |
 
 ### stdout contract is unchanged
 


### PR DESCRIPTION
Parent epic: #823. Part of #803.

## What

Slice 2 of #823: failed and cancelled headless runs stop exiting 0. Implements the terminal-event mapping ratified by the Slice 1 contract page (`website/docs/reference/exit-codes.md`).

- **New `cmd/harnesscli/exitcodes.go`** — `exitSuccess`(0) / `exitClientError`(1) / `exitRunFailed`(2) / `exitBlocked`(3) / `exitCancelled`(6) / `exitInterrupted`(130) and `exitCodeForTerminalEvent(harness.EventType) int`: `run.completed` → 0, `run.failed` → 2, `run.cancelled` → 6, unknown/empty/non-terminal → 1 (defensive non-zero default so a scripting caller never mistakes an unrecognized outcome for success). `exitBlocked` is wired in Slice 3.
- **`run()`** (`cmd/harnesscli/main.go`) returns `exitCodeForTerminalEvent(...)` after printing the unchanged `terminal_event=` stdout line; literal `1`/`130` returns in `run()` and `handleStreamError()` replaced with the named constants so the contract has exactly one source of truth.
- **`runContinue()`** (`cmd/harnesscli/runctl.go`) gets the same mapping; `-no-stream` stays 0/1 and never opens the event stream.
- stdout contract preserved (`run_id=` / `terminal_event=` lines); only the process exit code changes.
- Docs: contract page status table updated (failed 0→2, cancelled 0→6 marked implemented; blocked →3 still Slice 3), engineering-log entry, plan file updated.

## TDD

Failing-first (`cmd/harnesscli/exitcodes_test.go`, red as compile-undefined before implementation): mapping table covering all three terminal events plus non-terminal/unknown/empty; constant-value pins (0/1/2/3/6/130); `httptest` SSE streams asserting `run()` and `runContinue()` return 0/2/6 for completed/failed/cancelled with `run_id=`/`terminal_event=` stdout preserved; `-no-stream` proven to exit 0 without requesting `/events`.

## Tests run

- `go test ./cmd/harnesscli/... -count=1` — green (all packages; no existing test relied on failed/cancelled exiting 0, so none needed changing).
- `go test ./internal/harness/... -count=1` — green.
- `go test ./test/e2e/... -count=1` — green.
- `gofmt -l cmd/harnesscli/` clean; `go vet ./cmd/harnesscli/` clean.
- `cd website && npm run build` — `[SUCCESS]` with `onBrokenLinks: 'throw'`.

## Out of scope (later slices)

Slice 3: exit 3 on blocked headless runs (`exitBlocked` wiring). Slice 4: e2e exit-code assertions + per-command doc updates.