### PR TITLE
feat(tui): /init — generate AGENTS.md for the current workspace

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -200,6 +200,14 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeTitleCommand,
 		},
 		{
+			Name:        "init",
+			Description: "Generate an AGENTS.md for this workspace",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeInitCommand,
+		},
+		{
 			Name:        "rewind",
 			Description: "Choose and confirm a destructive session rewind",
 			Handler:     func(cmd Command) CommandResult { return CommandResult{Status: CmdOK} },

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"attach", "cancel", "clear", "config", "context", "cost", "dashboard", "doctor", "export", "help", "history", "hooks", "keys",
+		"attach", "cancel", "clear", "config", "context", "cost", "dashboard", "doctor", "export", "help", "history", "hooks", "init", "keys",
 		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents", "rewind", "title",
 	}

--- a/cmd/harnesscli/tui/init_agents.go
+++ b/cmd/harnesscli/tui/init_agents.go
@@ -1,0 +1,121 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/messagebubble"
+	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
+)
+
+// initAgentsPrompt is the fixed prompt /init sends through the normal run
+// path. It instructs the model to inspect the workspace and return only the
+// AGENTS.md markdown; the TUI writes that markdown to <workspace>/AGENTS.md
+// when the run completes. Keep it deterministic: the completion write path
+// (extractAgentsMarkdown) relies on the reply being markdown, optionally
+// wrapped in a single code fence.
+const initAgentsPrompt = `Analyze this repository and write an AGENTS.md file for it.
+
+AGENTS.md gives coding agents the context they need to work effectively in a repo. Base everything on what you actually find in the workspace — never invent commands, structure, or conventions.
+
+Cover, in this order:
+1. Overview: one paragraph on what the project is and does.
+2. Layout: the top-level directories and what each contains.
+3. Commands: exact build, test, and lint commands verified against the repo's own tooling (go.mod, package.json, Makefile, CI config, etc.).
+4. Conventions: code style, testing patterns, and commit/PR rules an agent must follow.
+
+Keep the result under 150 lines. Output ONLY the final markdown content for AGENTS.md — no preamble, no explanation, no trailing commentary.`
+
+// executeInitCommand implements /init: it runs initAgentsPrompt against the
+// current workspace via the normal run path and, when the run completes,
+// writes the assistant's markdown to <workspace>/AGENTS.md (see
+// completeInitAgentsMd, driven by pendingInitAgentsMd). An existing AGENTS.md
+// is only overwritten when the user passes the explicit "confirm" token —
+// the same approval pattern as /rewind <id> confirm.
+func executeInitCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	if len(cmd.Args) > 1 || (len(cmd.Args) == 1 && cmd.Args[0] != "confirm") {
+		return []tea.Cmd{m.setStatusMsg("Usage: /init [confirm] — generate AGENTS.md for this workspace")}, false
+	}
+	confirmed := len(cmd.Args) == 1
+
+	ws := m.initWorkspace()
+	if _, err := os.Stat(filepath.Join(ws, "AGENTS.md")); err == nil && !confirmed {
+		return []tea.Cmd{m.setStatusMsg("AGENTS.md already exists — run /init confirm to overwrite")}, false
+	}
+	if m.runActive {
+		return []tea.Cmd{m.setStatusMsg("A run is already active — wait for it to finish before /init")}, false
+	}
+
+	// Record the generation prompt as the user turn and start the run. The
+	// transcript keeps the literal prompt (the truthful record of what was
+	// sent); the bubble shows a short label to keep the viewport readable.
+	m.pendingInitAgentsMd = true
+	m.lastAssistantText = ""
+	m.responseStarted = false
+	m.activeAssistantLineCount = 0
+	m.clearThinkingBar()
+	m.pendingLastMsg = "/init — generate AGENTS.md"
+	m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
+		Role:      "user",
+		Content:   initAgentsPrompt,
+		Timestamp: time.Now(),
+	})
+	m.appendMessageBubble(messagebubble.RoleUser, "Generate AGENTS.md for this workspace (/init)")
+	effModel, effProvider := m.effectiveModelAndProvider()
+	return []tea.Cmd{
+		m.setStatusMsg("Generating AGENTS.md..."),
+		startRunCmd(m.config.BaseURL, initAgentsPrompt, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, ws, m.config.APIKey),
+	}, false
+}
+
+// completeInitAgentsMd writes the markdown produced by a /init run to
+// <workspace>/AGENTS.md and reports the outcome via a status message. Called
+// from the RunCompletedMsg handler when pendingInitAgentsMd is set.
+func (m *Model) completeInitAgentsMd() tea.Cmd {
+	content := extractAgentsMarkdown(m.lastAssistantText)
+	if content == "" {
+		return m.setStatusMsg("AGENTS.md not written — the run produced no markdown")
+	}
+	path := filepath.Join(m.initWorkspace(), "AGENTS.md")
+	if err := os.WriteFile(path, []byte(content+"\n"), 0o644); err != nil {
+		return m.setStatusMsg("Could not write AGENTS.md: " + err.Error())
+	}
+	return m.setStatusMsg("Wrote " + path)
+}
+
+// initWorkspace returns the workspace root for /init, defaulting to the
+// process working directory when the TUI was started without one (mirrors
+// resolveWorkspacePath in cmd/harnesscli).
+func (m Model) initWorkspace() string {
+	if ws := strings.TrimSpace(m.config.Workspace); ws != "" {
+		return ws
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	return "."
+}
+
+// extractAgentsMarkdown converts a /init run's assistant reply into file
+// content: surrounding whitespace is trimmed and a single wrapping code fence
+// (```markdown or bare ```) is removed when present. Fences inside the
+// document are preserved.
+func extractAgentsMarkdown(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasPrefix(trimmed, "```") {
+		return trimmed
+	}
+	lines := strings.Split(trimmed, "\n")
+	lines = lines[1:] // drop the opening fence line
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if n := len(lines); n > 0 && strings.TrimSpace(lines[n-1]) == "```" {
+		lines = lines[:n-1]
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}

--- a/cmd/harnesscli/tui/init_agents_internal_test.go
+++ b/cmd/harnesscli/tui/init_agents_internal_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import "testing"
+
+// TestExtractAgentsMarkdown covers the markdown extraction used when the /init
+// run completes: the assistant reply becomes the AGENTS.md content, with a
+// single wrapping code fence removed when present.
+func TestExtractAgentsMarkdown(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain markdown passes through",
+			input: "# Title\n\nbody\n",
+			want:  "# Title\n\nbody",
+		},
+		{
+			name:  "markdown fence unwrapped",
+			input: "```markdown\n# Title\n\nbody\n```\n",
+			want:  "# Title\n\nbody",
+		},
+		{
+			name:  "bare fence unwrapped",
+			input: "```\n# Title\n```\n",
+			want:  "# Title",
+		},
+		{
+			name:  "unterminated fence still yields content",
+			input: "```markdown\n# Title\n",
+			want:  "# Title",
+		},
+		{
+			name:  "leading whitespace before fence",
+			input: "  \n```markdown\n# Title\n```\n",
+			want:  "# Title",
+		},
+		{
+			name:  "empty input stays empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace only stays empty",
+			input: "   \n  \n",
+			want:  "",
+		},
+		{
+			name:  "fence only yields empty",
+			input: "```markdown\n```\n",
+			want:  "",
+		},
+		{
+			name:  "inner fences are preserved",
+			input: "# Title\n\n```sh\ngo build ./...\n```\n",
+			want:  "# Title\n\n```sh\ngo build ./...\n```",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractAgentsMarkdown(tc.input); got != tc.want {
+				t.Errorf("extractAgentsMarkdown(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/harnesscli/tui/init_agents_test.go
+++ b/cmd/harnesscli/tui/init_agents_test.go
@@ -1,0 +1,323 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+	"go-agent-harness/internal/systemprompt"
+)
+
+// initModelForInit creates a Model whose workspace is a temp directory, so
+// /init's AGENTS.md write path stays inside test-controlled storage.
+func initModelForInit(t *testing.T) (tui.Model, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	ws := t.TempDir()
+	cfg := tui.DefaultTUIConfig()
+	cfg.Workspace = ws
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return m2.(tui.Model), ws
+}
+
+// runInitToCompletion simulates the harness accepting the /init run and the
+// assistant replying with the given markdown before the run completes.
+func runInitToCompletion(t *testing.T, m tui.Model, assistantText string) tui.Model {
+	t.Helper()
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-init"})
+	m = m2.(tui.Model)
+	if assistantText != "" {
+		m2, _ = m.Update(tui.AssistantDeltaMsg{Delta: assistantText})
+		m = m2.(tui.Model)
+	}
+	m2, _ = m.Update(tui.RunCompletedMsg{RunID: "run-init"})
+	return m2.(tui.Model)
+}
+
+func readAgentsFile(t *testing.T, ws string) (string, bool) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(ws, "AGENTS.md"))
+	if os.IsNotExist(err) {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("ReadFile AGENTS.md: %v", err)
+	}
+	return string(data), true
+}
+
+// TestInitCommand_GeneratesAndWritesAgentsMd verifies the happy path: /init
+// starts a run with the generation prompt, and when the run completes the
+// assistant's markdown is written to <workspace>/AGENTS.md.
+func TestInitCommand_GeneratesAndWritesAgentsMd(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init")
+	if got := m.StatusMsg(); !strings.Contains(got, "Generating AGENTS.md") {
+		t.Errorf("StatusMsg() = %q, want a 'Generating AGENTS.md' notice", got)
+	}
+
+	// The generation prompt must be recorded as the user turn (it is what the
+	// run sends to the harness).
+	tr := m.Transcript()
+	if len(tr) == 0 {
+		t.Fatal("transcript empty after /init; the generation prompt was not submitted")
+	}
+	last := tr[len(tr)-1]
+	if last.Role != "user" {
+		t.Errorf("last transcript role = %q, want user", last.Role)
+	}
+	for _, want := range []string{"AGENTS.md", "build", "test"} {
+		if !strings.Contains(last.Content, want) {
+			t.Errorf("generation prompt must mention %q; got:\n%s", want, last.Content)
+		}
+	}
+
+	markdown := "# My Project\n\n## Build\n\n`go build ./...`\n"
+	m = runInitToCompletion(t, m, markdown)
+
+	content, ok := readAgentsFile(t, ws)
+	if !ok {
+		t.Fatal("AGENTS.md was not written after the /init run completed")
+	}
+	if content != markdown {
+		t.Errorf("AGENTS.md content = %q, want %q", content, markdown)
+	}
+	if got := m.StatusMsg(); !strings.Contains(got, "AGENTS.md") {
+		t.Errorf("StatusMsg() = %q, want confirmation of the written path", got)
+	}
+}
+
+// TestInitCommand_UnwrapsFencedMarkdown verifies that when the assistant wraps
+// the document in a ```markdown fence, the file gets the inner content only.
+func TestInitCommand_UnwrapsFencedMarkdown(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init")
+	m = runInitToCompletion(t, m, "```markdown\n# Fenced Project\n\nbody\n```\n")
+
+	content, ok := readAgentsFile(t, ws)
+	if !ok {
+		t.Fatal("AGENTS.md was not written")
+	}
+	if strings.Contains(content, "```") {
+		t.Errorf("AGENTS.md must not contain the wrapping fence, got:\n%s", content)
+	}
+	if !strings.Contains(content, "# Fenced Project") {
+		t.Errorf("AGENTS.md missing inner content, got:\n%s", content)
+	}
+}
+
+// TestInitCommand_RefusesOverwriteWithoutConfirm verifies that /init with an
+// existing AGENTS.md does not start a run and leaves the file untouched.
+func TestInitCommand_RefusesOverwriteWithoutConfirm(t *testing.T) {
+	m, ws := initModelForInit(t)
+	if err := os.WriteFile(filepath.Join(ws, "AGENTS.md"), []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	m = sendSlashCommand(m, "/init")
+
+	if m.RunActive() {
+		t.Error("/init must not start a run when AGENTS.md exists without confirm")
+	}
+	if got := m.StatusMsg(); !strings.Contains(got, "already exists") || !strings.Contains(got, "/init confirm") {
+		t.Errorf("StatusMsg() = %q, want an 'already exists' + '/init confirm' hint", got)
+	}
+	if content, _ := readAgentsFile(t, ws); content != "ORIGINAL" {
+		t.Errorf("AGENTS.md modified without confirm: %q", content)
+	}
+}
+
+// TestInitCommand_ConfirmOverwrites verifies that /init confirm runs the
+// generation and replaces the existing file on completion.
+func TestInitCommand_ConfirmOverwrites(t *testing.T) {
+	m, ws := initModelForInit(t)
+	if err := os.WriteFile(filepath.Join(ws, "AGENTS.md"), []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("seed AGENTS.md: %v", err)
+	}
+
+	m = sendSlashCommand(m, "/init confirm")
+	m = runInitToCompletion(t, m, "# Regenerated\n")
+
+	content, ok := readAgentsFile(t, ws)
+	if !ok {
+		t.Fatal("AGENTS.md missing after /init confirm")
+	}
+	if content != "# Regenerated\n" {
+		t.Errorf("AGENTS.md = %q, want regenerated content", content)
+	}
+}
+
+// TestInitCommand_RefusedWhileRunActive verifies /init does not hijack an
+// in-flight run: it refuses, and the other run's completion writes nothing.
+func TestInitCommand_RefusedWhileRunActive(t *testing.T) {
+	m, ws := initModelForInit(t)
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-other"})
+	m = m2.(tui.Model)
+
+	m = sendSlashCommand(m, "/init")
+	if got := m.StatusMsg(); !strings.Contains(got, "run") {
+		t.Errorf("StatusMsg() = %q, want a 'run already active' explanation", got)
+	}
+
+	// The other run finishes producing markdown — no AGENTS.md may be written.
+	m2, _ = m.Update(tui.AssistantDeltaMsg{Delta: "# Some Doc\n"})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.RunCompletedMsg{RunID: "run-other"})
+	m = m2.(tui.Model)
+
+	if _, ok := readAgentsFile(t, ws); ok {
+		t.Error("AGENTS.md must not be written when /init was refused")
+	}
+}
+
+// TestInitCommand_EmptyOutputDoesNotWrite verifies that a run producing no
+// usable markdown leaves the workspace without AGENTS.md.
+func TestInitCommand_EmptyOutputDoesNotWrite(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init")
+	m = runInitToCompletion(t, m, "")
+
+	if _, ok := readAgentsFile(t, ws); ok {
+		t.Error("AGENTS.md must not be written when the run produced no markdown")
+	}
+	if got := m.StatusMsg(); !strings.Contains(got, "AGENTS.md") {
+		t.Errorf("StatusMsg() = %q, want an explanation that nothing was written", got)
+	}
+}
+
+// TestInitCommand_RunFailureWritesNothing verifies that a failed run clears
+// the pending write: no file appears, and a later normal run completing with
+// markdown does not trigger a stale write.
+func TestInitCommand_RunFailureWritesNothing(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init")
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-init"})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.RunFailedMsg{RunID: "run-init", Error: "boom"})
+	m = m2.(tui.Model)
+
+	if _, ok := readAgentsFile(t, ws); ok {
+		t.Error("AGENTS.md must not be written after a failed run")
+	}
+
+	// A subsequent ordinary run completing with markdown must not write either.
+	m2, _ = m.Update(tui.RunStartedMsg{RunID: "run-next"})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.AssistantDeltaMsg{Delta: "# Not Agents\n"})
+	m = m2.(tui.Model)
+	m2, _ = m.Update(tui.RunCompletedMsg{RunID: "run-next"})
+	m = m2.(tui.Model)
+
+	if _, ok := readAgentsFile(t, ws); ok {
+		t.Error("stale /init state leaked into a later run and wrote AGENTS.md")
+	}
+}
+
+// TestInitCommand_UnknownArgShowsUsage verifies /init rejects unknown args.
+func TestInitCommand_UnknownArgShowsUsage(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init bogus")
+
+	if got := m.StatusMsg(); !strings.Contains(got, "Usage: /init") {
+		t.Errorf("StatusMsg() = %q, want a usage hint", got)
+	}
+	if _, ok := readAgentsFile(t, ws); ok {
+		t.Error("no file may be written for an invalid invocation")
+	}
+}
+
+// TestInitCommand_WrittenFilePickedUpBySystemPrompt verifies the file /init
+// writes is exactly what internal/systemprompt injects into the next run's
+// static prompt (the AGENTS_MD section via readAgentsMd).
+func TestInitCommand_WrittenFilePickedUpBySystemPrompt(t *testing.T) {
+	m, ws := initModelForInit(t)
+
+	m = sendSlashCommand(m, "/init")
+	markdown := "# Picked Up Project\n\n## Test\n\n`go test ./...`\n"
+	m = runInitToCompletion(t, m, markdown)
+
+	engine, err := systemprompt.NewFileEngine(makeInitPromptFixture(t))
+	if err != nil {
+		t.Fatalf("NewFileEngine: %v", err)
+	}
+	out, err := engine.Resolve(systemprompt.ResolveRequest{Model: "gpt-4o", WorkspacePath: ws})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !strings.Contains(out.StaticPrompt, "[SECTION AGENTS_MD]") {
+		t.Errorf("resolved prompt missing AGENTS_MD section:\n%s", out.StaticPrompt)
+	}
+	if !strings.Contains(out.StaticPrompt, "# Picked Up Project") {
+		t.Errorf("resolved prompt missing written AGENTS.md content:\n%s", out.StaticPrompt)
+	}
+}
+
+// TestInitCommand_Registered verifies the init command is registered.
+func TestInitCommand_Registered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("init") {
+		t.Fatal("built-in registry must register the init command")
+	}
+	entry, ok := r.Lookup("init")
+	if !ok || entry.Description == "" {
+		t.Fatal("init command must have a description for /help and autocomplete")
+	}
+}
+
+// TestInitCommand_InSlashComplete verifies /init appears in autocomplete.
+func TestInitCommand_InSlashComplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 120, 40)
+	m = typeIntoModel(m, "/ini")
+	if v := m.View(); !strings.Contains(v, "init") {
+		t.Errorf("slash-complete must contain 'init' when typing '/ini'; got:\n%s", v)
+	}
+}
+
+// makeInitPromptFixture writes a minimal prompt catalog usable by
+// systemprompt.NewFileEngine (mirrors internal/harness's runner fixture).
+func makeInitPromptFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	write := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	write("catalog.yaml", `version: 1
+defaults:
+  intent: general
+  model_profile: default
+intents:
+  general: intents/general.md
+model_profiles:
+  - name: default
+    match: "*"
+    file: models/default.md
+extensions:
+  behaviors_dir: extensions/behaviors
+  talents_dir: extensions/talents
+`)
+	write("base/main.md", "BASE")
+	write("intents/general.md", "INTENT")
+	write("models/default.md", "MODEL_DEFAULT")
+	write("extensions/behaviors/.keep", "")
+	write("extensions/talents/.keep", "")
+	return root
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -281,6 +281,11 @@ type Model struct {
 	// chars) so RunStartedMsg can record it on the session entry as LastMsg.
 	pendingLastMsg string
 
+	// pendingInitAgentsMd is true while a /init generation run is in flight;
+	// when the run completes, the assistant's markdown is written to
+	// <workspace>/AGENTS.md (see init_agents.go).
+	pendingInitAgentsMd bool
+
 	// Search overlay state (for /search and /history commands).
 	searchResults     []SearchResult
 	searchQuery       string
@@ -2997,6 +3002,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.runActive = false
 		m.cancelRun = nil
 		m.clearThinkingBar()
+		// A completed /init run writes its markdown to <workspace>/AGENTS.md.
+		if m.pendingInitAgentsMd {
+			m.pendingInitAgentsMd = false
+			cmds = append(cmds, m.completeInitAgentsMd())
+		}
 
 	case RunFailedMsg:
 		m.runActive = false
@@ -3005,6 +3015,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.activeAssistantLineCount = 0
 		m.responseStarted = false
 		m.clearThinkingBar()
+		if m.pendingInitAgentsMd {
+			m.pendingInitAgentsMd = false
+			cmds = append(cmds, m.setStatusMsg("AGENTS.md generation failed"))
+		}
 		errMsg := "run failed"
 		if msg.Error != "" {
 			errMsg = msg.Error

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -12,6 +12,7 @@ Command Registry - 120x40
 /help — Show help dialog
 /history — Search across stored session metadata
 /hooks — List loaded and skipped lifecycle hooks
+/init — Generate an AGENTS.md for this workspace
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -12,6 +12,7 @@ Command Registry - 200x50
 /help — Show help dialog
 /history — Search across stored session metadata
 /hooks — List loaded and skipped lifecycle hooks
+/init — Generate an AGENTS.md for this workspace
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -12,6 +12,7 @@ Command Registry - 80x24
 /help — Show help dialog
 /history — Search across stored session metadata
 /hooks — List loaded and skipped lifecycle hooks
+/init — Generate an AGENTS.md for this workspace
 /keys — Manage provider API keys
 /model — Select AI model
 /new — Start a new session (resets conversation)

--- a/docs/plans/822-qol-commands.md
+++ b/docs/plans/822-qol-commands.md
@@ -1,6 +1,72 @@
-# Plan: /title — name sessions and show the title in statusbar and picker
+# Plan: quality-of-life commands — epic #822 slices
 
-Epic: #822 (slice 1 of 5). Parent: #803. Branch: `epic/822-qol-commands`.
+Epic: #822. Parent: #803. Slice 1 branch: `epic/822-qol-commands` (merged, PR #842). Slice 2 branch: `epic/822-qol-commands-s2`.
+
+---
+
+# Slice 2: /init — generate AGENTS.md for the current workspace
+
+## Context
+
+- Problem: `internal/systemprompt` auto-injects `<workspace>/AGENTS.md` into the system prompt when present (`readAgentsMd`, engine.go), but nothing helps users create one.
+- User impact: `/init` produces a starter AGENTS.md via a normal harness run; the next run's system prompt contains it.
+- Constraints: write happens client-side after the run completes; overwrite requires explicit confirm; strict TDD.
+
+## Scope
+
+- In scope:
+  - `init` command in `builtinCommandEntries()` (`cmd_parser.go`).
+  - New `cmd/harnesscli/tui/init_agents.go`: fixed generation prompt (`initAgentsPrompt`), `executeInitCommand`, `extractAgentsMarkdown` (unwrap a single outer ``` fence), and the completion write path.
+  - Model state `pendingInitAgentsMd`; on `RunCompletedMsg` with the flag set, write `<workspace>/AGENTS.md` (workspace = `m.config.Workspace`, falling back to cwd like `resolveWorkspacePath`); on `RunFailedMsg`, clear the flag without writing.
+  - Overwrite guard: existing AGENTS.md + `/init` → hint to run `/init confirm`; `/init confirm` proceeds. Mirrors the `/rewind <id> confirm` approval pattern.
+  - `/init` refused while a run is active (avoids mixing the assistant-text accumulator).
+  - Docs: one row in `website/docs/cli/tui.md`, rows in `docs/ux-paths.md`, this plan.
+- Out of scope: server changes; other epic slices (`/add-dir`, `/feedback`, `/upgrade`).
+
+## Documentation Contract
+
+- Feature status: `implemented`
+- Public docs affected: `website/docs/cli/tui.md`, `docs/ux-paths.md`
+- Spec docs to update before code: none (epic #822 body is the contract)
+- Implementation notes to add after code: none required
+
+## Test Plan (TDD)
+
+- New failing tests to add first (`cmd/harnesscli/tui/init_agents_test.go`):
+  - `/init` starts a run carrying the generation prompt (observed via transcript), sets status, and writes `<workspace>/AGENTS.md` from the assistant markdown on completion.
+  - Existing AGENTS.md + `/init` → no run, file untouched, hint message. `/init confirm` → run proceeds, file overwritten on completion.
+  - `/init` while a run is active → refused; completion of the other run writes nothing.
+  - Empty/fence-only assistant output → no file written. Run failure → no file, flag cleared.
+  - `extractAgentsMarkdown` table: plain passthrough, ```markdown unwrap, ``` unwrap, unterminated fence, empty.
+  - Written file is picked up by `internal/systemprompt` (`NewFileEngine` + `Resolve` on a temp fixture; AGENTS_MD section contains the content).
+  - Registration: registry + slash-complete (`/in`).
+- Existing tests to update: `TestTUI364_RegistryCompleteness` known-commands list (add `init`).
+- Regression tests required: none beyond the above (additive change).
+
+## Cross-Surface Impact Map
+
+- None required: no provider/model flow, gateway, catalog, API-key, or server changes. The run uses the existing `startRunCmd` path unchanged.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (acceptance: repo without AGENTS.md → `/init` writes a plausible file; next run's prompt contains it — covered by the systemprompt integration test).
+- [x] Write failing tests first.
+- [x] Implement minimal code changes.
+- [x] Update docs (`tui.md`, `ux-paths.md`, plan).
+- [x] Run `go test ./cmd/harnesscli/... -count=1`; gofmt + go vet clean.
+- [ ] Push branch, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: model wraps the markdown in ``` fences → `extractAgentsMarkdown` strips a single outer fence; fence-only/empty output is treated as failure and nothing is written.
+- Risk: concurrent run mixing up `lastAssistantText` → `/init` refused while `runActive`.
+- Risk: tests writing outside temp dirs → every test sets `cfg.Workspace = t.TempDir()` (and HOME where the store matters).
+
+---
+
+# Slice 1: /title — name sessions and show the title in statusbar and picker
+
+Status: **implemented and merged** (PR #842). Original slice-1 plan below for reference.
 
 ## Context
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,7 +5,7 @@
 - `2026-07-19-issue-818-clipboard-image-plan.md` — Epic #818 slice 1: read images from the system clipboard into a temp file (in implementation).
 - `2026-07-19-issue-818-clipboard-image-impact-map.md` — One-page provider/model impact map for epic #818 slice 1.
 - `810-theme-system.md` — Theme system epic #810, slice 1: token schema + JSON loader with base-palette fallback (in implementation).
-- `822-qol-commands.md` — Epic #822 slice 1: `/title` command for naming sessions, shown in statusbar and session picker (in implementation).
+- `822-qol-commands.md` — Epic #822 plan. Slice 1 (`/title`, merged PR #842); slice 2 (`/init` AGENTS.md generation, in implementation).
 
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.

--- a/docs/ux-paths.md
+++ b/docs/ux-paths.md
@@ -339,6 +339,10 @@ Registry (`cmd_parser.go:79-194`): clear, context, export, help, keys, model, qu
 | `/title <text>` | set session title; persists; shown in statusbar + picker | OK | `model.go` (`executeTitleCommand`); title_test.go |
 | `/title` (no args) | show current title / "No title set" hint | OK | title_test.go |
 | `/title clear` | remove session title | OK | title_test.go |
+| `/init` | run generation prompt; write `<workspace>/AGENTS.md` on completion | OK | `init_agents.go` (`executeInitCommand`); init_agents_test.go |
+| `/init` (AGENTS.md exists) | refuse overwrite; hint `/init confirm`; file untouched | OK | init_agents_test.go |
+| `/init confirm` | overwrite existing AGENTS.md | OK | init_agents_test.go |
+| `/init` (run active) | refuse; no write on the other run's completion | OK | init_agents_test.go |
 | `/search <q>` | search transcript | OK | `model.go:1055-1068`; search_test.go (12+) |
 | `/search` (no args) | usage hint | OK | `model.go:1056-1058`; `TestSearch_BT002_EmptyQueryStatusMessage` |
 | `/history <q>` | search session meta | OK | `model.go:1070-1083`; `TestSearch_BT006_HistorySearchOpensOverlay` |

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -139,6 +139,7 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/profiles` | View and select a capability profile |
 | `/sessions` | Browse and resume past sessions |
 | `/title [text]` | Set or show the current session's title (`/title clear` removes it). Shown in the status bar and the `/sessions` picker, persisted across restarts |
+| `/init [confirm]` | Generate an `AGENTS.md` for the current workspace via a harness run. If `AGENTS.md` already exists, run `/init confirm` to overwrite it |
 | `/new` | Start a fresh conversation (resets conversation ID) |
 | `/search <query>` | Search the current session transcript |
 | `/history <query>` | Search across stored session metadata |


### PR DESCRIPTION
Parent epic: #822. Part of #803.

## What

Adds the `/init` slash command (slice 2 of #822):

- Sends a fixed generation prompt (top-level layout, build/test/lint commands, conventions) through the existing `startRunCmd` run path; the literal prompt is recorded in the transcript, the viewport bubble shows a short label.
- On `RunCompletedMsg`, the assistant's markdown is written to `<workspace>/AGENTS.md` (workspace = TUI config workspace, falling back to cwd like `resolveWorkspacePath`). `extractAgentsMarkdown` strips a single wrapping ``` fence; empty/fence-only output writes nothing.
- `RunFailedMsg` clears the pending write so no stale state leaks into later runs.
- Existing `AGENTS.md` requires `/init confirm` to overwrite — the same explicit-confirm pattern as `/rewind <id> confirm`. Without confirm: no run started, file untouched.
- `/init` is refused while a run is active (protects the assistant-text accumulator).
- The written file is exactly what `internal/systemprompt`'s `readAgentsMd` injects as the `AGENTS_MD` section of the next run's static prompt — covered by an integration test using `systemprompt.NewFileEngine` + `Resolve`.

## Tests (TDD — tests written first, watched fail, then implemented)

- Model-level: happy-path write + prompt recorded as the user turn, fence unwrap, overwrite refusal without confirm, confirm overwrite, run-active refusal (the other run's completion writes nothing), empty output, run failure (incl. stale-flag check on a later run), unknown-arg usage, systemprompt pickup, registry + slash-complete registration.
- Pure-function table test for `extractAgentsMarkdown` (9 cases) in `init_agents_internal_test.go`.
- `TestTUI364_RegistryCompleteness` inventory extended with `init`.

`go test ./cmd/harnesscli/... -count=1` — 27 packages ok, zero FAIL. gofmt/go vet clean on touched files.

## Docs

- `website/docs/cli/tui.md`: slash-command table row.
- `docs/ux-paths.md`: /init rows in the command table.
- Plan updated: `docs/plans/822-qol-commands.md` (+ plans index).