### PR TITLE
feat(cli): add harnesscli service start/stop/status lifecycle commands

### DIFF
--- a/cmd/harnesscli/service.go
+++ b/cmd/harnesscli/service.go
@@ -5,21 +5,26 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"go-agent-harness/internal/config"
 )
 
-// This file implements "harnesscli service install|uninstall" — user-level OS
-// service management for harnessd (launchd on macOS, systemd --user on Linux).
-// The generated unit runs harnessd with the same address resolution the daemon
-// itself uses (internal/config: default :8080, HARNESS_ADDR override), passed
-// through the unit's environment. Lifecycle subcommands (start/stop/status)
-// land in the next slice; here they are recognized stubs.
+// This file implements "harnesscli service install|uninstall|start|stop|status"
+// — user-level OS service management for harnessd (launchd on macOS, systemd
+// --user on Linux). The generated unit runs harnessd with the same address
+// resolution the daemon itself uses (internal/config: default :8080,
+// HARNESS_ADDR override), passed through the unit's environment. Lifecycle
+// commands shell out to launchctl/systemctl behind the injectable
+// serviceRunLifecycle runner; unit tests substitute a recording fake and never
+// exec real service managers.
 
 const (
 	// serviceLabel is the launchd job label and the reverse-DNS stem of the
@@ -37,15 +42,29 @@ const (
 // versa.
 var servicePlatform = runtime.GOOS
 
-// serviceRunLifecycle executes a lifecycle tool (launchctl/systemctl). It is a
-// var so tests can substitute a recording fake — unit tests must never exec
-// real service managers.
+// serviceRunLifecycle executes a lifecycle tool (launchctl/systemctl). On
+// failure the returned error wraps the tool's combined output so callers
+// surface actionable messages (e.g. "Boot-out failed: 3: No such process");
+// on success all output is discarded so chatty verbs like "launchctl print"
+// stay quiet. It is a var so tests can substitute a recording fake — unit
+// tests must never exec real service managers.
 var serviceRunLifecycle = func(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
-	cmd.Stdout = stderr
-	cmd.Stderr = stderr
-	return cmd.Run()
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		if trimmed := strings.TrimSpace(out.String()); trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
+	return nil
 }
+
+// serviceHealthClient probes the daemon's /healthz endpoint. The timeout is
+// short: a local daemon answers in milliseconds or not at all.
+var serviceHealthClient = &http.Client{Timeout: 3 * time.Second}
 
 // serviceOptions carries the resolved values embedded in a generated unit
 // file. All fields must be absolute (or address) values — the renderers are
@@ -75,7 +94,7 @@ func (o serviceOptions) stderrLogPath() string {
 func runService(args []string) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "harnesscli service: subcommand required")
-		fmt.Fprintln(stderr, "usage: harnesscli service <install|uninstall> [--flags]")
+		fmt.Fprintln(stderr, "usage: harnesscli service <install|uninstall|start|stop|status> [--flags]")
 		return 1
 	}
 	switch args[0] {
@@ -83,11 +102,14 @@ func runService(args []string) int {
 		return runServiceInstall(args[1:])
 	case "uninstall":
 		return runServiceUninstall(args[1:])
-	case "start", "stop", "status":
-		fmt.Fprintf(stderr, "harnesscli service %s: not yet implemented (install and uninstall are available; lifecycle commands land in the next slice)\n", args[0])
-		return 1
+	case "start":
+		return runServiceStart(args[1:])
+	case "stop":
+		return runServiceStop(args[1:])
+	case "status":
+		return runServiceStatus(args[1:])
 	default:
-		fmt.Fprintf(stderr, "harnesscli service: unknown subcommand %q (try: install, uninstall)\n", args[0])
+		fmt.Fprintf(stderr, "harnesscli service: unknown subcommand %q (try: install, uninstall, start, stop, status)\n", args[0])
 		return 1
 	}
 }
@@ -103,6 +125,177 @@ func serviceUnitPath(platform, home string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported platform %q (user services are supported on macOS via launchd and Linux via systemd --user)", platform)
 	}
+}
+
+// requireInstalledUnit resolves the unit path for the current platform and
+// verifies the unit file exists. On failure it prints the error to stderr and
+// returns ok=false; lifecycle commands must not touch the service manager
+// before install.
+func requireInstalledUnit(verb string) (unitPath string, ok bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service %s: resolve home directory: %v\n", verb, err)
+		return "", false
+	}
+	unitPath, err = serviceUnitPath(servicePlatform, home)
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service %s: %v\n", verb, err)
+		return "", false
+	}
+	if _, err := os.Stat(unitPath); os.IsNotExist(err) {
+		fmt.Fprintf(stderr, "harnesscli service %s: service not installed (no unit file at %s); run 'harnesscli service install' first\n", verb, unitPath)
+		return "", false
+	} else if err != nil {
+		fmt.Fprintf(stderr, "harnesscli service %s: stat unit file: %v\n", verb, err)
+		return "", false
+	}
+	return unitPath, true
+}
+
+// guiServiceTarget returns the launchd domain target ("gui/<uid>") or, when
+// withLabel is true, the full service target ("gui/<uid>/<label>").
+func guiServiceTarget(withLabel bool) string {
+	target := fmt.Sprintf("gui/%d", os.Getuid())
+	if withLabel {
+		target += "/" + serviceLabel
+	}
+	return target
+}
+
+// runServiceStart implements "harnesscli service start".
+func runServiceStart(args []string) int {
+	fs := flag.NewFlagSet("service start", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	unitPath, ok := requireInstalledUnit("start")
+	if !ok {
+		return 1
+	}
+
+	switch servicePlatform {
+	case "darwin":
+		if err := serviceRunLifecycle("launchctl", "bootstrap", guiServiceTarget(false), unitPath); err != nil {
+			// Bootstrap fails when the job is already loaded; kickstart -k
+			// restarts it instead, so "start" is idempotent for callers.
+			if kerr := serviceRunLifecycle("launchctl", "kickstart", "-k", guiServiceTarget(true)); kerr != nil {
+				fmt.Fprintf(stderr, "harnesscli service start: launchctl bootstrap: %v\n", err)
+				return 1
+			}
+			fmt.Fprintln(stdout, "harnessd service restarted (already loaded)")
+			return 0
+		}
+	case "linux":
+		if err := serviceRunLifecycle("systemctl", "--user", "start", serviceSystemdUnitName); err != nil {
+			fmt.Fprintf(stderr, "harnesscli service start: %v\n", err)
+			return 1
+		}
+	default:
+		fmt.Fprintf(stderr, "harnesscli service start: unsupported platform %q (user services are supported on macOS via launchd and Linux via systemd --user)\n", servicePlatform)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "harnessd service started")
+	return 0
+}
+
+// runServiceStop implements "harnesscli service stop".
+func runServiceStop(args []string) int {
+	fs := flag.NewFlagSet("service stop", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if _, ok := requireInstalledUnit("stop"); !ok {
+		return 1
+	}
+
+	switch servicePlatform {
+	case "darwin":
+		if err := serviceRunLifecycle("launchctl", "bootout", guiServiceTarget(true)); err != nil {
+			fmt.Fprintf(stderr, "harnesscli service stop: %v\n", err)
+			return 1
+		}
+	case "linux":
+		if err := serviceRunLifecycle("systemctl", "--user", "stop", serviceSystemdUnitName); err != nil {
+			fmt.Fprintf(stderr, "harnesscli service stop: %v\n", err)
+			return 1
+		}
+	default:
+		fmt.Fprintf(stderr, "harnesscli service stop: unsupported platform %q (user services are supported on macOS via launchd and Linux via systemd --user)\n", servicePlatform)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "harnessd service stopped")
+	return 0
+}
+
+// runServiceStatus implements "harnesscli service status". It reports three
+// layers: installed (unit file present, enforced by requireInstalledUnit),
+// running (service-manager query), and healthy (HTTP probe of the daemon's
+// /healthz). A query error from the service manager means "not running" —
+// both "launchctl print" and "systemctl --user is-active" exit non-zero for
+// that normal state — so it is reported, not treated as a command failure.
+func runServiceStatus(args []string) int {
+	fs := flag.NewFlagSet("service status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	baseURL := fs.String("base-url", "http://localhost:8080", "harness API base URL for the health probe")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	unitPath, ok := requireInstalledUnit("status")
+	if !ok {
+		return 1
+	}
+
+	if !serviceUnitRunning(servicePlatform) {
+		fmt.Fprintln(stdout, "status: installed, not running")
+		fmt.Fprintf(stdout, "unit: %s\n", unitPath)
+		fmt.Fprintln(stdout, "hint: run 'harnesscli service start'")
+		return 0
+	}
+
+	fmt.Fprintln(stdout, "status: running")
+	fmt.Fprintf(stdout, "unit: %s\n", unitPath)
+	healthURL := strings.TrimRight(*baseURL, "/") + "/healthz"
+	if err := probeServiceHealth(healthURL); err != nil {
+		fmt.Fprintf(stdout, "health: unreachable (%s: %v)\n", healthURL, err)
+		return 0
+	}
+	fmt.Fprintf(stdout, "health: healthy (%s)\n", healthURL)
+	return 0
+}
+
+// serviceUnitRunning queries the platform service manager for the
+// loaded/active state of the harnessd unit.
+func serviceUnitRunning(platform string) bool {
+	switch platform {
+	case "darwin":
+		return serviceRunLifecycle("launchctl", "print", guiServiceTarget(true)) == nil
+	case "linux":
+		return serviceRunLifecycle("systemctl", "--user", "is-active", serviceSystemdUnitName) == nil
+	default:
+		return false
+	}
+}
+
+// probeServiceHealth GETs the daemon's health endpoint and requires a 2xx
+// response.
+func probeServiceHealth(healthURL string) error {
+	resp, err := serviceHealthClient.Get(healthURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // renderServiceUnit renders the unit file for the given platform.
@@ -334,7 +527,7 @@ func unloadServiceBestEffort(platform string) {
 	switch platform {
 	case "darwin":
 		name = "launchctl"
-		args = []string{"bootout", fmt.Sprintf("gui/%d/%s", os.Getuid(), serviceLabel)}
+		args = []string{"bootout", guiServiceTarget(true)}
 	case "linux":
 		name = "systemctl"
 		args = []string{"--user", "disable", "--now", serviceSystemdUnitName}

--- a/cmd/harnesscli/service_test.go
+++ b/cmd/harnesscli/service_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,10 +19,28 @@ type recordedCommand struct {
 	args []string
 }
 
+// serviceRunnerFake records lifecycle-tool invocations and returns queued
+// errors in order (nil once the queue is drained), so tests can simulate
+// already-loaded, not-loaded, and failing service managers.
+type serviceRunnerFake struct {
+	calls []recordedCommand
+	errs  []error
+}
+
+func (f *serviceRunnerFake) run(name string, args ...string) error {
+	f.calls = append(f.calls, recordedCommand{name: name, args: append([]string(nil), args...)})
+	if len(f.errs) == 0 {
+		return nil
+	}
+	err := f.errs[0]
+	f.errs = f.errs[1:]
+	return err
+}
+
 // setupServiceTest isolates the service command surface: stdout/stderr are
 // captured, the platform is forced, and the lifecycle runner is replaced with
 // a recording fake so tests never exec real launchctl/systemctl.
-func setupServiceTest(t *testing.T, platform string) (outBuf, errBuf *bytes.Buffer, calls *[]recordedCommand) {
+func setupServiceTest(t *testing.T, platform string) (outBuf, errBuf *bytes.Buffer, runner *serviceRunnerFake) {
 	t.Helper()
 	origOut, origErr := stdout, stderr
 	origPlatform := servicePlatform
@@ -28,18 +49,49 @@ func setupServiceTest(t *testing.T, platform string) (outBuf, errBuf *bytes.Buff
 	outBuf, errBuf = &bytes.Buffer{}, &bytes.Buffer{}
 	stdout, stderr = outBuf, errBuf
 	servicePlatform = platform
-	calls = &[]recordedCommand{}
-	serviceRunLifecycle = func(name string, args ...string) error {
-		*calls = append(*calls, recordedCommand{name: name, args: append([]string(nil), args...)})
-		return nil
-	}
+	runner = &serviceRunnerFake{}
+	serviceRunLifecycle = runner.run
 
 	t.Cleanup(func() {
 		stdout, stderr = origOut, origErr
 		servicePlatform = origPlatform
 		serviceRunLifecycle = origRunner
 	})
-	return outBuf, errBuf, calls
+	return outBuf, errBuf, runner
+}
+
+// requireCalls asserts the exact sequence of lifecycle-tool invocations.
+func requireCalls(t *testing.T, got []recordedCommand, want ...recordedCommand) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("runner calls: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i].name != want[i].name || strings.Join(got[i].args, " ") != strings.Join(want[i].args, " ") {
+			t.Errorf("call %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+// guiDomain is the launchd user domain for the current uid.
+func guiDomain() string { return fmt.Sprintf("gui/%d", os.Getuid()) }
+
+// installServiceForTest installs a unit with a fake binary via the real
+// install command and returns the unit path.
+func installServiceForTest(t *testing.T, platform string) string {
+	t.Helper()
+	if code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"}); code != 0 {
+		t.Fatalf("install exit code: got %d", code)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	unitPath, err := serviceUnitPath(platform, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return unitPath
 }
 
 func writeFakeHarnessd(t *testing.T) (binDir, binPath string) {
@@ -121,7 +173,7 @@ func TestServiceRenderSystemdUnit(t *testing.T) {
 func TestServiceInstallLaunchdWritesFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	out, _, calls := setupServiceTest(t, "darwin")
+	out, _, runner := setupServiceTest(t, "darwin")
 
 	code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"})
 	if code != 0 {
@@ -143,9 +195,9 @@ func TestServiceInstallLaunchdWritesFile(t *testing.T) {
 	if info, err := os.Stat(filepath.Join(home, ".harness", "logs")); err != nil || !info.IsDir() {
 		t.Errorf("expected log dir ~/.harness/logs to be created: %v", err)
 	}
-	// Slice 1 install writes the unit only; it must not bootstrap/start anything.
-	if len(*calls) != 0 {
-		t.Errorf("install must not invoke lifecycle tools, got %v", *calls)
+	// Install writes the unit only; it must not bootstrap/start anything.
+	if len(runner.calls) != 0 {
+		t.Errorf("install must not invoke lifecycle tools, got %v", runner.calls)
 	}
 }
 
@@ -176,7 +228,7 @@ func TestServiceInstallSystemdWritesFile(t *testing.T) {
 func TestServiceInstallDryRunWritesNothing(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	out, _, calls := setupServiceTest(t, "darwin")
+	out, _, runner := setupServiceTest(t, "darwin")
 
 	code := dispatch([]string{"service", "install", "--dry-run", "--binary", "/fake/harnessd"})
 	if code != 0 {
@@ -193,8 +245,8 @@ func TestServiceInstallDryRunWritesNothing(t *testing.T) {
 	if !strings.Contains(out.String(), "<plist") || !strings.Contains(out.String(), "/fake/harnessd") {
 		t.Errorf("dry-run output should print the rendered plist")
 	}
-	if len(*calls) != 0 {
-		t.Errorf("dry-run must not invoke lifecycle tools, got %v", *calls)
+	if len(runner.calls) != 0 {
+		t.Errorf("dry-run must not invoke lifecycle tools, got %v", runner.calls)
 	}
 }
 
@@ -301,7 +353,7 @@ func TestServiceUninstallNotInstalledFails(t *testing.T) {
 func TestServiceUninstallRemovesFileAndBootsOut(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	_, _, calls := setupServiceTest(t, "darwin")
+	_, _, runner := setupServiceTest(t, "darwin")
 
 	if code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"}); code != 0 {
 		t.Fatalf("install exit code: got %d", code)
@@ -317,19 +369,15 @@ func TestServiceUninstallRemovesFileAndBootsOut(t *testing.T) {
 	}
 
 	// Best-effort launchctl bootout of the user agent before removal.
-	want := recordedCommand{
-		name: "launchctl",
-		args: []string{"bootout", fmt.Sprintf("gui/%d/com.gocode.harnessd", os.Getuid())},
-	}
-	if len(*calls) != 1 || (*calls)[0].name != want.name || strings.Join((*calls)[0].args, " ") != strings.Join(want.args, " ") {
-		t.Errorf("expected exactly %v, got %v", want, *calls)
-	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"bootout", guiDomain() + "/" + serviceLabel}},
+	)
 }
 
 func TestServiceUninstallSystemdDisableNow(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	_, _, calls := setupServiceTest(t, "linux")
+	_, _, runner := setupServiceTest(t, "linux")
 
 	if code := dispatch([]string{"service", "install", "--binary", "/fake/harnessd"}); code != 0 {
 		t.Fatalf("install exit code: got %d", code)
@@ -344,25 +392,294 @@ func TestServiceUninstallSystemdDisableNow(t *testing.T) {
 		t.Errorf("uninstall must remove %s", unitPath)
 	}
 
-	want := recordedCommand{name: "systemctl", args: []string{"--user", "disable", "--now", "harnessd.service"}}
-	if len(*calls) != 1 || (*calls)[0].name != want.name || strings.Join((*calls)[0].args, " ") != strings.Join(want.args, " ") {
-		t.Errorf("expected exactly %v, got %v", want, *calls)
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "systemctl", args: []string{"--user", "disable", "--now", "harnessd.service"}},
+	)
+}
+
+// --- Slice 2: lifecycle commands (start/stop/status) ---
+
+func TestServiceStartLaunchdBootstraps(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "darwin")
+	unitPath := installServiceForTest(t, "darwin")
+
+	code := dispatch([]string{"service", "start"})
+	if code != 0 {
+		t.Fatalf("start exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"bootstrap", guiDomain(), unitPath}},
+	)
+	if !strings.Contains(out.String(), "started") {
+		t.Errorf("start output %q should confirm the service started", out.String())
 	}
 }
 
-func TestServiceLifecycleStubsNotImplemented(t *testing.T) {
+func TestServiceStartLaunchdAlreadyLoadedKickstarts(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	setupServiceTest(t, "darwin")
+	out, _, runner := setupServiceTest(t, "darwin")
+	unitPath := installServiceForTest(t, "darwin")
+	// First call (bootstrap) fails because the job is already loaded; the
+	// fallback kickstart -k succeeds and restarts it.
+	runner.errs = []error{errors.New("Bootstrap failed: 5: Input/output error")}
 
-	for _, sub := range []string{"start", "stop", "status"} {
-		_, errOut, _ := setupServiceTest(t, "darwin")
-		code := dispatch([]string{"service", sub})
-		if code == 0 {
-			t.Errorf("service %s must exit non-zero until implemented", sub)
+	code := dispatch([]string{"service", "start"})
+	if code != 0 {
+		t.Fatalf("start exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"bootstrap", guiDomain(), unitPath}},
+		recordedCommand{name: "launchctl", args: []string{"kickstart", "-k", guiDomain() + "/" + serviceLabel}},
+	)
+	if !strings.Contains(out.String(), "restarted") {
+		t.Errorf("start output %q should report the restart of an already-loaded service", out.String())
+	}
+}
+
+func TestServiceStartLaunchdBootstrapFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, runner := setupServiceTest(t, "darwin")
+	installServiceForTest(t, "darwin")
+	runner.errs = []error{errors.New("bootstrap exploded"), errors.New("kickstart exploded")}
+
+	code := dispatch([]string{"service", "start"})
+	if code == 0 {
+		t.Fatal("start must fail when both bootstrap and kickstart fail")
+	}
+	if !strings.Contains(errOut.String(), "service start") || !strings.Contains(errOut.String(), "bootstrap exploded") {
+		t.Errorf("error %q should surface the bootstrap failure", errOut.String())
+	}
+}
+
+func TestServiceStartSystemdStarts(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "linux")
+	installServiceForTest(t, "linux")
+
+	code := dispatch([]string{"service", "start"})
+	if code != 0 {
+		t.Fatalf("start exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "systemctl", args: []string{"--user", "start", "harnessd.service"}},
+	)
+	if !strings.Contains(out.String(), "started") {
+		t.Errorf("start output %q should confirm the service started", out.String())
+	}
+}
+
+func TestServiceStartSystemdFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, runner := setupServiceTest(t, "linux")
+	installServiceForTest(t, "linux")
+	runner.errs = []error{errors.New("Failed to start harnessd.service: Unit not found")}
+
+	code := dispatch([]string{"service", "start"})
+	if code == 0 {
+		t.Fatal("start must fail when systemctl start fails")
+	}
+	if !strings.Contains(errOut.String(), "service start") {
+		t.Errorf("error %q should name the failing command", errOut.String())
+	}
+}
+
+func TestServiceStartNotInstalledFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, errOut, runner := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "start"})
+	if code == 0 {
+		t.Fatal("start before install must fail")
+	}
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+	if !strings.Contains(errOut.String(), "not installed") || !strings.Contains(errOut.String(), unitPath) {
+		t.Errorf("error %q should say not installed and name the unit path", errOut.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("start before install must not invoke lifecycle tools, got %v", runner.calls)
+	}
+}
+
+func TestServiceStartUnsupportedPlatformFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, _ := setupServiceTest(t, "windows")
+
+	code := dispatch([]string{"service", "start"})
+	if code == 0 {
+		t.Fatal("start on an unsupported platform must fail")
+	}
+	if !strings.Contains(errOut.String(), "unsupported platform") {
+		t.Errorf("error %q should report the unsupported platform", errOut.String())
+	}
+}
+
+func TestServiceStopLaunchdBootsOut(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "darwin")
+	installServiceForTest(t, "darwin")
+
+	code := dispatch([]string{"service", "stop"})
+	if code != 0 {
+		t.Fatalf("stop exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"bootout", guiDomain() + "/" + serviceLabel}},
+	)
+	if !strings.Contains(out.String(), "stopped") {
+		t.Errorf("stop output %q should confirm the service stopped", out.String())
+	}
+}
+
+func TestServiceStopSystemdStops(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "linux")
+	installServiceForTest(t, "linux")
+
+	code := dispatch([]string{"service", "stop"})
+	if code != 0 {
+		t.Fatalf("stop exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "systemctl", args: []string{"--user", "stop", "harnessd.service"}},
+	)
+	if !strings.Contains(out.String(), "stopped") {
+		t.Errorf("stop output %q should confirm the service stopped", out.String())
+	}
+}
+
+func TestServiceStopRunnerErrorFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, runner := setupServiceTest(t, "darwin")
+	installServiceForTest(t, "darwin")
+	runner.errs = []error{errors.New("Boot-out failed: 3: No such process")}
+
+	code := dispatch([]string{"service", "stop"})
+	if code == 0 {
+		t.Fatal("stop must fail when the service manager errors")
+	}
+	if !strings.Contains(errOut.String(), "service stop") || !strings.Contains(errOut.String(), "No such process") {
+		t.Errorf("error %q should surface the bootout failure", errOut.String())
+	}
+}
+
+func TestServiceStopNotInstalledFails(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	_, errOut, runner := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "stop"})
+	if code == 0 {
+		t.Fatal("stop before install must fail")
+	}
+	if !strings.Contains(errOut.String(), "not installed") {
+		t.Errorf("error %q should say not installed", errOut.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("stop before install must not invoke lifecycle tools, got %v", runner.calls)
+	}
+}
+
+func TestServiceStatusNotInstalledFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	_, errOut, _ := setupServiceTest(t, "darwin")
+
+	code := dispatch([]string{"service", "status"})
+	if code == 0 {
+		t.Fatal("status before install must fail")
+	}
+	unitPath := filepath.Join(home, "Library", "LaunchAgents", "com.gocode.harnessd.plist")
+	if !strings.Contains(errOut.String(), "not installed") || !strings.Contains(errOut.String(), unitPath) {
+		t.Errorf("error %q should say not installed and name the unit path", errOut.String())
+	}
+}
+
+func TestServiceStatusInstalledNotRunningLaunchd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "darwin")
+	unitPath := installServiceForTest(t, "darwin")
+	// launchctl print exits non-zero when the job is not loaded.
+	runner.errs = []error{errors.New("Could not find service \"com.gocode.harnessd\" in domain for uid")}
+
+	code := dispatch([]string{"service", "status"})
+	if code != 0 {
+		t.Fatalf("status exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"print", guiDomain() + "/" + serviceLabel}},
+	)
+	if !strings.Contains(out.String(), "not running") || !strings.Contains(out.String(), unitPath) {
+		t.Errorf("status output %q should report installed-but-not-running and the unit path", out.String())
+	}
+}
+
+func TestServiceStatusInstalledNotRunningSystemd(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "linux")
+	installServiceForTest(t, "linux")
+	// systemctl is-active exits non-zero (3) when the unit is inactive.
+	runner.errs = []error{errors.New("exit status 3")}
+
+	code := dispatch([]string{"service", "status"})
+	if code != 0 {
+		t.Fatalf("status exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "systemctl", args: []string{"--user", "is-active", "harnessd.service"}},
+	)
+	if !strings.Contains(out.String(), "not running") {
+		t.Errorf("status output %q should report installed-but-not-running", out.String())
+	}
+}
+
+func TestServiceStatusRunningHealthy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "darwin")
+	installServiceForTest(t, "darwin")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			w.WriteHeader(http.StatusOK)
+			return
 		}
-		if !strings.Contains(errOut.String(), "not yet implemented") {
-			t.Errorf("service %s error %q should say not yet implemented", sub, errOut.String())
-		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	code := dispatch([]string{"service", "status", "--base-url", ts.URL})
+	if code != 0 {
+		t.Fatalf("status exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"print", guiDomain() + "/" + serviceLabel}},
+	)
+	text := out.String()
+	if !strings.Contains(text, "running") || !strings.Contains(text, "healthy") {
+		t.Errorf("status output %q should report running and healthy", text)
+	}
+	if !strings.Contains(text, ts.URL+"/healthz") {
+		t.Errorf("status output %q should name the probed health URL", text)
+	}
+}
+
+func TestServiceStatusRunningButUnreachable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	out, _, runner := setupServiceTest(t, "darwin")
+	installServiceForTest(t, "darwin")
+
+	// Port 1 is never listening: the service manager reports the job loaded
+	// but the daemon does not answer the health probe.
+	code := dispatch([]string{"service", "status", "--base-url", "http://127.0.0.1:1"})
+	if code != 0 {
+		t.Fatalf("status exit code: got %d", code)
+	}
+	requireCalls(t, runner.calls,
+		recordedCommand{name: "launchctl", args: []string{"print", guiDomain() + "/" + serviceLabel}},
+	)
+	text := out.String()
+	if !strings.Contains(text, "running") || !strings.Contains(text, "unreachable") {
+		t.Errorf("status output %q should report running-but-unreachable", text)
 	}
 }
 

--- a/docs/plans/807-service-install.md
+++ b/docs/plans/807-service-install.md
@@ -1,4 +1,4 @@
-# Plan: harnesscli service install/uninstall (epic #807, slice 1)
+# Plan: harnesscli service OS-service commands (epic #807, slices 1–2)
 
 ## Context
 
@@ -8,52 +8,61 @@
   install`.
 - User impact: one-command persistent install of `harnessd` as a user-level
   launchd agent (macOS) or systemd `--user` unit (Linux), with log capture and
-  crash restart.
+  crash restart, plus lifecycle management without hand-typed
+  `launchctl`/`systemctl`.
 - Constraints: stdlib only (no plist/systemd libs); user-level services only
-  (no root/system units); tmux remains the dev-agent rule; this slice covers
-  ONLY install/uninstall + generators — start/stop/status are stubs for
-  slice 2.
+  (no root/system units); tmux remains the dev-agent rule. Slice 1 (merged,
+  PR #826) shipped install/uninstall + generators; this branch adds slice 2:
+  start/stop/status lifecycle.
 
 ## Scope
 
-- In scope:
-  - `cmd/harnesscli/service.go`: `runService` nested dispatch (install,
-    uninstall; start/stop/status stubbed as not-yet-implemented)
-  - `case "service":` in `dispatch()` (`cmd/harnesscli/auth.go`)
-  - Pure generators `renderLaunchdPlist(opts)` / `renderSystemdUnit(opts)`
-  - Resolution: `--binary` or `exec.LookPath("harnessd")`; `--addr` or
-    `internal/config` resolution (defaults `:8080`, `HARNESS_ADDR`);
-    `--log-dir` default `~/.harness/logs`
-  - `--dry-run` prints target path + rendered unit, writes nothing
-  - `uninstall` removes unit file + best-effort `launchctl bootout` /
-    `systemctl --user disable --now`
-- Out of scope: start/stop/status (slice 2), docs (slice 3), Windows,
-  system-wide units, daemon changes.
+- In scope (slice 2, this branch):
+  - `start`: darwin `launchctl bootstrap gui/<uid> <plist>` with
+    `kickstart -k gui/<uid>/com.gocode.harnessd` fallback when already loaded;
+    linux `systemctl --user start harnessd.service`
+  - `stop`: darwin `launchctl bootout gui/<uid>/com.gocode.harnessd`; linux
+    `systemctl --user stop harnessd.service`
+  - `status`: installed check (unit file present), loaded/active query
+    (`launchctl print` / `systemctl --user is-active`), HTTP health probe of
+    `<--base-url>/healthz` (flag default `http://localhost:8080`, mirroring
+    `cmd/harnesscli/main.go:144`)
+  - Clear "not installed" error (non-zero exit) for all lifecycle commands
+    run before `install`
+  - Real runner made quiet-on-success (buffered output shown only on failure)
+    so `launchctl print` doesn't spam the terminal
+- Delivered (slice 1, merged): `runService` dispatch, `case "service":` in
+  `dispatch()`, pure generators, `--binary`/`--addr`/`--log-dir` resolution,
+  `--dry-run`, `uninstall` with best-effort bootout/disable.
+- Out of scope: docs (slice 3), Windows, system-wide units, daemon changes.
 
 ## Documentation Contract
 
-- Feature status: `in implementation`
+- Feature status: slice 1 `implemented` (merged PR #826); slice 2
+  `in implementation`
 - Public docs affected: none in this slice (slice 3 owns
   `docs/runbooks/distribution.md` + `README.md`)
-- Spec docs to update before code: none
+- Spec docs to update before code: this file (done)
 - Implementation notes to add after code: none (slice 3)
 
 ## Test Plan (TDD)
 
 - New failing tests to add first (`cmd/harnesscli/service_test.go`):
-  - Golden-content: plist contains resolved binary path in ProgramArguments,
-    `KeepAlive`/`RunAtLoad` true, log paths, `HARNESS_ADDR`; unit contains
-    `ExecStart`, `Restart=on-failure`, `WantedBy=default.target`, env addr
-  - `--dry-run` writes nothing, prints target path + contents
-  - install writes plist (darwin) and unit (linux, injected platform) under
-    the temp-HOME paths
-  - binary resolution: `--binary` wins; missing harnessd on PATH errors
-  - addr resolution: `HARNESS_ADDR` env honored; `--addr` overrides env
-  - uninstall when not installed: non-zero + clear message; install→uninstall
-    removes file and invokes best-effort bootout/disable via injected runner
-  - stubs: start/stop/status report not-yet-implemented, non-zero exit
-- Existing tests to update: none
-- Regression tests required: none beyond the above (new feature)
+  - Fake-runner exact argument construction per platform and verb:
+    bootstrap/kickstart/bootout/print (darwin, exact `gui/<uid>[/<label>]`
+    domains), start/stop/is-active (linux)
+  - start: bootstrap success; already-loaded → kickstart -k restart; both
+    fail → non-zero + stderr; not installed → non-zero + clear message
+  - stop: success per platform; runner error → non-zero + stderr; not
+    installed → non-zero
+  - status table: not-installed (non-zero); installed-not-loaded (exit 0,
+    "not running"); loaded-and-healthy (httptest 200 on /healthz);
+    loaded-but-unreachable (closed port → "unreachable", exit 0)
+  - stub test from slice 1 removed (stubs replaced by real commands)
+- Existing tests to update: `setupServiceTest` helper now returns a
+  `serviceRunnerFake` with per-call error queue; slice-1 runner assertions
+  updated accordingly (same assertions, new accessor)
+- Regression tests required: none beyond the above
 
 ## Cross-Surface Impact Map
 
@@ -61,20 +70,30 @@
 
 ## Implementation Checklist
 
-- [x] Define acceptance criteria in tests.
-- [x] Write failing tests first; watch them fail (compile error: runService undefined).
-- [x] Implement minimal code changes.
-- [x] `go test ./cmd/harnesscli/ -run Service` green (17 tests).
-- [x] `go test ./cmd/harnesscli/...` full package green; gofmt + go vet clean.
-- [x] macOS acceptance: `--dry-run` prints plist; real install into temp HOME
-      passes `plutil -lint` (OK); ProgramArguments[0] = resolved harnessd path.
-- [ ] Commit, push `epic/807-service-install`, open PR (no merge).
+- [x] Slice 1: install/uninstall + generators, merged via PR #826.
+- [x] Update this plan for slice 2 before code.
+- [x] Write failing slice-2 tests first; watch them fail (16 red against stubs).
+- [x] Implement start/stop/status + quiet-on-success runner (rich wrapped
+      errors on failure).
+- [x] `go test ./cmd/harnesscli/ -run Service` green (32 tests).
+- [x] `go test ./cmd/harnesscli/... -count=1` full package green; gofmt +
+      go vet clean.
+- [x] macOS acceptance: install → start → status (running; healthy once the
+      daemon bound) → existing `harnesscli status --base-url ... <run-id>`
+      reached the daemon → stop → status (installed, not running, silent
+      stderr) → restart path → uninstall; `launchctl print` confirms the job
+      is gone.
+- [ ] Commit, push `epic/807-service-install-s2`, open PR (no merge).
 
 ## Risks and Mitigations
 
 - Risk: platform-specific code paths untestable on darwin dev machine.
-  Mitigation: injectable `servicePlatform` var + pure renderers; linux paths
-  fully exercised in unit tests.
+  Mitigation: injectable `servicePlatform` var; linux paths fully exercised
+  in unit tests.
 - Risk: unit tests invoking real launchctl/systemctl.
-  Mitigation: injectable `serviceRunCommand` runner var; tests substitute a
-  recording fake.
+  Mitigation: injectable `serviceRunLifecycle` runner var; tests substitute a
+  recording fake with an error queue.
+- Risk: `status` query verbs (`launchctl print`, `systemctl is-active`) exit
+  non-zero for the normal "not running" state.
+  Mitigation: status treats query error as the not-running state (never a
+  hard failure); only missing unit file fails the command.


### PR DESCRIPTION
Parent epic: #807. Part of #803.

## Slice 2 of #807: lifecycle commands

- `harnesscli service start`: darwin `launchctl bootstrap gui/<uid> <plist>` with `kickstart -k` fallback when already loaded (idempotent); linux `systemctl --user start`.
- `stop`: `launchctl bootout` / `systemctl --user stop`; runner errors surface with non-zero exit + stderr.
- `status`: distinguishes **not-installed** (non-zero exit, clear message) / **installed-not-running** / **running-healthy** / **running-but-unreachable** via unit-file check → `launchctl print` / `systemctl --user is-active` query → HTTP probe of `<--base-url>/healthz`.
- Runner is quiet on success and wraps tool output into errors on failure, so status queries stay silent while start/stop failures stay actionable.

## TDD + verification

- 16 new tests written first (watched red against the slice-1 stubs), now green: exact `launchctl`/`systemctl` argument construction per platform and verb (injected platform + recording fake runner with error queue), status table (httptest healthy / closed-port unreachable), not-installed errors for all three verbs. `go test ./cmd/harnesscli/ -run Service -count=1` ✅ (32 tests), full package `go test ./cmd/harnesscli/... -count=1` ✅, vet/gofmt clean.
- macOS end-to-end against a real built daemon: install → start → status running+healthy on `/healthz` → existing `harnesscli status --base-url ... <run-id>` reached the daemon → stop → status installed-not-running (silent stderr) → restart → uninstall; `launchctl print` confirms the job is fully removed.

Do not merge — slice 3 (docs) follows.