### PR TITLE
feat(subagents): swarm resume via resume_agent_ids

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -9,6 +9,32 @@
 - `harness acp -server` flag; resolution flag > `loadConfig().Server` > `http://localhost:8080`; Bearer key from `loadConfig()`.
 - Validation: strict TDD (failing tests first: `undefined: NewRunsClient`). `go test ./internal/acp/ -count=1` and `-race` green, incl. scripted-pipe flows — cancel mid-run issues the cancel POST and the prompt answers `cancelled`; concurrent sessions stay isolated; blocked-handler concurrency proof.
 
+## 2026-07-20 (Agent Swarm — Epic #808, Slice 2)
+
+- Extended `internal/subagents/swarm.go` with `resume_agent_ids`: entry `i`
+  pairs with `items[i]`, and the item's expanded prompt is delivered to the
+  existing subagent through the same messaging path `message_subagent` uses
+  (`Manager.Get` to resolve the run ID, then `RunSteerer.SteerRun`).
+- Validation rejects unknown IDs, duplicate IDs, more resume IDs than items,
+  and active-incompatible statuses (only `running`/`waiting_for_user` accept
+  steered messages, matching `SteerRun`'s contract). All checks run before
+  any member launches, so a bad request starts nothing.
+- Resumed members are scheduled first in the ramp, count against the same
+  concurrency allowance, and are cancelled through the manager on parent
+  cancellation like any started member.
+- Report order stays deterministic: non-resumed item members in item order,
+  then resumed members in resume order; resumed entries carry `Resumed: true`
+  and their subagent ID from the start. Steer failures land in the report
+  per member and never abort the cohort.
+- The swarm takes the steerer via a new `WithSwarmSteerer` option; slice 3
+  will wire it to the runner-backed steerer alongside the `agent_swarm` tool.
+- TDD: resume behavior tests landed first (failed on undefined
+  `WithSwarmSteerer`), covering the happy path, status compatibility table,
+  unknown-ID/duplicate/overflow rejection, scheduling order with cap 1,
+  report marking, steer-failure capture, and cancellation of resumed members.
+- Validation: `go test ./internal/subagents/... -count=1` and `-race` green;
+  new tests repeated 5x without flakes; full regression suite (see PR body).
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/808-agent-swarm.md
+++ b/docs/plans/808-agent-swarm.md
@@ -1,4 +1,4 @@
-# Plan: agent_swarm epic #808 — Slice 1: swarm orchestrator
+# Plan: agent_swarm epic #808 — Slices 1–2
 
 ## Context
 
@@ -8,24 +8,25 @@
 - User impact: the model must loop `start_subagent`/`wait_subagent` by hand,
   which is slow, error-prone, and burns turns.
 - Constraints: reuse `internal/subagents` Manager + `tools.SubagentManager`
-  (`InlineManager`); strict TDD; this PR covers ONLY Slice 1 (core `Swarm`
-  type in `internal/subagents`). Slices 2–4 (resume, deferred tool, TUI) are
-  out of scope here.
+  (`InlineManager`); strict TDD. Slice 1 (core `Swarm`) merged via PR #839.
+  This PR covers ONLY Slice 2 (resume via `resume_agent_ids`).
 
 ## Scope
 
-- In scope:
-  - `internal/subagents/swarm.go`: `SwarmRequest` (PromptTemplate, Items,
-    ResumeAgentIDs rejected until Slice 2, profile/model overrides),
-    validation, `Swarm.Run(ctx) (SwarmReport, error)`.
-  - Concurrency scheduler: 5 immediate starts, +1 every 700ms, cap read once
-    from `HARNESS_SWARM_MAX_CONCURRENCY` (default 128, clamped to 128).
-  - Caller context cancellation cancels every started member; per-member
-    errors are captured in the report and never abort the cohort.
-  - `SwarmReport` with per-member ID, item, status, output/error in
-    deterministic item order.
-- Out of scope: resume_agent_ids delivery (Slice 2), `agent_swarm` tool and
-  runner sole-call rule (Slice 3), TUI panel (Slice 4), new server endpoints.
+- In scope (Slice 2):
+  - Extend `internal/subagents/swarm.go`: `ResumeAgentIDs[i]` pairs with
+    `Items[i]` (first-K positional); resolve each ID upfront via
+    `tools.SubagentManager.Get`; reject unknown IDs, duplicate IDs,
+    more IDs than items, and active-incompatible statuses (only
+    `running`/`waiting_for_user` accept steered messages).
+  - Deliver the expanded prompt through the existing messaging path used by
+    `message_subagent`: `tools.RunSteerer.SteerRun(runID, prompt)`.
+  - Resumes are scheduled first in the ramp and count against the same
+    concurrency allowance; parent cancellation cancels resumed members too.
+  - Report order stays "items first, resumes later"; resumed members carry
+    `Resumed: true` and their subagent ID from the start.
+- Out of scope: `agent_swarm` deferred tool + runner sole-call rule
+  (Slice 3), TUI panel (Slice 4), new server endpoints.
 
 ## Documentation Contract
 
@@ -36,19 +37,20 @@
 
 ## Test Plan (TDD)
 
-- New failing tests to add first (`internal/subagents/swarm_test.go`):
-  - table-driven validation: missing `{{item}}` placeholder, empty items,
-    >128 items, duplicate expanded prompts, resume_agent_ids rejected
-  - ramp timing with injected manual ticker: 5 in-flight before first tick,
-    +1 per tick
-  - env cap: `HARNESS_SWARM_MAX_CONCURRENCY` honored; resolver default/clamp
-  - cancellation: parent cancel cancels all started members, unstarted
-    members reported cancelled, all reach terminal state
-  - aggregated report shape/order; per-member failure does not abort cohort
-  - acceptance: real `Manager` + `InlineManager` fan-out completes
-- Existing tests to update: none
-- Regression tests required: existing `internal/subagents` tests stay green
-  unmodified.
+- New failing tests to add first (`internal/subagents/swarm_resume_test.go`):
+  - resume happy path against a fake manager + fake steerer (steer carries
+    the expanded prompt to the resolved run ID; mixed cohort completes)
+  - unknown ID and active-incompatible status rejection (queued/completed/
+    failed/cancelled rejected; running/waiting_for_user accepted)
+  - duplicate resume ID rejection; more resume IDs than items rejection
+  - scheduling order: resumes precede new items (deterministic with cap 1)
+  - report marking: `Resumed` flag, ID, order (items first, resumes later)
+  - steer failure captured per member without aborting the cohort
+  - cancellation cancels resumed members as well as new members
+  - missing steerer with non-empty resume_agent_ids rejected
+- Existing tests to update: drop the "resume_agent_ids rejected" case from
+  the slice-1 validation table (now supported).
+- Regression tests required: all slice-1 swarm tests stay green.
 
 ## Cross-Surface Impact Map
 
@@ -67,10 +69,11 @@
 
 ## Risks and Mitigations
 
-- Risk: ramp timing tests flaking on wall-clock sleeps.
-- Mitigation: inject a manual ticker seam; wall-clock only for short
-  stability assertions with generous margins.
-- Risk: goroutine leak / hang when a member never terminates after cancel.
-- Mitigation: swarm issues `Cancel` for every started member and relies on
-  the documented `tools.SubagentManager` contract (cancel drives members to
-  a terminal state); the swarm-scoped context is always stopped on return.
+- Risk: status check races the member's own lifecycle (subagent finishes
+  between `Get` and `SteerRun`).
+- Mitigation: `SteerRun` errors are captured per member in the report; the
+  cohort is never aborted, matching slice-1 failure semantics.
+- Risk: report order confusing callers when resumes consume the first items.
+- Mitigation: deterministic documented order (non-resumed item members in
+  item order, then resumed members in resume-ID order), each entry carrying
+  its `item` and `resumed` marker.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -13,7 +13,7 @@
 - `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
-- `808-agent-swarm.md` — Agent swarm epic #808, Slice 1: swarm orchestrator with template fan-out, concurrency ramp, and cancellation (in implementation).
+- `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator (merged), Slice 2 resume via resume_agent_ids (in implementation).
 - `809-mcp-oauth.md` — Epic #809: slice 1 (static HTTP headers + typed auth errors, merged PR #840) and slice 2 (file-backed OAuth token store, in implementation).
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 slice 1 (in implementation): steer client plumbing (`steerRunCmd` + `harnesscli steer`).

--- a/internal/subagents/swarm.go
+++ b/internal/subagents/swarm.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go-agent-harness/internal/harness"
 	tools "go-agent-harness/internal/harness/tools"
 )
 
@@ -50,8 +51,12 @@ type SwarmRequest struct {
 	PromptTemplate string `json:"prompt_template"`
 	// Items holds 1..SwarmMaxMembers entries; expanded prompts must be distinct.
 	Items []string `json:"items"`
-	// ResumeAgentIDs reuses existing subagents instead of creating new ones.
-	// Reserved for Slice 2 of epic #808: any non-empty value is rejected.
+	// ResumeAgentIDs reuses existing subagents instead of creating new ones:
+	// entry i is paired with Items[i], and the item's expanded prompt is
+	// delivered to that subagent through the message_subagent steering path
+	// (RunSteerer.SteerRun on the resolved run ID). Resumed members are
+	// scheduled before new items. Requires len(ResumeAgentIDs) <= len(Items),
+	// distinct IDs, and each target in a running or waiting-for-user state.
 	ResumeAgentIDs []string `json:"resume_agent_ids,omitempty"`
 
 	Model                string                      `json:"model,omitempty"`
@@ -70,16 +75,18 @@ type SwarmRequest struct {
 
 // SwarmMemberReport is the per-member outcome of a swarm run.
 type SwarmMemberReport struct {
-	ID     string `json:"id,omitempty"`
-	Item   string `json:"item"`
-	Prompt string `json:"prompt"`
-	Status string `json:"status"` // "pending" | "completed" | "failed" | "cancelled" | ...
-	Output string `json:"output,omitempty"`
-	Error  string `json:"error,omitempty"`
+	ID      string `json:"id,omitempty"`
+	Item    string `json:"item"`
+	Prompt  string `json:"prompt"`
+	Status  string `json:"status"` // "pending" | "completed" | "failed" | "cancelled" | ...
+	Output  string `json:"output,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Resumed bool   `json:"resumed,omitempty"` // true when the member resumed an existing subagent
 }
 
-// SwarmReport aggregates every member outcome in deterministic order
-// (items first; resumed members would follow in later slices).
+// SwarmReport aggregates every member outcome in deterministic order:
+// non-resumed item members first (in item order), then resumed members (in
+// resume_agent_ids order).
 type SwarmReport struct {
 	Members   []SwarmMemberReport `json:"members"`
 	Total     int                 `json:"total"`
@@ -117,10 +124,12 @@ func (r realSwarmTicker) Stop()                  { r.t.Stop() }
 
 // Swarm is the agent_swarm orchestrator: it validates a template fan-out,
 // starts members through a tools.SubagentManager under a ramping concurrency
-// allowance, propagates caller cancellation to every member, and aggregates
-// the per-member results into one report.
+// allowance (resuming existing subagents through a tools.RunSteerer when
+// resume_agent_ids is set), propagates caller cancellation to every member,
+// and aggregates the per-member results into one report.
 type Swarm struct {
 	manager        tools.SubagentManager
+	steerer        tools.RunSteerer
 	maxConcurrency int
 	newTicker      func(time.Duration) swarmTicker
 }
@@ -135,6 +144,17 @@ func WithSwarmMaxConcurrency(n int) SwarmOption {
 	return func(s *Swarm) {
 		if n >= 1 {
 			s.maxConcurrency = n
+		}
+	}
+}
+
+// WithSwarmSteerer sets the RunSteerer used to deliver prompts to resumed
+// subagents (the same messaging path message_subagent uses). Required when a
+// request carries resume_agent_ids.
+func WithSwarmSteerer(steerer tools.RunSteerer) SwarmOption {
+	return func(s *Swarm) {
+		if steerer != nil {
+			s.steerer = steerer
 		}
 	}
 }
@@ -200,8 +220,18 @@ func (r SwarmRequest) expandedPrompts() ([]string, error) {
 	if len(r.Items) > SwarmMaxMembers {
 		return nil, fmt.Errorf("%w: items has %d entries, max is %d", ErrInvalidSwarmRequest, len(r.Items), SwarmMaxMembers)
 	}
-	if len(r.ResumeAgentIDs) > 0 {
-		return nil, fmt.Errorf("%w: resume_agent_ids is not supported yet", ErrInvalidSwarmRequest)
+	if len(r.ResumeAgentIDs) > len(r.Items) {
+		return nil, fmt.Errorf("%w: resume_agent_ids has %d entries but items has only %d", ErrInvalidSwarmRequest, len(r.ResumeAgentIDs), len(r.Items))
+	}
+	seenIDs := make(map[string]int, len(r.ResumeAgentIDs))
+	for i, id := range r.ResumeAgentIDs {
+		if strings.TrimSpace(id) == "" {
+			return nil, fmt.Errorf("%w: resume_agent_ids entry %d is empty", ErrInvalidSwarmRequest, i)
+		}
+		if prev, dup := seenIDs[id]; dup {
+			return nil, fmt.Errorf("%w: resume_agent_ids entries %d and %d are duplicate id %q", ErrInvalidSwarmRequest, prev, i, id)
+		}
+		seenIDs[id] = i
 	}
 
 	prompts := make([]string, len(r.Items))
@@ -239,8 +269,64 @@ func (r SwarmRequest) memberRequest(prompt string) tools.SubagentRequest {
 	}
 }
 
+// swarmMemberPlan is one member of the cohort in schedule order: resumes
+// first, then new items. reportIdx places the member in the deterministic
+// report order (new item members first, resumed members last).
+type swarmMemberPlan struct {
+	item       string
+	prompt     string
+	reportIdx  int
+	resumed    bool
+	subagentID string // resumed members only: canonical subagent ID from Get
+	runID      string // resumed members only: run to steer
+}
+
+// buildMemberPlans resolves resume_agent_ids against the manager (rejecting
+// unknown IDs and active-incompatible statuses) and lays out the cohort in
+// schedule order. Resume entry i consumes items[i]'s expanded prompt.
+func (s *Swarm) buildMemberPlans(ctx context.Context, req SwarmRequest, prompts []string) ([]swarmMemberPlan, error) {
+	k := len(req.ResumeAgentIDs)
+	n := len(req.Items)
+	plans := make([]swarmMemberPlan, 0, n)
+	for i, id := range req.ResumeAgentIDs {
+		res, err := s.manager.Get(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("%w: resume_agent_ids entry %q: %v", ErrInvalidSwarmRequest, id, err)
+		}
+		if !swarmResumeCompatibleStatus(res.Status) {
+			return nil, fmt.Errorf("%w: resume_agent_ids entry %q has status %q, want %q or %q",
+				ErrInvalidSwarmRequest, id, res.Status, harness.RunStatusRunning, harness.RunStatusWaitingForUser)
+		}
+		plans = append(plans, swarmMemberPlan{
+			item:       req.Items[i],
+			prompt:     prompts[i],
+			reportIdx:  (n - k) + i,
+			resumed:    true,
+			subagentID: res.ID,
+			runID:      res.RunID,
+		})
+	}
+	for j := k; j < n; j++ {
+		plans = append(plans, swarmMemberPlan{
+			item:      req.Items[j],
+			prompt:    prompts[j],
+			reportIdx: j - k,
+		})
+	}
+	return plans, nil
+}
+
+// swarmResumeCompatibleStatus reports whether a subagent can accept a steered
+// message: the same states RunSteerer.SteerRun accepts.
+func swarmResumeCompatibleStatus(status string) bool {
+	return status == string(harness.RunStatusRunning) || status == string(harness.RunStatusWaitingForUser)
+}
+
 // Run validates the request, fans the template out over the items, and blocks
-// until every member reaches a terminal state. Member failures are captured
+// until every member reaches a terminal state. Resume entries are resolved
+// against the manager up front (unknown IDs and inactive subagents reject the
+// whole request before anything launches) and receive their prompts through
+// the steering path, scheduled before new items. Member failures are captured
 // in the report and never abort the cohort. If ctx is cancelled, every
 // started member is cancelled through the manager, members that never started
 // are reported as cancelled, and Run returns the partial report together with
@@ -253,14 +339,25 @@ func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) 
 	if err != nil {
 		return SwarmReport{}, err
 	}
+	if len(req.ResumeAgentIDs) > 0 && s.steerer == nil {
+		return SwarmReport{}, fmt.Errorf("subagents: swarm has no run steerer for resume_agent_ids")
+	}
+	plans, err := s.buildMemberPlans(ctx, req, prompts)
+	if err != nil {
+		return SwarmReport{}, err
+	}
 
-	n := len(req.Items)
+	n := len(plans)
 	report := SwarmReport{Members: make([]SwarmMemberReport, n)}
-	for i := range req.Items {
-		report.Members[i] = SwarmMemberReport{
-			Item:   req.Items[i],
-			Prompt: prompts[i],
-			Status: swarmMemberStatusPending,
+	for _, p := range plans {
+		entry := &report.Members[p.reportIdx]
+		entry.Item = p.item
+		entry.Prompt = p.prompt
+		entry.Status = swarmMemberStatusPending
+		entry.Resumed = p.resumed
+		if p.resumed {
+			// The subagent already exists, so its ID is known up front.
+			entry.ID = p.subagentID
 		}
 	}
 
@@ -310,8 +407,34 @@ func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) 
 
 	launch := func(idx int) {
 		inFlight++
+		plan := plans[idx]
+		if plan.resumed {
+			go func() {
+				// Deliver the expanded prompt through the same messaging
+				// path message_subagent uses, then wait for the subagent's
+				// terminal state like any other member.
+				if err := s.steerer.SteerRun(plan.runID, plan.prompt); err != nil {
+					outcomes <- outcome{idx: idx, err: fmt.Errorf("resume subagent %q: %w", plan.subagentID, err)}
+					return
+				}
+				mu.Lock()
+				memberIDs[idx] = plan.subagentID
+				mu.Unlock()
+				// Same race as Start below: the swarm may have been
+				// cancelled while the steer was in flight.
+				if cancelled.Load() {
+					_ = s.manager.Cancel(context.Background(), plan.subagentID)
+				}
+				wres, werr := s.manager.Wait(swarmCtx, plan.subagentID)
+				if wres.ID == "" {
+					wres.ID = plan.subagentID
+				}
+				outcomes <- outcome{idx: idx, res: wres, err: werr}
+			}()
+			return
+		}
 		go func() {
-			res, err := s.manager.Start(ctx, req.memberRequest(prompts[idx]))
+			res, err := s.manager.Start(ctx, req.memberRequest(plan.prompt))
 			if err != nil {
 				outcomes <- outcome{idx: idx, err: err}
 				return
@@ -359,7 +482,7 @@ func (s *Swarm) Run(ctx context.Context, req SwarmRequest) (SwarmReport, error) 
 			mu.Lock()
 			memberDone[oc.idx] = true
 			mu.Unlock()
-			recordSwarmOutcome(&report.Members[oc.idx], oc.res, oc.err)
+			recordSwarmOutcome(&report.Members[plans[oc.idx].reportIdx], oc.res, oc.err)
 			for canLaunch() {
 				launch(started)
 				started++

--- a/internal/subagents/swarm_resume_test.go
+++ b/internal/subagents/swarm_resume_test.go
@@ -1,0 +1,382 @@
+package subagents
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// eventLog records the ordering between manager starts and steer calls so
+// scheduling order can be asserted deterministically.
+type eventLog struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (l *eventLog) add(e string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.events = append(l.events, e)
+}
+
+func (l *eventLog) snapshot() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.events...)
+}
+
+type steerCall struct{ runID, message string }
+
+// fakeRunSteerer implements tools.RunSteerer, recording steered messages.
+type fakeRunSteerer struct {
+	mu    sync.Mutex
+	calls []steerCall
+	err   error
+	log   *eventLog
+}
+
+func (f *fakeRunSteerer) SteerRun(runID, message string) error {
+	if f.log != nil {
+		f.log.add("steer:" + runID)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, steerCall{runID: runID, message: message})
+	return f.err
+}
+
+func (f *fakeRunSteerer) ParentRunID(string) (string, bool) { return "", false }
+
+func (f *fakeRunSteerer) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeRunSteerer) call(i int) steerCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[i]
+}
+
+func waitForSteerCount(t *testing.T, s *fakeRunSteerer, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.callCount() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("steer call count did not reach %d (got %d)", want, s.callCount())
+}
+
+func TestSwarmResumeHappyPath(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	fake.release()
+	steerer := &fakeRunSteerer{}
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b"},
+		ResumeAgentIDs: []string{"sub-1"},
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+
+	// The resumed subagent receives the first item's expanded prompt through
+	// the messaging path (SteerRun on its run ID, resolved via Get).
+	if steerer.callCount() != 1 {
+		t.Fatalf("steer calls = %d, want 1", steerer.callCount())
+	}
+	call := steerer.call(0)
+	if call.runID != "run-1" || call.message != "do a" {
+		t.Fatalf("steer call = (%q, %q), want (%q, %q)", call.runID, call.message, "run-1", "do a")
+	}
+
+	// Only one new subagent is created, for the remaining item.
+	if fake.startCount() != 1 {
+		t.Fatalf("started %d new members, want 1", fake.startCount())
+	}
+
+	if res.report.Total != 2 || res.report.Completed != 2 || res.report.Failed != 0 {
+		t.Fatalf("report counts = total:%d completed:%d failed:%d, want 2/2/0",
+			res.report.Total, res.report.Completed, res.report.Failed)
+	}
+
+	// Report order: non-resumed item members first, resumed members last.
+	newMember := res.report.Members[0]
+	if newMember.Item != "b" || newMember.Resumed {
+		t.Fatalf("member 0 = item:%q resumed:%v, want item b not resumed", newMember.Item, newMember.Resumed)
+	}
+	if newMember.Status != string(harness.RunStatusCompleted) {
+		t.Fatalf("member 0 Status = %q, want completed", newMember.Status)
+	}
+	resumed := res.report.Members[1]
+	if resumed.Item != "a" || !resumed.Resumed {
+		t.Fatalf("member 1 = item:%q resumed:%v, want item a resumed", resumed.Item, resumed.Resumed)
+	}
+	if resumed.ID != "sub-1" {
+		t.Fatalf("resumed member ID = %q, want sub-1", resumed.ID)
+	}
+	if resumed.Status != string(harness.RunStatusCompleted) {
+		t.Fatalf("resumed member Status = %q, want completed", resumed.Status)
+	}
+	if resumed.Output != "out-sub-1" {
+		t.Fatalf("resumed member Output = %q, want out-sub-1", resumed.Output)
+	}
+}
+
+func TestSwarmResumeStatusCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status  harness.RunStatus
+		wantErr bool
+	}{
+		{harness.RunStatusRunning, false},
+		{harness.RunStatusWaitingForUser, false},
+		{harness.RunStatusQueued, true},
+		{harness.RunStatusCompleted, true},
+		{harness.RunStatusFailed, true},
+		{harness.RunStatusCancelled, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			t.Parallel()
+			fake := newFakeSwarmManager()
+			fake.seed("sub-1", "run-1", string(tt.status))
+			fake.release()
+			steerer := &fakeRunSteerer{}
+			swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+
+			res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+				PromptTemplate: "do {{item}}",
+				Items:          []string{"a"},
+				ResumeAgentIDs: []string{"sub-1"},
+			}))
+			if tt.wantErr {
+				if res.err == nil {
+					t.Fatalf("Run error = nil, want rejection for status %q", tt.status)
+				}
+				if !errors.Is(res.err, ErrInvalidSwarmRequest) {
+					t.Fatalf("Run error = %v, want ErrInvalidSwarmRequest", res.err)
+				}
+				if !strings.Contains(res.err.Error(), string(tt.status)) {
+					t.Fatalf("Run error = %q, want status %q mentioned", res.err.Error(), tt.status)
+				}
+				if steerer.callCount() != 0 || fake.startCount() != 0 {
+					t.Fatalf("rejected request steered %d / started %d members, want 0/0",
+						steerer.callCount(), fake.startCount())
+				}
+				return
+			}
+			if res.err != nil {
+				t.Fatalf("Run error = %v, want nil for status %q", res.err, tt.status)
+			}
+			if steerer.callCount() != 1 {
+				t.Fatalf("steer calls = %d, want 1", steerer.callCount())
+			}
+		})
+	}
+}
+
+func TestSwarmResumeUnknownIDRejected(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	steerer := &fakeRunSteerer{}
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+
+	_, err := swarm.Run(context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a"},
+		ResumeAgentIDs: []string{"ghost"},
+	})
+	if err == nil {
+		t.Fatal("Run error = nil, want unknown resume id rejection")
+	}
+	if !errors.Is(err, ErrInvalidSwarmRequest) {
+		t.Fatalf("Run error = %v, want ErrInvalidSwarmRequest", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("Run error = %q, want the unknown id mentioned", err.Error())
+	}
+	if steerer.callCount() != 0 || fake.startCount() != 0 {
+		t.Fatalf("rejected request steered %d / started %d members, want 0/0",
+			steerer.callCount(), fake.startCount())
+	}
+}
+
+func TestSwarmResumeMissingSteererRejected(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	swarm := NewSwarm(fake) // no WithSwarmSteerer
+
+	_, err := swarm.Run(context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a"},
+		ResumeAgentIDs: []string{"sub-1"},
+	})
+	if err == nil {
+		t.Fatal("Run error = nil, want missing steerer rejection")
+	}
+	if !strings.Contains(err.Error(), "steerer") {
+		t.Fatalf("Run error = %q, want steerer mentioned", err.Error())
+	}
+	if fake.startCount() != 0 {
+		t.Fatalf("rejected request started %d members, want 0", fake.startCount())
+	}
+}
+
+func TestSwarmResumeScheduledBeforeNewItems(t *testing.T) {
+	t.Parallel()
+
+	log := &eventLog{}
+	fake := newFakeSwarmManager()
+	fake.log = log
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	steerer := &fakeRunSteerer{log: log}
+	mt := newManualTicker()
+	swarm := NewSwarm(fake,
+		WithSwarmSteerer(steerer),
+		WithSwarmMaxConcurrency(1),
+		withSwarmTickerFactory(manualTickerFactory(mt)),
+	)
+
+	done := runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b", "c"},
+		ResumeAgentIDs: []string{"sub-1"},
+	})
+
+	// With cap 1 the resume occupies the only slot first.
+	waitForSteerCount(t, steerer, 1)
+	time.Sleep(50 * time.Millisecond)
+	if got := fake.startCount(); got != 0 {
+		t.Fatalf("new members started before the resume completed: %d, want 0", got)
+	}
+
+	fake.finish("sub-1", tools.SubagentResult{ID: "sub-1", Status: string(harness.RunStatusCompleted), Output: "resumed-done"})
+	waitForStartCount(t, fake, 1)
+	fake.finish(fake.idForPrompt("do b"), tools.SubagentResult{Status: string(harness.RunStatusCompleted)})
+	waitForStartCount(t, fake, 2)
+	fake.finish(fake.idForPrompt("do c"), tools.SubagentResult{Status: string(harness.RunStatusCompleted)})
+
+	res := awaitSwarmRun(t, done)
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+
+	wantOrder := []string{"steer:run-1", "start:do b", "start:do c"}
+	gotOrder := log.snapshot()
+	if len(gotOrder) != len(wantOrder) {
+		t.Fatalf("event order = %v, want %v", gotOrder, wantOrder)
+	}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("event order = %v, want %v", gotOrder, wantOrder)
+		}
+	}
+
+	// Report order: new item members first (item order), resumed last.
+	if res.report.Members[0].Item != "b" || res.report.Members[1].Item != "c" {
+		t.Fatalf("report items = %q, %q, ..., want b, c first",
+			res.report.Members[0].Item, res.report.Members[1].Item)
+	}
+	last := res.report.Members[2]
+	if last.Item != "a" || !last.Resumed || last.ID != "sub-1" {
+		t.Fatalf("report member 2 = item:%q resumed:%v id:%q, want a/true/sub-1",
+			last.Item, last.Resumed, last.ID)
+	}
+	if last.Output != "resumed-done" {
+		t.Fatalf("resumed member Output = %q, want resumed-done", last.Output)
+	}
+}
+
+func TestSwarmResumeSteerFailureIsCaptured(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	fake.release()
+	steerer := &fakeRunSteerer{err: errors.New("steering buffer full")}
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b"},
+		ResumeAgentIDs: []string{"sub-1"},
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil (steer failures live in the report)", res.err)
+	}
+	if res.report.Completed != 1 || res.report.Failed != 1 {
+		t.Fatalf("report counts = completed:%d failed:%d, want 1/1", res.report.Completed, res.report.Failed)
+	}
+	resumed := res.report.Members[1]
+	if resumed.Status != string(harness.RunStatusFailed) {
+		t.Fatalf("resumed member Status = %q, want failed", resumed.Status)
+	}
+	if !strings.Contains(resumed.Error, "steering buffer full") {
+		t.Fatalf("resumed member Error = %q, want steering buffer full", resumed.Error)
+	}
+	if resumed.ID != "sub-1" || !resumed.Resumed {
+		t.Fatalf("resumed member = id:%q resumed:%v, want sub-1/true", resumed.ID, resumed.Resumed)
+	}
+	if res.report.Members[0].Status != string(harness.RunStatusCompleted) {
+		t.Fatalf("new member Status = %q, want completed", res.report.Members[0].Status)
+	}
+}
+
+func TestSwarmCancellationCancelsResumedMembers(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	steerer := &fakeRunSteerer{}
+	mt := newManualTicker()
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer), withSwarmTickerFactory(manualTickerFactory(mt)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runSwarmAsync(swarm, ctx, SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b", "c"},
+		ResumeAgentIDs: []string{"sub-1"},
+	})
+
+	waitForSteerCount(t, steerer, 1)
+	waitForStartCount(t, fake, 2)
+	cancel()
+
+	res := awaitSwarmRun(t, done)
+	if !errors.Is(res.err, context.Canceled) {
+		t.Fatalf("Run error = %v, want context.Canceled", res.err)
+	}
+	// The resumed member is cancelled through the manager like any started member.
+	if got := fake.cancelCount(); got != 3 {
+		t.Fatalf("manager Cancel calls = %d, want 3 (resume + 2 new)", got)
+	}
+	if res.report.Cancelled != 3 {
+		t.Fatalf("report Cancelled = %d, want 3", res.report.Cancelled)
+	}
+	resumed := res.report.Members[2]
+	if resumed.Status != string(harness.RunStatusCancelled) || resumed.ID != "sub-1" || !resumed.Resumed {
+		t.Fatalf("resumed member = status:%q id:%q resumed:%v, want cancelled/sub-1/true",
+			resumed.Status, resumed.ID, resumed.Resumed)
+	}
+}

--- a/internal/subagents/swarm_test.go
+++ b/internal/subagents/swarm_test.go
@@ -21,20 +21,32 @@ type fakeSwarmManager struct {
 	started     []tools.SubagentRequest
 	ids         []string
 	chans       map[string]chan tools.SubagentResult
+	seeded      map[string]tools.SubagentResult
 	cancelled   []string
 	releaseCh   chan struct{}
 	released    bool
 	startErr    error
 	startErrAt  int // 0-based start index that fails with startErr; -1 disables
 	startsTotal int
+	log         *eventLog
 }
 
 func newFakeSwarmManager() *fakeSwarmManager {
 	return &fakeSwarmManager{
 		chans:      make(map[string]chan tools.SubagentResult),
+		seeded:     make(map[string]tools.SubagentResult),
 		releaseCh:  make(chan struct{}),
 		startErrAt: -1,
 	}
+}
+
+// seed registers a pre-existing subagent (for resume_agent_ids tests) with a
+// wait channel like a started member's.
+func (f *fakeSwarmManager) seed(id, runID, status string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seeded[id] = tools.SubagentResult{ID: id, RunID: runID, Status: status}
+	f.chans[id] = make(chan tools.SubagentResult, 1)
 }
 
 func (f *fakeSwarmManager) Start(_ context.Context, req tools.SubagentRequest) (tools.SubagentResult, error) {
@@ -49,6 +61,9 @@ func (f *fakeSwarmManager) Start(_ context.Context, req tools.SubagentRequest) (
 	f.started = append(f.started, req)
 	f.ids = append(f.ids, id)
 	f.chans[id] = make(chan tools.SubagentResult, 1)
+	if f.log != nil {
+		f.log.add("start:" + req.Prompt)
+	}
 	return tools.SubagentResult{ID: id, RunID: id + "-run", Status: string(harness.RunStatusRunning)}, nil
 }
 
@@ -91,6 +106,9 @@ func (f *fakeSwarmManager) Get(_ context.Context, id string) (tools.SubagentResu
 		if known == id {
 			return tools.SubagentResult{ID: id, Status: string(harness.RunStatusRunning)}, nil
 		}
+	}
+	if res, ok := f.seeded[id]; ok {
+		return res, nil
 	}
 	return tools.SubagentResult{}, fmt.Errorf("unknown subagent %q", id)
 }
@@ -258,9 +276,14 @@ func TestSwarmRunValidation(t *testing.T) {
 			wantErr: "same prompt",
 		},
 		{
-			name:    "resume_agent_ids rejected until slice 2",
-			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a"}, ResumeAgentIDs: []string{"subagent_1"}},
-			wantErr: "resume",
+			name:    "more resume_agent_ids than items",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a"}, ResumeAgentIDs: []string{"s1", "s2"}},
+			wantErr: "resume_agent_ids",
+		},
+		{
+			name:    "duplicate resume_agent_ids",
+			req:     SwarmRequest{PromptTemplate: "do {{item}}", Items: []string{"a", "b"}, ResumeAgentIDs: []string{"s1", "s1"}},
+			wantErr: "duplicate",
 		},
 	}
 


### PR DESCRIPTION
Parent epic: #808. Part of #803.

## Slice 2 of #808

Extends the Slice-1 swarm orchestrator so `resume_agent_ids` reuses existing subagents instead of creating new ones.

### What landed

- `internal/subagents/swarm.go`
  - `resume_agent_ids[i]` pairs with `items[i]`; the item's expanded prompt is delivered through the same messaging path `message_subagent` uses: `Manager.Get` resolves the run ID, then `RunSteerer.SteerRun(runID, prompt)`.
  - Upfront validation (before anything launches): unknown IDs, duplicate IDs, more resume IDs than items, and active-incompatible statuses are rejected — only `running`/`waiting_for_user` accept steered messages, matching `SteerRun`'s contract.
  - Resumed members are scheduled first in the ramp, share the concurrency allowance, and are cancelled through the manager on parent cancellation.
  - Report order stays deterministic: non-resumed item members in item order, then resumed members in resume order; resumed entries carry `Resumed: true` and their subagent ID from the start.
  - Steer failures are captured per member in the report and never abort the cohort.
  - New `WithSwarmSteerer` option (Slice 3 wires it to the runner-backed steerer).
- `internal/subagents/swarm_resume_test.go` — TDD (red on undefined `WithSwarmSteerer`): happy path, status-compatibility table, unknown/duplicate/overflow rejection, cap-1 scheduling order, report marking, steer-failure capture, cancellation of resumed members.
- Plan doc + plans index + engineering-log entry.

### Verification

- `go test ./internal/subagents/ -count=1` — ok
- `go test ./internal/subagents/ -count=1 -race` — ok
- `go test ./internal/subagents/ -count=5 -run 'TestSwarm|TestResolveSwarm'` — ok (no flakes)
- `gofmt -l internal/subagents/`, `go vet ./internal/subagents/` — clean
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — PASS: `coveragegate: PASS (total=84.0%, min=80.0%, zero-functions=0)`