### PR TITLE
feat(server): POST /v1/conversations/{id}/undo route

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -35,6 +35,15 @@
 - Validation: `go test ./internal/subagents/... -count=1` and `-race` green;
   new tests repeated 5x without flakes; full regression suite (see PR body).
 
+## 2026-07-20 (`/undo` HTTP Route — Epic #805, Slice 2)
+
+- Added `POST /v1/conversations/{id}/undo` (`internal/server/http_conversations.go`), routed next to `compact` with the same guards: POST-only (405 otherwise), `runs:write` scope (403), and `blockConversationCrossTenant` (cross-tenant 404, verified non-mutating).
+- Handler `handleUndoConversation` delegates to Slice 1's `ConversationStore.UndoPrompts`. Body accepts `{"count": N}` (absent → default 1) or `{"to_step": S}`; empty body is treated as all-defaults. `to_step` is resolved to a count by `undoCountForStep`, which rejects steps that are negative, beyond history, or pointing at a non-prompt (non-`user` or `is_meta`) message with 400 before the store is called.
+- Error mapping: `ErrUndoCrossesCompaction` → 409 `undo_crosses_compaction`; `ErrUndoCountOutOfRange` → 400; unknown conversation → 404; missing store → 501. Success returns `{"undone": true, "removed_from_step": S, "remaining_messages": M}` where M counts the persisted messages including the `is_meta` undo-boundary marker.
+- Boundary semantics are store-enforced (Slice 1): the target prompt must sit strictly above the most recent `is_compact_summary` message; anything at or below the boundary is refused and the conversation is left untouched. This holds for both `count` and `to_step` forms.
+- In-memory caveat, same as the existing compact route: the mutation is store-only, so `GET {id}/messages` on a conversation still resident in the runner's memory shows the pre-undo snapshot until the run ends or the daemon restarts (the store fallback then serves the truncated history). The TUI slice refetches after undo.
+- Validation: failing-first tests in `internal/server/http_undo_test.go` (10 endpoint behavior tests) and `internal/server/http_undo_tenant_test.go` (cross-tenant 404 + no-mutation, `runs:read`-only 403); `go test ./internal/server/ -run 'Undo|TenantIsolation' -count=1` green. tmux smoke against `harnessd` (fake provider, `HARNESS_CONVERSATION_DB` set): `POST .../undo {"count":1}` → 200 `{"undone":true,"removed_from_step":2,"remaining_messages":3}`; after restart, `GET .../messages` serves the truncated history with the marker.
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/805-undo-prompts.md
+++ b/docs/plans/805-undo-prompts.md
@@ -1,62 +1,62 @@
-# Plan: 805-undo-prompts — Slice 1: ConversationStore.UndoPrompts
+# Plan: 805-undo-prompts
 
 Parent epic: #805 (`/undo` — remove recent prompts from the active context). Parent tracker: #803.
-This plan covers **Slice 1 only**: `feat(harness): add ConversationStore.UndoPrompts with compaction-boundary guard`.
+Slice 1 (`ConversationStore.UndoPrompts`) is **implemented and merged** (PR #838). This plan now tracks **Slice 2**: `feat(server): POST /v1/conversations/{id}/undo route`.
 
 ## Context
 
 - Problem: a mis-typed or derailing prompt currently lives in go-code's context forever; the only escape is `/clear`, which destroys the whole session. kimi-code's `/undo [count]` trims the last N user prompts plus everything after them.
-- User impact: store-level truncation is the foundation for the server route (Slice 2) and TUI command (Slices 3–4).
-- Constraints: transactional; must refuse undo across a compaction boundary; must persist an undo-boundary marker; strict TDD per `docs/runbooks/testing.md`; reuse the `CompactConversation` transactional pattern in `internal/harness/conversation_store_sqlite.go`.
+- User impact: the HTTP route exposes the Slice 1 store operation to the TUI (Slice 3) and any API client.
+- Constraints: strict TDD per `docs/runbooks/testing.md`; route must sit next to `compact` in `handleConversations` with identical auth (`runs:write`) and tenant-isolation (`blockConversationCrossTenant`) shape; error mapping reuses Slice 1's typed sentinels.
 
 ## Scope
 
 - In scope:
-  - `UndoPrompts(ctx, convID string, count int) (removedFromStep int, err error)` on `ConversationStore` (`internal/harness/conversation_store.go`).
-  - SQLite implementation in `internal/harness/conversation_store_sqlite.go` (Nth-from-last non-meta `user` message lookup, compaction guard, transactional delete, `is_meta` marker insert, `msg_count`/`updated_at` maintenance).
-  - Typed sentinel errors `ErrUndoCrossesCompaction` and `ErrUndoCountOutOfRange` for server-side 409/400 mapping in Slice 2.
-  - Behavior tests in `internal/harness/conversation_undo_test.go` (mirrors `conversation_compact_test.go` file layout).
-  - Stub implementations on all in-repo `ConversationStore` fakes so the repo compiles.
-- Out of scope: server route, TUI command/picker, redo, rewind coupling, in-place prompt editing (later slices / out of epic scope).
+  - `POST /v1/conversations/{id}/undo` branch in `handleConversations` (`internal/server/http_conversations.go`), POST-only, `runs:write`, cross-tenant 404.
+  - `handleUndoConversation` modeled on `handleCompactConversation`: body `{"count": N}` (absent → default 1) or `{"to_step": S}` (undo back to the prompt at step S; computed into a count), empty body treated as defaults; response `{"undone": true, "removed_from_step": S, "remaining_messages": M}`.
+  - Error mapping: `ErrUndoCrossesCompaction` → 409; `ErrUndoCountOutOfRange` and bad `to_step` → 400; unknown conversation → 404; no store → 501; GET → 405.
+  - Behavior tests in `internal/server/http_undo_test.go` (mirrors `http_compact_test.go`) + cross-tenant/scope tests in `internal/server/http_undo_tenant_test.go` (package `server_test`, reusing `newRunlessConversationFixture`).
+  - Engineering-log entry per epic doc requirements (endpoint + boundary semantics).
+- Out of scope: TUI `/undo` command (Slice 3), picker overlay (Slice 4), in-memory reconciliation of an active run's snapshot (matches compact's store-only semantics; the TUI refetches after undo in Slice 3).
 
 ## Documentation Contract
 
 - Feature status: `in implementation`
-- Public docs affected: none (store-level change; user-facing docs land with the TUI slice).
+- Public docs affected: none (operator route lists land with the TUI slice per anti-ghost-feature rule; the route is only described in the engineering log once test-covered).
 - Spec docs to update before code: this plan.
-- Implementation notes to add after code: engineering-log entry lands with Slice 2 per epic doc-requirements; folder index update for this plan file.
+- Implementation notes to add after code: `docs/logs/engineering-log.md` entry (required by epic #805 once Slice 2 lands).
 
 ## Test Plan (TDD)
 
-- New failing tests to add first (`internal/harness/conversation_undo_test.go`):
-  - `TestUndoPrompts_RemovesLastPromptAndTail` — undo 1 removes the last user prompt and trailing assistant/tool messages; `removedFromStep` is the prompt's step; `LoadMessages` round-trip reflects truncation.
-  - `TestUndoPrompts_WalksBackNUserPromptsSkippingMeta` — undo N targets the Nth-from-last non-meta user message; interleaved `is_meta` user-role messages are not counted.
-  - `TestUndoPrompts_CountOutOfRange` — count 0, negative count, and count greater than the number of user prompts all return `ErrUndoCountOutOfRange`.
-  - `TestUndoPrompts_RefusesToCrossCompactionBoundary` — target step at or below the max `is_compact_summary` step returns `ErrUndoCrossesCompaction`; undo above the boundary still succeeds.
-  - `TestUndoPrompts_PersistsBoundaryMarker` — an `is_meta` marker message exists at `removedFromStep` after undo and round-trips through `LoadMessages`; a subsequent undo skips the marker.
-  - `TestUndoPrompts_ConversationNotFound` — unknown convID errors.
-- Existing tests to update: none (new capability).
-- Regression tests required: repo-wide compile check (`go build ./...`, `go vet ./...`) forces all fakes to satisfy the extended interface.
+- New failing tests to add first:
+  - `internal/server/http_undo_test.go`: basic happy path (count, response shape, store truncation verified); default count on `{}` and on empty body; 400 on count 0 / negative / too large; 409 across a compaction boundary (conversation unchanged); `to_step` happy path + 400 on non-prompt step / out-of-range step / combined with count; 404 unknown conversation; 400 invalid JSON; 405 on GET; 501 without a store.
+  - `internal/server/http_undo_tenant_test.go`: cross-tenant POST → 404 and no mutation (positive control: owner 200); key with only `runs:read` → 403.
+- Existing tests to update: none.
+- Regression tests required: `go test ./internal/server/ -run 'Undo|TenantIsolation'`; full `internal/server` + `internal/harness` suites.
 
 ## Cross-Surface Impact Map
 
-- Not a provider/model flow change — no impact map required. Server API and TUI surfaces are explicitly later slices.
+- Not a provider/model flow change — no impact map required. TUI surface is a later slice.
 
-## Implementation Checklist
+## Implementation Checklist (Slice 2)
 
 - [x] Define acceptance criteria in tests (listed above).
 - [x] Document feature status and exact contract before code (this plan).
-- [x] Write failing tests first; verify they fail to compile/run for the right reason (no `UndoPrompts` symbol).
-- [x] Implement minimal code changes (interface + SQLite store + sentinel errors + fake stubs).
-- [x] Run `go test ./internal/harness/ -run Undo -count=1` green.
-- [x] Run `go test` on every touched package (`internal/harness`, `internal/server` if fakes touched).
+- [x] Write failing tests first; verify red for the right reason (POST undo → 404 from the catch-all).
+- [x] Implement minimal code changes (route branch + handler).
+- [x] Run `go test ./internal/server/ -run 'Undo|TenantIsolation' -count=1` green.
+- [x] Run full `go test ./internal/server/... ./internal/harness/... -count=1` green.
 - [x] gofmt + go vet clean.
-- [x] Update `docs/plans/INDEX.md` with this plan (documentation-maintenance runbook).
-- [ ] Commit, push `epic/805-undo-prompts`, open PR (no merge).
+- [x] Engineering-log entry; update `docs/plans/INDEX.md` description if materially changed.
+- [ ] Commit, push `epic/805-undo-prompts-s2`, open PR (no merge).
 
 ## Risks and Mitigations
 
-- Risk: marker message could be counted as an undo target on later undos, corrupting count semantics.
-  - Mitigation: marker is `is_meta = 1`; the target query filters `role = 'user' AND is_meta = 0`; covered by the subsequent-undo test.
-- Risk: other worktree slices implement the same interface extension concurrently and conflict.
-  - Mitigation: keep the diff minimal and exactly to the epic-specified signature so any merge conflict is trivial.
+- Risk: `to_step` lets a caller target a non-prompt message, producing confusing truncations.
+  - Mitigation: handler rejects `to_step` that does not reference a non-meta `user` message with 400 before calling the store; the store's own guards still apply to the computed count.
+- Risk: undo on a conversation with an in-flight run leaves the runner's in-memory snapshot stale.
+  - Mitigation: same semantics as the existing compact route (store mutation only); Slice 3 refetches messages after undo. Documented in the handler comment.
+
+## Slice 1 record (completed, PR #838)
+
+- Added `ConversationStore.UndoPrompts` + SQLite implementation + `ErrUndoCrossesCompaction`/`ErrUndoCountOutOfRange` + `is_meta` boundary marker; tests in `internal/harness/conversation_undo_test.go`; all repo fakes updated. Details in git history (`dec0d0c1`).

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -27,7 +27,7 @@
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
 - `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged) and slice 2 (session/new + session/prompt over the runs API, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
-- `805-undo-prompts.md` — Epic #805 Slice 1 plan: `ConversationStore.UndoPrompts` with compaction-boundary guard (in implementation).
+- `805-undo-prompts.md` — Epic #805 plan: Slice 1 `ConversationStore.UndoPrompts` (merged, PR #838); Slice 2 `POST /v1/conversations/{id}/undo` route (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.
 

--- a/internal/server/http_conversations.go
+++ b/internal/server/http_conversations.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -154,6 +156,23 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleCompactConversation(w, r, parts[0])
+		return
+	}
+
+	// POST /v1/conversations/{id}/undo — drop recent prompts from the active context (runs:write) (Issue #805)
+	if len(parts) == 2 && parts[1] == "undo" {
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w, http.MethodPost)
+			return
+		}
+		if !hasScope(r.Context(), store.ScopeRunsWrite) {
+			writeScopeError(w, store.ScopeRunsWrite)
+			return
+		}
+		if s.blockConversationCrossTenant(w, r, parts[0]) {
+			return
+		}
+		s.handleUndoConversation(w, r, parts[0])
 		return
 	}
 
@@ -393,6 +412,110 @@ func (s *Server) handleCompactConversation(w http.ResponseWriter, r *http.Reques
 		"compacted":     true,
 		"message_count": len(msgs),
 	})
+}
+
+// handleUndoConversation handles POST /v1/conversations/{id}/undo.
+// It removes the last N user prompts (default 1) and every message after them
+// from the persisted conversation (Issue #805). The body accepts either
+// {"count": N} or {"to_step": S} (undo back to the prompt at step S); an empty
+// or field-less body undoes the single most recent prompt.
+//
+// Like the compact route, this mutates only the persisted conversation; a
+// caller with an in-flight run (the TUI) refetches messages after success.
+func (s *Server) handleUndoConversation(w http.ResponseWriter, r *http.Request, convID string) {
+	store := s.runner.GetConversationStore()
+	if store == nil {
+		writeError(w, http.StatusNotImplemented, "not_implemented", "conversation persistence is not configured")
+		return
+	}
+
+	var req struct {
+		Count  *int `json:"count"`
+		ToStep *int `json:"to_step"`
+	}
+	// io.EOF (empty body) is accepted as an all-defaults request.
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
+		return
+	}
+	if req.Count != nil && req.ToStep != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "provide count or to_step, not both")
+		return
+	}
+
+	count := 1
+	if req.Count != nil {
+		count = *req.Count
+	}
+	if req.ToStep != nil {
+		resolved, err := undoCountForStep(r, store, convID, *req.ToStep)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+				return
+			}
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		count = resolved
+	}
+
+	removedFromStep, err := store.UndoPrompts(r.Context(), convID, count)
+	if err != nil {
+		switch {
+		case errors.Is(err, harness.ErrUndoCrossesCompaction):
+			writeError(w, http.StatusConflict, "undo_crosses_compaction", err.Error())
+		case errors.Is(err, harness.ErrUndoCountOutOfRange):
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		case strings.Contains(err.Error(), "not found"):
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+		default:
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		}
+		return
+	}
+
+	msgs, err := store.LoadMessages(r.Context(), convID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"undone":             true,
+		"removed_from_step":  removedFromStep,
+		"remaining_messages": len(msgs),
+	})
+}
+
+// undoCountForStep converts a to_step undo request into a prompt count for
+// ConversationStore.UndoPrompts: the referenced step must exist and point at a
+// non-meta user prompt, and the count is the number of non-meta user prompts
+// from that step through the newest. The store's own range and compaction
+// guards still apply to the resolved count.
+func undoCountForStep(r *http.Request, store harness.ConversationStore, convID string, step int) (int, error) {
+	if step < 0 {
+		return 0, fmt.Errorf("to_step must be >= 0, got %d", step)
+	}
+	msgs, err := store.LoadMessages(r.Context(), convID)
+	if err != nil {
+		return 0, fmt.Errorf("load messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return 0, fmt.Errorf("conversation %q not found", convID)
+	}
+	if step >= len(msgs) {
+		return 0, fmt.Errorf("to_step %d is beyond the conversation history (%d messages)", step, len(msgs))
+	}
+	if msgs[step].Role != "user" || msgs[step].IsMeta {
+		return 0, fmt.Errorf("to_step %d does not reference a user prompt", step)
+	}
+	count := 0
+	for i := step; i < len(msgs); i++ {
+		if msgs[i].Role == "user" && !msgs[i].IsMeta {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // handleConversationsCleanup handles POST /v1/conversations/cleanup.

--- a/internal/server/http_undo_tenant_test.go
+++ b/internal/server/http_undo_tenant_test.go
@@ -1,0 +1,161 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// postJSON issues a POST with a JSON body as the given bearer token.
+func postJSON(t *testing.T, ts *httptest.Server, token, path, body string) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+path, bytes.NewBufferString(body))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestTenantIsolation_UndoConversation_CrossTenantDenied (epic #805 Slice 2):
+// tenant B must not be able to undo prompts in tenant A's conversation — the
+// cross-tenant gate fires with 404 before the handler runs, and the failed
+// attempt must not mutate the conversation. The owner's undo still works
+// (positive control proving the 404 is the gate, not a broken route).
+func TestTenantIsolation_UndoConversation_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newRunlessConversationFixture(t)
+	undoPath := "/v1/conversations/" + f.convID + "/undo"
+
+	// Negative control first: tenant B POST undo -> 404 (must not reveal or mutate).
+	if code, body := postJSON(t, f.ts, f.tokenB, undoPath, `{"count":1}`); code != http.StatusNotFound {
+		t.Errorf("tenant B POST undo: got %d, want 404; body %s", code, body)
+	}
+
+	// Tenant B's attempt must NOT have truncated tenant A's conversation.
+	if code, body := f.get(t, f.tokenA, "/v1/conversations/"+f.convID+"/messages"); code != http.StatusOK {
+		t.Fatalf("tenant A GET messages after B's undo attempt: got %d, want 200; body %s", code, body)
+	} else {
+		var resp struct {
+			Messages []harness.Message `json:"messages"`
+		}
+		if err := json.Unmarshal([]byte(body), &resp); err != nil {
+			t.Fatalf("decode messages: %v (%s)", err, body)
+		}
+		if len(resp.Messages) != 2 {
+			t.Errorf("cross-tenant undo mutated the conversation: got %d messages, want 2", len(resp.Messages))
+		}
+	}
+
+	// Positive control: tenant A (owner) can undo; without this a 404 above
+	// could mean a broken route rather than a real tenant gate.
+	code, body := postJSON(t, f.ts, f.tokenA, undoPath, `{"count":1}`)
+	if code != http.StatusOK {
+		t.Fatalf("tenant A POST undo: got %d, want 200; body %s", code, body)
+	}
+	var resp struct {
+		Undone            bool `json:"undone"`
+		RemovedFromStep   int  `json:"removed_from_step"`
+		RemainingMessages int  `json:"remaining_messages"`
+	}
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("decode undo response: %v (%s)", err, body)
+	}
+	if !resp.Undone || resp.RemainingMessages != 1 {
+		t.Errorf("unexpected undo response: %+v (want undone=true, remaining_messages=1 marker)", resp)
+	}
+}
+
+// TestUndoConversationEndpoint_RequiresRunsWrite (epic #805 Slice 2): the undo
+// route is destructive, so a key carrying only runs:read must be rejected with
+// 403, while a runs:write key on the owning tenant succeeds.
+func TestUndoConversationEndpoint_RequiresRunsWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	ms := store.NewMemoryStore()
+
+	tenantW := "tenant-writer"
+	tokenW, keyW := generateFastAPIKey(t, tenantW, "writer key", []string{
+		store.ScopeRunsRead,
+		store.ScopeRunsWrite,
+	})
+	if err := ms.CreateAPIKey(ctx, keyW); err != nil {
+		t.Fatalf("CreateAPIKey writer: %v", err)
+	}
+
+	tokenR, keyR := generateFastAPIKey(t, tenantW, "reader key", []string{
+		store.ScopeRunsRead,
+	})
+	if err := ms.CreateAPIKey(ctx, keyR); err != nil {
+		t.Fatalf("CreateAPIKey reader: %v", err)
+	}
+
+	cs, err := harness.NewSQLiteConversationStore(filepath.Join(t.TempDir(), "undo-scope.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteConversationStore: %v", err)
+	}
+	if err := cs.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = cs.Close() })
+
+	convID := "conv-undo-scope"
+	if err := cs.SaveConversation(ctx, convID, []harness.Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+	}); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+	if err := cs.UpdateConversationMeta(ctx, convID, "", tenantW); err != nil {
+		t.Fatalf("UpdateConversationMeta: %v", err)
+	}
+
+	runner := harness.NewRunner(
+		fakeprovider.New(nil),
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "test-model", Store: ms, ConversationStore: cs},
+	)
+	h := server.NewWithOptions(server.ServerOptions{Store: ms, Runner: runner})
+	ts := httptest.NewServer(h)
+	t.Cleanup(func() {
+		ts.Close()
+		runner.Shutdown(context.Background())
+	})
+
+	undoPath := "/v1/conversations/" + convID + "/undo"
+
+	// runs:read-only key -> 403 insufficient_scope, and no mutation.
+	if code, body := postJSON(t, ts, tokenR, undoPath, `{"count":1}`); code != http.StatusForbidden {
+		t.Errorf("read-only POST undo: got %d, want 403; body %s", code, body)
+	}
+	loaded, err := cs.LoadMessages(ctx, convID)
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Errorf("read-only undo mutated the conversation: got %d messages, want 2", len(loaded))
+	}
+
+	// runs:write key on the owning tenant -> 200 (proves the 403 is the scope gate).
+	if code, body := postJSON(t, ts, tokenW, undoPath, `{"count":1}`); code != http.StatusOK {
+		t.Errorf("writer POST undo: got %d, want 200; body %s", code, body)
+	}
+}

--- a/internal/server/http_undo_test.go
+++ b/internal/server/http_undo_test.go
@@ -1,0 +1,380 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+)
+
+// ---------------------------------------------------------------------------
+// Epic #805 Slice 2: POST /v1/conversations/{id}/undo tests
+// ---------------------------------------------------------------------------
+
+// seedUndoConversation saves an alternating user/assistant history of nPairs
+// prompt-response pairs (2*nPairs messages) and returns the convID.
+func seedUndoConversation(t *testing.T, store *harness.SQLiteConversationStore, convID string, nPairs int) string {
+	t.Helper()
+	msgs := make([]harness.Message, 0, 2*nPairs)
+	for i := 1; i <= nPairs; i++ {
+		msgs = append(msgs,
+			harness.Message{Role: "user", Content: fmt.Sprintf("%s-q%d", convID, i)},
+			harness.Message{Role: "assistant", Content: fmt.Sprintf("%s-a%d", convID, i)},
+		)
+	}
+	if err := store.SaveConversation(context.Background(), convID, msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+	return convID
+}
+
+func newUndoTestServer(t *testing.T, store harness.ConversationStore) *httptest.Server {
+	t.Helper()
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{ConversationStore: store},
+	)
+	ts := httptest.NewServer(New(runner))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestUndoConversationEndpoint_Basic(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	seedUndoConversation(t, store, "conv-http-undo", 3) // steps 0..5
+
+	ts := newUndoTestServer(t, store)
+
+	body := bytes.NewBufferString(`{"count":2}`)
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-http-undo/undo", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, b)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["undone"] != true {
+		t.Errorf("expected undone=true, got %v", resp["undone"])
+	}
+	// count=2 targets the 2nd-from-last prompt: user msg at step 2.
+	if got, ok := resp["removed_from_step"].(float64); !ok || int(got) != 2 {
+		t.Errorf("removed_from_step: got %v (%T), want 2", resp["removed_from_step"], resp["removed_from_step"])
+	}
+	// Steps 0,1 kept + undo-boundary marker at step 2 = 3 messages.
+	if got, ok := resp["remaining_messages"].(float64); !ok || int(got) != 3 {
+		t.Errorf("remaining_messages: got %v (%T), want 3", resp["remaining_messages"], resp["remaining_messages"])
+	}
+
+	// Verify the persisted conversation reflects the truncation.
+	loaded, err := store.LoadMessages(ctx, "conv-http-undo")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != 3 {
+		t.Fatalf("expected 3 messages after undo, got %d: %+v", len(loaded), loaded)
+	}
+	if loaded[0].Content != "conv-http-undo-q1" || loaded[1].Content != "conv-http-undo-a1" {
+		t.Errorf("kept messages wrong: %+v", loaded)
+	}
+	if !loaded[2].IsMeta {
+		t.Errorf("expected trailing is_meta undo-boundary marker, got %+v", loaded[2])
+	}
+}
+
+func TestUndoConversationEndpoint_DefaultCount(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	seedUndoConversation(t, store, "conv-undo-default", 2) // steps 0..3
+	seedUndoConversation(t, store, "conv-undo-empty", 2)
+
+	ts := newUndoTestServer(t, store)
+
+	// Absent count in an otherwise valid JSON body defaults to 1.
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-default/undo", "application/json", bytes.NewBufferString(`{}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200 for {}, got %d: %s", res.StatusCode, b)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, ok := resp["removed_from_step"].(float64); !ok || int(got) != 2 {
+		t.Errorf("removed_from_step: got %v, want 2 (last prompt)", resp["removed_from_step"])
+	}
+
+	// An empty body is accepted as all-defaults (undo last prompt).
+	res2, err := http.Post(ts.URL+"/v1/conversations/conv-undo-empty/undo", "application/json", bytes.NewBufferString(""))
+	if err != nil {
+		t.Fatalf("POST undo empty body: %v", err)
+	}
+	defer res2.Body.Close()
+	if res2.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res2.Body)
+		t.Fatalf("expected 200 for empty body, got %d: %s", res2.StatusCode, b)
+	}
+	var resp2 map[string]any
+	if err := json.NewDecoder(res2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, ok := resp2["removed_from_step"].(float64); !ok || int(got) != 2 {
+		t.Errorf("empty-body removed_from_step: got %v, want 2", resp2["removed_from_step"])
+	}
+}
+
+func TestUndoConversationEndpoint_BadCount(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	seedUndoConversation(t, store, "conv-undo-badcount", 2) // 2 prompts
+
+	ts := newUndoTestServer(t, store)
+
+	for _, body := range []string{`{"count":0}`, `{"count":-3}`, `{"count":9}`} {
+		res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-badcount/undo", "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("POST undo %s: %v", body, err)
+		}
+		b, _ := io.ReadAll(res.Body)
+		res.Body.Close()
+		if res.StatusCode != http.StatusBadRequest {
+			t.Errorf("POST %s: expected 400, got %d: %s", body, res.StatusCode, b)
+		}
+	}
+
+	// Failed undos must leave the conversation untouched.
+	loaded, err := store.LoadMessages(ctx, "conv-undo-badcount")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != 4 {
+		t.Fatalf("conversation mutated by failed undos: got %d messages, want 4", len(loaded))
+	}
+}
+
+func TestUndoConversationEndpoint_CrossesCompaction(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+
+	msgs := []harness.Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "system", Content: "summary of earlier context", IsCompactSummary: true},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := store.SaveConversation(ctx, "conv-undo-compacted", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	ts := newUndoTestServer(t, store)
+
+	// count=2 targets q1 at step 0, below the compaction summary at step 2.
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-compacted/undo", "application/json", bytes.NewBufferString(`{"count":2}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	b, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", res.StatusCode, b)
+	}
+	if !strings.Contains(string(b), "undo_crosses_compaction") {
+		t.Errorf("expected undo_crosses_compaction error code, got: %s", b)
+	}
+
+	// The conversation must be unchanged after a refused undo.
+	loaded, err := store.LoadMessages(ctx, "conv-undo-compacted")
+	if err != nil {
+		t.Fatalf("LoadMessages: %v", err)
+	}
+	if len(loaded) != len(msgs) {
+		t.Fatalf("conversation mutated by refused undo: got %d messages, want %d", len(loaded), len(msgs))
+	}
+}
+
+func TestUndoConversationEndpoint_ToStep(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	seedUndoConversation(t, store, "conv-undo-tostep", 3) // steps 0..5
+
+	ts := newUndoTestServer(t, store)
+
+	// to_step=4 references the last user prompt: same result as count=1.
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-tostep/undo", "application/json", bytes.NewBufferString(`{"to_step":4}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, b)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got, ok := resp["removed_from_step"].(float64); !ok || int(got) != 4 {
+		t.Errorf("removed_from_step: got %v, want 4", resp["removed_from_step"])
+	}
+	if got, ok := resp["remaining_messages"].(float64); !ok || int(got) != 5 {
+		t.Errorf("remaining_messages: got %v, want 5 (4 kept + marker)", resp["remaining_messages"])
+	}
+}
+
+func TestUndoConversationEndpoint_ToStepInvalid(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	seedUndoConversation(t, store, "conv-undo-tostep-bad", 2) // steps 0..3
+
+	ts := newUndoTestServer(t, store)
+
+	cases := map[string]string{
+		"assistant message step": `{"to_step":1}`,
+		"step beyond history":    `{"to_step":99}`,
+		"negative step":          `{"to_step":-1}`,
+		"count and to_step both": `{"count":1,"to_step":2}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-tostep-bad/undo", "application/json", bytes.NewBufferString(body))
+			if err != nil {
+				t.Fatalf("POST undo %s: %v", body, err)
+			}
+			b, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+			if res.StatusCode != http.StatusBadRequest {
+				t.Errorf("POST %s: expected 400, got %d: %s", body, res.StatusCode, b)
+			}
+		})
+	}
+}
+
+func TestUndoConversationEndpoint_ToStepCrossesCompaction(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	msgs := []harness.Message{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "system", Content: "summary", IsCompactSummary: true},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	if err := store.SaveConversation(context.Background(), "conv-undo-tostep-compact", msgs); err != nil {
+		t.Fatalf("SaveConversation: %v", err)
+	}
+
+	ts := newUndoTestServer(t, store)
+
+	// to_step=0 is a valid prompt reference, but it sits below the compaction
+	// summary at step 2, so the store guard maps to 409.
+	res, err := http.Post(ts.URL+"/v1/conversations/conv-undo-tostep-compact/undo", "application/json", bytes.NewBufferString(`{"to_step":0}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	b, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", res.StatusCode, b)
+	}
+}
+
+func TestUndoConversationEndpoint_NonExistentConversation(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ts := newUndoTestServer(t, store)
+
+	res, err := http.Post(ts.URL+"/v1/conversations/does-not-exist/undo", "application/json", bytes.NewBufferString(`{"count":1}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	b, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for non-existent conversation, got %d: %s", res.StatusCode, b)
+	}
+}
+
+func TestUndoConversationEndpoint_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ts := newUndoTestServer(t, store)
+
+	res, err := http.Post(ts.URL+"/v1/conversations/any-conv/undo", "application/json", bytes.NewBufferString(`not json`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for invalid JSON, got %d", res.StatusCode)
+	}
+}
+
+func TestUndoConversationEndpoint_WrongMethod(t *testing.T) {
+	t.Parallel()
+
+	store := newTestSQLiteStore(t)
+	ts := newUndoTestServer(t, store)
+
+	res, err := http.Get(ts.URL + "/v1/conversations/any-conv/undo")
+	if err != nil {
+		t.Fatalf("GET undo: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", res.StatusCode)
+	}
+}
+
+func TestUndoConversationEndpoint_NoStore(t *testing.T) {
+	t.Parallel()
+
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "ok"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{}, // no store
+	)
+	ts := httptest.NewServer(New(runner))
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/conversations/any-conv/undo", "application/json", bytes.NewBufferString(`{"count":1}`))
+	if err != nil {
+		t.Fatalf("POST undo: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", res.StatusCode)
+	}
+}


### PR DESCRIPTION
Parent epic: #805. Part of #803.

## What

Slice 2 of the `/undo` epic: the HTTP surface for Slice 1's store operation.

- Route `undo` in `handleConversations` (`internal/server/http_conversations.go`) next to `compact`: POST-only (405), `runs:write` scope (403), `blockConversationCrossTenant` (cross-tenant 404, non-mutating).
- `handleUndoConversation` modeled on `handleCompactConversation`: body `{"count": N}` (absent → default 1) or `{"to_step": S}` resolved to a prompt count by `undoCountForStep` (400 on negative/out-of-history step or a step referencing a non-prompt message; 400 when both fields are sent). Empty body = undo last prompt.
- Error mapping: `ErrUndoCrossesCompaction` → 409 `undo_crosses_compaction`; `ErrUndoCountOutOfRange` → 400; unknown conversation → 404; no store → 501. Response: `{"undone": true, "removed_from_step": S, "remaining_messages": M}`.
- Store-only mutation, same semantics as the existing compact route (in-memory snapshots reconcile on refetch/restart; the TUI slice refetches after undo).

## Tests (strict TDD — red verified as 404 from the routing catch-all before implementation)

- `internal/server/http_undo_test.go` (10 tests): basic + response shape + persisted truncation; default count on `{}` and on empty body; 400 on count 0/negative/too-large (conversation untouched); 409 across compaction (untouched); `to_step` happy path; `to_step` 400s; `to_step` across compaction → 409; 404 unknown conversation; 400 invalid JSON; 405 on GET; 501 without store.
- `internal/server/http_undo_tenant_test.go` (2 tests): cross-tenant POST → 404 with no mutation + owner positive control; `runs:read`-only key → 403 with no mutation.

## Verification (all actually run)

- `go test ./internal/server/ -run 'Undo|TenantIsolation' -count=1` — PASS (all 12 new + all pre-existing TenantIsolation tests)
- `go test ./internal/server/... ./internal/harness/... -count=1` — PASS (9 packages)
- `go vet ./internal/server/...` clean; touched files gofmt-clean
- tmux smoke vs `harnessd` (fake provider + `HARNESS_CONVERSATION_DB`): two runs on one conversation → `POST /v1/conversations/{id}/undo {"count":1}` → 200 `{"remaining_messages":3,"removed_from_step":2,"undone":true}`; after daemon restart, `GET {id}/messages` serves the truncated history with the `is_meta` undo-boundary marker. GET on the route → 405.

Engineering-log entry added per epic doc requirements. Plan: `docs/plans/805-undo-prompts.md`.