### PR TITLE
feat(harness): expose background bash jobs to the task union

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -447,6 +447,7 @@ type serverBootstrapOptions struct {
 	rolloutDir       string
 	hooksSummary     hooks.Summary
 	callbackMgr      *htools.CallbackManager
+	jobTracker       *harness.JobTracker
 }
 
 func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
@@ -475,5 +476,6 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		RolloutDir:       opts.rolloutDir,
 		HooksSummary:     opts.hooksSummary,
 		CallbackLister:   opts.callbackMgr,
+		JobTracker:       opts.jobTracker,
 	}
 }

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -609,6 +609,13 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		log.Printf("delayed callbacks enabled")
 	}
 
+	// Daemon-level background bash job tracker (epic #814 slice 2). Every
+	// tool registry built with baseRegistryOptions — main, per-run
+	// provisioned-workspace, and subagent worktree registries — registers its
+	// JobManager here so GET /v1/tasks can enumerate bash jobs daemon-wide
+	// and POST /v1/jobs/{id}/kill can terminate them.
+	jobTracker := harness.NewJobTracker()
+
 	// MCP server startup: TOML config (layers 1-3, no profile) then env var
 	// servers are registered additively. TOML entries take precedence over env
 	// var entries with the same name.
@@ -761,6 +768,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		ModelCatalog:       modelCatalog,
 		CronClient:         cronClient,
 		CallbackManager:    callbackMgr,
+		JobTracker:         jobTracker,
 		Activations:        activations,
 		Sourcegraph: htools.SourcegraphConfig{
 			Endpoint: sourcegraphEndpoint,
@@ -942,6 +950,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		callbackStarter:      callbackStarter,
 		callbackBridge:       callbackBridge,
 		callbackMgr:          callbackMgr,
+		jobTracker:           jobTracker,
 		msgSummarizer:        msgSummarizer,
 		skillManager:         skillManager,
 		hooksSummary:         hooksSummary,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -83,6 +83,7 @@ type httpRuntimeOptions struct {
 	callbackStarter      *callbackRunStarter
 	callbackBridge       *harness.CallbackEventBridge
 	callbackMgr          *htools.CallbackManager
+	jobTracker           *harness.JobTracker
 	msgSummarizer        *lazySummarizer
 	skillManager         server.SkillManager
 	hooksSummary         hooks.Summary
@@ -284,6 +285,7 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		rolloutDir:       opts.runnerCfg.RolloutDir,
 		hooksSummary:     opts.hooksSummary,
 		callbackMgr:      opts.callbackMgr,
+		jobTracker:       opts.jobTracker,
 	}))
 
 	// Mount the MCP server at /mcp so external MCP clients can drive the harness.

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -44,6 +44,14 @@
 - In-memory caveat, same as the existing compact route: the mutation is store-only, so `GET {id}/messages` on a conversation still resident in the runner's memory shows the pre-undo snapshot until the run ends or the daemon restarts (the store fallback then serves the truncated history). The TUI slice refetches after undo.
 - Validation: failing-first tests in `internal/server/http_undo_test.go` (10 endpoint behavior tests) and `internal/server/http_undo_tenant_test.go` (cross-tenant 404 + no-mutation, `runs:read`-only 403); `go test ./internal/server/ -run 'Undo|TenantIsolation' -count=1` green. tmux smoke against `harnessd` (fake provider, `HARNESS_CONVERSATION_DB` set): `POST .../undo {"count":1}` → 200 `{"undone":true,"removed_from_step":2,"remaining_messages":3}`; after restart, `GET .../messages` serves the truncated history with the marker.
 
+## 2026-07-19 (Unified /tasks Panel — Epic #814, Slice 2)
+
+- Background bash jobs are now enumerable and killable daemon-wide. `JobManager.List` (`internal/harness/tools/bash_manager.go` unexported `list` + exported wrapper in `job_manager_exports.go`) returns `JobInfo` snapshots (id, command, working dir, started-at, tenant, running, exit code, timed-out) with a `Status()` of `running`/`exited`/`timed_out`; `runBackground` captures the originating run's tenant from `RunMetadataFromContext`.
+- New `harness.JobTracker` (`internal/harness/job_tracker.go`): per-registry job managers register via the new `DefaultRegistryOptions.JobTracker` (unregister on registry shutdown), so the main registry, per-run provisioned-workspace registries (runner.go), and subagent worktree registries are all covered. Task IDs are namespaced `jm<N>:job_<n>` because managers number jobs from `job_1` independently.
+- Server: `GET /v1/tasks` unions `bash_job` entries (label = command, cancel action while running) with the same tenant filtering as callbacks; new `POST /v1/jobs/{id}/kill` (runs:write, 404 unknown/cross-tenant, 501 unconfigured) reuses `JobManager.Kill`.
+- harnessd: one `JobTracker` created in `main.go`, threaded via `baseRegistryOptions` and `runtime_container`/`bootstrap_helpers` into `ServerOptions.JobTracker`.
+- Validation: failing-first tests — `bash_manager_list_test.go` (7 tests incl. race-checked concurrency), `job_tracker_test.go` (6 tests incl. registry-wiring integration through the real `bash` tool and `job_output`), and 8 new `http_tasks_test.go` tests. `go test ./internal/server/ ./internal/harness/ ./internal/harness/tools/ ./cmd/harnessd/ -count=1` all pass; the pre-existing flaky `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly` passed in this run.
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/814-tasks-panel.md
+++ b/docs/plans/814-tasks-panel.md
@@ -1,57 +1,81 @@
-# Plan: GET /v1/tasks union endpoint (epic #814, slice 1)
+# Plan: unified /tasks background panel (epic #814)
 
-## Context
+## Slice 1 (merged, PR #834): GET /v1/tasks union endpoint for subagents, cron, callbacks
 
-- Problem: background work (subagents, cron jobs, delayed callbacks) is only visible through separate surfaces; there is no single endpoint answering "what is running right now?".
-- User impact: TUI `/tasks` panel (later slices) and non-TUI clients need one authenticated union endpoint.
-- Constraints: slice 1 of epic #814 only — subagents + cron + callbacks. Bash jobs are slice 2, TUI panel is slice 3. Strict TDD per `docs/runbooks/testing.md`.
+- `internal/server/http_tasks.go`: unified `Task` DTO + `GET /v1/tasks` (runs:read) unioning subagents, cron jobs, pending callbacks.
+- `CallbackManager.ListAll` for cross-conversation pending-callback enumeration; daemon wired via `ServerOptions.CallbackLister`.
 
-## Scope
+## Slice 2 (this branch, epic/814-tasks-panel-s2): expose background bash jobs to the task union
+
+### Context
+
+- Problem: background bash jobs run through the agent-facing `job_output`/`job_kill` tools backed by a per-registry `JobManager` (`internal/harness/tools/bash_manager.go`). Registries are built per daemon (`cmd/harnessd/runtime_container.go`) and per provisioned-workspace run (`internal/harness/runner.go:1148`), so jobs are not enumerable or killable daemon-wide.
+- User impact: `GET /v1/tasks` must answer "what background bash jobs are running?" and the daemon must be able to kill them server-side.
+- Constraints: slice 2 only — no TUI changes (slice 3), no generic `/v1/tasks/{id}/cancel` for other types. Strict TDD.
+
+### Scope
 
 - In scope:
-  - Unified `Task` DTO + `GET /v1/tasks` handler in `internal/server/http_tasks.go` (new).
-  - Route registration in `internal/server/http.go` next to `/v1/subagents` and `/v1/cron/jobs`, requiring `runs:read`.
-  - `CallbackManager.ListAll()` for cross-conversation enumeration of pending callbacks (`internal/harness/tools/delayed_callback.go`).
-  - Server wiring: new `CallbackLister` option on `ServerOptions`; pass the daemon's `*tools.CallbackManager` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
-- Out of scope: bash jobs in the union, any cancel/kill endpoint, TUI changes (later slices).
+  - `JobManager.List()` snapshot (unexported `list()` in `bash_manager.go`, exported wrapper in `job_manager_exports.go` per the existing pattern) returning `JobInfo{ID, Command, WorkingDir, StartedAt, TenantID, Running, ExitCode, TimedOut}`; tenant captured from `RunMetadataFromContext` in `runBackground`.
+  - Daemon-level `JobTracker` (`internal/harness/job_tracker.go`): register/unregister per-registry managers, `List()` union with namespaced task IDs (`jm<N>:job_<n>`), `Get`, and `Kill` reusing `JobManager.Kill`.
+  - `DefaultRegistryOptions.JobTracker` so the main registry, per-run workspace registries (runner.go:1148), and subagent worktree registries all register their managers; unregister via registry shutdown hook.
+  - Server: `bash_job` entries in `GET /v1/tasks` (status `running`/`exited`/`timed_out`, label = command, tenant-filtered like callbacks) and `POST /v1/jobs/{id}/kill` (runs:write, 404 unknown/cross-tenant, 501 unconfigured).
+  - harnessd wiring: one `JobTracker` created in `main.go`, threaded to `baseRegistryOptions` and `ServerOptions.JobTracker`.
+- Out of scope: TUI panel (slice 3), panel stop actions for other task types (slice 4), changing agent-facing `shell_id` format (`job_<n>` stays), the pre-existing flaky `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly`.
 
-## Documentation Contract
+### Test Plan (TDD)
 
-- Feature status: `in implementation`
-- Public docs affected: none (new endpoint; later slices own user-facing `/tasks` docs).
-- Spec docs to update before code: none.
-- Implementation notes to add after code: engineering log entry per runbook.
+- New failing tests first:
+  - `internal/harness/tools/bash_manager_list_test.go`: empty List; running → exited transition with exit code; timed-out status; ttl-evicted jobs absent; tenant captured from run metadata; concurrent List/RunBackground/Kill (race).
+  - `internal/harness/job_tracker_test.go`: register idempotence + unique refs; List unions with namespaced IDs; unregister removes; Get; Kill routes to the right manager and unknown ID → ErrJobNotFound.
+  - `internal/server/http_tasks_test.go` (extend): `bash_job` union entries (status/label/actions); tenant filtering; `POST /v1/jobs/{id}/kill` kills a real running job (200, `job_output` shows not-running), 404 unknown, 404 cross-tenant, 403 without runs:write, 405 on GET, 501 when tracker unconfigured.
+- Regression net: the above plus existing slice-1 handler tests.
 
-## Test Plan (TDD)
+### Cross-Surface Impact Map
 
-- New failing tests to add first:
-  - `internal/harness/tools/delayed_callback_test.go`: `ListAll` returns pending callbacks across conversations; fired/canceled excluded; empty manager returns empty.
-  - `internal/server/http_tasks_test.go`:
-    - empty union → 200 with `"tasks": []`;
-    - subagent entries map to `type=subagent` with status/label/age/actions;
-    - cron entries map to `type=cron`;
-    - callback entries map to `type=callback`;
-    - tenant filtering matches `/v1/subagents` and `/v1/cron/jobs` behavior;
-    - missing `runs:read` scope → 403; unauthenticated → 401 (auth enabled);
-    - nil sources are skipped (partial union still 200).
-- Existing tests to update: none expected.
-- Regression tests required: handler tests above are the regression net.
+- Not required (no provider/model flow, gateway routing, catalog, or API-key surface). Config: None. Server API: `/v1/tasks` gains `bash_job` entries; new `/v1/jobs/{id}/kill`. TUI state: None (slice 3). Regression tests: listed above.
 
-## Cross-Surface Impact Map
-
-- Required? This adds a server API route but does not touch provider/model flows, gateway routing, model catalogs, API-key management, or provider plumbing → not required. Config: None. TUI state: None (slice 3). Regression tests: new handler tests listed above.
-
-## Implementation Checklist
+### Implementation Checklist
 
 - [x] Define acceptance criteria in tests.
-- [x] Write failing tests first (`internal/server/http_tasks_test.go`, `delayed_callback_test.go` addition).
-- [x] Implement `CallbackManager.ListAll`.
-- [x] Implement `internal/server/http_tasks.go` (DTO, mapping, tenant filter, sorting) + route in `http.go`.
-- [x] Wire `CallbackLister` through `ServerOptions` and `cmd/harnessd`.
-- [x] gofmt + go vet clean; `go test ./internal/server/... ./internal/harness/tools/... ./cmd/harnessd/... -count=1` green (one pre-existing `internal/harness/tools` failure also red on main — see engineering log).
-- [x] Update engineering log; commit, push `epic/814-tasks-panel`, open PR (no merge).
+- [x] Failing tests first (tools list, tracker, server union + kill).
+- [x] `JobManager.List` + tenant capture.
+- [x] `JobTracker` + `DefaultRegistryOptions.JobTracker` + tools_default registration/unregistration.
+- [x] Server union + kill route + harnessd wiring.
+- [x] gofmt/vet clean; package tests green; docs (this plan, engineering log, indexes).
+- [x] Commit, push `epic/814-tasks-panel-s2`, open PR (no merge).
 
-## Risks and Mitigations
+### Risks and Mitigations
 
-- Risk: tenant-scoping semantics differ per source (subagents normalize ""→"default"; cron exact-match with ""-caller passthrough).
-- Mitigation: reuse the existing helpers verbatim (`filterSubagentsByTenant`, `filterCronJobsByTenant`) and mirror the cron helper shape for callbacks, with tests for each.
+- Risk: job IDs collide across managers (each starts at `job_1`). Mitigation: tracker namespaces task IDs as `jm<N>:job_<n>`; kill parses the namespace.
+- Risk: tracker grows unboundedly with per-run registries. Mitigation: registry shutdown hook unregisters; entries are tiny; closed managers hold no jobs.
+- Risk: flaky `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly` (pre-existing on main) interferes with package test runs. Mitigation: re-run targeted tests; report exact failing command if it persists; do not fix it here.
+
+## Documentation Contract (slice 2)
+
+- Feature status: `in implementation`
+- Public docs affected: none (server-internal; TUI docs land with slice 3).
+- Implementation notes after code: engineering log entry.
+
+## Slice 1 detail (kept for reference)
+
+### Context
+
+- Problem: background work (subagents, cron jobs, delayed callbacks) is only visible through separate surfaces; there is no single endpoint answering "what is running right now?".
+- Constraints: slice 1 of epic #814 only — subagents + cron + callbacks.
+
+### Scope
+
+- Unified `Task` DTO + `GET /v1/tasks` handler in `internal/server/http_tasks.go`.
+- Route registration in `internal/server/http.go` next to `/v1/subagents` and `/v1/cron/jobs`, requiring `runs:read`.
+- `CallbackManager.ListAll()` for cross-conversation enumeration of pending callbacks (`internal/harness/tools/delayed_callback.go`).
+- Server wiring: new `CallbackLister` option on `ServerOptions`; pass the daemon's `*tools.CallbackManager` through `cmd/harnessd` (`main.go` → `runtime_container.go` → `bootstrap_helpers.go`).
+
+### Test Plan (TDD) — done
+
+- `internal/harness/tools/delayed_callback_test.go`: `ListAll` across conversations; fired/canceled excluded; empty manager.
+- `internal/server/http_tasks_test.go`: empty union → 200 `{"tasks": []}`; per-source typing; tenant filtering; 401/403; nil sources skipped.
+
+### Implementation Checklist (slice 1)
+
+- [x] All items complete; merged via PR #834.

--- a/internal/harness/job_tracker.go
+++ b/internal/harness/job_tracker.go
@@ -1,0 +1,145 @@
+package harness
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// ErrJobNotFound is returned by JobTracker.Kill when the (possibly
+// namespaced) task ID does not identify any tracked background job.
+var ErrJobNotFound = errors.New("background job not found")
+
+// TrackedJob pairs a daemon-unique task ID with a job snapshot. TaskID is
+// namespaced as "<managerRef>:<shellID>" (e.g. "jm2:job_1") because every
+// JobManager numbers its own jobs from job_1 and IDs collide across managers.
+type TrackedJob struct {
+	TaskID string
+	Info   htools.JobInfo
+}
+
+// JobTracker is the daemon-level registry of per-registry JobManagers. Each
+// tool registry built by NewDefaultRegistryWithOptions owns a JobManager;
+// registries created with DefaultRegistryOptions.JobTracker set register
+// their manager here so the /v1/tasks union (epic #814) can enumerate and
+// kill background bash jobs across the whole daemon — main registry, per-run
+// provisioned-workspace registries, and subagent worktree registries alike.
+//
+// All methods are safe for concurrent use.
+type JobTracker struct {
+	mu       sync.RWMutex
+	nextSeq  uint64
+	managers map[string]*htools.JobManager // ref -> manager
+	refs     map[*htools.JobManager]string // manager -> ref (idempotent Register)
+}
+
+// NewJobTracker returns an empty tracker.
+func NewJobTracker() *JobTracker {
+	return &JobTracker{
+		managers: make(map[string]*htools.JobManager),
+		refs:     make(map[*htools.JobManager]string),
+	}
+}
+
+// Register makes a manager's jobs visible to List/Get/Kill and returns the
+// manager's ref. Registering the same manager twice returns the original ref.
+func (t *JobTracker) Register(m *htools.JobManager) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if ref, ok := t.refs[m]; ok {
+		return ref
+	}
+	t.nextSeq++
+	ref := fmt.Sprintf("jm%d", t.nextSeq)
+	t.managers[ref] = m
+	t.refs[m] = ref
+	return ref
+}
+
+// Unregister removes the manager with the given ref. Unknown refs are a no-op.
+func (t *JobTracker) Unregister(ref string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	m, ok := t.managers[ref]
+	if !ok {
+		return
+	}
+	delete(t.managers, ref)
+	delete(t.refs, m)
+}
+
+// List unions job snapshots across every registered manager, namespacing each
+// job's ID into a daemon-unique TaskID. Output is sorted by TaskID for
+// deterministic responses.
+func (t *JobTracker) List() []TrackedJob {
+	t.mu.RLock()
+	type entry struct {
+		ref string
+		mgr *htools.JobManager
+	}
+	entries := make([]entry, 0, len(t.managers))
+	for ref, mgr := range t.managers {
+		entries = append(entries, entry{ref: ref, mgr: mgr})
+	}
+	t.mu.RUnlock()
+
+	var out []TrackedJob
+	for _, e := range entries {
+		for _, info := range e.mgr.List() {
+			out = append(out, TrackedJob{
+				TaskID: e.ref + ":" + info.ID,
+				Info:   info,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TaskID < out[j].TaskID })
+	return out
+}
+
+// Get returns the tracked job for a namespaced task ID, or false when the
+// manager ref, the job, or the ID format itself is unknown.
+func (t *JobTracker) Get(taskID string) (TrackedJob, bool) {
+	mgr, shellID, ok := t.resolve(taskID)
+	if !ok {
+		return TrackedJob{}, false
+	}
+	for _, info := range mgr.List() {
+		if info.ID == shellID {
+			return TrackedJob{TaskID: taskID, Info: info}, true
+		}
+	}
+	return TrackedJob{}, false
+}
+
+// Kill terminates the job identified by a namespaced task ID, reusing the
+// owning manager's Kill (same mechanism as the agent-facing job_kill tool).
+// Unknown task IDs return ErrJobNotFound.
+func (t *JobTracker) Kill(taskID string) error {
+	mgr, shellID, ok := t.resolve(taskID)
+	if !ok {
+		return ErrJobNotFound
+	}
+	if _, err := mgr.Kill(shellID); err != nil {
+		return fmt.Errorf("%w: %v", ErrJobNotFound, err)
+	}
+	return nil
+}
+
+// resolve splits a namespaced task ID and returns the owning manager.
+func (t *JobTracker) resolve(taskID string) (*htools.JobManager, string, bool) {
+	ref, shellID, found := strings.Cut(taskID, ":")
+	if !found || ref == "" || shellID == "" {
+		return nil, "", false
+	}
+	t.mu.RLock()
+	mgr, ok := t.managers[ref]
+	t.mu.RUnlock()
+	if !ok {
+		return nil, "", false
+	}
+	return mgr, shellID, true
+}

--- a/internal/harness/job_tracker_test.go
+++ b/internal/harness/job_tracker_test.go
@@ -1,0 +1,247 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// startTrackedJob starts a background job on the manager and returns its
+// shell_id.
+func startTrackedJob(t *testing.T, mgr *htools.JobManager, command string) string {
+	t.Helper()
+	result, err := mgr.RunBackground(command, 60, "")
+	if err != nil {
+		t.Fatalf("RunBackground(%q): %v", command, err)
+	}
+	shellID, _ := result["shell_id"].(string)
+	if shellID == "" {
+		t.Fatalf("RunBackground(%q) returned no shell_id: %v", command, result)
+	}
+	return shellID
+}
+
+func TestJobTrackerRegisterIdempotentAndUnique(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgrA := htools.NewJobManager(t.TempDir(), nil)
+	mgrB := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgrA.Shutdown(context.Background()) }()
+	defer func() { _ = mgrB.Shutdown(context.Background()) }()
+
+	refA1 := tracker.Register(mgrA)
+	refA2 := tracker.Register(mgrA)
+	if refA1 != refA2 {
+		t.Fatalf("re-registering the same manager returned %q then %q, want identical refs", refA1, refA2)
+	}
+	refB := tracker.Register(mgrB)
+	if refA1 == refB {
+		t.Fatalf("distinct managers got the same ref %q", refA1)
+	}
+}
+
+func TestJobTrackerListUnionsWithNamespacedIDs(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgrA := htools.NewJobManager(t.TempDir(), nil)
+	mgrB := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgrA.Shutdown(context.Background()) }()
+	defer func() { _ = mgrB.Shutdown(context.Background()) }()
+
+	refA := tracker.Register(mgrA)
+	refB := tracker.Register(mgrB)
+	jobA := startTrackedJob(t, mgrA, "sleep 30")
+	jobB := startTrackedJob(t, mgrB, "sleep 31")
+
+	// Both managers number their first job job_1; the tracker must namespace.
+	if jobA != jobB {
+		t.Fatalf("test premise broken: expected colliding shell ids, got %q and %q", jobA, jobB)
+	}
+
+	listed := tracker.List()
+	if len(listed) != 2 {
+		t.Fatalf("List returned %d jobs, want 2: %+v", len(listed), listed)
+	}
+	byTaskID := make(map[string]TrackedJob, 2)
+	for _, tj := range listed {
+		byTaskID[tj.TaskID] = tj
+		if tj.Info.Command == "" || !tj.Info.Running {
+			t.Errorf("tracked job %+v missing command or not running", tj)
+		}
+	}
+	wantA := refA + ":" + jobA
+	wantB := refB + ":" + jobB
+	if _, ok := byTaskID[wantA]; !ok {
+		t.Errorf("missing task %q in union; got %v", wantA, byTaskID)
+	}
+	if _, ok := byTaskID[wantB]; !ok {
+		t.Errorf("missing task %q in union; got %v", wantB, byTaskID)
+	}
+}
+
+func TestJobTrackerUnregisterRemovesManager(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgr := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	ref := tracker.Register(mgr)
+	startTrackedJob(t, mgr, "sleep 30")
+	if got := len(tracker.List()); got != 1 {
+		t.Fatalf("List before unregister returned %d jobs, want 1", got)
+	}
+
+	tracker.Unregister(ref)
+	if got := tracker.List(); len(got) != 0 {
+		t.Fatalf("List after unregister returned %d jobs, want 0: %+v", len(got), got)
+	}
+	// Unknown refs unregister cleanly (no panic).
+	tracker.Unregister(ref)
+	tracker.Unregister("jm999")
+}
+
+func TestJobTrackerGet(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgr := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	ref := tracker.Register(mgr)
+	shellID := startTrackedJob(t, mgr, "sleep 30")
+	taskID := ref + ":" + shellID
+
+	tj, ok := tracker.Get(taskID)
+	if !ok {
+		t.Fatalf("Get(%q) not found", taskID)
+	}
+	if tj.Info.ID != shellID || tj.Info.Command != "sleep 30" {
+		t.Errorf("Get(%q) = %+v, want job %s command 'sleep 30'", taskID, tj, shellID)
+	}
+
+	if _, ok := tracker.Get("jm999:job_1"); ok {
+		t.Error("Get with unknown manager ref should report not found")
+	}
+	if _, ok := tracker.Get(ref + ":job_999"); ok {
+		t.Error("Get with unknown job id should report not found")
+	}
+	if _, ok := tracker.Get("no-separator"); ok {
+		t.Error("Get with malformed task id should report not found")
+	}
+}
+
+func TestJobTrackerKill(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgrA := htools.NewJobManager(t.TempDir(), nil)
+	mgrB := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgrA.Shutdown(context.Background()) }()
+	defer func() { _ = mgrB.Shutdown(context.Background()) }()
+
+	refA := tracker.Register(mgrA)
+	refB := tracker.Register(mgrB)
+	jobA := startTrackedJob(t, mgrA, "sleep 30")
+	jobB := startTrackedJob(t, mgrB, "sleep 30")
+
+	// Kill manager A's job via the namespaced task ID.
+	if err := tracker.Kill(refA + ":" + jobA); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := mgrA.Output(jobA, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", jobA, err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job %s still running after kill", jobA)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Manager B's identically-named job must be untouched.
+	outB, err := mgrB.Output(jobB, false)
+	if err != nil {
+		t.Fatalf("Output(%s): %v", jobB, err)
+	}
+	if running, _ := outB["running"].(bool); !running {
+		t.Error("kill routed to the wrong manager: B's job is not running")
+	}
+
+	// Unknown task IDs surface ErrJobNotFound.
+	for _, bad := range []string{"jm999:job_1", refB + ":job_999", "no-separator", ""} {
+		if err := tracker.Kill(bad); !errors.Is(err, ErrJobNotFound) {
+			t.Errorf("Kill(%q) error = %v, want ErrJobNotFound", bad, err)
+		}
+	}
+}
+
+// TestDefaultRegistryJobManagerRegistersWithTracker proves the production
+// wiring path (epic #814 slice 2): a registry built with
+// DefaultRegistryOptions.JobTracker exposes its background bash jobs to the
+// tracker, and unregisters on shutdown.
+func TestDefaultRegistryJobManagerRegistersWithTracker(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		ApprovalMode: ToolApprovalModeFullAuto,
+		JobTracker:   tracker,
+	})
+
+	if got := tracker.List(); len(got) != 0 {
+		t.Fatalf("tracker has %d jobs before any bash call, want 0", len(got))
+	}
+
+	if _, err := registry.Execute(context.Background(), "bash", json.RawMessage(`{"command":"sleep 30","run_in_background":true}`)); err != nil {
+		t.Fatalf("bash run_in_background: %v", err)
+	}
+
+	listed := tracker.List()
+	if len(listed) != 1 {
+		t.Fatalf("tracker has %d jobs after background bash, want 1: %+v", len(listed), listed)
+	}
+	if listed[0].Info.Command != "sleep 30" || !listed[0].Info.Running {
+		t.Errorf("tracked job = %+v, want running 'sleep 30'", listed[0])
+	}
+
+	// Kill through the tracker, then confirm via the job_output tool.
+	if err := tracker.Kill(listed[0].TaskID); err != nil {
+		t.Fatalf("tracker.Kill: %v", err)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := registry.Execute(context.Background(), "job_output", json.RawMessage(`{"shell_id":"`+listed[0].Info.ID+`"}`))
+		if err != nil {
+			t.Fatalf("job_output: %v", err)
+		}
+		if strings.Contains(out, `"running":false`) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job_output still reports running after kill: %s", out)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Registry shutdown unregisters the manager from the tracker.
+	if err := registry.Shutdown(context.Background()); err != nil {
+		t.Fatalf("registry.Shutdown: %v", err)
+	}
+	if got := tracker.List(); len(got) != 0 {
+		t.Fatalf("tracker has %d jobs after registry shutdown, want 0: %+v", len(got), got)
+	}
+}

--- a/internal/harness/tools/bash_manager.go
+++ b/internal/harness/tools/bash_manager.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,6 +40,9 @@ type backgroundJob struct {
 	command    string
 	workingDir string
 	startedAt  time.Time
+	// tenantID is the tenant of the run that started the job, captured from
+	// the tool execution context. Empty for unscoped/legacy callers.
+	tenantID string
 
 	stdout *headTailBuffer
 	stderr *headTailBuffer
@@ -233,11 +237,19 @@ func (m *JobManager) runBackground(ctx context.Context, command string, timeoutS
 	}
 	id := "job_" + strconv.FormatUint(atomic.AddUint64(&m.nextID, 1), 10)
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
+	// Capture the originating run's tenant so daemon-wide listings (the
+	// /v1/tasks union) can scope jobs to their owning tenant. Absent for
+	// callers without run metadata (e.g. the exported RunBackground wrapper).
+	var tenantID string
+	if md, ok := RunMetadataFromContext(ctx); ok {
+		tenantID = md.TenantID
+	}
 	job := &backgroundJob{
 		id:         id,
 		command:    command,
 		workingDir: workDir,
 		startedAt:  m.now(),
+		tenantID:   tenantID,
 		stdout:     newHeadTailBuffer(m.maxOutputBytes),
 		stderr:     newHeadTailBuffer(m.maxOutputBytes),
 		cancel:     cancel,
@@ -435,6 +447,80 @@ func (m *JobManager) get(id string) *backgroundJob {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.jobs[id]
+}
+
+// Job status values reported by JobInfo.Status. These are the bash_job
+// statuses surfaced by the /v1/tasks union (epic #814).
+const (
+	JobStatusRunning  = "running"
+	JobStatusExited   = "exited"
+	JobStatusTimedOut = "timed_out"
+)
+
+// JobInfo is a point-in-time snapshot of a background job, safe to read
+// without holding any manager locks. It carries everything the /v1/tasks
+// union needs to render a bash_job row: identity, command, start time,
+// owning tenant, and outcome.
+type JobInfo struct {
+	ID         string
+	Command    string
+	WorkingDir string
+	StartedAt  time.Time
+	// TenantID is the tenant of the run that started the job; empty when the
+	// job was started without run metadata.
+	TenantID string
+	Running  bool
+	ExitCode int
+	TimedOut bool
+}
+
+// Status collapses the job's outcome flags into a single status string:
+// running while in flight, timed_out when the timeout killed it, exited
+// otherwise (success, failure, or kill).
+func (j JobInfo) Status() string {
+	if j.Running {
+		return JobStatusRunning
+	}
+	if j.TimedOut {
+		return JobStatusTimedOut
+	}
+	return JobStatusExited
+}
+
+// list returns a snapshot of every job currently tracked by the manager,
+// sorted by start time then ID for deterministic output. Jobs already evicted
+// by the finished-job TTL are absent. Safe for concurrent use with
+// runBackground, kill, and cleanupExpired.
+func (m *JobManager) list() []JobInfo {
+	m.mu.RLock()
+	jobs := make([]*backgroundJob, 0, len(m.jobs))
+	for _, job := range m.jobs {
+		jobs = append(jobs, job)
+	}
+	m.mu.RUnlock()
+
+	out := make([]JobInfo, 0, len(jobs))
+	for _, job := range jobs {
+		job.mu.Lock()
+		out = append(out, JobInfo{
+			ID:         job.id,
+			Command:    job.command,
+			WorkingDir: job.workingDir,
+			StartedAt:  job.startedAt,
+			TenantID:   job.tenantID,
+			Running:    !job.done,
+			ExitCode:   job.exitCode,
+			TimedOut:   job.timedOut,
+		})
+		job.mu.Unlock()
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].StartedAt.Equal(out[j].StartedAt) {
+			return out[i].StartedAt.Before(out[j].StartedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
 }
 
 func (m *JobManager) cleanupExpired() {

--- a/internal/harness/tools/bash_manager_list_test.go
+++ b/internal/harness/tools/bash_manager_list_test.go
@@ -1,0 +1,255 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitJobDone polls the job until it reports not-running or the deadline
+// passes. It fails the test on timeout.
+func waitJobDone(t *testing.T, mgr *JobManager, shellID string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		result, err := mgr.Output(shellID, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", shellID, err)
+		}
+		if running, _ := result["running"].(bool); !running {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job %s still running after 10s", shellID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func startBackgroundJob(t *testing.T, mgr *JobManager, ctx context.Context, command string, timeoutSeconds int) string {
+	t.Helper()
+	result, err := mgr.runBackground(ctx, command, timeoutSeconds, "")
+	if err != nil {
+		t.Fatalf("runBackground(%q): %v", command, err)
+	}
+	shellID, _ := result["shell_id"].(string)
+	if shellID == "" {
+		t.Fatalf("runBackground(%q) returned no shell_id: %v", command, result)
+	}
+	return shellID
+}
+
+func TestJobManagerListEmpty(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	if got := mgr.List(); len(got) != 0 {
+		t.Fatalf("List on empty manager returned %d jobs: %+v", len(got), got)
+	}
+}
+
+func TestJobManagerListRunningThenKilled(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	shellID := startBackgroundJob(t, mgr, context.Background(), "sleep 30", 60)
+
+	jobs := mgr.List()
+	if len(jobs) != 1 {
+		t.Fatalf("List returned %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	job := jobs[0]
+	if job.ID != shellID {
+		t.Errorf("job ID = %q, want %q", job.ID, shellID)
+	}
+	if job.Command != "sleep 30" {
+		t.Errorf("job Command = %q, want %q", job.Command, "sleep 30")
+	}
+	if !job.Running {
+		t.Error("job should be running")
+	}
+	if job.Status() != JobStatusRunning {
+		t.Errorf("job Status() = %q, want %q", job.Status(), JobStatusRunning)
+	}
+	if job.StartedAt.IsZero() {
+		t.Error("job StartedAt is zero")
+	}
+
+	if _, err := mgr.Kill(shellID); err != nil {
+		t.Fatalf("Kill(%s): %v", shellID, err)
+	}
+	waitJobDone(t, mgr, shellID)
+
+	jobs = mgr.List()
+	if len(jobs) != 1 {
+		t.Fatalf("List after kill returned %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	if jobs[0].Running {
+		t.Error("killed job should not be running")
+	}
+	if jobs[0].Status() != JobStatusExited {
+		t.Errorf("killed job Status() = %q, want %q", jobs[0].Status(), JobStatusExited)
+	}
+}
+
+func TestJobManagerListExitedWithExitCode(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	shellID := startBackgroundJob(t, mgr, context.Background(), "exit 3", 30)
+	waitJobDone(t, mgr, shellID)
+
+	jobs := mgr.List()
+	if len(jobs) != 1 {
+		t.Fatalf("List returned %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	if jobs[0].Running {
+		t.Error("finished job should not be running")
+	}
+	if jobs[0].ExitCode != 3 {
+		t.Errorf("ExitCode = %d, want 3", jobs[0].ExitCode)
+	}
+	if jobs[0].TimedOut {
+		t.Error("TimedOut should be false for a normally exited job")
+	}
+	if jobs[0].Status() != JobStatusExited {
+		t.Errorf("Status() = %q, want %q", jobs[0].Status(), JobStatusExited)
+	}
+}
+
+func TestJobManagerListTimedOut(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	shellID := startBackgroundJob(t, mgr, context.Background(), "sleep 30", 1)
+	waitJobDone(t, mgr, shellID)
+
+	jobs := mgr.List()
+	if len(jobs) != 1 {
+		t.Fatalf("List returned %d jobs, want 1: %+v", len(jobs), jobs)
+	}
+	if !jobs[0].TimedOut {
+		t.Error("TimedOut should be true for a job that hit its timeout")
+	}
+	if jobs[0].Status() != JobStatusTimedOut {
+		t.Errorf("Status() = %q, want %q", jobs[0].Status(), JobStatusTimedOut)
+	}
+}
+
+func TestJobManagerListExcludesTTLEvicted(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	clock := func() time.Time { return now }
+	mgr := NewJobManager(t.TempDir(), clock)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	shellID := startBackgroundJob(t, mgr, context.Background(), "true", 30)
+	waitJobDone(t, mgr, shellID)
+
+	if got := mgr.List(); len(got) != 1 {
+		t.Fatalf("List before eviction returned %d jobs, want 1", len(got))
+	}
+
+	// Advance past the 30-minute TTL and trigger cleanup; the evicted job must
+	// no longer be listed.
+	now = now.Add(31 * time.Minute)
+	mgr.cleanupExpired()
+
+	if got := mgr.List(); len(got) != 0 {
+		t.Fatalf("List after TTL eviction returned %d jobs, want 0: %+v", len(got), got)
+	}
+}
+
+func TestJobManagerListCapturesTenant(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	tenantCtx := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{
+		RunID:    "run-1",
+		TenantID: "tenant-x",
+	})
+	tenantJob := startBackgroundJob(t, mgr, tenantCtx, "sleep 30", 60)
+	plainJob := startBackgroundJob(t, mgr, context.Background(), "sleep 30", 60)
+
+	byID := make(map[string]JobInfo, 2)
+	for _, job := range mgr.List() {
+		byID[job.ID] = job
+	}
+	if got := byID[tenantJob].TenantID; got != "tenant-x" {
+		t.Errorf("tenant job TenantID = %q, want tenant-x", got)
+	}
+	if got := byID[plainJob].TenantID; got != "" {
+		t.Errorf("metadata-less job TenantID = %q, want empty", got)
+	}
+}
+
+func TestJobManagerListConcurrent(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	var wg sync.WaitGroup
+	// Writers: start and kill jobs.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 5; j++ {
+				result, err := mgr.runBackground(context.Background(), fmt.Sprintf("sleep %d", 30+j), 60, "")
+				if err != nil {
+					continue
+				}
+				if shellID, _ := result["shell_id"].(string); shellID != "" && j%2 == 0 {
+					_, _ = mgr.Kill(shellID)
+				}
+			}
+		}(i)
+	}
+	// Readers: list continuously.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				for _, job := range mgr.List() {
+					_ = job.Status()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestJobInfoStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		info JobInfo
+		want string
+	}{
+		{"running", JobInfo{Running: true}, JobStatusRunning},
+		{"exited", JobInfo{Running: false, TimedOut: false, ExitCode: 0}, JobStatusExited},
+		{"failed still exited", JobInfo{Running: false, TimedOut: false, ExitCode: 1}, JobStatusExited},
+		{"timed out", JobInfo{Running: false, TimedOut: true}, JobStatusTimedOut},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.info.Status(); got != tc.want {
+				t.Errorf("Status() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/harness/tools/job_manager_exports.go
+++ b/internal/harness/tools/job_manager_exports.go
@@ -31,3 +31,10 @@ func (m *JobManager) Output(shellID string, wait bool) (map[string]any, error) {
 func (m *JobManager) Kill(shellID string) (map[string]any, error) {
 	return m.kill(shellID)
 }
+
+// List is an exported wrapper for the unexported list method, returning a
+// snapshot of all tracked background jobs. Used by the daemon-level job
+// tracker backing the /v1/tasks union (epic #814).
+func (m *JobManager) List() []JobInfo {
+	return m.list()
+}

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -85,6 +85,11 @@ type DefaultRegistryOptions struct {
 	// GoalManager, when non-nil, enables the goals tool for persistent,
 	// cross-session goal tracking. Backed by a persistent store in production.
 	GoalManager deferred.GoalCreator
+	// JobTracker, when non-nil, registers this registry's background-job
+	// manager for daemon-wide enumeration/kill (GET /v1/tasks,
+	// POST /v1/jobs/{id}/kill; epic #814 slice 2). The manager unregisters
+	// itself when the registry shuts down.
+	JobTracker *JobTracker
 }
 
 // conversationStoreAdapter adapts ConversationStore (harness package) to htools.ConversationReader.
@@ -495,6 +500,17 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 	// -- Register all tools in the registry --
 	registry = NewRegistry()
 	registry.RegisterShutdownHook(jobManager.Shutdown)
+
+	// Expose this registry's background jobs to the daemon-wide /v1/tasks
+	// union (epic #814 slice 2). The manager unregisters when the registry
+	// shuts down so the tracker does not retain dead registries.
+	if opts.JobTracker != nil {
+		jobTrackerRef := opts.JobTracker.Register(jobManager)
+		registry.RegisterShutdownHook(func(context.Context) error {
+			opts.JobTracker.Unregister(jobTrackerRef)
+			return nil
+		})
+	}
 
 	for _, t := range coreTools {
 		def := ToolDefinition{

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -90,7 +90,12 @@ type ServerOptions struct {
 	// CallbackLister enumerates pending delayed callbacks across all
 	// conversations for GET /v1/tasks (epic #814). Optional; when nil the
 	// tasks union simply contains no callback entries.
-	CallbackLister   CallbackLister
+	CallbackLister CallbackLister
+	// JobTracker enumerates and kills background bash jobs across all tool
+	// registries for GET /v1/tasks and POST /v1/jobs/{id}/kill (epic #814
+	// slice 2). Optional; when nil, bash_job entries are absent and the kill
+	// route returns 501.
+	JobTracker       *harness.JobTracker
 	ProviderRegistry *catalog.ProviderRegistry
 	Checkpoints      checkpointManager
 	// Store is an optional persistence layer for run state.
@@ -213,6 +218,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		mcpConnector:      opts.MCPConnector,
 		subagentManager:   opts.SubagentManager,
 		callbackLister:    opts.CallbackLister,
+		jobTracker:        opts.JobTracker,
 		checkpoints:       opts.Checkpoints,
 		runStore:          opts.Store,
 		approvalBroker:    opts.ApprovalBroker,
@@ -300,6 +306,10 @@ func (s *Server) buildMux() http.Handler {
 	// pending delayed callbacks; epic #814). Requires runs:read, consistent
 	// with the per-source list routes above.
 	mux.Handle("/v1/tasks", auth(read(http.HandlerFunc(s.handleTasks))))
+
+	// POST /v1/jobs/{id}/kill — daemon-side kill path for background bash
+	// jobs (epic #814 slice 2). Requires runs:write; scope enforced inside.
+	mux.Handle("/v1/jobs/", auth(http.HandlerFunc(s.handleJobByID)))
 
 	// /v1/skills — GET requires runs:read; POST /verify requires runs:write.
 	mux.Handle("/v1/skills", auth(read(http.HandlerFunc(s.handleSkillsRoot))))
@@ -434,6 +444,10 @@ type Server struct {
 	// conversations for GET /v1/tasks (epic #814). When nil, callbacks are
 	// simply absent from the union.
 	callbackLister CallbackLister
+
+	// jobTracker enumerates and kills background bash jobs daemon-wide for
+	// GET /v1/tasks and POST /v1/jobs/{id}/kill (epic #814 slice 2).
+	jobTracker *harness.JobTracker
 
 	// runStore is an optional persistence layer for run state (issue #7).
 	// When non-nil, GET /v1/runs supports filtering and run history survives restarts.

--- a/internal/server/http_tasks.go
+++ b/internal/server/http_tasks.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"go-agent-harness/internal/harness"
@@ -11,13 +14,12 @@ import (
 	"go-agent-harness/internal/subagents"
 )
 
-// Task type values returned by GET /v1/tasks. bash_job arrives with the
-// background-jobs slice of epic #814; the union endpoint unions the three
-// daemon-reachable sources first.
+// Task type values returned by GET /v1/tasks.
 const (
 	TaskTypeSubagent = "subagent"
 	TaskTypeCron     = "cron"
 	TaskTypeCallback = "callback"
+	TaskTypeBashJob  = "bash_job"
 )
 
 // Task action values advertise which stop/control operations the client can
@@ -101,6 +103,17 @@ func (s *Server) handleTasks(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if s.jobTracker != nil {
+		caller := TenantIDFromContext(r.Context())
+		for _, tj := range s.jobTracker.List() {
+			// Same tenant rule as callbacks/cron above.
+			if caller != "" && tj.Info.TenantID != caller {
+				continue
+			}
+			tasks = append(tasks, taskFromBashJob(tj, now))
+		}
+	}
+
 	// Deterministic ordering: oldest first, ties broken by type then id, so
 	// clients and tests see a stable list regardless of map iteration order.
 	sort.Slice(tasks, func(i, j int) bool {
@@ -173,6 +186,70 @@ func taskFromCallback(info tools.CallbackInfo, now time.Time) Task {
 		AgeSeconds: taskAgeSeconds(info.CreatedAt, now),
 		Actions:    []string{TaskActionCancel},
 	}
+}
+
+// taskFromBashJob maps a tracked background bash job onto the unified DTO.
+// Running jobs can be cancelled (via POST /v1/jobs/{id}/kill); finished jobs
+// offer no actions — the JobManager TTL reclaims them.
+func taskFromBashJob(tj harness.TrackedJob, now time.Time) Task {
+	actions := []string{}
+	if tj.Info.Running {
+		actions = []string{TaskActionCancel}
+	}
+	return Task{
+		ID:         tj.TaskID,
+		Type:       TaskTypeBashJob,
+		Status:     tj.Info.Status(),
+		Label:      tj.Info.Command,
+		StartedAt:  tj.Info.StartedAt,
+		AgeSeconds: taskAgeSeconds(tj.Info.StartedAt, now),
+		Actions:    actions,
+	}
+}
+
+// handleJobByID serves POST /v1/jobs/{id}/kill, the daemon-side kill path for
+// background bash jobs (epic #814 slice 2). The {id} is the namespaced task
+// ID from GET /v1/tasks ("<managerRef>:<shellID>"). Requires runs:write,
+// matching the mutating subagent/cron routes. Cross-tenant kills are 404
+// (not 403), matching subagent cancel semantics.
+func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
+	if s.jobTracker == nil {
+		writeError(w, http.StatusNotImplemented, "not_configured", "job tracker is not configured")
+		return
+	}
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/jobs/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "kill" {
+		writeError(w, http.StatusNotFound, "not_found", "job action not found")
+		return
+	}
+	id := parts[0]
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if !hasScope(r.Context(), store.ScopeRunsWrite) {
+		writeScopeError(w, store.ScopeRunsWrite)
+		return
+	}
+	// Tenant scoping: when auth is enabled, the caller may only kill their own
+	// tenant's jobs. Mirrors the list filter in handleTasks.
+	if caller := TenantIDFromContext(r.Context()); caller != "" {
+		tj, ok := s.jobTracker.Get(id)
+		if !ok || tj.Info.TenantID != caller {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+			return
+		}
+	}
+	if err := s.jobTracker.Kill(id); err != nil {
+		if errors.Is(err, harness.ErrJobNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "kill_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "killed": true})
 }
 
 // taskAgeSeconds computes a non-negative age in whole seconds. Clock skew or

--- a/internal/server/http_tasks_test.go
+++ b/internal/server/http_tasks_test.go
@@ -324,3 +324,310 @@ func TestTasksEndpoint_MethodNotAllowed(t *testing.T) {
 		t.Fatalf("POST /v1/tasks: status %d, want 405", code)
 	}
 }
+
+// --- bash_job union + kill endpoint (epic #814 slice 2) ---
+
+// newTrackedJobManager returns a JobManager registered on a tracker, plus the
+// tracker. The manager is shut down with test cleanup.
+func newTrackedJobManager(t *testing.T) (*harness.JobTracker, *tools.JobManager) {
+	t.Helper()
+	tracker := harness.NewJobTracker()
+	mgr := tools.NewJobManager(t.TempDir(), nil)
+	tracker.Register(mgr)
+	t.Cleanup(func() { _ = mgr.Shutdown(context.Background()) })
+	return tracker, mgr
+}
+
+func startBashJob(t *testing.T, mgr *tools.JobManager, ctx context.Context, command string) string {
+	t.Helper()
+	result, err := mgr.RunBackgroundWithContext(ctx, command, 60, "")
+	if err != nil {
+		t.Fatalf("RunBackgroundWithContext(%q): %v", command, err)
+	}
+	shellID, _ := result["shell_id"].(string)
+	if shellID == "" {
+		t.Fatalf("RunBackgroundWithContext(%q) returned no shell_id: %v", command, result)
+	}
+	return shellID
+}
+
+func tenantJobCtx(tenantID string) context.Context {
+	return context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{
+		RunID:    "run-1",
+		TenantID: tenantID,
+	})
+}
+
+// TestTasksEndpoint_UnionsBashJobs verifies background bash jobs appear in the
+// union as bash_job entries with running/exited statuses and a cancel action
+// only while running.
+func TestTasksEndpoint_UnionsBashJobs(t *testing.T) {
+	t.Parallel()
+
+	tracker, mgr := newTrackedJobManager(t)
+	runningID := startBashJob(t, mgr, context.Background(), "sleep 30")
+	exitedID := startBashJob(t, mgr, context.Background(), "true")
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := mgr.Output(exitedID, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", exitedID, err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("exited job did not finish in time")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasks := listTasks(t, ts, "")
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks: status %d, want 200", code)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("got %d tasks, want 2 bash jobs: %+v", len(tasks), tasks)
+	}
+	byLabel := make(map[string]Task, 2)
+	for _, task := range tasks {
+		if task.Type != "bash_job" {
+			t.Errorf("task %s type = %q, want bash_job", task.ID, task.Type)
+		}
+		byLabel[task.Label] = task
+	}
+	running, ok := byLabel["sleep 30"]
+	if !ok {
+		t.Fatalf("no task labelled 'sleep 30': %+v", tasks)
+	}
+	if running.Status != "running" {
+		t.Errorf("running job status = %q, want running", running.Status)
+	}
+	if len(running.Actions) != 1 || running.Actions[0] != "cancel" {
+		t.Errorf("running job actions = %v, want [cancel]", running.Actions)
+	}
+	exited, ok := byLabel["true"]
+	if !ok {
+		t.Fatalf("no task labelled 'true': %+v", tasks)
+	}
+	if exited.Status != "exited" {
+		t.Errorf("finished job status = %q, want exited", exited.Status)
+	}
+	if len(exited.Actions) != 0 {
+		t.Errorf("finished job actions = %v, want []", exited.Actions)
+	}
+	_ = runningID
+}
+
+// TestTasksEndpoint_BashJobTenantFiltering verifies bash jobs are scoped to
+// the caller's tenant like the other task sources.
+func TestTasksEndpoint_BashJobTenantFiltering(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	tokenA, keyA := newSubagentTenantAPIKey(t, "tenant-alpha", "key A")
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+
+	tracker, mgr := newTrackedJobManager(t)
+	startBashJob(t, mgr, tenantJobCtx("tenant-alpha"), "sleep 30")
+	startBashJob(t, mgr, tenantJobCtx("tenant-bravo"), "sleep 31")
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms, JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, tasks := listTasks(t, ts, tokenA)
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/tasks as A: status %d, want 200", code)
+	}
+	if len(tasks) != 1 || tasks[0].Label != "sleep 30" {
+		t.Fatalf("tenant A sees %+v, want exactly the tenant-alpha job", tasks)
+	}
+}
+
+// TestJobKillEndpoint verifies the full slice-2 acceptance flow at the HTTP
+// layer: a running bash job listed in /v1/tasks is killed via
+// POST /v1/jobs/{id}/kill, after which job_output reports it terminated.
+func TestJobKillEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tracker, mgr := newTrackedJobManager(t)
+	shellID := startBashJob(t, mgr, context.Background(), "sleep 30")
+
+	var taskID string
+	for id := range func() map[string]bool {
+		out := map[string]bool{}
+		for _, tj := range tracker.List() {
+			out[tj.TaskID] = true
+		}
+		return out
+	}() {
+		taskID = id
+	}
+	if taskID == "" {
+		t.Fatal("tracker has no jobs")
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, body := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/jobs/"+taskID+"/kill", nil)
+	if code != http.StatusOK {
+		t.Fatalf("POST /v1/jobs/%s/kill: status %d, body %s; want 200", taskID, code, body)
+	}
+
+	// job_output must reflect termination.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := mgr.Output(shellID, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", shellID, err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job %s still running after kill endpoint", shellID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The union now reports the job as exited, no longer running.
+	_, tasks := listTasks(t, ts, "")
+	if len(tasks) != 1 || tasks[0].Status != "exited" {
+		t.Fatalf("after kill, tasks = %+v, want one exited bash_job", tasks)
+	}
+}
+
+// TestJobKillEndpoint_NotFound verifies unknown task IDs return 404.
+func TestJobKillEndpoint_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newTrackedJobManager(t)
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	for _, id := range []string{"jm999:job_1", "jm1:job_999", "no-separator"} {
+		code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/jobs/"+id+"/kill", nil)
+		if code != http.StatusNotFound {
+			t.Errorf("POST /v1/jobs/%s/kill: status %d, want 404", id, code)
+		}
+	}
+}
+
+// TestJobKillEndpoint_CrossTenant verifies a caller cannot kill another
+// tenant's bash job (404, not 403, matching subagent cancel semantics).
+func TestJobKillEndpoint_CrossTenant(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	_, keyA := newSubagentTenantAPIKey(t, "tenant-alpha", "key A")
+	tokenB, keyB := newSubagentTenantAPIKey(t, "tenant-bravo", "key B")
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	tracker, mgr := newTrackedJobManager(t)
+	shellID := startBashJob(t, mgr, tenantJobCtx("tenant-alpha"), "sleep 30")
+	var taskID string
+	for _, tj := range tracker.List() {
+		taskID = tj.TaskID
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms, JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, body := doSubagentRequest(t, ts, http.MethodPost, tokenB, "/v1/jobs/"+taskID+"/kill", nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("cross-tenant kill: status %d, body %s; want 404", code, body)
+	}
+	out, err := mgr.Output(shellID, false)
+	if err != nil {
+		t.Fatalf("Output(%s): %v", shellID, err)
+	}
+	if running, _ := out["running"].(bool); !running {
+		t.Fatal("cross-tenant kill terminated the job")
+	}
+}
+
+// TestJobKillEndpoint_AuthEnforced verifies the kill endpoint requires
+// authentication and runs:write when auth is enabled.
+func TestJobKillEndpoint_AuthEnforced(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	rawRead, keyRead, err := store.GenerateAPIKey("tenant-alpha", "reader", []string{store.ScopeRunsRead})
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	keyRead = minCostRehash(t, rawRead, keyRead)
+	if err := ms.CreateAPIKey(context.Background(), keyRead); err != nil {
+		t.Fatalf("CreateAPIKey reader: %v", err)
+	}
+	tokenWrite, keyWrite := newSubagentTenantAPIKey(t, "tenant-alpha", "writer")
+	if err := ms.CreateAPIKey(context.Background(), keyWrite); err != nil {
+		t.Fatalf("CreateAPIKey writer: %v", err)
+	}
+
+	tracker, mgr := newTrackedJobManager(t)
+	startBashJob(t, mgr, tenantJobCtx("tenant-alpha"), "sleep 30")
+	var taskID string
+	for _, tj := range tracker.List() {
+		taskID = tj.TaskID
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms, JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	if code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/jobs/"+taskID+"/kill", nil); code != http.StatusUnauthorized {
+		t.Fatalf("kill without token: status %d, want 401", code)
+	}
+	if code, _ := doSubagentRequest(t, ts, http.MethodPost, rawRead, "/v1/jobs/"+taskID+"/kill", nil); code != http.StatusForbidden {
+		t.Fatalf("kill with read-only token: status %d, want 403", code)
+	}
+	if code, _ := doSubagentRequest(t, ts, http.MethodPost, tokenWrite, "/v1/jobs/"+taskID+"/kill", nil); code != http.StatusOK {
+		t.Fatalf("kill with runs:write token: status %d, want 200", code)
+	}
+}
+
+// TestJobKillEndpoint_MethodNotAllowed verifies non-POST methods are rejected.
+func TestJobKillEndpoint_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newTrackedJobManager(t)
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodGet, "", "/v1/jobs/jm1:job_1/kill", nil)
+	if code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /v1/jobs/jm1:job_1/kill: status %d, want 405", code)
+	}
+}
+
+// TestJobKillEndpoint_NotConfigured verifies 501 when no tracker is wired.
+func TestJobKillEndpoint_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t)})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/jobs/jm1:job_1/kill", nil)
+	if code != http.StatusNotImplemented {
+		t.Fatalf("kill with unconfigured tracker: status %d, want 501", code)
+	}
+}


### PR DESCRIPTION
Parent epic: #814. Part of #803.

## Slice 2 of epic #814 (unified /tasks background panel)

- `JobManager.List()` snapshot (unexported `list` in `bash_manager.go` + exported wrapper in `job_manager_exports.go`, per the existing pattern) returning `JobInfo{ID, Command, WorkingDir, StartedAt, TenantID, Running, ExitCode, TimedOut}` with `Status()` = `running`/`exited`/`timed_out`. `runBackground` captures the originating run's tenant from `RunMetadataFromContext`.
- New daemon-level `harness.JobTracker` (`internal/harness/job_tracker.go`): per-registry managers register via the new `DefaultRegistryOptions.JobTracker` and unregister on registry shutdown — covering the main registry, per-run provisioned-workspace registries (`runner.go`), and subagent worktree registries. Task IDs are namespaced `jm<N>:job_<n>` (managers number jobs from `job_1` independently). `Get`/`Kill` route through the owning manager, reusing `JobManager.Kill`.
- Server: `GET /v1/tasks` unions `bash_job` entries (label = command, `cancel` action while running, same tenant filtering as callbacks); new `POST /v1/jobs/{id}/kill` (runs:write, 404 unknown/cross-tenant, 501 unconfigured).
- harnessd: one `JobTracker` from `main.go` threaded via `baseRegistryOptions` + `runtime_container`/`bootstrap_helpers` into `ServerOptions.JobTracker`.

## Tests (strict TDD — failing first)

- `internal/harness/tools/bash_manager_list_test.go` (7 tests): empty, running→killed transition, exit code, timed-out, TTL eviction, tenant capture, concurrent list/start/kill (race-checked).
- `internal/harness/job_tracker_test.go` (6 tests): register idempotence/uniqueness, namespaced union over colliding shell ids, unregister, Get, Kill routing + `ErrJobNotFound`, plus a full registry-wiring integration test through the real `bash` tool and `job_output`.
- `internal/server/http_tasks_test.go` (8 new tests): bash_job union entries, tenant filtering, kill endpoint (200 + `job_output` reflects termination + union shows exited), 404 unknown, 404 cross-tenant, 401/403 auth, 405 method, 501 unconfigured.

## Verification

- `go test ./internal/server/ -count=1` — ok (10.8s)
- `go test ./internal/harness/ -count=1` — ok (3.6s, incl. new wiring test)
- `go test ./internal/harness/tools/ -count=1` — ok (16.2s; the pre-existing flaky `TestJobManagerRunForegroundStreamingOverlongLineReturnsPromptly` passed this run)
- `go test ./cmd/harnessd/ -count=1` — ok (4.3s)
- gofmt/go vet clean on all touched files.

Out of scope (later slices): TUI `/tasks` overlay (slice 3), panel stop/view actions (slice 4).