### PR TITLE
feat(tui): run shell-mode commands locally with streamed output card

### DIFF
--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -327,8 +327,19 @@ type Model struct {
 
 	// shellMode tracks whether the input area is in shell mode (entered with
 	// "!" on an empty input, exited with Backspace/Esc on an empty input or on
-	// submit). Slice 1 of epic #811 ships input state only — no execution.
+	// submit).
 	shellMode bool
+
+	// shellExecs tracks running shell-mode commands by call ID (epic #811,
+	// slice 2). Each executor streams output into its tool-style card.
+	shellExecs map[string]*shellExec
+	// shellRunningID is the call ID of the most recently started shell-mode
+	// command; Esc/Ctrl-C interrupt it while set.
+	shellRunningID string
+	// shellExecSeq numbers shell-mode commands for stable call IDs.
+	shellExecSeq int
+	// shellExecTimeout bounds shell-mode commands (default 120s).
+	shellExecTimeout time.Duration
 
 	// pluginsDir is the directory from which custom slash-command plugins are loaded.
 	// Defaults to ~/.config/harnesscli/plugins when empty.
@@ -352,16 +363,17 @@ func spinnerSeed(cfg TUIConfig) int64 {
 
 func New(cfg TUIConfig) Model {
 	m := Model{
-		config:          cfg,
-		keys:            DefaultKeyMap(),
-		theme:           DefaultTheme(),
-		contextGrid:     contextgrid.New(),
-		statsPanel:      statspanel.New(nil),
-		costDisplay:     costdisplay.New(),
-		spinner:         spinner.New(spinnerSeed(cfg)),
-		thinkingBar:     thinkingbar.New(),
-		interruptBanner: interruptui.New(),
-		selectedModel:   cfg.Model,
+		config:           cfg,
+		keys:             DefaultKeyMap(),
+		theme:            DefaultTheme(),
+		contextGrid:      contextgrid.New(),
+		statsPanel:       statspanel.New(nil),
+		costDisplay:      costdisplay.New(),
+		spinner:          spinner.New(spinnerSeed(cfg)),
+		thinkingBar:      thinkingbar.New(),
+		interruptBanner:  interruptui.New(),
+		selectedModel:    cfg.Model,
+		shellExecTimeout: defaultShellExecTimeout,
 	}
 	m.modelSwitcher = modelswitcher.New(cfg.Model)
 	// Initialize history store with defaults.
@@ -700,6 +712,73 @@ func (m *Model) enterShellMode() {
 func (m *Model) exitShellMode() {
 	m.shellMode = false
 	m.input = m.input.SetShellMode(false)
+}
+
+// ShellCommandRunning reports whether a shell-mode command is currently
+// running (for testing).
+func (m Model) ShellCommandRunning() bool {
+	return m.shellRunningID != ""
+}
+
+// WithShellExecTimeout returns a copy of the Model with the shell-mode
+// execution timeout set (for tests; default is 120s).
+func (m Model) WithShellExecTimeout(d time.Duration) Model {
+	m.shellExecTimeout = d
+	return m
+}
+
+// startShellCommand launches a shell-mode command locally and opens its
+// tool-style "shell" card. The returned cmds poll the executor so output
+// streams into the card; Update() itself never blocks on the process.
+func (m *Model) startShellCommand(command string) []tea.Cmd {
+	m.shellExecSeq++
+	callID := fmt.Sprintf("shell-%d", m.shellExecSeq)
+
+	inputJSON, _ := json.Marshal(map[string]string{"command": command})
+	m.handleToolStart(callID, "shell", json.RawMessage(inputJSON))
+	// Shell cards render expanded so the streamed output is visible live.
+	if m.toolExpanded == nil {
+		m.toolExpanded = make(map[string]bool)
+	}
+	m.toolExpanded[callID] = true
+	if view, ok := m.toolViews[callID]; ok {
+		view.Expanded = true
+		m.toolViews[callID] = view
+		m.appendToolUseView(view)
+	}
+
+	ex, err := startShellExec(callID, command, m.shellExecTimeout)
+	if err != nil {
+		m.handleToolError(callID, err.Error(), 0)
+		return nil
+	}
+	if m.shellExecs == nil {
+		m.shellExecs = make(map[string]*shellExec)
+	}
+	m.shellExecs[callID] = ex
+	m.shellRunningID = callID
+	return []tea.Cmd{waitShellExecMsg(ex)}
+}
+
+// interruptShellCommand kills the currently running shell-mode command, if
+// any. The executor's done message finalizes the card as interrupted.
+func (m *Model) interruptShellCommand() {
+	if m.shellRunningID == "" {
+		return
+	}
+	if ex, ok := m.shellExecs[m.shellRunningID]; ok {
+		ex.kill()
+	}
+}
+
+// shellErrorText composes the error-card text for a failed, timed-out, or
+// interrupted shell command: the summary first, then the bounded output so it
+// is not lost (the tooluse ErrorView renders only ErrorText).
+func shellErrorText(summary, output string) string {
+	if strings.TrimSpace(output) == "" {
+		return summary
+	}
+	return summary + "\n" + output
 }
 
 // InterruptBannerVisible returns true when the interrupt confirmation banner is
@@ -1095,7 +1174,8 @@ func parseToolParams(raw json.RawMessage) []tooluse.Param {
 }
 
 func extractToolCommand(toolName string, raw json.RawMessage, fallback string) string {
-	if !strings.EqualFold(toolName, "bash") {
+	lowerName := strings.ToLower(toolName)
+	if !strings.EqualFold(toolName, "bash") && lowerName != "shell" && lowerName != "run_shell_cmd" {
 		return ""
 	}
 	var command string
@@ -2004,6 +2084,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.setStatusMsg("Run interrupted — press ctrl+c again to quit"))
 				return m, tea.Batch(cmds...)
 			}
+			// A running shell-mode command is killed first (epic #811,
+			// slice 2) — Ctrl+C must not quit the TUI out from under it.
+			if m.shellRunningID != "" {
+				m.interruptShellCommand()
+				cmds = append(cmds, m.setStatusMsg("Shell command interrupted — press ctrl+c again to quit"))
+				return m, tea.Batch(cmds...)
+			}
 			// No active run: hide banner if somehow visible, then quit.
 			m.interruptBanner = m.interruptBanner.Hide()
 			return m, tea.Quit
@@ -2145,6 +2232,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cancelRun = nil
 				m.interruptActiveToolCall()
 				cmds = append(cmds, m.setStatusMsg("Interrupted"))
+				return m, tea.Batch(cmds...)
+			}
+			// A running shell-mode command is interrupted before anything
+			// input-related (epic #811, slice 2). The executor's done message
+			// finalizes the card.
+			if m.shellRunningID != "" {
+				m.interruptShellCommand()
+				cmds = append(cmds, m.setStatusMsg("Interrupting shell command..."))
 				return m, tea.Batch(cmds...)
 			}
 			// Shell mode: Esc on an already-empty input exits shell mode
@@ -2865,12 +2960,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Close the dropdown whenever a command is submitted.
 		m.slashComplete = m.slashComplete.Close()
-		// Shell mode (epic #811, slice 1): local execution is not implemented
-		// yet — acknowledge the command with a stub status message and return
-		// to normal mode. Slice 2 replaces this stub with real execution.
+		// Shell mode (epic #811, slice 2): run the command locally from the TUI
+		// process and stream output into a tool-style "shell" card. Submitting
+		// returns to normal mode (kimi behavior).
 		if m.shellMode {
 			m.exitShellMode()
-			cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("shell: %q not executed (execution arrives in the next slice)", msg.Value)))
+			cmds = append(cmds, m.startShellCommand(msg.Value)...)
 			return m, tea.Batch(cmds...)
 		}
 		// Check if it's a slash command; dispatch if so.
@@ -2960,6 +3055,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case ToolCallChunkMsg:
 		m.handleToolChunk(msg.CallID, msg.Chunk)
+
+	case shellExecOutputMsg:
+		// Streamed shell-mode output: append to the card and keep polling.
+		m.handleToolChunk(msg.CallID, msg.Chunk)
+		if ex, ok := m.shellExecs[msg.CallID]; ok {
+			cmds = append(cmds, waitShellExecMsg(ex))
+		}
+
+	case shellExecDoneMsg:
+		// Terminal message for a shell-mode command — finalize its card. No
+		// re-poll: the executor emits nothing after done.
+		delete(m.shellExecs, msg.CallID)
+		if m.shellRunningID == msg.CallID {
+			m.shellRunningID = ""
+		}
+		switch {
+		case msg.Interrupted:
+			m.handleToolError(msg.CallID, shellErrorText("interrupted", msg.Output), 0)
+		case msg.TimedOut:
+			m.handleToolError(msg.CallID, shellErrorText(fmt.Sprintf("timed out after %v", msg.Timeout), msg.Output), 0)
+		case msg.Err != nil:
+			m.handleToolError(msg.CallID, shellErrorText(msg.Err.Error(), msg.Output), 0)
+		case msg.ExitCode != 0:
+			m.handleToolError(msg.CallID, shellErrorText(fmt.Sprintf("exit status %d", msg.ExitCode), msg.Output), 0)
+		default:
+			m.handleToolResult(msg.CallID, msg.Output, 0)
+		}
 
 	case RunStartedMsg:
 		m.RunID = msg.RunID

--- a/cmd/harnesscli/tui/shellexec.go
+++ b/cmd/harnesscli/tui/shellexec.go
@@ -1,0 +1,246 @@
+package tui
+
+// Shell-mode local executor (epic #811, slice 2).
+//
+// A shell-mode command runs in the TUI process via `sh -c`, never on the
+// harnessd server and never through the agent's bash tool. Execution is fully
+// asynchronous so Update() never blocks: startShellExec spawns the process and
+// a pump goroutine; the model polls the executor's message channel with a
+// tea.Cmd (same pattern as the SSE bridge's pollSSECmd). The pump emits
+// shellExecOutputMsg deltas as output arrives (capped) and exactly one
+// shellExecDoneMsg when the process exits, carrying the exit code and a
+// bounded head/tail of the combined stdout/stderr.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"sync/atomic"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	// defaultShellExecTimeout bounds a shell-mode command when no explicit
+	// timeout is configured (kimi-code parity: 120s).
+	defaultShellExecTimeout = 120 * time.Second
+
+	// shellExecMaxOutputBytes caps the combined stdout/stderr retained for the
+	// final card (head+tail), matching the bash-plugin capture budget.
+	shellExecMaxOutputBytes = 30 * 1024
+
+	// shellExecMaxStreamBytes caps how much output is forwarded as live deltas.
+	// Beyond it the card stops updating live but the final done message still
+	// carries the bounded head/tail, so floods like `yes` stay memory-safe.
+	shellExecMaxStreamBytes = 30 * 1024
+
+	// shellExecTruncationMarker separates head and tail in over-cap output.
+	shellExecTruncationMarker = "\n...[truncated output]...\n"
+)
+
+// shellExecOutputMsg carries one streamed chunk of combined stdout/stderr.
+type shellExecOutputMsg struct {
+	CallID string
+	Chunk  string
+}
+
+// shellExecDoneMsg is emitted exactly once when the process exits.
+type shellExecDoneMsg struct {
+	CallID string
+	// Output is the bounded head/tail of combined stdout/stderr.
+	Output   string
+	ExitCode int
+	// TimedOut is true when the configured timeout killed the command.
+	TimedOut bool
+	// Timeout is the configured timeout, set when TimedOut is true.
+	Timeout time.Duration
+	// Interrupted is true when kill() (Esc/Ctrl-C) stopped the command.
+	Interrupted bool
+	// Err is set for start/wait failures unrelated to the exit code.
+	Err error
+}
+
+// shellExec tracks one running shell-mode command.
+type shellExec struct {
+	callID  string
+	command string
+	// ch delivers output/done messages to the tea loop. It is buffered so the
+	// pump never blocks on a busy loop; deltas are dropped when full (the done
+	// message still carries the bounded final output).
+	ch chan tea.Msg
+	// cancel terminates the process (group) via the command context.
+	cancel context.CancelFunc
+	// interrupted records that kill() — not a failure or timeout — ended the
+	// command. Read by the pump when composing the done message.
+	interrupted atomic.Bool
+}
+
+// startShellExec launches `sh -c command` in the background. The process runs
+// in its own process group so a cancel kills the whole tree. A timeout <= 0
+// uses defaultShellExecTimeout.
+func startShellExec(callID, command string, timeout time.Duration) (*shellExec, error) {
+	if timeout <= 0 {
+		timeout = defaultShellExecTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	configureShellGroupKill(cmd)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	// stderr flows into the same pipe so the card shows interleaved output.
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	ex := &shellExec{
+		callID:  callID,
+		command: command,
+		ch:      make(chan tea.Msg, 64),
+		cancel:  cancel,
+	}
+	go ex.pump(cmd, stdout, ctx, timeout)
+	return ex, nil
+}
+
+// kill stops the command and marks the done message as an interruption.
+func (ex *shellExec) kill() {
+	ex.interrupted.Store(true)
+	ex.cancel()
+}
+
+// pump reads the combined output until EOF, waits for the process, and emits
+// the terminal done message. It runs on its own goroutine for the lifetime of
+// the process.
+func (ex *shellExec) pump(cmd *exec.Cmd, r io.Reader, ctx context.Context, timeout time.Duration) {
+	buf := newShellOutputBuffer(shellExecMaxOutputBytes)
+	readBuf := make([]byte, 4096)
+	streamed := 0
+	for {
+		n, err := r.Read(readBuf)
+		if n > 0 {
+			chunk := readBuf[:n]
+			buf.Write(chunk)
+			if streamed < shellExecMaxStreamBytes {
+				select {
+				case ex.ch <- shellExecOutputMsg{CallID: ex.callID, Chunk: string(chunk)}:
+					streamed += n
+				default:
+					// The tea loop is busy; drop this live delta. The bounded
+					// final output still arrives with the done message.
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	waitErr := cmd.Wait()
+	done := shellExecDoneMsg{CallID: ex.callID, Output: buf.String()}
+	switch {
+	case ex.interrupted.Load():
+		done.Interrupted = true
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		// The context deadline fired and killed the process group.
+		done.TimedOut = true
+		done.Timeout = timeout
+	case waitErr == nil:
+		done.ExitCode = 0
+	default:
+		var exitErr *exec.ExitError
+		if errors.As(waitErr, &exitErr) {
+			done.ExitCode = exitErr.ExitCode()
+		} else {
+			done.Err = waitErr
+		}
+	}
+	// Blocking send: done is the terminal message and must not be dropped.
+	ex.ch <- done
+}
+
+// waitShellExecMsg returns a tea.Cmd that receives the executor's next
+// message. The model re-issues it after every delta; the done message ends the
+// chain, so no poll outlives the process.
+func waitShellExecMsg(ex *shellExec) tea.Cmd {
+	return func() tea.Msg {
+		return <-ex.ch
+	}
+}
+
+// shellOutputBuffer is a fixed-capacity writer keeping the first headCap and
+// last tailCap bytes with a truncation marker between them when the total
+// exceeds the cap. Mirrors the bash-plugin capture strategy
+// (cmd/harnesscli/tui/plugin/execute.go), which is unexported there.
+type shellOutputBuffer struct {
+	max      int
+	headCap  int
+	tailCap  int
+	total    int
+	headData []byte
+	tailData []byte
+}
+
+func newShellOutputBuffer(max int) *shellOutputBuffer {
+	if max <= 0 {
+		max = shellExecMaxOutputBytes
+	}
+	headCap := max / 2
+	tailCap := max - headCap
+	return &shellOutputBuffer{
+		max:      max,
+		headCap:  headCap,
+		tailCap:  tailCap,
+		headData: make([]byte, 0, headCap),
+		tailData: make([]byte, 0, tailCap),
+	}
+}
+
+func (b *shellOutputBuffer) Write(p []byte) (int, error) {
+	b.total += len(p)
+	remaining := p
+
+	if len(b.headData) < b.headCap {
+		n := b.headCap - len(b.headData)
+		if n > len(remaining) {
+			n = len(remaining)
+		}
+		b.headData = append(b.headData, remaining[:n]...)
+		remaining = remaining[n:]
+	}
+
+	if b.tailCap > 0 && len(remaining) > 0 {
+		if len(remaining) >= b.tailCap {
+			b.tailData = append(b.tailData[:0], remaining[len(remaining)-b.tailCap:]...)
+		} else {
+			b.tailData = append(b.tailData, remaining...)
+			if len(b.tailData) > b.tailCap {
+				b.tailData = append([]byte{}, b.tailData[len(b.tailData)-b.tailCap:]...)
+			}
+		}
+	}
+
+	return len(p), nil
+}
+
+func (b *shellOutputBuffer) String() string {
+	if b.total <= b.max {
+		combined := make([]byte, 0, len(b.headData)+len(b.tailData))
+		combined = append(combined, b.headData...)
+		combined = append(combined, b.tailData...)
+		return string(combined)
+	}
+	combined := make([]byte, 0, len(b.headData)+len(shellExecTruncationMarker)+len(b.tailData))
+	combined = append(combined, b.headData...)
+	combined = append(combined, []byte(shellExecTruncationMarker)...)
+	combined = append(combined, b.tailData...)
+	return string(combined)
+}

--- a/cmd/harnesscli/tui/shellexec_internal_test.go
+++ b/cmd/harnesscli/tui/shellexec_internal_test.go
@@ -1,0 +1,137 @@
+package tui
+
+// Unit tests for the shell-mode local executor (epic #811, slice 2):
+// stdout/stderr capture, non-zero exit, timeout kill, bounded output,
+// streaming deltas, and kill() interruption.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// collectShellMsgs drains ex.ch until the done message, returning all streamed
+// chunks and the final done message.
+func collectShellMsgs(t *testing.T, ex *shellExec) (chunks []string, done shellExecDoneMsg) {
+	t.Helper()
+	timeout := time.After(15 * time.Second)
+	for {
+		select {
+		case msg := <-ex.ch:
+			switch m := msg.(type) {
+			case shellExecOutputMsg:
+				chunks = append(chunks, m.Chunk)
+			case shellExecDoneMsg:
+				return chunks, m
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for shell exec to finish")
+		}
+	}
+}
+
+func TestShellExec_CapturesStdout(t *testing.T) {
+	ex, err := startShellExec("shell-1", "echo hello", 5*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	_, done := collectShellMsgs(t, ex)
+	if done.Err != nil {
+		t.Fatalf("unexpected error: %v", done.Err)
+	}
+	if done.ExitCode != 0 {
+		t.Errorf("exit code: got %d, want 0", done.ExitCode)
+	}
+	if !strings.Contains(done.Output, "hello") {
+		t.Errorf("output must contain stdout, got %q", done.Output)
+	}
+}
+
+func TestShellExec_CapturesStderr(t *testing.T) {
+	ex, err := startShellExec("shell-1", "echo oops >&2", 5*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	_, done := collectShellMsgs(t, ex)
+	if !strings.Contains(done.Output, "oops") {
+		t.Errorf("output must contain stderr, got %q", done.Output)
+	}
+}
+
+func TestShellExec_NonZeroExit(t *testing.T) {
+	ex, err := startShellExec("shell-1", "exit 3", 5*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	_, done := collectShellMsgs(t, ex)
+	if done.ExitCode != 3 {
+		t.Errorf("exit code: got %d, want 3", done.ExitCode)
+	}
+}
+
+func TestShellExec_TimeoutKillsProcess(t *testing.T) {
+	start := time.Now()
+	ex, err := startShellExec("shell-1", "sleep 30", 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	_, done := collectShellMsgs(t, ex)
+	elapsed := time.Since(start)
+	if !done.TimedOut {
+		t.Error("done must report TimedOut when the timeout kills the command")
+	}
+	if elapsed > 10*time.Second {
+		t.Errorf("timeout kill took too long: %v (command must not run to completion)", elapsed)
+	}
+}
+
+func TestShellExec_OutputBounded(t *testing.T) {
+	// ~100KB of output — far above the 30KB cap.
+	ex, err := startShellExec("shell-1", "yes a | head -c 100000", 15*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	_, done := collectShellMsgs(t, ex)
+	// The bounded buffer keeps head+tail within the cap plus a truncation marker.
+	if len(done.Output) > shellExecMaxOutputBytes+256 {
+		t.Errorf("output must be bounded near %d bytes, got %d", shellExecMaxOutputBytes, len(done.Output))
+	}
+	if !strings.Contains(done.Output, "truncated") {
+		t.Errorf("over-cap output must carry a truncation marker, got %q", done.Output[:200])
+	}
+}
+
+func TestShellExec_StreamsDeltasBeforeDone(t *testing.T) {
+	ex, err := startShellExec("shell-1", "printf a; sleep 0.2; printf b", 5*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	chunks, done := collectShellMsgs(t, ex)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one streamed delta before the done message")
+	}
+	joined := strings.Join(chunks, "")
+	if joined != "ab" {
+		t.Errorf("streamed deltas must reconstruct the output, got %q", joined)
+	}
+	if done.ExitCode != 0 {
+		t.Errorf("exit code: got %d, want 0", done.ExitCode)
+	}
+}
+
+func TestShellExec_KillInterrupts(t *testing.T) {
+	ex, err := startShellExec("shell-1", "sleep 30", 30*time.Second)
+	if err != nil {
+		t.Fatalf("startShellExec: %v", err)
+	}
+	start := time.Now()
+	ex.kill()
+	_, done := collectShellMsgs(t, ex)
+	elapsed := time.Since(start)
+	if !done.Interrupted {
+		t.Error("done must report Interrupted after kill()")
+	}
+	if elapsed > 10*time.Second {
+		t.Errorf("kill took too long: %v", elapsed)
+	}
+}

--- a/cmd/harnesscli/tui/shellexec_kill_other.go
+++ b/cmd/harnesscli/tui/shellexec_kill_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package tui
+
+import "os/exec"
+
+// configureShellGroupKill is a no-op on non-Unix platforms: there is no
+// syscall-level process-group kill there, so exec.CommandContext's default
+// behavior (kill only the direct child) is kept.
+func configureShellGroupKill(cmd *exec.Cmd) {}

--- a/cmd/harnesscli/tui/shellexec_kill_unix.go
+++ b/cmd/harnesscli/tui/shellexec_kill_unix.go
@@ -1,0 +1,35 @@
+//go:build unix
+
+package tui
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// shellGroupKillWaitDelay bounds how long cmd.Wait waits for inherited I/O
+// pipes to close once the command's process group is gone, after which Wait
+// returns an error wrapping exec.ErrWaitDelay instead of hanging.
+const shellGroupKillWaitDelay = 2 * time.Second
+
+// configureShellGroupKill places cmd in its own process group and overrides
+// exec.CommandContext's default Cancel (which SIGKILLs only the direct child)
+// with a kill of the whole group, so children spawned by `sh -c` die on
+// timeout and on Esc/Ctrl-C too. Mirrors configureGroupKill in
+// internal/harness/tools/exec_group_unix.go (#786), which is unexported.
+func configureShellGroupKill(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	cmd.WaitDelay = shellGroupKillWaitDelay
+}

--- a/cmd/harnesscli/tui/shellmode_exec_test.go
+++ b/cmd/harnesscli/tui/shellmode_exec_test.go
@@ -1,0 +1,162 @@
+package tui_test
+
+// Tests for shell-mode local execution (epic #811, slice 2):
+// submitting in shell mode runs the command locally from the TUI process and
+// streams stdout/stderr into a tool-style "shell" card in the conversation
+// view; Esc interrupts a running command; non-zero exits are reported.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui"
+)
+
+// unwrapSingle executes a tea.Cmd expected to wrap at most one real command
+// (the shell-mode flow only ever batches a single poll/submit cmd) and returns
+// the resulting message.
+func unwrapSingle(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected a cmd, got nil")
+	}
+	msg := cmd()
+	bm, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return msg
+	}
+	if len(bm) != 1 {
+		t.Fatalf("expected a single-cmd batch, got %d cmds", len(bm))
+	}
+	return bm[0]()
+}
+
+// submitShellCommand enters shell mode, types the command, presses Enter, and
+// feeds the resulting CommandSubmittedMsg back into the model — the full real
+// key flow. Returns the updated model and the executor's poll cmd.
+func submitShellCommand(t *testing.T, m tui.Model, command string) (tui.Model, tea.Cmd) {
+	t.Helper()
+	m = typeIntoModel(m, "!")
+	m = typeIntoModel(m, command)
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	msg := unwrapSingle(t, cmd)
+	m3, pollCmd := m.Update(msg)
+	return m3.(tui.Model), pollCmd
+}
+
+// drainShell drives the executor's poll cmd until the active shell card leaves
+// the running state, simulating Bubble Tea's message loop.
+func drainShell(t *testing.T, m tui.Model, cmd tea.Cmd) tui.Model {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for m.ActiveToolCallStatus() == "running" {
+		if time.Now().After(deadline) {
+			t.Fatal("shell command did not finish in time")
+		}
+		msg := unwrapSingle(t, cmd)
+		m2, next := m.Update(msg)
+		m = m2.(tui.Model)
+		cmd = next
+	}
+	return m
+}
+
+func TestShellMode_ExecutesAndStreamsIntoCard(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m, pollCmd := submitShellCommand(t, m, "echo hello")
+
+	if m.ShellMode() {
+		t.Error("submitting in shell mode must return to normal mode")
+	}
+	if got := m.ActiveToolCallStatus(); got != "running" {
+		t.Fatalf("after submit the shell card must be running, got %q", got)
+	}
+
+	m = drainShell(t, m, pollCmd)
+
+	if got := m.ActiveToolCallStatus(); got != "completed" {
+		t.Errorf("shell card must complete after the command exits, got %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "hello") {
+		t.Errorf("shell card must contain the command output, got:\n%s", view)
+	}
+	if view := m.View(); !strings.Contains(view, "shell") {
+		t.Errorf("output must render as a 'shell' tool card, got:\n%s", view)
+	}
+}
+
+func TestShellMode_NonZeroExitShownInCard(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m, pollCmd := submitShellCommand(t, m, "exit 1")
+	m = drainShell(t, m, pollCmd)
+
+	if got := m.ActiveToolCallStatus(); got != "error" {
+		t.Errorf("a failing command must render an error card, got %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "exit status 1") {
+		t.Errorf("the card must report the non-zero exit, got:\n%s", view)
+	}
+}
+
+func TestShellMode_EscInterruptsRunningCommand(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m, pollCmd := submitShellCommand(t, m, "sleep 999")
+	if got := m.ActiveToolCallStatus(); got != "running" {
+		t.Fatalf("precondition: shell command must be running, got %q", got)
+	}
+
+	start := time.Now()
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = m2.(tui.Model)
+	m = drainShell(t, m, pollCmd)
+
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Errorf("Esc interrupt took too long (%v) — the process must be killed, not awaited", elapsed)
+	}
+	if got := m.ActiveToolCallStatus(); got != "error" {
+		t.Errorf("an interrupted command must render an error card, got %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "interrupted") {
+		t.Errorf("the card must report the interruption, got:\n%s", view)
+	}
+}
+
+func TestShellMode_CtrlCKillsInsteadOfQuitting(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m, pollCmd := submitShellCommand(t, m, "sleep 999")
+	if got := m.ActiveToolCallStatus(); got != "running" {
+		t.Fatalf("precondition: shell command must be running, got %q", got)
+	}
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	m = m2.(tui.Model)
+
+	// Ctrl+C while a shell command runs must kill the command, NOT quit the
+	// TUI. tea.Quit would return a QuitMsg immediately; any other cmd (e.g.
+	// the status tick) blocks, so probe with a timeout instead of executing
+	// it inline.
+	if cmd != nil {
+		result := make(chan tea.Msg, 1)
+		go func() { result <- cmd() }()
+		select {
+		case msg := <-result:
+			if _, isQuit := msg.(tea.QuitMsg); isQuit {
+				t.Fatal("ctrl+c while a shell command runs must not quit the TUI")
+			}
+		case <-time.After(500 * time.Millisecond):
+			// Still blocking — not a quit.
+		}
+	}
+	m = drainShell(t, m, pollCmd)
+	if got := m.ActiveToolCallStatus(); got != "error" {
+		t.Errorf("the killed command must render an error card, got %q", got)
+	}
+}

--- a/cmd/harnesscli/tui/shellmode_test.go
+++ b/cmd/harnesscli/tui/shellmode_test.go
@@ -155,7 +155,7 @@ func TestShellMode_PastedBangCommandEntersShellMode(t *testing.T) {
 	}
 }
 
-func TestShellMode_SubmitIsStubAndReturnsToNormalMode(t *testing.T) {
+func TestShellMode_SubmitExecutesAndReturnsToNormalMode(t *testing.T) {
 	m := initModel(t, 80, 24)
 	m = typeIntoModel(m, "!")
 	m = typeIntoModel(m, "echo hi")
@@ -163,24 +163,22 @@ func TestShellMode_SubmitIsStubAndReturnsToNormalMode(t *testing.T) {
 		t.Fatal("precondition: shell mode must be active")
 	}
 
-	// Simulate the input area emitting the submit message (slice 1 has no
-	// execution yet — the model must stub it out).
-	m2, _ := m.Update(inputarea.CommandSubmittedMsg{Value: "echo hi"})
+	// Slice 2: submitting in shell mode executes the command locally and shows
+	// a running "shell" card (the slice-1 stub status message is gone).
+	m2, cmd := m.Update(inputarea.CommandSubmittedMsg{Value: "echo hi"})
 	m = m2.(tui.Model)
 
 	if m.ShellMode() {
 		t.Error("submitting in shell mode must return to normal mode")
 	}
-	if m.RunActive() {
-		t.Error("the shell-mode submit stub must not start an agent run")
+	if strings.Contains(m.StatusMsg(), "not executed") {
+		t.Errorf("shell commands must execute now — stale stub status %q", m.StatusMsg())
 	}
-	status := m.StatusMsg()
-	if !strings.Contains(status, "not executed") {
-		t.Errorf("stub submit must set a status message saying the command was not executed, got %q", status)
+	if got := m.ActiveToolCallStatus(); got != "running" {
+		t.Errorf("submit must start local execution as a running shell card, got %q", got)
 	}
-	if !strings.Contains(status, "echo hi") {
-		t.Errorf("stub status message must name the command, got %q", status)
-	}
+	// Reap the spawned process before the test exits.
+	_ = drainShell(t, m, cmd)
 }
 
 func TestShellMode_SurvivesWindowResize(t *testing.T) {

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -73,6 +73,28 @@
 - Strict TDD: `cmd/harnesscli/tui/steer_events_test.go` (package `tui_test`, `sse_events_test.go` pattern) drives scripted `SSEEventMsg`s — marker+message in viewport, exactly one role-`user` transcript entry, distinction from a typed prompt, five malformed-payload shapes (no panic, no marker, transcript unchanged, run stays active).
 - Validation: `go test ./cmd/harnesscli/... -count=1` all ok (incl. `sse_events_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `keys_test.go` guards); `go test ./internal/server/ ./internal/harness/ -count=1` ok; gofmt/vet clean.
 
+## 2026-07-20 (Shell Mode Slice 2 — Epic #811)
+
+- Shell-mode submit now executes the command locally in the TUI process
+  (`sh -c`, 120s default timeout) and streams combined stdout/stderr into a
+  tool-style `shell` card, replacing the slice-1 stub. The executor
+  (`cmd/harnesscli/tui/shellexec.go`) is fully async: a pump goroutine feeds
+  output/done messages on a buffered channel that the model polls with a
+  tea.Cmd, so `Update()` never blocks.
+- Output is bounded twice: live deltas stop after 30KB, and the final done
+  message carries a 30KB head+tail buffer (same strategy as bash plugins), so
+  flood commands like `yes` stay memory-safe.
+- Esc and Ctrl-C kill the whole process group (`Setpgid` + group SIGKILL +
+  `WaitDelay`, mirroring `internal/harness/tools/exec_group_unix.go` #786);
+  the done message then finalizes the card as interrupted. Cards reuse the
+  existing `handleToolStart`/`handleToolChunk`/`handleToolResult`/
+  `handleToolError` pipeline; `extractToolCommand` now covers `shell`.
+- Known limitation: the tooluse `ErrorView` renders only `ErrorText`, so
+  failed commands report `exit status N` plus the bounded output as reflowed
+  error text (same behavior as agent bash errors today).
+- Validation: `go test ./cmd/harnesscli/... -count=1` green; gofmt/vet clean
+  on touched files.
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/811-shell-mode.md
+++ b/docs/plans/811-shell-mode.md
@@ -1,6 +1,79 @@
-# Plan: shell mode — Slice 1: shell-mode input state with `!` prefix entry/exit
+# Plan: shell mode — epic #811 (slices 1-2)
 
-Parent epic: #811 (parent tracking: #803). This plan covers ONLY slice 1 of the epic.
+Parent epic: #811 (parent tracking: #803).
+
+## Slice 2: run shell-mode commands locally with streamed output card
+
+Status: `in implementation` (building on merged slice 1).
+
+### Context
+
+- Problem: slice 1 shipped shell-mode input state with a submit stub. Slice 2
+  executes the submitted command locally from the `harnesscli` TUI process and
+  streams stdout/stderr into the conversation view as a tool-style card.
+- User impact: `!echo hello` renders a `shell` card containing `hello`;
+  `!sleep 999` is interruptible with Esc/Ctrl-C; `!false` shows a non-zero exit.
+- Constraints: `Update()` must never block (async pattern from
+  `plugin/execute.go`); output bounded (head+tail, same 30KB cap as bash
+  plugins); kill the whole process group on interrupt (pattern from
+  `internal/harness/tools/exec_group_unix.go`, #786).
+
+### Scope
+
+- In scope:
+  - New `cmd/harnesscli/tui/shellexec.go` — `tea.Cmd`-based executor:
+    `exec.CommandContext(ctx, "sh", "-c", ...)` with configurable timeout
+    (default 120s), combined stdout/stderr, per-read delta messages (capped),
+    and a final done message carrying exit code + bounded head/tail output.
+  - `shellexec_kill_unix.go` / `shellexec_kill_other.go` — process-group kill
+    (mirrors `configureGroupKill`, which is unexported in its package).
+  - `cmd/harnesscli/tui/model.go` — route `CommandSubmittedMsg` to the executor
+    while `shellMode` is set (replacing the slice-1 stub); exit shell mode on
+    submit; card lifecycle via existing `handleToolStart`/`handleToolChunk`/
+    `handleToolResult`/`handleToolError` with tool name `shell`; Esc and
+    Ctrl-C kill the running command; `extractToolCommand` extended to `shell`.
+- Out of scope (later slices): context injection (3), Ctrl+B background
+  handoff (4), persisted shell history (5). No server/API changes.
+
+### Test Plan (TDD)
+
+- Executor unit tests (`shellexec_internal_test.go`, package `tui`):
+  stdout capture, stderr capture, non-zero exit code, timeout kills process,
+  output buffer bounded at cap, streaming deltas arrive before done,
+  `kill()` interrupts promptly.
+- Model tests (`shellmode_exec_test.go`, package `tui_test`):
+  submit runs the command and produces running → completed card with output;
+  `exit 1` shows non-zero exit in the card; Esc interrupts `sleep 999` fast;
+  shell mode resets to normal after submit. Update the slice-1 stub test to
+  the new execution behavior.
+- Regression: full `./cmd/harnesscli/...` suite stays green; slice-1
+  entry/exit tests unchanged.
+
+### Cross-Surface Impact Map
+
+- Config: None. Server API: None (shell mode runs in the TUI process).
+- TUI state: `shellExecs map[string]*shellExec` + `shellRunningID` +
+  `shellExecSeq` + `shellExecTimeout` on the root Model; executors run as
+  goroutines feeding tea messages.
+- Known rendering limitation: tooluse `ErrorView` shows only `ErrorText`
+  (agent bash errors behave the same), so failed commands report
+  `exit status N` plus the bounded output as reflowed error text; the pristine
+  streamed output remains visible while running. Refinable in later slices.
+
+### Implementation Checklist (slice 2)
+
+- [x] Slice 1 merged: input state, marker, border, entry/exit, stub submit.
+- [x] Write failing executor + model tests first; watch them fail.
+- [x] shellexec.go executor (start/delta/done, bounded buffer, timeout).
+- [x] Process-group kill files (unix + fallback).
+- [x] model.go: submit routes to executor; card lifecycle; Esc/Ctrl-C kill.
+- [x] `go test ./cmd/harnesscli/... -count=1` green; gofmt + go vet clean.
+- [x] Engineering-log entry; plan/index maintenance.
+- [ ] Commit, push `epic/811-shell-mode-s2`, open PR (do not merge).
+
+## Slice 1: shell-mode input state with `!` prefix entry/exit
+
+Status: `implemented` (merged to main via PR #843).
 
 ## Context
 


### PR DESCRIPTION
Parent epic: #811. Part of #803.