### PR TITLE
feat(acp): session/new and session/prompt over the runs API

### DIFF
--- a/cmd/harnesscli/acp.go
+++ b/cmd/harnesscli/acp.go
@@ -14,6 +14,10 @@ import (
 // stdout/stderr pattern in main.go).
 var stdin io.Reader = os.Stdin
 
+// defaultACPServerURL is used when neither -server nor a saved config names
+// a harnessd.
+const defaultACPServerURL = "http://localhost:8080"
+
 // runACP implements "harness acp": it serves the Agent Client Protocol
 // (newline-delimited JSON-RPC 2.0) over stdin/stdout so ACP-compatible
 // editors (Zed, JetBrains via ACP) can drive go-code as a subprocess.
@@ -21,14 +25,38 @@ var stdin io.Reader = os.Stdin
 func runACP(args []string) int {
 	fs := flag.NewFlagSet("acp", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	serverFlag := fs.String("server", "", "harness server URL (default: ~/.harness/config.json server or "+defaultACPServerURL+")")
 	if err := fs.Parse(args); err != nil {
 		return 1
 	}
 
+	baseURL, apiKey := resolveACPServer(*serverFlag)
 	server := acp.NewServer(stdin, stdout, stderr)
+	server.EnableSessions(acp.NewRunsClient(baseURL, apiKey))
 	if err := server.Serve(context.Background()); err != nil {
 		fmt.Fprintf(stderr, "harnesscli acp: %v\n", err)
 		return 1
 	}
 	return 0
+}
+
+// resolveACPServer picks the harnessd base URL and API key for the ACP
+// adapter. Precedence: -server flag > saved config server > default
+// localhost. The API key comes from the saved config (harness auth login);
+// a missing or unreadable config just means no credentials, matching the
+// rest of the CLI.
+func resolveACPServer(flagValue string) (baseURL, apiKey string) {
+	if flagValue != "" {
+		baseURL = flagValue
+	}
+	if cfg, err := loadConfig(); err == nil && cfg != nil {
+		if baseURL == "" && cfg.Server != "" {
+			baseURL = cfg.Server
+		}
+		apiKey = cfg.APIKey
+	}
+	if baseURL == "" {
+		baseURL = defaultACPServerURL
+	}
+	return baseURL, apiKey
 }

--- a/cmd/harnesscli/acp_test.go
+++ b/cmd/harnesscli/acp_test.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // swapACPStdio redirects the package-level stdin/stdout/stderr used by runACP
@@ -101,4 +110,292 @@ func TestDispatch_ACPRoutedToRunACP(t *testing.T) {
 	if !strings.Contains(outBuf.String(), `"agentCapabilities"`) {
 		t.Fatalf("dispatch(acp) did not serve the ACP handshake; stdout: %q", outBuf.String())
 	}
+}
+
+// --- Slice 2: session flow against a fake harnessd ---
+
+// acpFakeHarness is a minimal harnessd double for the CLI-level ACP tests:
+// POST /v1/runs, GET /v1/runs/{id}/events, POST /v1/runs/{id}/cancel.
+type acpFakeHarness struct {
+	*httptest.Server
+	mu       sync.Mutex
+	prompt   string
+	auth     string
+	runID    string
+	cancelCh chan string
+	events   chan string // terminal event type to emit
+	created  chan struct{}
+}
+
+func newACPFakeHarness(t *testing.T) *acpFakeHarness {
+	t.Helper()
+	fh := &acpFakeHarness{
+		cancelCh: make(chan string, 1),
+		events:   make(chan string),
+		created:  make(chan struct{}),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/runs", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Prompt string `json:"prompt"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		fh.mu.Lock()
+		fh.prompt = body.Prompt
+		fh.auth = r.Header.Get("Authorization")
+		fh.runID = "run-1"
+		fh.mu.Unlock()
+		close(fh.created)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"run_id":"run-1","status":"running"}`)
+	})
+	mux.HandleFunc("GET /v1/runs/run-1/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		fmt.Fprint(w, "id: run-1:1\nevent: run.started\ndata: {\"type\":\"run.started\"}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+		select {
+		case typ := <-fh.events:
+			fmt.Fprintf(w, "id: run-1:2\nevent: %s\ndata: {\"type\":%q,\"payload\":{}}\n\n", typ, typ)
+			if flusher != nil {
+				flusher.Flush()
+			}
+		case <-r.Context().Done():
+		}
+	})
+	mux.HandleFunc("POST /v1/runs/run-1/cancel", func(w http.ResponseWriter, r *http.Request) {
+		fh.cancelCh <- "run-1"
+		// Mirror harnessd: cancel terminates the run on the event stream.
+		go func() { fh.events <- "run.cancelled" }()
+		fmt.Fprint(w, `{"status":"cancelling"}`)
+	})
+	fh.Server = httptest.NewServer(mux)
+	t.Cleanup(fh.Server.Close)
+	return fh
+}
+
+// acpScript drives runACP through interactive pipes.
+type acpScript struct {
+	t      *testing.T
+	inW    *io.PipeWriter
+	out    *bufio.Reader
+	done   chan int
+	nextID int
+}
+
+func startACPScript(t *testing.T, args []string) *acpScript {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	origStdin, origStdout, origStderr := stdin, stdout, stderr
+	errBuf := &bytes.Buffer{}
+	stdin, stdout, stderr = inR, outW, errBuf
+	t.Cleanup(func() {
+		stdin, stdout, stderr = origStdin, origStdout, origStderr
+		inR.Close()
+		outR.Close()
+		outW.Close()
+	})
+	s := &acpScript{t: t, inW: inW, out: bufio.NewReader(outR), done: make(chan int, 1)}
+	go func() { s.done <- runACP(args) }()
+	return s
+}
+
+func (s *acpScript) send(method string, params any) int {
+	s.t.Helper()
+	s.nextID++
+	msg := map[string]any{"jsonrpc": "2.0", "id": s.nextID, "method": method}
+	if params != nil {
+		msg["params"] = params
+	}
+	b, _ := json.Marshal(msg)
+	if _, err := s.inW.Write(append(b, '\n')); err != nil {
+		s.t.Fatalf("write: %v", err)
+	}
+	return s.nextID
+}
+
+func (s *acpScript) notify(method string, params any) {
+	s.t.Helper()
+	b, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "method": method, "params": params})
+	if _, err := s.inW.Write(append(b, '\n')); err != nil {
+		s.t.Fatalf("write notification: %v", err)
+	}
+}
+
+func (s *acpScript) read() map[string]any {
+	s.t.Helper()
+	type res struct {
+		line string
+		err  error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		line, err := s.out.ReadString('\n')
+		ch <- res{line, err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			s.t.Fatalf("read: %v", r.err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimRight(r.line, "\n")), &m); err != nil {
+			s.t.Fatalf("bad response line %q: %v", r.line, err)
+		}
+		return m
+	case <-time.After(15 * time.Second):
+		s.t.Fatal("timed out waiting for response")
+		return nil
+	}
+}
+
+func (s *acpScript) close() {
+	s.t.Helper()
+	s.inW.Close()
+	select {
+	case code := <-s.done:
+		if code != 0 {
+			s.t.Fatalf("runACP = %d, want 0", code)
+		}
+	case <-time.After(15 * time.Second):
+		s.t.Fatal("runACP did not return after stdin close")
+	}
+}
+
+func (s *acpScript) newSession() string {
+	s.t.Helper()
+	s.send("session/new", map[string]any{"cwd": "/tmp", "mcpServers": []any{}})
+	resp := s.read()
+	if errObj, ok := resp["error"]; ok {
+		s.t.Fatalf("session/new failed: %v", errObj)
+	}
+	result, _ := resp["result"].(map[string]any)
+	sid, _ := result["sessionId"].(string)
+	if sid == "" {
+		s.t.Fatalf("session/new returned no sessionId: %v", resp)
+	}
+	return sid
+}
+
+func TestRunACP_SessionPromptAgainstFakeServer(t *testing.T) {
+	fh := newACPFakeHarness(t)
+	s := startACPScript(t, []string{"-server", fh.URL})
+
+	s.send("initialize", map[string]any{"protocolVersion": 1})
+	if resp := s.read(); resp["error"] != nil {
+		t.Fatalf("initialize failed: %v", resp["error"])
+	}
+	sid := s.newSession()
+
+	promptID := s.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "build me a thing"}},
+	})
+	select {
+	case <-fh.created:
+	case <-time.After(10 * time.Second):
+		t.Fatal("fake harnessd never received POST /v1/runs")
+	}
+	if fh.prompt != "build me a thing" {
+		t.Fatalf("harnessd received prompt %q, want %q", fh.prompt, "build me a thing")
+	}
+	go func() { fh.events <- "run.completed" }()
+
+	resp := s.read()
+	if fmt.Sprintf("%v", resp["id"]) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %v, want %d", resp["id"], promptID)
+	}
+	result, _ := resp["result"].(map[string]any)
+	if result["stopReason"] != "end_turn" {
+		t.Fatalf("stopReason = %v, want end_turn (full response: %v)", result["stopReason"], resp)
+	}
+	s.close()
+}
+
+func TestRunACP_UsesConfigServerAndAPIKey(t *testing.T) {
+	fh := newACPFakeHarness(t)
+
+	// Write a config the way `harness auth login` would, in a temp HOME.
+	tmpHome := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Cleanup(func() { os.Setenv("HOME", oldHome) })
+	os.Setenv("HOME", tmpHome)
+	cfgDir := filepath.Join(tmpHome, ".harness")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := map[string]string{"server": fh.URL, "api_key": "cfg-secret"}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// No -server flag: server URL and credentials must come from the config.
+	s := startACPScript(t, nil)
+	s.send("initialize", map[string]any{"protocolVersion": 1})
+	s.read()
+	sid := s.newSession()
+	s.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "go"}},
+	})
+	select {
+	case <-fh.created:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run request did not reach the config-specified server")
+	}
+	if fh.auth != "Bearer cfg-secret" {
+		t.Fatalf("Authorization = %q, want Bearer cfg-secret", fh.auth)
+	}
+	go func() { fh.events <- "run.completed" }()
+	resp := s.read()
+	result, _ := resp["result"].(map[string]any)
+	if result["stopReason"] != "end_turn" {
+		t.Fatalf("stopReason = %v, want end_turn", result["stopReason"])
+	}
+	s.close()
+}
+
+func TestRunACP_CancelMidRunIssuesCancelPOST(t *testing.T) {
+	fh := newACPFakeHarness(t)
+	s := startACPScript(t, []string{"-server", fh.URL})
+
+	s.send("initialize", map[string]any{"protocolVersion": 1})
+	s.read()
+	sid := s.newSession()
+	promptID := s.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "long running"}},
+	})
+	select {
+	case <-fh.created:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run never started")
+	}
+
+	s.notify("session/cancel", map[string]any{"sessionId": sid})
+
+	select {
+	case <-fh.cancelCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("cancel POST never reached harnessd")
+	}
+
+	resp := s.read()
+	if fmt.Sprintf("%v", resp["id"]) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %v, want prompt id %d", resp["id"], promptID)
+	}
+	if resp["error"] != nil {
+		t.Fatalf("cancelled prompt must not error, got %v", resp["error"])
+	}
+	result, _ := resp["result"].(map[string]any)
+	if result["stopReason"] != "cancelled" {
+		t.Fatalf("stopReason = %v, want cancelled", result["stopReason"])
+	}
+	s.close()
 }

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,14 @@
 # Engineering Log
 
+## 2026-07-20 (ACP Server Mode — Epic #806, Slice 2)
+
+- `internal/acp` sessions over the runs API: `session/new` (unique `sess_<hex>` ids, cwd/mcpServers accepted but not acted on), `session/prompt` (content-block text extraction — text blocks joined, `resource_link` contributes its URI, empty extraction -> `-32602`), `session/cancel` notification -> `POST /v1/runs/{id}/cancel`. One ACP session maps to one run; a second prompt on a used session errors `-32603` (multi-turn is a later epic).
+- New stdlib `RunsClient` (`client.go`): bounded client for `POST /v1/runs` and cancel, no-timeout client for the SSE subscription; `WaitTerminal` scans `GET /v1/runs/{id}/events` to a terminal event, tracking `run.cost_limit_reached` as a flag (it is non-terminal — the run then completes).
+- Stop reasons: `run.completed` -> `end_turn`, cost-limit + completed -> `max_turn_requests`, `run.failed` -> `refusal`, `run.cancelled` -> `cancelled`.
+- Dispatch is now concurrent: `session/prompt` holds its response open until the run terminates, so handlers run in goroutines or a mid-turn `session/cancel` could never be read. Writes stay mutex-serialized; `Serve` drains in-flight handlers at EOF. The slice-1 ordering test was updated to correlate pipelined responses by id (JSON-RPC clients never relied on order).
+- `harness acp -server` flag; resolution flag > `loadConfig().Server` > `http://localhost:8080`; Bearer key from `loadConfig()`.
+- Validation: strict TDD (failing tests first: `undefined: NewRunsClient`). `go test ./internal/acp/ -count=1` and `-race` green, incl. scripted-pipe flows — cancel mid-run issues the cancel POST and the prompt answers `cancelled`; concurrent sessions stay isolated; blocked-handler concurrency proof.
+
 ## 2026-07-20 (Issue #854 TUI Subscription Credential Import)
 
 - Replaced the stale `/keys` startup hint based on nonexistent `KIMI_SUBSCRIPTION_AUTH` with synchronous, local-only reads of both harness-owned Codex and Kimi credential stores. The TUI stores only a non-secret availability marker.

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -1,14 +1,16 @@
-# Plan: ACP slice 1 — stdio JSON-RPC framing and initialize handshake
+# Plan: ACP epic #806 — stdio ACP server mode
 
-Epic: #806 (parent #803). Slice 1 of 5. Branch: `epic/806-acp-server`.
+Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `epic/806-acp-server-s2` (slice 2).
 
-## Context
+## Slice 1 — stdio JSON-RPC framing and initialize handshake (MERGED)
+
+### Context
 
 - Problem: go-code has no Agent Client Protocol surface; editors (Zed, JetBrains) cannot spawn or drive it.
 - User impact: without ACP, go-code is invisible to ACP clients.
-- Constraints: this slice only covers newline-delimited JSON-RPC 2.0 framing over stdio plus the `initialize` handshake and spec-correct error handling. No sessions, no runs API, no SSE — those are slices 2–4. Stdlib only (`encoding/json`); no new dependencies. stdout carries protocol messages only; diagnostics go to stderr. A pre-existing `internal/harnessacp` + `cmd/harness-acp` adapter (based on `github.com/coder/acp-go-sdk`) exists; the epic deliberately specifies a new stdlib-only `internal/acp` package and a `harness acp` subcommand — do not touch the existing adapter.
+- Constraints: slice 1 covers newline-delimited JSON-RPC 2.0 framing over stdio plus the `initialize` handshake and spec-correct error handling. Stdlib only (`encoding/json`); no new dependencies. stdout carries protocol messages only; diagnostics go to stderr. A pre-existing `internal/harnessacp` + `cmd/harness-acp` adapter (based on `github.com/coder/acp-go-sdk`) exists; the epic deliberately specifies a new stdlib-only `internal/acp` package and a `harness acp` subcommand — do not touch the existing adapter.
 
-## Scope
+### Scope (slice 1)
 
 - In scope:
   - New `internal/acp` package: framed reader/writer over `io.Reader`/`io.Writer` (newline-delimited JSON), goroutine-safe writer, JSON-RPC 2.0 envelope types and error codes (`-32700`, `-32600`, `-32601`, `-32602`).
@@ -16,35 +18,53 @@ Epic: #806 (parent #803). Slice 1 of 5. Branch: `epic/806-acp-server`.
   - New `cmd/harnesscli/acp.go` with `runACP(args)`; `case "acp"` in `dispatch` (`cmd/harnesscli/auth.go`).
 - Out of scope: `session/new`, `session/prompt`, `session/cancel`, `session/update`, `session/request_permission`, `--server` flag / runs API wiring (slices 2–4), docs/e2e (slice 5).
 
+## Slice 2 — session/new and session/prompt over the runs API (IN IMPLEMENTATION)
+
+### Scope (slice 2)
+
+- In scope:
+  - `internal/acp/client.go`: stdlib `RunsClient` — `StartRun` (POST `/v1/runs` with `{"prompt": ...}`), `CancelRun` (POST `/v1/runs/{id}/cancel`), `WaitTerminal` (GET `/v1/runs/{id}/events` SSE scan until a terminal event, tracking `run.cost_limit_reached`). Bearer auth from config. Two HTTP clients: bounded timeout for request/response, no timeout for SSE.
+  - `internal/acp/session.go`: mutex-guarded session store (sessionId -> runId, one run per session); `session/new` (unique `sess_<hex>` ids, accepts cwd/mcpServers without acting on them); `session/prompt` (content-block text extraction: `text` blocks joined, `resource_link` contributes its URI; empty extraction -> `-32602`); `session/cancel` notification -> cancel POST.
+  - Stop reasons: `run.completed` -> `end_turn`, `run.cost_limit_reached` + completed -> `max_turn_requests`, `run.failed` -> `refusal`, `run.cancelled` -> `cancelled`.
+  - Concurrent dispatch in `server.go`: `session/prompt` holds its response open until the run terminates, so handlers must run in goroutines or a mid-turn `session/cancel` could never be read. Writes stay serialized by the Conn mutex; `Serve` drains in-flight handlers before returning at EOF. `-32603` internal error code added.
+  - `cmd/harnesscli/acp.go`: `--server` flag; resolution flag > `loadConfig().Server` > `http://localhost:8080`; API key from `loadConfig()`; `EnableSessions(client)` on the server.
+- Out of scope: `session/update` translation (slice 3), `session/request_permission` (slice 4), multi-turn (one run per ACP session — second `session/prompt` on the same session errors), MCP-server wiring from `session/new` params, docs/e2e (slice 5).
+
+### Test Plan (TDD, slice 2)
+
+- New failing tests:
+  - `internal/acp`: RunsClient against httptest (start/cancel/auth header/error paths; SSE terminal wait incl. cost-limit flag, ping/retry lines skipped, stream-ended-early error); content-block extraction table; stop-reason table; `session/new` uniqueness; `session/prompt` unknown session / second prompt rejected; full flows over scripted stdio (prompt -> `end_turn`; cancel mid-run -> cancel POST + `cancelled` stop reason via `io.Pipe` staging); concurrent sessions isolated; handler-concurrency proof (blocked handler does not stall `initialize`).
+  - `cmd/harnesscli`: scripted initialize -> session/new -> session/prompt against an httptest harnessd double via `--server`; config-driven server URL + Bearer key; cancel mid-run issues the cancel POST.
+- Existing tests to update: `TestServerSequentialRequestsAnsweredInOrder` — responses are correlated by id instead of slice position (concurrent dispatch does not guarantee response order; JSON-RPC clients correlate by id).
+
+### Acceptance (slice 2)
+
+- Scripted stdio exchange — `initialize`, `session/new`, `session/prompt` against the fake server — returns a `session/prompt` result whose `stopReason` matches the fake's terminal SSE event; cancel mid-run issues the cancel POST.
+- `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
+
 ## Documentation Contract
 
-- Feature status: `in implementation`
+- Feature status: slice 1 `implemented` (PR #835); slice 2 `in implementation`.
 - Public docs affected: none (user-facing docs land in slice 5).
 - Spec docs to update before code: this plan.
 - Implementation notes to add after code: engineering-log entry.
 
-## Test Plan (TDD)
-
-- New failing tests to add first:
-  - `internal/acp`: framing (single message, partial line across reads, multiple messages per read, oversized line, goroutine-safe concurrent writes); `initialize` response shape + version negotiation; invalid params `-32602`; malformed JSON `-32700`; valid JSON / invalid request `-32600` table; unknown method `-32601`; notifications and response-shaped messages produce no output; EOF exits cleanly.
-  - `cmd/harnesscli`: `runACP` serves `initialize` over injected stdin/stdout and exits 0 on EOF; `dispatch(["acp"])` routes to `runACP`.
-- Existing tests to update: none.
-- Regression tests required: none beyond the above (new feature).
-
 ## Cross-Surface Impact Map
 
-- None — no provider/model flow, gateway routing, model catalog, API-key, or TUI provider plumbing changes. New leaf package + one dispatch case only.
+- None — no provider/model flow, gateway routing, model catalog, API-key, or TUI provider plumbing changes. New leaf package + dispatch case + CLI flags only. The runs API is consumed as an HTTP client; no server-side changes.
 
 ## Implementation Checklist
 
-- [x] Define acceptance criteria in tests (listed above; epic acceptance: `printf '...initialize...' | harness acp` prints a single JSON-RPC result with capabilities).
-- [ ] Write failing tests first.
-- [ ] Implement minimal code changes.
-- [ ] gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
-- [ ] Update docs indexes (plans INDEX) and engineering log.
-- [ ] Push branch and open PR (no merge — sibling agents continue later slices).
+- [x] Slice 1: framing + initialize, merged via PR #835.
+- [x] Slice 2: write failing tests first (red: `undefined: NewRunsClient`; CLI red: `-server` flag undefined).
+- [x] Slice 2: implement minimal code changes (`client.go`, `session.go`, concurrent dispatch in `server.go`, flags in `acp.go`).
+- [ ] Slice 2: gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
+- [x] Slice 2: update engineering log.
+- [ ] Slice 2: push branch `epic/806-acp-server-s2` and open PR (no merge).
 
 ## Risks and Mitigations
 
 - Risk: collision/confusion with existing `internal/harnessacp` (SDK-based adapter).
 - Mitigation: keep new code strictly in `internal/acp` + `cmd/harnesscli/acp.go`; do not modify the existing adapter; note the distinction in the PR body.
+- Risk: concurrent dispatch regresses slice-1 ordering assumptions.
+- Mitigation: responses correlated by id in the updated test; writer stays mutex-serialized; handler-concurrency proof test.

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -58,9 +58,9 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - [x] Slice 1: framing + initialize, merged via PR #835.
 - [x] Slice 2: write failing tests first (red: `undefined: NewRunsClient`; CLI red: `-server` flag undefined).
 - [x] Slice 2: implement minimal code changes (`client.go`, `session.go`, concurrent dispatch in `server.go`, flags in `acp.go`).
-- [ ] Slice 2: gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
+- [x] Slice 2: gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
 - [x] Slice 2: update engineering log.
-- [ ] Slice 2: push branch `epic/806-acp-server-s2` and open PR (no merge).
+- [x] Slice 2: push branch `epic/806-acp-server-s2` and open PR (no merge) — PR #874.
 
 ## Risks and Mitigations
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -26,7 +26,7 @@
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
-- `806-acp-server.md` — ACP server mode epic #806, slice 1: stdio JSON-RPC framing and initialize handshake in the stdlib-only `internal/acp` package plus the `harness acp` subcommand (in implementation).
+- `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged) and slice 2 (session/new + session/prompt over the runs API, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
 - `805-undo-prompts.md` — Epic #805 Slice 1 plan: `ConversationStore.UndoPrompts` with compaction-boundary guard (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.

--- a/internal/acp/client.go
+++ b/internal/acp/client.go
@@ -1,0 +1,251 @@
+package acp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Harness run lifecycle event types the ACP adapter reacts to. Terminal for a
+// prompt turn: run.completed / run.failed / run.cancelled.
+// run.cost_limit_reached is non-terminal — the run then completes — so it is
+// tracked as a flag on the outcome instead.
+const (
+	eventTypeRunCompleted        = "run.completed"
+	eventTypeRunFailed           = "run.failed"
+	eventTypeRunCancelled        = "run.cancelled"
+	eventTypeRunCostLimitReached = "run.cost_limit_reached"
+)
+
+// maxResponseBodyBytes bounds how much of any non-streaming harnessd response
+// body is read into memory.
+const maxResponseBodyBytes = 8 * 1024 * 1024
+
+// maxSSELineSize bounds a single SSE line; longer lines are drained and the
+// event they belong to is skipped, mirroring the harnesscli SSE client.
+const maxSSELineSize = 16 * 1024 * 1024
+
+// RunsClient is a minimal stdlib HTTP/SSE client for the harnessd runs API.
+// It exists so the ACP server can map one ACP session onto one go-code run
+// without pulling in the harness internals.
+type RunsClient struct {
+	baseURL string
+	apiKey  string
+	// http is for bounded request/response calls (start, cancel).
+	http *http.Client
+	// stream is for the SSE event subscription and must have no client-level
+	// timeout: runs can legitimately stream for a long time.
+	stream *http.Client
+}
+
+// NewRunsClient returns a client for the given harnessd base URL. apiKey is
+// sent as a Bearer token when non-empty.
+func NewRunsClient(baseURL, apiKey string) *RunsClient {
+	return &RunsClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 60 * time.Second},
+		stream:  &http.Client{},
+	}
+}
+
+// do executes req with the client's credentials and bounded client.
+func (c *RunsClient) do(req *http.Request) (*http.Response, error) {
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	return c.http.Do(req)
+}
+
+// StartRun POSTs /v1/runs with the given prompt and returns the new run id.
+func (c *RunsClient) StartRun(ctx context.Context, prompt string) (string, error) {
+	body, err := json.Marshal(map[string]string{"prompt": prompt})
+	if err != nil {
+		return "", fmt.Errorf("encode run request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/runs", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build run request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.do(req)
+	if err != nil {
+		return "", fmt.Errorf("send run request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("read run response: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("start run: harnessd returned %s: %s", resp.Status, strings.TrimSpace(string(respBody)))
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return "", fmt.Errorf("decode run response: %w", err)
+	}
+	if created.RunID == "" {
+		return "", fmt.Errorf("decode run response: missing run_id")
+	}
+	return created.RunID, nil
+}
+
+// CancelRun POSTs /v1/runs/{id}/cancel. The call is idempotent server-side
+// for terminal runs; unknown runs surface as an error.
+func (c *RunsClient) CancelRun(ctx context.Context, runID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/runs/"+runID+"/cancel", nil)
+	if err != nil {
+		return fmt.Errorf("build cancel request: %w", err)
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("send cancel request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("cancel run %s: harnessd returned %s", runID, resp.Status)
+	}
+	return nil
+}
+
+// terminalOutcome describes how a run ended, from the ACP adapter's view.
+type terminalOutcome struct {
+	eventType string // run.completed | run.failed | run.cancelled
+	costLimit bool   // run.cost_limit_reached was seen before completion
+	errText   string // run.failed payload error, when present
+}
+
+// WaitTerminal subscribes to GET /v1/runs/{id}/events and blocks until a
+// terminal run event arrives, the stream breaks, or ctx is cancelled.
+func (c *RunsClient) WaitTerminal(ctx context.Context, runID string) (terminalOutcome, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/runs/"+runID+"/events", nil)
+	if err != nil {
+		return terminalOutcome{}, fmt.Errorf("build events request: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := c.stream.Do(req)
+	if err != nil {
+		return terminalOutcome{}, fmt.Errorf("subscribe to run events: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+		return terminalOutcome{}, fmt.Errorf("subscribe to run events: harnessd returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+
+	var out terminalOutcome
+	reader := bufio.NewReaderSize(resp.Body, 64*1024)
+	var block []string
+	for {
+		line, err := readSSELine(reader)
+		if err != nil {
+			if err == io.EOF {
+				return terminalOutcome{}, fmt.Errorf("event stream ended before a terminal event")
+			}
+			return terminalOutcome{}, fmt.Errorf("read event stream: %w", err)
+		}
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			// Blank line terminates an SSE block.
+			typ, payload := parseSSEBlock(block)
+			block = block[:0]
+			if typ == "" {
+				continue
+			}
+			if typ == eventTypeRunCostLimitReached {
+				out.costLimit = true
+				continue
+			}
+			if typ == eventTypeRunCompleted || typ == eventTypeRunFailed || typ == eventTypeRunCancelled {
+				out.eventType = typ
+				out.errText = payloadError(payload)
+				return out, nil
+			}
+			continue // non-terminal event; slice 3 translates these into session/update
+		}
+		block = append(block, line)
+	}
+}
+
+// readSSELine reads one '\n'-terminated line (without the delimiter),
+// tolerating arbitrarily long lines by draining them.
+func readSSELine(r *bufio.Reader) (string, error) {
+	var buf []byte
+	for {
+		frag, err := r.ReadSlice('\n')
+		if len(buf)+len(frag) <= maxSSELineSize {
+			buf = append(buf, frag...)
+		}
+		switch {
+		case err == nil:
+			return string(buf[:len(buf)-1]), nil
+		case err == bufio.ErrBufferFull:
+			continue
+		case err == io.EOF && len(buf) > 0:
+			return string(buf), nil
+		default:
+			return "", err
+		}
+	}
+}
+
+// parseSSEBlock extracts the event type and data payload from one SSE block.
+// Comment (":") and field lines other than event:/data: are ignored.
+func parseSSEBlock(lines []string) (eventType string, data string) {
+	var dataLines []string
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, ":"):
+			// keepalive comment
+		case strings.HasPrefix(line, "event:"):
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	data = strings.Join(dataLines, "")
+	if eventType == "" && data != "" {
+		// Fall back to the type member inside the JSON payload.
+		var probe struct {
+			Type string `json:"type"`
+		}
+		if json.Unmarshal([]byte(data), &probe) == nil {
+			eventType = probe.Type
+		}
+	}
+	return eventType, data
+}
+
+// payloadError extracts the "error" member of an event payload, if present.
+func payloadError(data string) string {
+	if data == "" {
+		return ""
+	}
+	var probe struct {
+		Payload struct {
+			Error string `json:"error"`
+		} `json:"payload"`
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(data), &probe) != nil {
+		return ""
+	}
+	if probe.Payload.Error != "" {
+		return probe.Payload.Error
+	}
+	return probe.Error
+}

--- a/internal/acp/client_test.go
+++ b/internal/acp/client_test.go
@@ -1,0 +1,221 @@
+package acp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunsClientStartRun(t *testing.T) {
+	t.Run("posts prompt with bearer auth and returns run id", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "test-key")
+
+		runID, err := c.StartRun(context.Background(), "say hi")
+		if err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
+		if runID == "" {
+			t.Fatal("StartRun returned empty run id")
+		}
+		if got := fh.promptOf(runID); got != "say hi" {
+			t.Fatalf("fake harness received prompt %q, want %q", got, "say hi")
+		}
+		fh.mu.Lock()
+		auth := fh.runAuths[runID]
+		fh.mu.Unlock()
+		if auth != "Bearer test-key" {
+			t.Fatalf("Authorization header = %q, want %q", auth, "Bearer test-key")
+		}
+	})
+
+	t.Run("server error is surfaced", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `{"error":{"code":"nope","message":"boom"}}`, http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		c := NewRunsClient(srv.URL, "")
+		if _, err := c.StartRun(context.Background(), "hi"); err == nil {
+			t.Fatal("expected error for 500 response")
+		}
+	})
+
+	t.Run("response without run_id is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"status":"running"}`))
+		}))
+		defer srv.Close()
+		c := NewRunsClient(srv.URL, "")
+		if _, err := c.StartRun(context.Background(), "hi"); err == nil {
+			t.Fatal("expected error for missing run_id")
+		}
+	})
+}
+
+func TestRunsClientCancelRun(t *testing.T) {
+	t.Run("posts to the cancel route with auth", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "k")
+		runID, err := c.StartRun(context.Background(), "hi")
+		if err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
+		if err := c.CancelRun(context.Background(), runID); err != nil {
+			t.Fatalf("CancelRun: %v", err)
+		}
+		if !fh.cancelled(runID) {
+			t.Fatalf("fake harness saw no cancel POST for %s", runID)
+		}
+		fh.mu.Lock()
+		auth := fh.cancelAuths[runID]
+		fh.mu.Unlock()
+		if auth != "Bearer k" {
+			t.Fatalf("cancel Authorization = %q, want Bearer k", auth)
+		}
+	})
+
+	t.Run("unknown run is an error", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		if err := c.CancelRun(context.Background(), "run-999"); err == nil {
+			t.Fatal("expected error cancelling unknown run")
+		}
+	})
+}
+
+func TestRunsClientWaitTerminal(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("run.completed yields completed outcome", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		run := fh.run(runID)
+		go func() {
+			run.emit("run.started", "{}")
+			run.emit("assistant.message.delta", `{"text":"he"}`)
+			run.finish("run.completed", `{"output":"hello"}`)
+		}()
+		out, err := c.WaitTerminal(ctx, runID)
+		if err != nil {
+			t.Fatalf("WaitTerminal: %v", err)
+		}
+		if out.eventType != "run.completed" || out.costLimit {
+			t.Fatalf("outcome = %+v, want run.completed without cost limit", out)
+		}
+	})
+
+	t.Run("cost limit event is tracked through completion", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		run := fh.run(runID)
+		go func() {
+			run.emit("run.cost_limit_reached", `{"max_cost_usd":1.0}`)
+			run.finish("run.completed", `{"output":"partial"}`)
+		}()
+		out, err := c.WaitTerminal(ctx, runID)
+		if err != nil {
+			t.Fatalf("WaitTerminal: %v", err)
+		}
+		if out.eventType != "run.completed" || !out.costLimit {
+			t.Fatalf("outcome = %+v, want run.completed WITH cost limit", out)
+		}
+	})
+
+	t.Run("run.failed carries the error text", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		run := fh.run(runID)
+		go run.finish("run.failed", `{"error":"provider exploded"}`)
+		out, err := c.WaitTerminal(ctx, runID)
+		if err != nil {
+			t.Fatalf("WaitTerminal: %v", err)
+		}
+		if out.eventType != "run.failed" || !strings.Contains(out.errText, "provider exploded") {
+			t.Fatalf("outcome = %+v, want run.failed with error text", out)
+		}
+	})
+
+	t.Run("run.cancelled yields cancelled outcome", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		run := fh.run(runID)
+		go run.finish("run.cancelled", `{}`)
+		out, err := c.WaitTerminal(ctx, runID)
+		if err != nil {
+			t.Fatalf("WaitTerminal: %v", err)
+		}
+		if out.eventType != "run.cancelled" {
+			t.Fatalf("outcome = %+v, want run.cancelled", out)
+		}
+	})
+
+	t.Run("stream ending before a terminal event is an error", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		run := fh.run(runID)
+		go func() {
+			run.emit("run.started", "{}")
+			close(run.events) // stream dies mid-run
+		}()
+		if _, err := c.WaitTerminal(ctx, runID); err == nil {
+			t.Fatal("expected error when stream ends without terminal event")
+		}
+	})
+
+	t.Run("non-2xx events response is an error", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		if _, err := c.WaitTerminal(ctx, "run-999"); err == nil {
+			t.Fatal("expected error for unknown run events subscription")
+		}
+	})
+
+	t.Run("context cancellation aborts the wait", func(t *testing.T) {
+		fh := newFakeHarness(t)
+		c := NewRunsClient(fh.URL, "")
+		runID, _ := c.StartRun(ctx, "hi")
+		waitCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+		if _, err := c.WaitTerminal(waitCtx, runID); err == nil {
+			t.Fatal("expected error when context is cancelled mid-wait")
+		}
+	})
+}
+
+// TestRunsClientWaitTerminalSkipsNonDataLines pins tolerance for SSE comment
+// (": ping") keepalives and retry lines, which harnessd emits periodically.
+func TestRunsClientWaitTerminalSkipsNonDataLines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/runs" {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"run_id":"run-1","status":"running"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(": ping\n\n"))
+		_, _ = w.Write([]byte("retry: 3000\n"))
+		_, _ = w.Write([]byte("id: run-1:1\nevent: run.completed\ndata: {\"type\":\"run.completed\",\"payload\":{\"output\":\"x\"}}\n\n"))
+	}))
+	defer srv.Close()
+
+	c := NewRunsClient(srv.URL, "")
+	if _, err := c.StartRun(context.Background(), "hi"); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	out, err := c.WaitTerminal(context.Background(), "run-1")
+	if err != nil {
+		t.Fatalf("WaitTerminal: %v", err)
+	}
+	if out.eventType != "run.completed" {
+		t.Fatalf("outcome = %+v", out)
+	}
+}

--- a/internal/acp/fakeharness_test.go
+++ b/internal/acp/fakeharness_test.go
@@ -1,0 +1,199 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeEvent is one SSE event the fake harnessd emits on a run's stream.
+type fakeEvent struct {
+	typ     string
+	payload string
+}
+
+// fakeRun is one run inside the fake harnessd. Events are pushed through the
+// events channel; the SSE handler forwards them until it sees a terminal
+// event, mirroring harnessd's real stream-then-close behavior.
+type fakeRun struct {
+	id     string
+	prompt string
+	events chan fakeEvent
+}
+
+// emit queues a non-terminal event. It blocks until the SSE reader consumes
+// it, which synchronizes the test with the subscriber.
+func (r *fakeRun) emit(typ, payload string) { r.events <- fakeEvent{typ: typ, payload: payload} }
+
+// finish emits a terminal event and closes the stream.
+func (r *fakeRun) finish(typ, payload string) {
+	r.events <- fakeEvent{typ: typ, payload: payload}
+	close(r.events)
+}
+
+// fakeHarness is an httptest double for harnessd's runs API:
+// POST /v1/runs, GET /v1/runs/{id}/events, POST /v1/runs/{id}/cancel.
+type fakeHarness struct {
+	t   *testing.T
+	mux *http.ServeMux
+	*httptest.Server
+
+	mu          sync.Mutex
+	runs        map[string]*fakeRun
+	bodies      map[string]string // run id -> raw POST /v1/runs body
+	runAuths    map[string]string // run id -> Authorization header on POST /v1/runs
+	cancels     []string          // run ids that received POST cancel
+	cancelAuths map[string]string
+	nextID      int
+}
+
+func newFakeHarness(t *testing.T) *fakeHarness {
+	t.Helper()
+	fh := &fakeHarness{
+		t:           t,
+		mux:         http.NewServeMux(),
+		runs:        map[string]*fakeRun{},
+		bodies:      map[string]string{},
+		runAuths:    map[string]string{},
+		cancelAuths: map[string]string{},
+	}
+	fh.mux.HandleFunc("POST /v1/runs", fh.handlePostRun)
+	fh.mux.HandleFunc("/v1/runs/", fh.handleRunByID)
+	fh.Server = httptest.NewServer(fh.mux)
+	t.Cleanup(fh.Server.Close)
+	return fh
+}
+
+func (fh *fakeHarness) handlePostRun(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Prompt string `json:"prompt"`
+	}
+	var raw map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if p, ok := raw["prompt"].(string); ok {
+		body.Prompt = p
+	}
+	rawBody, _ := json.Marshal(raw)
+
+	fh.mu.Lock()
+	fh.nextID++
+	id := fmt.Sprintf("run-%d", fh.nextID)
+	run := &fakeRun{id: id, prompt: body.Prompt, events: make(chan fakeEvent)}
+	fh.runs[id] = run
+	fh.bodies[id] = string(rawBody)
+	fh.runAuths[id] = r.Header.Get("Authorization")
+	fh.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	fmt.Fprintf(w, `{"run_id":%q,"status":"running"}`, id)
+}
+
+func (fh *fakeHarness) handleRunByID(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/v1/runs/"), "/")
+	if len(parts) != 2 {
+		http.NotFound(w, r)
+		return
+	}
+	runID, sub := parts[0], parts[1]
+	fh.mu.Lock()
+	run, ok := fh.runs[runID]
+	fh.mu.Unlock()
+	if !ok {
+		http.Error(w, `{"error":{"code":"not_found","message":"run not found"}}`, http.StatusNotFound)
+		return
+	}
+	switch sub {
+	case "events":
+		fh.serveEvents(w, r, run)
+	case "cancel":
+		fh.mu.Lock()
+		fh.cancels = append(fh.cancels, runID)
+		fh.cancelAuths[runID] = r.Header.Get("Authorization")
+		fh.mu.Unlock()
+		// Mirror real harnessd: a cancel terminates the run with run.cancelled
+		// on the event stream.
+		go run.finish("run.cancelled", `{}`)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"cancelling"}`)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// serveEvents streams the run's queued events as SSE in harnessd's wire
+// format (id/retry/event/data lines, blank-line terminated), closing the
+// stream after a terminal event.
+func (fh *fakeHarness) serveEvents(w http.ResponseWriter, r *http.Request, run *fakeRun) {
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	seq := 0
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, ok := <-run.events:
+			if !ok {
+				return
+			}
+			seq++
+			payload := ev.payload
+			if payload == "" {
+				payload = "{}"
+			}
+			fmt.Fprintf(w, "id: %s:%d\n", run.id, seq)
+			fmt.Fprint(w, "retry: 3000\n")
+			fmt.Fprintf(w, "event: %s\n", ev.typ)
+			fmt.Fprintf(w, "data: {\"id\":%q,\"run_id\":%q,\"type\":%q,\"payload\":%s}\n\n", fmt.Sprintf("%s:%d", run.id, seq), run.id, ev.typ, payload)
+			if flusher != nil {
+				flusher.Flush()
+			}
+			if ev.typ == "run.completed" || ev.typ == "run.failed" || ev.typ == "run.cancelled" {
+				return
+			}
+		}
+	}
+}
+
+// run returns the fake run with the given id (or the only run, when id is "").
+func (fh *fakeHarness) run(id string) *fakeRun {
+	fh.t.Helper()
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	if id == "" && len(fh.runs) == 1 {
+		for _, r := range fh.runs {
+			return r
+		}
+	}
+	r, ok := fh.runs[id]
+	if !ok {
+		fh.t.Fatalf("fake harness: no run %q (have %v)", id, fh.runs)
+	}
+	return r
+}
+
+func (fh *fakeHarness) promptOf(id string) string {
+	fh.t.Helper()
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	return fh.runs[id].prompt
+}
+
+func (fh *fakeHarness) cancelled(id string) bool {
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	for _, c := range fh.cancels {
+		if c == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -28,6 +28,9 @@ const (
 	CodeMethodNotFound = -32601
 	// CodeInvalidParams is returned when a request's params fail validation.
 	CodeInvalidParams = -32602
+	// CodeInternalError is returned when the agent itself fails (e.g. the
+	// harnessd runs API is unreachable or a session state invariant breaks).
+	CodeInternalError = -32603
 )
 
 // request is the wire shape of a JSON-RPC 2.0 request or notification.

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 )
 
 // Handler implements one JSON-RPC method. It returns either a result value
@@ -17,10 +18,16 @@ type Handler func(ctx context.Context, params json.RawMessage) (any, *rpcError)
 // Server is a JSON-RPC 2.0 server speaking newline-delimited JSON over a
 // Conn. It answers the ACP `initialize` handshake out of the box; later
 // slices register session methods on top.
+//
+// Handlers run concurrently: session/prompt holds its response open until the
+// run terminates, and a mid-turn session/cancel must still be read and
+// processed. Responses may therefore arrive in any order (JSON-RPC clients
+// correlate by id); writes stay serialized by the Conn's mutex.
 type Server struct {
 	conn     *Conn
 	diag     io.Writer
 	handlers map[string]Handler
+	wg       sync.WaitGroup // in-flight handler goroutines
 }
 
 // NewServer returns a Server reading requests from r, writing protocol
@@ -46,7 +53,9 @@ func (s *Server) Handle(method string, h Handler) {
 }
 
 // Serve reads and dispatches messages until the input reaches EOF (clean
-// shutdown, returns nil), the context is cancelled, or an I/O error occurs.
+// shutdown: it then waits for in-flight handlers to finish writing their
+// responses before returning nil), the context is cancelled, or an I/O error
+// occurs.
 func (s *Server) Serve(ctx context.Context) error {
 	for {
 		if err := ctx.Err(); err != nil {
@@ -60,6 +69,7 @@ func (s *Server) Serve(ctx context.Context) error {
 			continue
 		}
 		if errors.Is(err, io.EOF) {
+			s.wg.Wait() // drain in-flight handlers so their responses land
 			return nil
 		}
 		if err != nil {
@@ -107,18 +117,31 @@ func (s *Server) dispatch(ctx context.Context, line []byte) error {
 		return s.writeError(requestID(req.ID), CodeMethodNotFound, fmt.Sprintf("Method not found: %s", req.Method))
 	}
 
-	result, rpcErr := h(ctx, req.Params)
-	if req.ID == nil {
-		// Notifications never receive responses, success or error.
-		if rpcErr != nil {
-			fmt.Fprintf(s.diag, "acp: notification %q failed: %s\n", req.Method, rpcErr.Message)
+	// Run the handler in its own goroutine so a long-lived method (notably
+	// session/prompt, which stays open until the run terminates) does not
+	// block reading and dispatching later messages (notably session/cancel).
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		result, rpcErr := h(ctx, req.Params)
+		if req.ID == nil {
+			// Notifications never receive responses, success or error.
+			if rpcErr != nil {
+				fmt.Fprintf(s.diag, "acp: notification %q failed: %s\n", req.Method, rpcErr.Message)
+			}
+			return
 		}
-		return nil
-	}
-	if rpcErr != nil {
-		return s.writeError(requestID(req.ID), rpcErr.Code, rpcErr.Message)
-	}
-	return s.writeResult(requestID(req.ID), result)
+		if rpcErr != nil {
+			if err := s.writeError(requestID(req.ID), rpcErr.Code, rpcErr.Message); err != nil {
+				fmt.Fprintf(s.diag, "acp: write error response for %q: %v\n", req.Method, err)
+			}
+			return
+		}
+		if err := s.writeResult(requestID(req.ID), result); err != nil {
+			fmt.Fprintf(s.diag, "acp: write result for %q: %v\n", req.Method, err)
+		}
+	}()
+	return nil
 }
 
 // writeResult sends a success response.

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
+	"time"
 )
 
 // serveOnce drives a Server over the given input until EOF and returns the
@@ -267,7 +270,11 @@ func TestServerResponseShapedMessagesAreIgnored(t *testing.T) {
 	}
 }
 
-func TestServerSequentialRequestsAnsweredInOrder(t *testing.T) {
+// TestServerPipelinedRequestsAllAnswered replaces the slice-1 ordering test:
+// handlers now run concurrently (so a mid-turn session/cancel can be read
+// while session/prompt is open), which means pipelined responses may arrive
+// in any order. JSON-RPC clients correlate responses by id, not position.
+func TestServerPipelinedRequestsAllAnswered(t *testing.T) {
 	input := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n" +
 		`{"jsonrpc":"2.0","id":2,"method":"bogus/method"}` + "\n" +
 		"garbage\n" +
@@ -277,18 +284,62 @@ func TestServerSequentialRequestsAnsweredInOrder(t *testing.T) {
 	if len(resps) != 4 {
 		t.Fatalf("got %d responses, want 4: %v", len(resps), lines)
 	}
-	if string(resps[0].ID) != "1" || resps[0].Error != nil {
-		t.Errorf("resp 0: want initialize result id=1, got %+v", resps[0])
+	byID := map[string]rpcResponse{}
+	for _, r := range resps {
+		byID[string(r.ID)] = r
 	}
-	if string(resps[1].ID) != "2" || resps[1].Error == nil || resps[1].Error.Code != CodeMethodNotFound {
-		t.Errorf("resp 1: want -32601 id=2, got %+v", resps[1])
+	if r, ok := byID["1"]; !ok || r.Error != nil {
+		t.Errorf("want initialize result id=1, got %+v", r)
 	}
-	if string(resps[2].ID) != "null" || resps[2].Error == nil || resps[2].Error.Code != CodeParseError {
-		t.Errorf("resp 2: want -32700 id=null, got %+v", resps[2])
+	if r, ok := byID["2"]; !ok || r.Error == nil || r.Error.Code != CodeMethodNotFound {
+		t.Errorf("want -32601 id=2, got %+v", r)
 	}
-	if string(resps[3].ID) != "4" || resps[3].Error != nil {
-		t.Errorf("resp 3: want initialize result id=4, got %+v", resps[3])
+	if r, ok := byID["null"]; !ok || r.Error == nil || r.Error.Code != CodeParseError {
+		t.Errorf("want -32700 id=null, got %+v", r)
 	}
+	if r, ok := byID["4"]; !ok || r.Error != nil {
+		t.Errorf("want initialize result id=4, got %+v", r)
+	}
+}
+
+// TestServerHandlersRunConcurrently proves a blocked handler does not stall
+// later requests — the property session/cancel relies on while session/prompt
+// is holding its response open.
+func TestServerHandlersRunConcurrently(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	t.Cleanup(func() { inR.Close(); outR.Close(); outW.Close() })
+
+	srv := NewServer(inR, outW, io.Discard)
+	unblock := make(chan struct{})
+	started := make(chan struct{})
+	srv.Handle("test/block", func(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+		close(started)
+		<-unblock
+		return map[string]any{"done": true}, nil
+	})
+
+	c := newScriptedClient(t, srv, inW, outR)
+
+	blockedID := c.send("test/block", nil)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("blocked handler never started")
+	}
+
+	// While test/block is stuck, initialize must still be answered.
+	initResp := c.request("initialize", map[string]any{"protocolVersion": 1})
+	if initResp.Error != nil {
+		t.Fatalf("initialize failed while handler blocked: %+v", initResp.Error)
+	}
+
+	close(unblock)
+	blockedResp := c.readResponse()
+	if string(blockedResp.ID) != fmt.Sprintf("%d", blockedID) || blockedResp.Error != nil {
+		t.Fatalf("blocked request response = %+v, want result id=%d", blockedResp, blockedID)
+	}
+	c.close()
 }
 
 func TestServerOversizedMessageRejectedStreamStaysAligned(t *testing.T) {

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -1,0 +1,232 @@
+package acp
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// ACP stop reasons (https://agentclientprotocol.com/protocol/prompt-turn).
+const (
+	stopReasonEndTurn         = "end_turn"
+	stopReasonMaxTurnRequests = "max_turn_requests"
+	stopReasonRefusal         = "refusal"
+	stopReasonCancelled       = "cancelled"
+)
+
+// stopReasonFor maps a run's terminal outcome onto the ACP stop reason the
+// session/prompt response must carry.
+func stopReasonFor(o terminalOutcome) string {
+	switch o.eventType {
+	case eventTypeRunCompleted:
+		if o.costLimit {
+			return stopReasonMaxTurnRequests
+		}
+		return stopReasonEndTurn
+	case eventTypeRunCancelled:
+		return stopReasonCancelled
+	default: // run.failed and anything unexpected
+		return stopReasonRefusal
+	}
+}
+
+// contentBlock is one element of a session/prompt prompt array. Only the
+// fields the adapter consumes are decoded; unknown members are ignored.
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+	URI  string `json:"uri"`
+	Name string `json:"name"`
+}
+
+// extractPromptText flattens ACP content blocks into the plain-text prompt
+// sent to harnessd. Text blocks contribute their text; resource_link blocks
+// contribute their URI (the baseline content type every ACP agent must
+// accept). Blocks of unsupported types (image, audio, embedded resources —
+// all advertised as unsupported) are skipped. An empty result is invalid
+// params.
+func extractPromptText(blocks []contentBlock) (string, *rpcError) {
+	parts := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if s := strings.TrimSpace(b.Text); s != "" {
+				parts = append(parts, s)
+			}
+		case "resource_link":
+			if s := strings.TrimSpace(b.URI); s != "" {
+				parts = append(parts, s)
+			}
+		default:
+			// Unsupported content types are skipped; clients were told via
+			// promptCapabilities not to send them.
+		}
+	}
+	if len(parts) == 0 {
+		return "", &rpcError{Code: CodeInvalidParams, Message: "Invalid params: prompt contains no usable text or resource_link content"}
+	}
+	return strings.Join(parts, "\n"), nil
+}
+
+// acpSession is one ACP session. One session maps to at most one go-code run
+// (multi-turn is a later epic).
+type acpSession struct {
+	id   string
+	cwd  string
+	run  string // harnessd run id, set once a prompt starts it
+	used bool   // true once a prompt turn has run
+	// cancelRequested is set when session/cancel arrives before the run id
+	// is stored (the run is still being created); handleSessionPrompt issues
+	// the cancel as soon as it has the run id.
+	cancelRequested bool
+}
+
+// sessionStore is a mutex-guarded sessionId -> session map.
+type sessionStore struct {
+	mu   sync.Mutex
+	byID map[string]*acpSession
+}
+
+func newSessionStore() *sessionStore {
+	return &sessionStore{byID: map[string]*acpSession{}}
+}
+
+// EnableSessions registers the ACP session methods (session/new,
+// session/prompt, session/cancel) backed by the given harnessd runs client.
+// Without it, session methods answer -32601 like any other unknown method.
+func (s *Server) EnableSessions(client *RunsClient) {
+	ss := &sessionHandlers{client: client, store: newSessionStore(), diag: s.diag}
+	s.Handle("session/new", ss.handleSessionNew)
+	s.Handle("session/prompt", ss.handleSessionPrompt)
+	s.Handle("session/cancel", ss.handleSessionCancel)
+}
+
+// sessionHandlers holds the state shared by the session method handlers.
+type sessionHandlers struct {
+	client *RunsClient
+	store  *sessionStore
+	diag   io.Writer
+}
+
+// handleSessionNew creates a fresh session and returns its id. The cwd and
+// mcpServers params are accepted per the spec; the harness executes tools in
+// its own workspace, so neither is acted on in this slice.
+func (h *sessionHandlers) handleSessionNew(_ context.Context, params json.RawMessage) (any, *rpcError) {
+	var req struct {
+		CWD string `json:"cwd"`
+	}
+	if len(params) > 0 {
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, &rpcError{Code: CodeInvalidParams, Message: "Invalid params: " + err.Error()}
+		}
+	}
+	id := "sess_" + randomHex(8)
+	h.store.mu.Lock()
+	h.store.byID[id] = &acpSession{id: id, cwd: req.CWD}
+	h.store.mu.Unlock()
+	return map[string]any{"sessionId": id}, nil
+}
+
+// handleSessionPrompt starts the session's run on harnessd and holds the
+// response open until the run reaches a terminal state, then answers with
+// the mapped ACP stop reason.
+func (h *sessionHandlers) handleSessionPrompt(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+	var req struct {
+		SessionID string         `json:"sessionId"`
+		Prompt    []contentBlock `json:"prompt"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &rpcError{Code: CodeInvalidParams, Message: "Invalid params: " + err.Error()}
+	}
+
+	h.store.mu.Lock()
+	sess, ok := h.store.byID[req.SessionID]
+	if !ok {
+		h.store.mu.Unlock()
+		return nil, &rpcError{Code: CodeInvalidParams, Message: fmt.Sprintf("Invalid params: unknown sessionId %q", req.SessionID)}
+	}
+	if sess.used {
+		h.store.mu.Unlock()
+		return nil, &rpcError{Code: CodeInternalError, Message: "session already has a run; multi-turn sessions are not supported yet"}
+	}
+	sess.used = true
+	h.store.mu.Unlock()
+
+	prompt, rpcErr := extractPromptText(req.Prompt)
+	if rpcErr != nil {
+		return nil, rpcErr
+	}
+
+	runID, err := h.client.StartRun(ctx, prompt)
+	if err != nil {
+		return nil, &rpcError{Code: CodeInternalError, Message: "start run: " + err.Error()}
+	}
+	h.store.mu.Lock()
+	sess.run = runID
+	cancelRequested := sess.cancelRequested
+	h.store.mu.Unlock()
+	// A session/cancel that arrived while the run was being created is
+	// applied now that the run id is known.
+	if cancelRequested {
+		if err := h.client.CancelRun(ctx, runID); err != nil {
+			fmt.Fprintf(h.diag, "acp: cancel run %s: %v\n", runID, err)
+		}
+	}
+
+	outcome, err := h.client.WaitTerminal(ctx, runID)
+	if err != nil {
+		return nil, &rpcError{Code: CodeInternalError, Message: "wait for run: " + err.Error()}
+	}
+	return map[string]any{"stopReason": stopReasonFor(outcome)}, nil
+}
+
+// handleSessionCancel implements the session/cancel notification: cancel the
+// session's run on harnessd. Cancelling a session with no run (or an unknown
+// session) is a no-op logged to diagnostics — notifications get no response.
+func (h *sessionHandlers) handleSessionCancel(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+	var req struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		fmt.Fprintf(h.diag, "acp: session/cancel with invalid params: %v\n", err)
+		return nil, nil
+	}
+	h.store.mu.Lock()
+	sess, ok := h.store.byID[req.SessionID]
+	runID := ""
+	if ok {
+		runID = sess.run
+		if runID == "" && sess.used {
+			// A prompt turn is starting but hasn't stored its run id yet;
+			// handleSessionPrompt applies the cancel as soon as it does.
+			sess.cancelRequested = true
+		}
+	}
+	h.store.mu.Unlock()
+	if runID == "" {
+		if ok && sess.used {
+			fmt.Fprintf(h.diag, "acp: session/cancel for session %q before its run started; will cancel on start\n", req.SessionID)
+		} else {
+			fmt.Fprintf(h.diag, "acp: session/cancel for session %q with no active run; ignored\n", req.SessionID)
+		}
+		return nil, nil
+	}
+	if err := h.client.CancelRun(ctx, runID); err != nil {
+		fmt.Fprintf(h.diag, "acp: cancel run %s: %v\n", runID, err)
+	}
+	return nil, nil
+}
+
+// randomHex returns n random bytes hex-encoded (2n chars).
+func randomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("acp: crypto/rand unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -1,0 +1,587 @@
+package acp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scriptedClient drives a Server over interactive pipes: requests are written
+// line by line and responses read back as they arrive, so tests can stage
+// mid-turn interactions (e.g. session/cancel while session/prompt is open).
+type scriptedClient struct {
+	t      *testing.T
+	inW    *io.PipeWriter
+	out    *bufio.Reader
+	done   chan error
+	nextID int
+}
+
+func newScriptedClient(t *testing.T, srv *Server, inW *io.PipeWriter, outR *io.PipeReader) *scriptedClient {
+	t.Helper()
+	c := &scriptedClient{
+		t:    t,
+		inW:  inW,
+		out:  bufio.NewReaderSize(outR, 1024*1024),
+		done: make(chan error, 1),
+	}
+	go func() { c.done <- srv.Serve(context.Background()) }()
+	return c
+}
+
+// newSessionServer wires a Server to the fake harnessd and returns the
+// scripted client plus pipe handles.
+func newSessionServer(t *testing.T, fh *fakeHarness, apiKey string) *scriptedClient {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	t.Cleanup(func() { outR.Close(); outW.Close(); inR.Close() })
+	srv := NewServer(inR, outW, io.Discard)
+	srv.EnableSessions(NewRunsClient(fh.URL, apiKey))
+	return newScriptedClient(t, srv, inW, outR)
+}
+
+func (c *scriptedClient) send(method string, params any) int {
+	c.t.Helper()
+	c.nextID++
+	id := c.nextID
+	msg := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			c.t.Fatalf("marshal params: %v", err)
+		}
+		msg["params"] = json.RawMessage(b)
+	}
+	b, _ := json.Marshal(msg)
+	if _, err := c.inW.Write(append(b, '\n')); err != nil {
+		c.t.Fatalf("write request: %v", err)
+	}
+	return id
+}
+
+func (c *scriptedClient) notify(method string, params any) {
+	c.t.Helper()
+	msg := map[string]any{"jsonrpc": "2.0", "method": method, "params": params}
+	b, _ := json.Marshal(msg)
+	if _, err := c.inW.Write(append(b, '\n')); err != nil {
+		c.t.Fatalf("write notification: %v", err)
+	}
+}
+
+// readResponse reads one response line, with a timeout so a wedged server
+// fails the test instead of hanging it.
+func (c *scriptedClient) readResponse() rpcResponse {
+	c.t.Helper()
+	type lineRes struct {
+		line string
+		err  error
+	}
+	ch := make(chan lineRes, 1)
+	go func() {
+		line, err := c.out.ReadString('\n')
+		ch <- lineRes{line, err}
+	}()
+	select {
+	case lr := <-ch:
+		if lr.err != nil {
+			c.t.Fatalf("read response: %v", lr.err)
+		}
+		var resp rpcResponse
+		if err := json.Unmarshal([]byte(strings.TrimRight(lr.line, "\n")), &resp); err != nil {
+			c.t.Fatalf("response line is not JSON: %q: %v", lr.line, err)
+		}
+		return resp
+	case <-time.After(15 * time.Second):
+		c.t.Fatal("timed out waiting for server response")
+		return rpcResponse{}
+	}
+}
+
+// request sends a request and reads its response, asserting the id echoes.
+func (c *scriptedClient) request(method string, params any) rpcResponse {
+	c.t.Helper()
+	id := c.send(method, params)
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", id) {
+		c.t.Fatalf("response id %s does not match request id %d", resp.ID, id)
+	}
+	return resp
+}
+
+// close closes stdin and asserts the server drains and exits cleanly.
+func (c *scriptedClient) close() {
+	c.t.Helper()
+	c.inW.Close()
+	select {
+	case err := <-c.done:
+		if err != nil {
+			c.t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		c.t.Fatal("Serve did not return after stdin close")
+	}
+}
+
+func initialize(t *testing.T, c *scriptedClient) {
+	t.Helper()
+	resp := c.request("initialize", map[string]any{"protocolVersion": 1})
+	if resp.Error != nil {
+		t.Fatalf("initialize failed: %+v", resp.Error)
+	}
+}
+
+func sessionNew(t *testing.T, c *scriptedClient) string {
+	t.Helper()
+	resp := c.request("session/new", map[string]any{"cwd": "/tmp/work", "mcpServers": []any{}})
+	if resp.Error != nil {
+		t.Fatalf("session/new failed: %+v", resp.Error)
+	}
+	var result struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("session/new result shape: %v (%s)", err, resp.Result)
+	}
+	if result.SessionID == "" {
+		t.Fatal("session/new returned empty sessionId")
+	}
+	return result.SessionID
+}
+
+// waitFor polls cond until it holds or the timeout expires.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", what)
+}
+
+func TestExtractPromptText(t *testing.T) {
+	cases := []struct {
+		name    string
+		blocks  []contentBlock
+		want    string
+		wantErr bool
+	}{
+		{"single text block", []contentBlock{{Type: "text", Text: "hello world"}}, "hello world", false},
+		{"text blocks joined", []contentBlock{{Type: "text", Text: "a"}, {Type: "text", Text: "b"}}, "a\nb", false},
+		{"resource link contributes its URI", []contentBlock{
+			{Type: "text", Text: "check this"},
+			{Type: "resource_link", URI: "file:///repo/main.go", Name: "main.go"},
+		}, "check this\nfile:///repo/main.go", false},
+		{"resource link alone", []contentBlock{{Type: "resource_link", URI: "file:///repo/main.go"}}, "file:///repo/main.go", false},
+		{"unsupported block types are skipped", []contentBlock{
+			{Type: "image"},
+			{Type: "text", Text: "real"},
+		}, "real", false},
+		{"only unsupported blocks is an error", []contentBlock{{Type: "image"}}, "", true},
+		{"empty prompt is an error", []contentBlock{}, "", true},
+		{"blank text blocks are an error", []contentBlock{{Type: "text", Text: "  "}}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, rpcErr := extractPromptText(tc.blocks)
+			if tc.wantErr {
+				if rpcErr == nil || rpcErr.Code != CodeInvalidParams {
+					t.Fatalf("want -32602, got text %q err %+v", got, rpcErr)
+				}
+				return
+			}
+			if rpcErr != nil {
+				t.Fatalf("unexpected error: %+v", rpcErr)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStopReasonMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		out  terminalOutcome
+		want string
+	}{
+		{"completed", terminalOutcome{eventType: "run.completed"}, "end_turn"},
+		{"completed after cost limit", terminalOutcome{eventType: "run.completed", costLimit: true}, "max_turn_requests"},
+		{"failed", terminalOutcome{eventType: "run.failed", errText: "boom"}, "refusal"},
+		{"cancelled", terminalOutcome{eventType: "run.cancelled"}, "cancelled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stopReasonFor(tc.out); got != tc.want {
+				t.Fatalf("stopReasonFor(%+v) = %q, want %q", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionNewReturnsUniqueIDs(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+
+	a, b := sessionNew(t, c), sessionNew(t, c)
+	if a == b {
+		t.Fatalf("session ids must be unique, got %q twice", a)
+	}
+}
+
+func TestSessionPromptUnknownSession(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	initialize(t, c)
+
+	resp := c.request("session/prompt", map[string]any{
+		"sessionId": "sess_does_not_exist",
+		"prompt":    []map[string]any{{"type": "text", "text": "hi"}},
+	})
+	if resp.Error == nil || resp.Error.Code != CodeInvalidParams {
+		t.Fatalf("want -32602 for unknown session, got %+v", resp.Error)
+	}
+}
+
+func TestSessionPromptStartsRunAndCompletesEndTurn(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "secret-key")
+	defer c.close()
+	initialize(t, c)
+	sid := sessionNew(t, c)
+
+	respCh := make(chan rpcResponse, 1)
+	go func() {
+		respCh <- c.request("session/prompt", map[string]any{
+			"sessionId": sid,
+			"prompt": []map[string]any{
+				{"type": "text", "text": "say hi"},
+				{"type": "resource_link", "uri": "file:///repo/a.go", "name": "a.go"},
+			},
+		})
+	}()
+
+	// The run must exist (prompt blocked in flight) before we finish it.
+	waitFor(t, "run to be created", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 1
+	})
+	fh.mu.Lock()
+	var runID string
+	for id := range fh.runs {
+		runID = id
+	}
+	fh.mu.Unlock()
+
+	// Assert the extracted prompt text and bearer auth reached harnessd.
+	if got := fh.promptOf(runID); got != "say hi\nfile:///repo/a.go" {
+		t.Fatalf("harnessd received prompt %q, want %q", got, "say hi\nfile:///repo/a.go")
+	}
+	fh.mu.Lock()
+	auth := fh.runAuths[runID]
+	fh.mu.Unlock()
+	if auth != "Bearer secret-key" {
+		t.Fatalf("Authorization = %q, want Bearer secret-key", auth)
+	}
+
+	run := fh.run(runID)
+	go func() {
+		run.emit("run.started", "{}")
+		run.finish("run.completed", `{"output":"hi there"}`)
+	}()
+
+	resp := <-respCh
+	if resp.Error != nil {
+		t.Fatalf("session/prompt failed: %+v", resp.Error)
+	}
+	var result struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v (%s)", err, resp.Result)
+	}
+	if result.StopReason != "end_turn" {
+		t.Fatalf("stopReason = %q, want end_turn", result.StopReason)
+	}
+}
+
+func TestSessionPromptStopReasonVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		finish func(run *fakeRun)
+		want   string
+	}{
+		{"completed", func(run *fakeRun) { run.finish("run.completed", `{}`) }, "end_turn"},
+		{"cost limited", func(run *fakeRun) {
+			run.emit("run.cost_limit_reached", `{}`)
+			run.finish("run.completed", `{}`)
+		}, "max_turn_requests"},
+		{"failed", func(run *fakeRun) { run.finish("run.failed", `{"error":"boom"}`) }, "refusal"},
+		{"cancelled server-side", func(run *fakeRun) { run.finish("run.cancelled", `{}`) }, "cancelled"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fh := newFakeHarness(t)
+			c := newSessionServer(t, fh, "")
+			defer c.close()
+			initialize(t, c)
+			sid := sessionNew(t, c)
+
+			respCh := make(chan rpcResponse, 1)
+			go func() {
+				respCh <- c.request("session/prompt", map[string]any{
+					"sessionId": sid,
+					"prompt":    []map[string]any{{"type": "text", "text": "go"}},
+				})
+			}()
+			waitFor(t, "run to be created", func() bool {
+				fh.mu.Lock()
+				defer fh.mu.Unlock()
+				return len(fh.runs) == 1
+			})
+			go tc.finish(fh.run(""))
+
+			resp := <-respCh
+			if resp.Error != nil {
+				t.Fatalf("session/prompt failed: %+v", resp.Error)
+			}
+			var result struct {
+				StopReason string `json:"stopReason"`
+			}
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				t.Fatalf("result shape: %v", err)
+			}
+			if result.StopReason != tc.want {
+				t.Fatalf("stopReason = %q, want %q", result.StopReason, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionPromptSecondPromptOnSameSessionRejected(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	initialize(t, c)
+	sid := sessionNew(t, c)
+
+	respCh := make(chan rpcResponse, 1)
+	go func() {
+		respCh <- c.request("session/prompt", map[string]any{
+			"sessionId": sid,
+			"prompt":    []map[string]any{{"type": "text", "text": "go"}},
+		})
+	}()
+	waitFor(t, "run to be created", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 1
+	})
+	go fh.run("").finish("run.completed", `{}`)
+	first := <-respCh
+	if first.Error != nil {
+		t.Fatalf("first prompt failed: %+v", first.Error)
+	}
+
+	second := c.request("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "again"}},
+	})
+	if second.Error == nil {
+		t.Fatalf("second prompt on a used session must fail, got result %s", second.Result)
+	}
+}
+
+func TestSessionCancelMidRunCancelsAndRespondsCancelled(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	initialize(t, c)
+	sid := sessionNew(t, c)
+
+	promptID := c.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "long task"}},
+	})
+	waitFor(t, "run to be created", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 1
+	})
+	runID := fh.run("").id
+
+	// The fake harnessd answers cancel by terminating the run, like the real one.
+	c.notify("session/cancel", map[string]any{"sessionId": sid})
+
+	waitFor(t, "cancel POST to reach harnessd", func() bool { return fh.cancelled(runID) })
+
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %s, want prompt id %d", resp.ID, promptID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("cancelled prompt must not error (spec: return cancelled stop reason), got %+v", resp.Error)
+	}
+	var result struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v", err)
+	}
+	if result.StopReason != "cancelled" {
+		t.Fatalf("stopReason = %q, want cancelled", result.StopReason)
+	}
+}
+
+// TestSessionCancelArrivingBeforeRunStartAppliesCancel pins the mid-start
+// race: session/cancel arrives after session/prompt has begun (POST /v1/runs
+// in flight) but before the run id is stored. The cancel must not be dropped
+// — it is applied as soon as the run id is known.
+func TestSessionCancelArrivingBeforeRunStartAppliesCancel(t *testing.T) {
+	releasePost := make(chan struct{})
+	postSeen := make(chan struct{})
+	cancelSeen := make(chan string, 1)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/runs", func(w http.ResponseWriter, r *http.Request) {
+		close(postSeen)
+		<-releasePost // hold the run creation until cancel has arrived
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		fmt.Fprint(w, `{"run_id":"run-gated","status":"running"}`)
+	})
+	mux.HandleFunc("POST /v1/runs/run-gated/cancel", func(w http.ResponseWriter, r *http.Request) {
+		cancelSeen <- "run-gated"
+		fmt.Fprint(w, `{"status":"cancelling"}`)
+	})
+	mux.HandleFunc("GET /v1/runs/run-gated/events", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "id: run-gated:1\nevent: run.cancelled\ndata: {\"type\":\"run.cancelled\"}\n\n")
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	t.Cleanup(func() { inR.Close(); outR.Close(); outW.Close() })
+	s := NewServer(inR, outW, io.Discard)
+	s.EnableSessions(NewRunsClient(srv.URL, ""))
+	c := newScriptedClient(t, s, inW, outR)
+	defer c.close()
+
+	initialize(t, c)
+	sid := sessionNew(t, c)
+	promptID := c.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "go"}},
+	})
+	select {
+	case <-postSeen:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run creation POST never started")
+	}
+
+	// Cancel while the run creation is still in flight (no run id stored yet).
+	c.notify("session/cancel", map[string]any{"sessionId": sid})
+	close(releasePost)
+
+	select {
+	case got := <-cancelSeen:
+		if got != "run-gated" {
+			t.Fatalf("cancelled run %q, want run-gated", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("cancel POST was dropped when it arrived mid-start")
+	}
+
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %s, want %d", resp.ID, promptID)
+	}
+	var result struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v", err)
+	}
+	if result.StopReason != "cancelled" {
+		t.Fatalf("stopReason = %q, want cancelled", result.StopReason)
+	}
+}
+
+func TestConcurrentSessionsStayIsolated(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	initialize(t, c)
+	sidA := sessionNew(t, c)
+	sidB := sessionNew(t, c)
+
+	idA := c.send("session/prompt", map[string]any{
+		"sessionId": sidA,
+		"prompt":    []map[string]any{{"type": "text", "text": "task-A"}},
+	})
+	idB := c.send("session/prompt", map[string]any{
+		"sessionId": sidB,
+		"prompt":    []map[string]any{{"type": "text", "text": "task-B"}},
+	})
+
+	waitFor(t, "both runs to exist", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 2
+	})
+
+	// Finish whichever run got prompt A as failed, the other as completed.
+	fh.mu.Lock()
+	var runA, runB *fakeRun
+	for _, r := range fh.runs {
+		if r.prompt == "task-A" {
+			runA = r
+		} else {
+			runB = r
+		}
+	}
+	fh.mu.Unlock()
+	if runA == nil || runB == nil {
+		t.Fatalf("could not map runs to prompts (A=%p B=%p)", runA, runB)
+	}
+	go runA.finish("run.failed", `{"error":"A exploded"}`)
+	go runB.finish("run.completed", `{}`)
+
+	got := map[string]string{}
+	for i := 0; i < 2; i++ {
+		resp := c.readResponse()
+		if resp.Error != nil {
+			t.Fatalf("prompt failed: %+v", resp.Error)
+		}
+		var result struct {
+			StopReason string `json:"stopReason"`
+		}
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			t.Fatalf("result shape: %v", err)
+		}
+		got[string(resp.ID)] = result.StopReason
+	}
+	if got[fmt.Sprintf("%d", idA)] != "refusal" {
+		t.Fatalf("session A stopReason = %q, want refusal", got[fmt.Sprintf("%d", idA)])
+	}
+	if got[fmt.Sprintf("%d", idB)] != "end_turn" {
+		t.Fatalf("session B stopReason = %q, want end_turn", got[fmt.Sprintf("%d", idB)])
+	}
+}


### PR DESCRIPTION
Parent epic: #806. Part of #803.

## What
Slice 2 of epic #806 (ACP server mode for Zed/JetBrains):

- `internal/acp/session.go`: session store (one ACP session == one go-code run), `session/new` with unique `sess_` ids, `session/prompt` (content-block text extraction: text blocks joined, `resource_link` contributes its URI; empty extraction -> `-32602`), `session/cancel` notification -> `POST /v1/runs/{id}/cancel`. Second prompt on a used session errors (`-32603`; multi-turn is a later epic).
- `internal/acp/client.go`: stdlib `RunsClient` — bounded client for start/cancel, no-timeout client for the SSE subscription; `WaitTerminal` scans `GET /v1/runs/{id}/events` to a terminal event, tracking `run.cost_limit_reached` as a flag (it is non-terminal server-side).
- Stop reasons per spec: `run.completed` -> `end_turn`, cost-limit + completed -> `max_turn_requests`, `run.failed` -> `refusal`, `run.cancelled` -> `cancelled`.
- **Concurrent dispatch** in `server.go`: `session/prompt` holds its response open until the run terminates, so handlers run in goroutines or a mid-turn `session/cancel` could never be read. Writes stay mutex-serialized; `Serve` drains in-flight handlers at EOF. (Slice-1 ordering test updated to correlate by id — JSON-RPC clients never relied on response order.)
- Race fix: `session/cancel` arriving while `POST /v1/runs` is still in flight (no run id stored yet) is applied as soon as `StartRun` returns instead of being dropped — pinned by a gated-POST regression test.
- `harness acp -server` flag; resolution flag > `loadConfig().Server` > `http://localhost:8080`; Bearer key from `loadConfig()`.

Still distinct from the SDK-based `internal/harnessacp` adapter (epic #746); untouched. `session/update` translation and `session/request_permission` land in slices 3–4.

## Tests (strict TDD — failing tests first)
- `internal/acp`: RunsClient against an httptest harnessd double (start/cancel/auth/error paths, SSE terminal wait incl. cost-limit flag, ping/retry tolerance, early stream end, ctx cancel); content-block extraction table; stop-reason table; scripted io.Pipe stdio client: prompt -> `end_turn`, cancel mid-run -> cancel POST + `cancelled`, cancel mid-start race, concurrent sessions isolated, blocked-handler concurrency proof.
- `cmd/harnesscli`: scripted initialize -> session/new -> session/prompt against the fake via `-server`; config-driven server URL + Bearer key; cancel mid-run issues the cancel POST.

## Validation run
- `go test ./internal/acp/ -count=1` — ok; with `-race` — ok
- `go test ./cmd/harnesscli/... -count=1` — ok (all packages)
- `gofmt`/`go vet` clean on touched files

Do not merge — slices 3–5 follow.