### PR TITLE
test(tui): cover shell-mode timeout path and test seams (#875)

### DIFF
--- a/cmd/harnesscli/tui/shellmode_exec_test.go
+++ b/cmd/harnesscli/tui/shellmode_exec_test.go
@@ -160,3 +160,38 @@ func TestShellMode_CtrlCKillsInsteadOfQuitting(t *testing.T) {
 		t.Errorf("the killed command must render an error card, got %q", got)
 	}
 }
+
+// Regression for issue #875: the shell-mode test seams
+// (WithShellExecTimeout/ShellCommandRunning) must be exercised — and the
+// timeout path itself was untested. A command outliving the configured
+// timeout is killed by the executor's context deadline and finalized as a
+// timed-out error card; the running flag clears once the done message lands.
+func TestShellMode_CommandTimesOut(t *testing.T) {
+	m := initModel(t, 80, 24)
+
+	m = m.WithShellExecTimeout(100 * time.Millisecond)
+	if m.ShellCommandRunning() {
+		t.Fatal("no shell command may be running before submit")
+	}
+
+	m, pollCmd := submitShellCommand(t, m, "sleep 999")
+	if !m.ShellCommandRunning() {
+		t.Fatal("precondition: a shell command must be running after submit")
+	}
+
+	start := time.Now()
+	m = drainShell(t, m, pollCmd)
+
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Errorf("timeout kill took too long (%v) — the executor must honor the configured timeout", elapsed)
+	}
+	if m.ShellCommandRunning() {
+		t.Error("ShellCommandRunning must clear once the done message lands")
+	}
+	if got := m.ActiveToolCallStatus(); got != "error" {
+		t.Errorf("a timed-out command must render an error card, got %q", got)
+	}
+	if view := m.View(); !strings.Contains(view, "timed out") {
+		t.Errorf("the card must report the timeout, got:\n%s", view)
+	}
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,11 @@
 # Engineering Log
 
+## 2026-07-20 (Issue #875 Shell-Mode Test-Seam Coverage Fix)
+
+- Symptom: post-merge regression gate (`scripts/test-regression.sh`) failed after PR #870 landed: `coveragegate` flagged `(*Model).ShellCommandRunning` and `(*Model).WithShellExecTimeout` (cmd/harnesscli/tui/model.go) at 0.0%.
+- Cause: PR #870 added both exported test seams but its `shellmode_exec_test.go` detects the running state via `ActiveToolCallStatus()` and never overrides the 120s default timeout, so the seams were dead code; the PR's validation ran only `go test ./cmd/harnesscli/...`, not the full gate.
+- Fix (test-only): added `TestShellMode_CommandTimesOut` driving a real timeout kill through the executor — `WithShellExecTimeout(100ms)` + `sleep 999` — asserting the running flag transitions (`ShellCommandRunning` false→true→false), the timed-out error card, and prompt kill. Both functions now report 100%; the timeout finalization path (`timed out after …` card) is behaviorally pinned for the first time.
+
 ## 2026-07-20 (ACP Server Mode — Epic #806, Slice 2)
 
 - `internal/acp` sessions over the runs API: `session/new` (unique `sess_<hex>` ids, cwd/mcpServers accepted but not acted on), `session/prompt` (content-block text extraction — text blocks joined, `resource_link` contributes its URI, empty extraction -> `-32602`), `session/cancel` notification -> `POST /v1/runs/{id}/cancel`. One ACP session maps to one run; a second prompt on a used session errors `-32603` (multi-turn is a later epic).


### PR DESCRIPTION
## Summary

Post-merge regression gate failed after #870 merged: `coveragegate` flagged `ShellCommandRunning` and `WithShellExecTimeout` (cmd/harnesscli/tui/model.go) at 0.0% — both exported test seams were added but never used.

## Fix (test-only)

`TestShellMode_CommandTimesOut` drives a real executor timeout kill — `WithShellExecTimeout(100ms)` + `sleep 999` — asserting:
- `ShellCommandRunning()` transitions false→true (after submit) →false (after the done message lands)
- the card finalizes as an error reporting `timed out after …` (previously untested timeout path)
- the kill is prompt (<10s, actual ~100ms)

Verified: `go tool cover -func` reports both seams at 100.0%; `go test ./cmd/harnesscli/... -count=1` green; gofmt clean.

Fixes #875