### PR TITLE
docs(install): document service install in distribution runbook and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ Completed runs also keep a searchable workflow recap when persistence is enabled
 goal, changed files, tests run, failure cause, fix pattern, useful commands, and
 a continuation prompt. `go-code search <query>` matches those recap fields.
 
+### Run as an OS service (optional)
+
+To keep `harnessd` running across logins and crashes without managing a
+terminal, install it as a user-level OS service (launchd on macOS,
+`systemd --user` on Linux — no sudo):
+
+```bash
+harnesscli service install   # write the unit file
+harnesscli service start     # start it now
+harnesscli service status    # installed? running? healthy?
+harnesscli service stop
+harnesscli service uninstall
+```
+
+Details, flags, log locations, and troubleshooting:
+[`docs/runbooks/distribution.md`](docs/runbooks/distribution.md#os-service-install).
+
 ## API Keys
 
 Set the provider keys you plan to use before starting a run:
@@ -96,7 +113,7 @@ go run ./cmd/harnessd
 go run ./cmd/harnesscli -base-url http://127.0.0.1:8080 -prompt "Summarize the repository"
 ```
 
-Long-running local servers should be started in tmux:
+Long-running local servers for repository development agents should be started in tmux (the runbook rule for dev workflows — end users should prefer `harnesscli service install`, above):
 
 ```bash
 tmux new-session -d -s go-code-server 'cd /path/to/go-code && go run ./cmd/harnessd'

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,11 @@
 # Engineering Log
 
+## 2026-07-20 (OS-Service Install for harnessd — Epic #807)
+
+- Shipped `harnesscli service install|uninstall|start|stop|status` for end users: user-level launchd agent on macOS (`~/Library/LaunchAgents/com.gocode.harnessd.plist`, `RunAtLoad`+`KeepAlive`) and `systemd --user` unit on Linux (`~/.config/systemd/user/harnessd.service`, `Restart=on-failure`, `WantedBy=default.target`). Slice 1 (PR #826): install/uninstall + pure unit generators with `--binary`/`--addr`/`--log-dir`/`--dry-run`; addr resolution reuses the daemon's own stack (`HARNESS_ADDR` env or `~/.harness/config.toml`, default `:8080`) exported into the unit environment. Slice 2 (PR #866): lifecycle commands over launchctl/systemctl behind an injectable runner; `status` distinguishes not-installed / installed-not-running / running-healthy / running-unreachable via a `GET /healthz` probe.
+- Slice 3 (this change, docs-only): new "OS Service Install" section in `docs/runbooks/distribution.md` (commands, per-OS unit paths, log locations, flags, troubleshooting incl. `launchctl print gui/$(id -u)/com.gocode.harnessd` and `journalctl --user -u harnessd`, lingering note, scope guardrails); README gains an end-user pointer and the tmux guidance is explicitly re-scoped to repository dev agents.
+- Validation: slices 1–2 landed under strict TDD (`go test ./cmd/harnesscli/ -run Service -count=1` — 32 tests) plus real launchd end-to-end on macOS (install → start → healthy status → stop → uninstall; `plutil -lint` OK). Slice 3 verified every documented flag/path/command against `cmd/harnesscli/service.go` and live `-h` output; no code changed.
+
 ## 2026-07-20 (Issue #875 Shell-Mode Test-Seam Coverage Fix)
 
 - Symptom: post-merge regression gate (`scripts/test-regression.sh`) failed after PR #870 landed: `coveragegate` flagged `(*Model).ShellCommandRunning` and `(*Model).WithShellExecTimeout` (cmd/harnesscli/tui/model.go) at 0.0%.

--- a/docs/plans/807-service-install.md
+++ b/docs/plans/807-service-install.md
@@ -1,4 +1,4 @@
-# Plan: harnesscli service OS-service commands (epic #807, slices 1–2)
+# Plan: harnesscli service OS-service commands (epic #807, slices 1–3)
 
 ## Context
 
@@ -12,57 +12,48 @@
   `launchctl`/`systemctl`.
 - Constraints: stdlib only (no plist/systemd libs); user-level services only
   (no root/system units); tmux remains the dev-agent rule. Slice 1 (merged,
-  PR #826) shipped install/uninstall + generators; this branch adds slice 2:
-  start/stop/status lifecycle.
+  PR #826) shipped install/uninstall + generators; slice 2 (merged, PR #866)
+  shipped start/stop/status; this branch adds slice 3: documentation.
 
 ## Scope
 
-- In scope (slice 2, this branch):
-  - `start`: darwin `launchctl bootstrap gui/<uid> <plist>` with
-    `kickstart -k gui/<uid>/com.gocode.harnessd` fallback when already loaded;
-    linux `systemctl --user start harnessd.service`
-  - `stop`: darwin `launchctl bootout gui/<uid>/com.gocode.harnessd`; linux
-    `systemctl --user stop harnessd.service`
-  - `status`: installed check (unit file present), loaded/active query
-    (`launchctl print` / `systemctl --user is-active`), HTTP health probe of
-    `<--base-url>/healthz` (flag default `http://localhost:8080`, mirroring
-    `cmd/harnesscli/main.go:144`)
-  - Clear "not installed" error (non-zero exit) for all lifecycle commands
-    run before `install`
-  - Real runner made quiet-on-success (buffered output shown only on failure)
-    so `launchctl print` doesn't spam the terminal
-- Delivered (slice 1, merged): `runService` dispatch, `case "service":` in
-  `dispatch()`, pure generators, `--binary`/`--addr`/`--log-dir` resolution,
-  `--dry-run`, `uninstall` with best-effort bootout/disable.
-- Out of scope: docs (slice 3), Windows, system-wide units, daemon changes.
+- In scope (slice 3, this branch — docs-only):
+  - `docs/runbooks/distribution.md`: "OS Service Install" section — commands,
+    per-OS unit paths, log locations, flags, lifecycle notes, troubleshooting
+    (`launchctl print`, `systemctl --user status`, `journalctl --user -u
+    harnessd`, lingering), scope guardrails
+  - `README.md`: end-user pointer to `harnesscli service install`; tmux
+    guidance explicitly re-scoped to repository dev agents
+  - `docs/runbooks/INDEX.md`: distribution entry updated
+  - `docs/logs/engineering-log.md`: epic entry
+- Delivered (slice 1, merged PR #826): `runService` dispatch, `case
+  "service":` in `dispatch()`, pure generators,
+  `--binary`/`--addr`/`--log-dir` resolution, `--dry-run`, `uninstall` with
+  best-effort bootout/disable.
+- Delivered (slice 2, merged PR #866): `start` (bootstrap + kickstart -k
+  fallback), `stop` (bootout / systemctl stop), `status` (installed check,
+  loaded/active query, `/healthz` probe), quiet-on-success runner with rich
+  wrapped errors.
+- Out of scope: Windows, system-wide units, daemon changes.
 
 ## Documentation Contract
 
-- Feature status: slice 1 `implemented` (merged PR #826); slice 2
+- Feature status: slices 1–2 `implemented` (merged PRs #826, #866); slice 3
   `in implementation`
-- Public docs affected: none in this slice (slice 3 owns
-  `docs/runbooks/distribution.md` + `README.md`)
+- Public docs affected: `docs/runbooks/distribution.md`, `README.md`,
+  `docs/runbooks/INDEX.md`, `docs/logs/engineering-log.md` (all this branch)
 - Spec docs to update before code: this file (done)
-- Implementation notes to add after code: none (slice 3)
+- Implementation notes to add after code: engineering-log entry (this branch)
 
 ## Test Plan (TDD)
 
-- New failing tests to add first (`cmd/harnesscli/service_test.go`):
-  - Fake-runner exact argument construction per platform and verb:
-    bootstrap/kickstart/bootout/print (darwin, exact `gui/<uid>[/<label>]`
-    domains), start/stop/is-active (linux)
-  - start: bootstrap success; already-loaded → kickstart -k restart; both
-    fail → non-zero + stderr; not installed → non-zero + clear message
-  - stop: success per platform; runner error → non-zero + stderr; not
-    installed → non-zero
-  - status table: not-installed (non-zero); installed-not-loaded (exit 0,
-    "not running"); loaded-and-healthy (httptest 200 on /healthz);
-    loaded-but-unreachable (closed port → "unreachable", exit 0)
-  - stub test from slice 1 removed (stubs replaced by real commands)
-- Existing tests to update: `setupServiceTest` helper now returns a
-  `serviceRunnerFake` with per-call error queue; slice-1 runner assertions
-  updated accordingly (same assertions, new accessor)
-- Regression tests required: none beyond the above
+- Slice 3 is docs-only: no new tests. Validation = every documented
+  command/flag/path checked against `cmd/harnesscli/service.go` and live
+  `-h` output of a built binary; `go test ./cmd/harnesscli/ -run Service
+  -count=1` re-run to confirm the documented behavior is the tested behavior.
+- Slice 1–2 tests (merged): 32 `Service` tests — generator golden content,
+  install/dry-run/binary/addr resolution, uninstall, fake-runner exact
+  argument construction per platform/verb, status table.
 
 ## Cross-Surface Impact Map
 
@@ -71,19 +62,11 @@
 ## Implementation Checklist
 
 - [x] Slice 1: install/uninstall + generators, merged via PR #826.
-- [x] Update this plan for slice 2 before code.
-- [x] Write failing slice-2 tests first; watch them fail (16 red against stubs).
-- [x] Implement start/stop/status + quiet-on-success runner (rich wrapped
-      errors on failure).
-- [x] `go test ./cmd/harnesscli/ -run Service` green (32 tests).
-- [x] `go test ./cmd/harnesscli/... -count=1` full package green; gofmt +
-      go vet clean.
-- [x] macOS acceptance: install → start → status (running; healthy once the
-      daemon bound) → existing `harnesscli status --base-url ... <run-id>`
-      reached the daemon → stop → status (installed, not running, silent
-      stderr) → restart path → uninstall; `launchctl print` confirms the job
-      is gone.
-- [ ] Commit, push `epic/807-service-install-s2`, open PR (no merge).
+- [x] Slice 2: start/stop/status lifecycle, merged via PR #866.
+- [x] Write distribution runbook OS-service section.
+- [x] README end-user pointer + tmux re-scope; INDEX + engineering log.
+- [ ] Validate docs against implementation (flags, paths, commands).
+- [ ] Commit, push `epic/807-service-install-s3`, open PR (no merge).
 
 ## Risks and Mitigations
 

--- a/docs/runbooks/INDEX.md
+++ b/docs/runbooks/INDEX.md
@@ -9,7 +9,7 @@
 - `symphony.md`: How to run OpenAI Symphony for this repository with the wrapper script.
 - `symphony-issue-authoring.md`: How to write GitHub issues that Symphony can execute autonomously with strict TDD, behavior tests, regression gates, and merge rules.
 - `deployment.md`: MVP deployment runbook with security and verification checks.
-- `distribution.md`: Installer, GitHub Pages, release archive, Homebrew, and release checklist guidance for distributing go-code.
+- `distribution.md`: Installer, OS service install (`harnesscli service` launchd/systemd user units), GitHub Pages, release archive, Homebrew, and release checklist guidance for distributing go-code.
 - `worktree-flow.md`: Required worktree-first development and merge workflow.
 - `issue-triage.md`: How to capture bugs/problems as GitHub issues.
 - `documentation-maintenance.md`: How to maintain per-folder indexes and documentation quality.

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -47,6 +47,53 @@ The wrapper must:
 - resolve the caller's project root and pass it as the run workspace
 - work when launched from any repository, not just from this repo
 
+## OS Service Install
+
+End users can run `harnessd` as a persistent, user-level OS service instead of a hand-managed process. No sudo is needed:
+
+```bash
+harnesscli service install    # write the unit file
+harnesscli service start      # start it now
+harnesscli service status     # installed? running? healthy?
+harnesscli service stop       # stop it
+harnesscli service uninstall  # stop (best-effort) and remove the unit file
+```
+
+What gets written:
+
+| Platform | Unit file | Manager |
+| --- | --- | --- |
+| macOS | `~/Library/LaunchAgents/com.gocode.harnessd.plist` (label `com.gocode.harnessd`) | launchd user agent in `gui/<uid>` |
+| Linux | `~/.config/systemd/user/harnessd.service` | `systemd --user` |
+
+- The macOS agent sets `RunAtLoad` and `KeepAlive`, so the daemon starts at login and relaunches on crash. The Linux unit sets `Restart=on-failure` and installs into `default.target`, so it starts with the user session and restarts on failure.
+- Logs go to `~/.harness/logs/harnessd.stdout.log` and `~/.harness/logs/harnessd.stderr.log` on both platforms (override the directory with `--log-dir`). On Linux, daemon output goes to those files; `journalctl --user -u harnessd` shows unit lifecycle events.
+
+`install` flags:
+
+- `--binary PATH`: the `harnessd` executable to run. Default: `harnessd` looked up on `PATH` (the Homebrew- or installer-provided binary). The unit embeds the absolute path.
+- `--addr ADDR`: listen address exported to the daemon as `HARNESS_ADDR`. Default: the same resolution the daemon applies to itself — `HARNESS_ADDR` env or `~/.harness/config.toml`, falling back to `:8080`.
+- `--log-dir DIR`: log directory (default `~/.harness/logs`).
+- `--dry-run`: print the rendered unit and its target path without writing anything.
+
+Lifecycle notes:
+
+- `install` only writes the unit file; it does not start the daemon. Run `harnesscli service start`, or log out and back in (login triggers `RunAtLoad` / `default.target`).
+- `start` is idempotent on macOS: an already-loaded agent is restarted with `launchctl kickstart -k`.
+- `status` exits non-zero with a clear message when the service is not installed. Otherwise it reports the running state and probes `GET <base-url>/healthz` (`--base-url` flag, default `http://localhost:8080`), so "running, healthy" is distinguished from "running but unreachable".
+- `uninstall` best-effort stops and disables the service (`launchctl bootout` / `systemctl --user disable --now`), then removes the unit file. It fails with a clear "not installed" message when the service was never installed.
+- `start`, `stop`, and `status` also fail with the same "not installed" message when run before `install`.
+
+Troubleshooting:
+
+- macOS state query: `launchctl print gui/$(id -u)/com.gocode.harnessd`.
+- Linux state query: `systemctl --user status harnessd`; lifecycle events: `journalctl --user -u harnessd`.
+- Linux boot persistence without an interactive login requires lingering: `loginctl enable-linger "$USER"`.
+- If the `harnessd` binary moves, re-run `harnesscli service install --binary <new-path>` — the unit embeds the absolute path and is not watched for changes.
+- The service managers do not create the log directory; `install` creates it. If you deleted it, re-run `install` or `mkdir -p ~/.harness/logs`.
+
+Scope guardrails: user-level services only — no root launchd daemons, no system systemd units, no Windows support. Repository dev agents keep using tmux per the worktree runbooks; the service install targets end users running go-code as a tool.
+
 ## GitHub Pages
 
 The public landing page source lives in `docs/site/`.


### PR DESCRIPTION
Parent epic: #807. Part of #803.

## Slice 3 of #807 (final): documentation

- `docs/runbooks/distribution.md`: new **OS Service Install** section — commands, per-OS unit file table (launchd plist / systemd `--user` unit), log locations, `install` flags, lifecycle notes (install ≠ start; idempotent macOS start via `kickstart -k`; status exit semantics and `/healthz` probe), troubleshooting (`launchctl print gui/$(id -u)/com.gocode.harnessd`, `systemctl --user status`, `journalctl --user -u harnessd`, `loginctl enable-linger`, binary-moved reinstall), and scope guardrails (user-level only; tmux stays the repo dev-agent rule).
- `README.md`: end-user **Run as an OS service (optional)** pointer under Install; tmux guidance in Running From Source explicitly re-scoped to repository dev agents.
- `docs/runbooks/INDEX.md` entry updated; `docs/logs/engineering-log.md` epic entry added; plan doc closed out.

## Validation (docs-only, no code changes)

- Every documented flag checked against live `harnesscli service install -h` / `service status -h` output of a freshly built binary.
- Every documented path, label, unit name, log filename, and probe endpoint checked against `cmd/harnesscli/service.go` constants.
- `go test ./cmd/harnesscli/ -run Service -count=1` re-run green (32 tests) — documented behavior is the tested behavior.

Epic #807 acceptance is now fully covered: install/start/stop/status/uninstall documented end-to-end for macOS and Linux. Do not merge until reviewed.