### PR TITLE
feat(cli): exit 3 when a headless run blocks on user input

### DIFF
--- a/cmd/harnesscli/exitcodes.go
+++ b/cmd/harnesscli/exitcodes.go
@@ -43,3 +43,31 @@ func exitCodeForTerminalEvent(et harness.EventType) int {
 		return exitClientError
 	}
 }
+
+// isBlockedEvent reports whether an event signals that the run cannot proceed
+// without input a headless caller will never provide: a question
+// (run.waiting_for_user) or an approval (tool.approval_required /
+// plan.approval_required — there is no dedicated waiting-for-approval run
+// event; these are the signal, with the run status transitioning to
+// waiting_for_approval).
+func isBlockedEvent(et harness.EventType) bool {
+	switch et {
+	case harness.EventRunWaitingForUser, harness.EventToolApprovalRequired, harness.EventPlanApprovalRequired:
+		return true
+	default:
+		return false
+	}
+}
+
+// blockedEventReason describes why a blocked signal stopped a headless run,
+// for the stderr message printed on the exitBlocked path.
+func blockedEventReason(et harness.EventType) string {
+	switch et {
+	case harness.EventRunWaitingForUser:
+		return "waiting for user input"
+	case harness.EventToolApprovalRequired, harness.EventPlanApprovalRequired:
+		return "waiting for approval"
+	default:
+		return "blocked"
+	}
+}

--- a/cmd/harnesscli/exitcodes_test.go
+++ b/cmd/harnesscli/exitcodes_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"go-agent-harness/internal/harness"
@@ -59,6 +60,259 @@ func TestExitCodeForTerminalEvent(t *testing.T) {
 				t.Fatalf("exitCodeForTerminalEvent(%q) = %d, want %d", tc.event, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsBlockedEvent(t *testing.T) {
+	cases := []struct {
+		event harness.EventType
+		want  bool
+	}{
+		{harness.EventRunWaitingForUser, true},
+		{harness.EventToolApprovalRequired, true},
+		{harness.EventPlanApprovalRequired, true},
+		{harness.EventRunCompleted, false},
+		{harness.EventRunFailed, false},
+		{harness.EventRunCancelled, false},
+		{harness.EventRunStarted, false},
+		{harness.EventMaxTurnsExhausted, false},
+		{harness.EventType(""), false},
+	}
+	for _, tc := range cases {
+		if got := isBlockedEvent(tc.event); got != tc.want {
+			t.Errorf("isBlockedEvent(%q) = %v, want %v", tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestBlockedEventReason(t *testing.T) {
+	cases := []struct {
+		event harness.EventType
+		want  string
+	}{
+		{harness.EventRunWaitingForUser, "waiting for user input"},
+		{harness.EventToolApprovalRequired, "waiting for approval"},
+		{harness.EventPlanApprovalRequired, "waiting for approval"},
+	}
+	for _, tc := range cases {
+		if got := blockedEventReason(tc.event); got != tc.want {
+			t.Errorf("blockedEventReason(%q) = %q, want %q", tc.event, got, tc.want)
+		}
+	}
+}
+
+// stubStdinTerminal swaps the injectable terminal-detection double and
+// restores it after the test, so blocked-path tests never need a real TTY.
+func stubStdinTerminal(t *testing.T, isTerminal bool) {
+	t.Helper()
+	orig := stdinIsTerminal
+	stdinIsTerminal = func() bool { return isTerminal }
+	t.Cleanup(func() { stdinIsTerminal = orig })
+}
+
+// blockedSignals are the three events the contract treats as "the run cannot
+// proceed without input a headless caller will never provide".
+var blockedSignals = []struct {
+	name       string
+	event      string
+	wantReason string
+}{
+	{"question-blocked", "run.waiting_for_user", "waiting for user input"},
+	{"tool-approval-blocked", "tool.approval_required", "waiting for approval"},
+	{"plan-approval-blocked", "plan.approval_required", "waiting for approval"},
+}
+
+// TestRunBlockedSignalExits3WhenStdinNonInteractive drives run() against a
+// scripted SSE server that emits a blocked signal and then holds the stream
+// open forever. With non-interactive stdin the CLI must stop streaming, exit
+// 3, print a stderr message naming the run ID and the continue command, and
+// leave the server-side run intact (no cancel POST).
+func TestRunBlockedSignalExits3WhenStdinNonInteractive(t *testing.T) {
+	for _, tc := range blockedSignals {
+		t.Run(tc.name, func(t *testing.T) {
+			stubStdinTerminal(t, false)
+
+			var cancelRequested atomic.Bool
+			mux := http.NewServeMux()
+			mux.HandleFunc("/v1/runs", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("unexpected method: %s", r.Method)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(w, `{"run_id":"run_abc","status":"queued"}`)
+			})
+			mux.HandleFunc("/v1/runs/run_abc/events", func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+				_, _ = io.WriteString(w, "event: "+tc.event+"\n")
+				_, _ = io.WriteString(w, "data: {\"id\":\"e1\",\"run_id\":\"run_abc\",\"type\":\""+tc.event+"\"}\n\n")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				// Hold the stream open: no terminal event ever arrives. The
+				// client must abort on its own; the handler returns once the
+				// client closes the connection.
+				<-r.Context().Done()
+			})
+			mux.HandleFunc("/v1/runs/run_abc/cancel", func(w http.ResponseWriter, _ *http.Request) {
+				cancelRequested.Store(true)
+				w.WriteHeader(http.StatusOK)
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			outBuf, errBuf, restore := captureOutput(t)
+			defer restore()
+
+			origRequestClient := requestHTTPClient
+			origStreamClient := streamHTTPClient
+			requestHTTPClient = ts.Client()
+			streamHTTPClient = ts.Client()
+			defer func() {
+				requestHTTPClient = origRequestClient
+				streamHTTPClient = origStreamClient
+			}()
+
+			code := run([]string{"-base-url=" + ts.URL, "-prompt=test prompt"})
+			if code != 3 {
+				t.Fatalf("run() exit code = %d, want 3 (stderr=%s)", code, errBuf.String())
+			}
+
+			errOutput := errBuf.String()
+			for _, want := range []string{"run_abc", tc.event, tc.wantReason, "harnesscli continue run_abc"} {
+				if !strings.Contains(errOutput, want) {
+					t.Errorf("stderr missing %q:\n%s", want, errOutput)
+				}
+			}
+
+			output := outBuf.String()
+			for _, want := range []string{"run_id=run_abc", tc.event} {
+				if !strings.Contains(output, want) {
+					t.Errorf("stdout missing %q (blocked event line must still be printed):\n%s", want, output)
+				}
+			}
+
+			if cancelRequested.Load() {
+				t.Error("server-side run must be left intact, but a cancel POST was received")
+			}
+		})
+	}
+}
+
+// TestRunBlockedSignalKeepsStreamingWhenStdinIsTerminal proves interactive
+// behavior is unchanged: with a TTY stdin the blocked signal does not abort
+// the stream, and the run exits with the subsequent terminal event's code.
+func TestRunBlockedSignalKeepsStreamingWhenStdinIsTerminal(t *testing.T) {
+	for _, tc := range blockedSignals {
+		t.Run(tc.name, func(t *testing.T) {
+			stubStdinTerminal(t, true)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/v1/runs", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(w, `{"run_id":"run_abc","status":"queued"}`)
+			})
+			mux.HandleFunc("/v1/runs/run_abc/events", func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+				_, _ = io.WriteString(w, "event: "+tc.event+"\n")
+				_, _ = io.WriteString(w, "data: {\"id\":\"e1\",\"run_id\":\"run_abc\",\"type\":\""+tc.event+"\"}\n\n")
+				_, _ = io.WriteString(w, "event: run.completed\n")
+				_, _ = io.WriteString(w, "data: {\"id\":\"e2\",\"run_id\":\"run_abc\",\"type\":\"run.completed\"}\n\n")
+			})
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			outBuf, errBuf, restore := captureOutput(t)
+			defer restore()
+
+			origRequestClient := requestHTTPClient
+			origStreamClient := streamHTTPClient
+			requestHTTPClient = ts.Client()
+			streamHTTPClient = ts.Client()
+			defer func() {
+				requestHTTPClient = origRequestClient
+				streamHTTPClient = origStreamClient
+			}()
+
+			code := run([]string{"-base-url=" + ts.URL, "-prompt=test prompt"})
+			if code != 0 {
+				t.Fatalf("run() exit code = %d, want 0 — blocked signal must not abort an interactive stream (stderr=%s)", code, errBuf.String())
+			}
+			output := outBuf.String()
+			for _, want := range []string{tc.event, "terminal_event=run.completed"} {
+				if !strings.Contains(output, want) {
+					t.Errorf("stdout missing %q — stream must continue past the blocked signal:\n%s", want, output)
+				}
+			}
+			if errBuf.Len() != 0 {
+				t.Errorf("expected empty stderr for interactive stream, got %q", errBuf.String())
+			}
+		})
+	}
+}
+
+// TestRunContinueBlockedSignalExits3WhenStdinNonInteractive applies the same
+// blocked contract to the streaming continue path.
+func TestRunContinueBlockedSignalExits3WhenStdinNonInteractive(t *testing.T) {
+	stubStdinTerminal(t, false)
+
+	var cancelRequested atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_prev/continue":
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode continue body: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"run_id":"run_next","status":"queued"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/runs/run_next/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "event: run.waiting_for_user\n")
+			_, _ = io.WriteString(w, "data: {\"id\":\"run_next:0\",\"run_id\":\"run_next\",\"type\":\"run.waiting_for_user\"}\n\n")
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			<-r.Context().Done()
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs/run_next/cancel":
+			cancelRequested.Store(true)
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	outBuf, errBuf, restore := captureOutput(t)
+	defer restore()
+
+	origRequestClient := requestHTTPClient
+	origStreamClient := streamHTTPClient
+	requestHTTPClient = ts.Client()
+	streamHTTPClient = ts.Client()
+	defer func() {
+		requestHTTPClient = origRequestClient
+		streamHTTPClient = origStreamClient
+	}()
+
+	code := runContinue([]string{"-base-url=" + ts.URL, "run_prev", "follow up"})
+	if code != 3 {
+		t.Fatalf("runContinue() exit code = %d, want 3 (stderr=%s)", code, errBuf.String())
+	}
+	errOutput := errBuf.String()
+	for _, want := range []string{"run_next", "run.waiting_for_user", "harnesscli continue run_next"} {
+		if !strings.Contains(errOutput, want) {
+			t.Errorf("stderr missing %q:\n%s", want, errOutput)
+		}
+	}
+	if !strings.Contains(outBuf.String(), "run_id=run_next") {
+		t.Errorf("stdout missing run_id line:\n%s", outBuf.String())
+	}
+	if cancelRequested.Load() {
+		t.Error("server-side run must be left intact, but a cancel POST was received")
 	}
 }
 

--- a/cmd/harnesscli/main.go
+++ b/cmd/harnesscli/main.go
@@ -214,10 +214,35 @@ func run(args []string) int {
 	fmt.Fprintf(stdout, "run_id=%s\n", runID)
 	terminalEvent, err := streamRunEvents(ctx, streamHTTPClient, *baseURL, runID, stdout)
 	if err != nil {
+		var blocked *runBlockedError
+		if errors.As(err, &blocked) {
+			reportRunBlocked(runID, blocked.eventType)
+			return exitBlocked
+		}
 		return handleStreamError(ctx, requestHTTPClient, *baseURL, runID, err)
 	}
 	fmt.Fprintf(stdout, "terminal_event=%s\n", terminalEvent)
 	return exitCodeForTerminalEvent(harness.EventType(terminalEvent))
+}
+
+// runBlockedError is returned by the streaming loop when a blocked signal
+// (run.waiting_for_user, tool.approval_required, or plan.approval_required)
+// arrives while stdin is non-interactive. It is not a stream failure: the
+// server-side run is left intact so an operator can resume it later.
+type runBlockedError struct {
+	eventType harness.EventType
+}
+
+func (e *runBlockedError) Error() string {
+	return fmt.Sprintf("run blocked: %s", e.eventType)
+}
+
+// reportRunBlocked prints the blocked diagnosis for a headless caller: why
+// the run stopped, that the server-side run is untouched, and how to resume
+// it interactively.
+func reportRunBlocked(runID string, eventType harness.EventType) {
+	fmt.Fprintf(stderr, "harnesscli: run %s blocked: %s (%s); stdin is non-interactive, exiting; server-side run left intact\n", runID, blockedEventReason(eventType), eventType)
+	fmt.Fprintf(stderr, "harnesscli: resume with: harnesscli continue %s <prompt>\n", runID)
 }
 
 // handleStreamError decides how to report a streamRunEvents failure. If ctx
@@ -436,6 +461,14 @@ func processSSEBlock(raw string, out io.Writer) (string, bool, error) {
 
 	if harness.IsTerminalEvent(event.Type) {
 		return string(event.Type), true, nil
+	}
+	// A blocked signal with non-interactive stdin aborts the stream: the
+	// run is waiting on input a headless caller will never provide, so
+	// streaming further would block forever. With an interactive stdin the
+	// stream stays open (unchanged behavior); interactive answer wiring is
+	// the ask-user epic's scope.
+	if isBlockedEvent(event.Type) && !stdinIsTerminal() {
+		return "", false, &runBlockedError{eventType: event.Type}
 	}
 	return "", false, nil
 }

--- a/cmd/harnesscli/runctl.go
+++ b/cmd/harnesscli/runctl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -401,6 +402,11 @@ func runContinue(args []string) int {
 	}
 	terminalEvent, err := streamRunEvents(context.Background(), streamHTTPClient, *baseURL, created.RunID, stdout)
 	if err != nil {
+		var blocked *runBlockedError
+		if errors.As(err, &blocked) {
+			reportRunBlocked(created.RunID, blocked.eventType)
+			return exitBlocked
+		}
 		fmt.Fprintf(stderr, "harnesscli continue: stream events: %v\n", err)
 		return exitClientError
 	}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,6 +1,5 @@
 # Engineering Log
 
-<<<<<<< HEAD
 ## 2026-07-20 (OS-Service Install for harnessd — Epic #807)
 
 - Shipped `harnesscli service install|uninstall|start|stop|status` for end users: user-level launchd agent on macOS (`~/Library/LaunchAgents/com.gocode.harnessd.plist`, `RunAtLoad`+`KeepAlive`) and `systemd --user` unit on Linux (`~/.config/systemd/user/harnessd.service`, `Restart=on-failure`, `WantedBy=default.target`). Slice 1 (PR #826): install/uninstall + pure unit generators with `--binary`/`--addr`/`--log-dir`/`--dry-run`; addr resolution reuses the daemon's own stack (`HARNESS_ADDR` env or `~/.harness/config.toml`, default `:8080`) exported into the unit environment. Slice 2 (PR #866): lifecycle commands over launchctl/systemctl behind an injectable runner; `status` distinguishes not-installed / installed-not-running / running-healthy / running-unreachable via a `GET /healthz` probe.
@@ -28,6 +27,14 @@
   deliberately, so partial output is not context-worthy.
 - Validation: `go test ./cmd/harnesscli/... -count=1` green (27 packages);
   gofmt/vet clean on touched files.
+
+## 2026-07-20 (Headless Exit Codes — Epic #823, Slice 3)
+
+- A headless run that blocks on input it will never receive no longer streams forever: `processSSEBlock` (`cmd/harnesscli/main.go`) now classifies `run.waiting_for_user`, `tool.approval_required`, and `plan.approval_required` via `isBlockedEvent` (`cmd/harnesscli/exitcodes.go`), and when stdin is non-interactive the stream loop returns a `runBlockedError`. `run()` and streaming `runContinue()` map it to exit 3 (`exitBlocked`) with a stderr message naming the run ID, the reason, and the `harnesscli continue <run-id>` resume command.
+- The server-side run is never auto-cancelled on the blocked path (resumable by design); the blocked event line is still printed to stdout before exit, preserving the every-event-is-printed contract.
+- Terminal detection reuses the package's existing injectable `stdinIsTerminal` double (`cmd/harnesscli/plugins.go:107`) — no new TTY dependency, tests stub it. Interactive stdin behavior is unchanged: blocked signals do not abort the stream (interactive answer wiring remains the ask-user epic's scope, per the epic's cross-epic constraint).
+- TDD: failing-first tests cover all three blocked signals × (non-interactive → exit 3 + stderr content + no cancel POST; simulated TTY → stream continues to the terminal event's code), plus `runContinue()` blocked → 3 and unit tables for `isBlockedEvent`/`blockedEventReason`.
+- Validation: `go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1` green; gofmt/vet clean.
 
 ## 2026-07-20 (Issue #875 Shell-Mode Test-Seam Coverage Fix)
 

--- a/docs/plans/823-exit-codes.md
+++ b/docs/plans/823-exit-codes.md
@@ -3,10 +3,26 @@
 ## Slice status
 
 - Slice 1 (docs contract): **merged** (PR #824, branch `epic/823-exit-codes`).
-- Slice 2 (map terminal events to exit codes): **this branch** (`epic/823-exit-codes-s2`), branched from `origin/main` after the Slice 1 merge.
-- Slices 3–4 (blocked detection; e2e + per-command docs): future branches.
+- Slice 2 (map terminal events to exit codes): **merged** (PR #861, branch `epic/823-exit-codes-s2`).
+- Slice 3 (exit 3 on blocked headless runs): **this branch** (`epic/823-exit-codes-s3`), branched from `origin/main` after the Slice 2 merge.
+- Slice 4 (e2e assertions + per-command docs): future branch.
 
-## Slice 2 scope
+## Slice 3 scope
+
+- `cmd/harnesscli/exitcodes.go`: `isBlockedEvent` (run.waiting_for_user, tool.approval_required, plan.approval_required) and `blockedEventReason` (question-blocked vs approval-blocked wording). The contract's blocked signals, in the same single-source-of-truth file as the code table.
+- `cmd/harnesscli/main.go`: `runBlockedError`; `processSSEBlock` returns it when a blocked signal arrives while `stdinIsTerminal()` is false (interactive stdin: stream unchanged, stays open — ask-user wiring is the other epic's scope); `run()` maps it to `exitBlocked` after `reportRunBlocked` prints the run ID, reason, and `harnesscli continue <run-id>` resume command to stderr. Terminal detection reuses the existing injectable `stdinIsTerminal` double (`cmd/harnesscli/plugins.go:107`); no new TTY dependency.
+- `cmd/harnesscli/runctl.go` `runContinue()`: same blocked mapping (contract applies to streaming continue).
+- Server-side run never auto-cancelled on the blocked path; blocked event line still printed to stdout (every-event-printed contract preserved).
+- Docs: contract page blocked section + status table now describe implemented behavior; engineering-log entry.
+
+## Slice 3 test plan (TDD)
+
+- Failing-first (`cmd/harnesscli/exitcodes_test.go`): all three blocked signals × (non-interactive stdin → exit 3, stderr names run ID + reason + event + resume command, no cancel POST reaches the server, blocked event line still on stdout; simulated TTY → stream continues and the subsequent terminal event's code is returned); `runContinue()` blocked → 3; unit tables for `isBlockedEvent` / `blockedEventReason`.
+- Servers hold the SSE stream open after the blocked signal so a regression to "stream forever" hangs the test, not just fails an assertion.
+- Regression guard: slice-2 exit-code tests and all existing `cmd/harnesscli` tests unchanged and green.
+- Verification: `go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1`, gofmt, go vet.
+
+## Slice 2 record (completed)
 
 - New `cmd/harnesscli/exitcodes.go`: constants `exitSuccess`(0) / `exitClientError`(1) / `exitRunFailed`(2) / `exitBlocked`(3) / `exitCancelled`(6) / `exitInterrupted`(130) and `exitCodeForTerminalEvent(harness.EventType) int`; unknown/empty/non-terminal events map to 1 (defensive non-zero default). `exitBlocked` is defined here and wired in Slice 3.
 - `cmd/harnesscli/main.go` `run()`: terminal return becomes `exitCodeForTerminalEvent(...)`; literal `1` returns in `run()` and `1`/`130` in `handleStreamError()` replaced with the named constants (one source of truth). `terminal_event=` stdout line and interrupt-cancel behavior untouched.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -22,7 +22,7 @@
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.
 - `2026-07-20-subscription-auth-foundation-846-plan.md` — Epic #846 subscription-auth foundation: token-source, dynamic request auth, refresh cache, and registry plumbing (in implementation).
 - `2026-07-20-subscription-auth-foundation-846-impact-map.md` — Cross-surface impact map for Epic #846 provider credential plumbing.
-- `823-exit-codes.md` — Epic #823 headless CLI exit-code contract: Slice 1 (docs contract) merged; Slice 2 (terminal-event→exit-code mapping) in implementation.
+- `823-exit-codes.md` — Epic #823 headless CLI exit-code contract: Slices 1–2 merged (docs contract; terminal-event mapping); Slice 3 (blocked exit 3) in implementation.
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).

--- a/website/docs/reference/exit-codes.md
+++ b/website/docs/reference/exit-codes.md
@@ -9,7 +9,7 @@ import { Callout } from '@site/src/components/ui';
 This page is the **exit-code contract for headless `harnesscli` usage** — the one-shot streaming mode (`harnesscli -prompt ...`) and the streaming `continue` subcommand. It exists so shell scripts and CI pipelines can branch on a run's outcome via `$?` instead of parsing stdout.
 
 <Callout type="info">
-**Contract status.** Tracking issue: epic #823 (part of the kimi-code parity program #803). The run terminal-event mapping (`0`/`1`/`2`/`6`/`130`) is **implemented and in effect**; the blocked exit `3` is ratified here and lands with slice 3 of the epic — until then a blocked headless run keeps streaming. See the [current vs. contracted behavior](#current-vs-contracted-behavior) table below for the per-outcome status. The single source of truth in code is `cmd/harnesscli/exitcodes.go`.
+**Contract status.** Tracking issue: epic #823 (part of the kimi-code parity program #803). The full run contract (`0`/`1`/`2`/`3`/`6`/`130`) is **implemented and in effect** — terminal-event mapping in slice 2, blocked detection in slice 3. The goal-status mapping below remains reserved for a future goal-scoped headless surface. The single source of truth in code is `cmd/harnesscli/exitcodes.go`.
 </Callout>
 
 The contract adopts [kimi-code](https://github.com/MoonshotAI/kimi-code)'s headless codes where semantics align: kimi's `kimi -p` exits `0` when a goal completes, `3` when it blocks, `6` when it pauses, and non-zero on turn failure. Aligning on the same numbers means scripts written against one CLI keep working against the other.
@@ -72,12 +72,12 @@ A run is **blocked** when it cannot make progress without input a headless calle
 
 There is no dedicated "waiting-for-approval" run event — the approval-required events are the signal, and the run status transitions to `waiting_for_approval`.
 
-Contracted behavior when a blocked signal is observed in one-shot or streaming `continue` mode:
+Behavior when a blocked signal is observed in one-shot or streaming `continue` mode (implemented in epic #823 slice 3):
 
-- **stdin is not a terminal** (piped/redirected, the CI case): the CLI prints the blocked reason and run ID to **stderr**, stops streaming, and exits `3`. The server-side run is left intact — no auto-cancel — so an operator can resume it later with `harnesscli continue <run-id> <prompt>` or by answering via `POST /v1/runs/{id}/input` (questions) or `/approve` / `/deny` (approvals).
+- **stdin is not a terminal** (piped/redirected, the CI case): the CLI prints the blocked reason and run ID to **stderr**, stops streaming, and exits `3`. The server-side run is left intact — no auto-cancel — so an operator can resume it later with `harnesscli continue <run-id> <prompt>` (the resume command is named in the stderr message) or by answering via `POST /v1/runs/{id}/input` (questions) or `/approve` / `/deny` (approvals).
 - **stdin is a terminal**: behavior is unchanged — the stream stays open and no exit-3 shortcut is taken. Interactive answer wiring in the streaming loop is a separate epic's scope; that epic must preserve exit `3` for non-interactive stdin.
 
-The terminal check uses the same `term.IsTerminal` test the `--tui` path already uses (`cmd/harnesscli/main.go:517`).
+The terminal check uses the package's shared injectable `term.IsTerminal`-based stdin double (`stdinIsTerminal`, `cmd/harnesscli/plugins.go:107`), the same style of terminal detection the `--tui` path uses for stdout.
 
 ---
 
@@ -113,7 +113,7 @@ This goal mapping is **documentation-only in this epic**. There is no goal-scope
 
 ## Current vs. contracted behavior
 
-This table is the reviewer-facing diff of process outcomes. Rows marked **implemented** are in effect today; rows marked **changes** land with the remaining implementation slices of epic #823.
+This table records how process outcomes changed over epic #823. All rows are implemented and in effect today.
 
 | Outcome | Pre-epic exit code | Contracted exit code | Status |
 |---|---|---|---|
@@ -122,7 +122,7 @@ This table is the reviewer-facing diff of process outcomes. Rows marked **implem
 | SIGINT/SIGTERM interrupt | `130` | `130` | Implemented (unchanged) |
 | `run.failed` | `0` | `2` | **Implemented** (epic #823 slice 2) — was an unconditional `0` at the old `cmd/harnesscli/main.go:219-220` and `cmd/harnesscli/runctl.go:324-330` paths |
 | `run.cancelled` | `0` | `6` | **Implemented** (epic #823 slice 2) — same former unconditional-`0` paths |
-| Blocked, stdin non-interactive | (streams forever) | `3` | **Changes** (epic #823 slice 3) — today the CLI waits on the SSE stream indefinitely |
+| Blocked, stdin non-interactive | (streams forever) | `3` | **Implemented** (epic #823 slice 3) — was an indefinite wait on the SSE stream |
 
 ### stdout contract is unchanged
 


### PR DESCRIPTION
Parent epic: #823. Part of #803.

## What

Slice 3 of #823: a non-interactive caller gets a deterministic blocked signal instead of an infinite stream. Completes the run side of the Slice 1 contract (`website/docs/reference/exit-codes.md`).

- **Blocked classification** (`cmd/harnesscli/exitcodes.go`): `isBlockedEvent` covers the three contract signals — `run.waiting_for_user` (question-blocked), `tool.approval_required` / `plan.approval_required` (approval-blocked; no dedicated waiting-for-approval event exists) — plus `blockedEventReason` for the stderr wording.
- **Stream loop** (`cmd/harnesscli/main.go` `processSSEBlock`): when a blocked signal arrives while `stdinIsTerminal()` is false, the loop returns `runBlockedError`. With interactive stdin the stream stays open — behavior unchanged; interactive answer wiring remains the ask-user epic's scope (cross-epic constraint from the epic body).
- **Exit 3 wiring**: `run()` and streaming `runContinue()` map `runBlockedError` to `exitBlocked` after `reportRunBlocked` prints the run ID, the reason (`waiting for user input` / `waiting for approval`), and `harnesscli continue <run-id>` to stderr. The server-side run is **never auto-cancelled** (resumable by design); the blocked event line is still printed to stdout, preserving the every-event-is-printed contract.
- **Terminal detection** reuses the package's existing injectable `stdinIsTerminal` double (`cmd/harnesscli/plugins.go:107`) — no new TTY dependency; tests stub it instead of needing a real TTY.
- Docs: contract page blocked section + status table now describe implemented behavior; engineering-log entry; plan file updated.

## TDD

Failing-first (undefined `isBlockedEvent`/`blockedEventReason`, then behavior failures): all three blocked signals × (non-interactive stdin → exit 3, stderr names run ID + reason + event + resume command, **no cancel POST reaches the server**, blocked event line still on stdout; simulated TTY → stream continues and the subsequent terminal event's code is returned); `runContinue()` blocked → 3; unit tables. Test servers **hold the SSE stream open** after the blocked signal, so a regression to infinite streaming hangs the test rather than passing silently.

## Tests run

- `go test ./cmd/harnesscli/... -count=1` — green (whole tree; no existing tests needed changes).
- `go test ./internal/harness/... -count=1` — green.
- `go test ./test/e2e/... -count=1` — green (ok, 1.731s).
- `gofmt -l cmd/harnesscli/` clean; `go vet ./cmd/harnesscli/` clean.
- `cd website && npm run build` — `[SUCCESS]` with `onBrokenLinks: 'throw'`.

## Out of scope (slice 4)

E2E exit-code assertions over real HTTP+SSE, wrapper-propagation check, and per-command doc updates (`harnesscli.md`, `cli-flags.md`, `go-code-wrapper.md`).