### PR TITLE
feat(harnesscli): /compact [instruction] slash command

### DIFF
--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -217,6 +217,54 @@ func cancelRunCmd(baseURL, runID, apiKey string) tea.Cmd {
 	}
 }
 
+// compactRunCmd POSTs {"mode":"hybrid","instruction":...} to
+// /v1/runs/{id}/compact for the active run (server: internal/server/http_runs.go
+// handleRunCompact). The instruction is an optional free-text preserve-hint
+// for the summarizer (epic #817); mode is always hybrid — strip remains
+// available via the raw API only. The response carries the resolved mode, the
+// number of messages removed, and (for hybrid) the compaction summary.
+func compactRunCmd(baseURL, runID, instruction, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		body, err := json.Marshal(map[string]string{"mode": "hybrid", "instruction": instruction})
+		if err != nil {
+			return CompactResultMsg{RunID: runID, Err: "encode request: " + err.Error()}
+		}
+		endpoint := strings.TrimRight(baseURL, "/") + "/v1/runs/" + url.PathEscape(runID) + "/compact"
+		req, err := newHarnessRequest(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body), apiKey)
+		if err != nil {
+			return CompactResultMsg{RunID: runID, Err: "build request: " + err.Error()}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+		if err != nil {
+			return CompactResultMsg{RunID: runID, Err: "request failed: " + err.Error()}
+		}
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return CompactResultMsg{RunID: runID, Err: "read response: " + err.Error()}
+		}
+		if resp.StatusCode >= 300 {
+			return CompactResultMsg{RunID: runID, Err: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))}
+		}
+		var payload struct {
+			OK              bool   `json:"ok"`
+			MessagesRemoved int    `json:"messages_removed"`
+			Mode            string `json:"mode"`
+			Summary         string `json:"summary"`
+		}
+		if err := json.Unmarshal(respBody, &payload); err != nil {
+			return CompactResultMsg{RunID: runID, Err: "decode response: " + err.Error()}
+		}
+		return CompactResultMsg{
+			RunID:           runID,
+			Mode:            payload.Mode,
+			Summary:         payload.Summary,
+			MessagesRemoved: payload.MessagesRemoved,
+		}
+	}
+}
+
 // steerRunCmd POSTs a steering message to /v1/runs/{id}/steer for the active
 // run (server: internal/server/http_runs.go handleRunSteer). The server queues
 // the message and the harness injects it as a user message at the next step

--- a/cmd/harnesscli/tui/api_auth_test.go
+++ b/cmd/harnesscli/tui/api_auth_test.go
@@ -18,6 +18,7 @@ package tui
 //	api.go          startRunCmd                    harnessd    yes (newHarnessRequest)
 //	api.go          fetchRunsCmd                    harnessd    yes
 //	api.go          cancelRunCmd                    harnessd    yes
+//	api.go          compactRunCmd                   harnessd    yes
 //	api.go          steerRunCmd                     harnessd    yes
 //	api.go          replayRunCmd                    harnessd    yes
 //	api.go          continueRunCmd                  harnessd    yes
@@ -77,6 +78,12 @@ func harnessAuthCases() []harnessAuthCase {
 			name: "cancelRunCmd",
 			call: func(ts *httptest.Server, apiKey string) any {
 				return cancelRunCmd(ts.URL, "run-1", apiKey)()
+			},
+		},
+		{
+			name: "compactRunCmd",
+			call: func(ts *httptest.Server, apiKey string) any {
+				return compactRunCmd(ts.URL, "run-1", "keep the SQL schema", apiKey)()
 			},
 		},
 		{

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -284,6 +284,14 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeCancelCommand,
 		},
 		{
+			Name:        "compact",
+			Description: "Compact the active run's context (/compact [instruction])",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeCompactCommand,
+		},
+		{
 			Name:        "replay",
 			Description: "Replay a run",
 			Handler: func(cmd Command) CommandResult {

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -361,7 +361,7 @@ func TestTUI041_VisualSnapshot_200x50(t *testing.T) {
 func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 	r := tui.NewCommandRegistry()
 	required := []string{
-		"clear", "context", "export", "help", "keys",
+		"clear", "compact", "context", "export", "help", "keys",
 		"model", "quit", "stats", "subagents",
 		"attach", "cancel", "doctor", "permissions", "replay", "resume", "runs",
 	}
@@ -396,7 +396,7 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"attach", "cancel", "clear", "config", "context", "cost", "dashboard", "doctor", "export", "fork", "help", "history", "hooks", "init", "keys",
+		"attach", "cancel", "clear", "compact", "config", "context", "cost", "dashboard", "doctor", "export", "fork", "help", "history", "hooks", "init", "keys",
 		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents", "rewind", "theme", "title", "undo",
 	}

--- a/cmd/harnesscli/tui/compact_command_test.go
+++ b/cmd/harnesscli/tui/compact_command_test.go
@@ -1,0 +1,218 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Tests in this file cover epic #817 slice 3: the /compact [instruction]
+// slash command against the active run.
+// Helpers testRunControlModel and lastCmd live in run_control_command_test.go.
+
+// TestCompactCommand_NoActiveRunShowsUsage verifies /compact without an
+// active run shows a usage/status error and issues no HTTP request.
+func TestCompactCommand_NoActiveRunShowsUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("no request expected without an active run, got %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+
+	m := testRunControlModel(srv.URL)
+	// No active run: m.runActive == false, m.RunID == "".
+	cmds, quit := executeCompactCommand(&m, Command{Name: "compact", Args: []string{"keep", "x"}})
+	if quit {
+		t.Fatal("/compact must not quit")
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected exactly 1 status cmd, got %d", len(cmds))
+	}
+	// setStatusMsg mutates the model directly; the returned cmd is only the
+	// auto-dismiss tick.
+	status := m.StatusMsg()
+	if !strings.Contains(status, "Usage: /compact") {
+		t.Fatalf("StatusMsg() = %q, want usage hint", status)
+	}
+	if !strings.Contains(status, "active run") {
+		t.Fatalf("StatusMsg() = %q, want active-run requirement", status)
+	}
+}
+
+// TestCompactCommand_JoinsInstructionAndPostsHybrid verifies /compact with an
+// active run POSTs {"mode":"hybrid","instruction":<args joined verbatim>} to
+// /v1/runs/{id}/compact and reports messages removed on success.
+func TestCompactCommand_JoinsInstructionAndPostsHybrid(t *testing.T) {
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/runs/run_active_1/compact" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"messages_removed":3,"mode":"hybrid","summary":"kept the essentials"}`))
+	}))
+	defer srv.Close()
+
+	m := testRunControlModel(srv.URL)
+	m.runActive = true
+	m.RunID = "run_active_1"
+
+	cmds, quit := executeCompactCommand(&m, Command{
+		Name: "compact",
+		Args: []string{"keep", "the", "failing", "test", "output"},
+	})
+	if quit {
+		t.Fatal("/compact must not quit")
+	}
+	msg := lastCmd(t, cmds)()
+
+	if payload["mode"] != "hybrid" {
+		t.Fatalf("payload mode = %v, want hybrid", payload["mode"])
+	}
+	if payload["instruction"] != "keep the failing test output" {
+		t.Fatalf("payload instruction = %v, want args joined verbatim", payload["instruction"])
+	}
+
+	result, ok := msg.(CompactResultMsg)
+	if !ok {
+		t.Fatalf("expected CompactResultMsg, got %T: %+v", msg, msg)
+	}
+	if result.Err != "" {
+		t.Fatalf("unexpected error: %s", result.Err)
+	}
+	if result.MessagesRemoved != 3 {
+		t.Fatalf("MessagesRemoved = %d, want 3", result.MessagesRemoved)
+	}
+	if result.Mode != "hybrid" || result.Summary != "kept the essentials" {
+		t.Fatalf("Mode/Summary = %q/%q, want hybrid/kept the essentials", result.Mode, result.Summary)
+	}
+
+	m2, _ := m.Update(msg)
+	m = m2.(Model)
+	if !strings.Contains(m.StatusMsg(), "3 messages removed") {
+		t.Fatalf("StatusMsg() = %q, want messages-removed report", m.StatusMsg())
+	}
+}
+
+// TestCompactCommand_NoArgsSendsEmptyInstruction verifies /compact with no
+// arguments still compacts (mode hybrid, empty instruction).
+func TestCompactCommand_NoArgsSendsEmptyInstruction(t *testing.T) {
+	var payload map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"messages_removed":1,"mode":"hybrid","summary":""}`))
+	}))
+	defer srv.Close()
+
+	m := testRunControlModel(srv.URL)
+	m.runActive = true
+	m.RunID = "run_active_1"
+
+	cmds, quit := executeCompactCommand(&m, Command{Name: "compact"})
+	if quit {
+		t.Fatal("/compact must not quit")
+	}
+	msg := lastCmd(t, cmds)()
+	if result, ok := msg.(CompactResultMsg); !ok || result.Err != "" {
+		t.Fatalf("expected successful CompactResultMsg, got %+v", msg)
+	}
+
+	if payload["mode"] != "hybrid" {
+		t.Fatalf("payload mode = %v, want hybrid", payload["mode"])
+	}
+	if payload["instruction"] != "" {
+		t.Fatalf("payload instruction = %v, want empty for bare /compact", payload["instruction"])
+	}
+}
+
+// TestCompactCommand_ServerErrorShowsFailureStatus verifies a server-side
+// failure (e.g. 409 run_not_active) surfaces as a failed status line.
+func TestCompactCommand_ServerErrorShowsFailureStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"run_not_active","message":"run is not active"}}`))
+	}))
+	defer srv.Close()
+
+	m := testRunControlModel(srv.URL)
+	m.runActive = true
+	m.RunID = "run_active_1"
+
+	cmds, quit := executeCompactCommand(&m, Command{Name: "compact"})
+	if quit {
+		t.Fatal("/compact must not quit")
+	}
+	msg := lastCmd(t, cmds)()
+	result, ok := msg.(CompactResultMsg)
+	if !ok {
+		t.Fatalf("expected CompactResultMsg, got %T", msg)
+	}
+	if result.Err == "" {
+		t.Fatal("expected Err on 409 response")
+	}
+
+	m2, _ := m.Update(msg)
+	m = m2.(Model)
+	if !strings.Contains(m.StatusMsg(), "compact failed") {
+		t.Fatalf("StatusMsg() = %q, want compact failed", m.StatusMsg())
+	}
+}
+
+// TestCompactCommand_AppearsInRegistryHelpAndSlashComplete verifies the
+// command is registered with a description and shows up in /help and slash
+// completion (both are registry-driven).
+func TestCompactCommand_AppearsInRegistryHelpAndSlashComplete(t *testing.T) {
+	reg := NewCommandRegistry()
+	entry, ok := reg.Lookup("compact")
+	if !ok {
+		t.Fatal("compact command not registered")
+	}
+	if entry.Description == "" {
+		t.Error("compact command has empty description")
+	}
+	if entry.Execute == nil {
+		t.Error("compact command has nil Execute")
+	}
+
+	// /help view lists the command.
+	m := testRunControlModel("http://localhost:8080")
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = m2.(Model)
+	helpCmds, _ := executeHelpCommand(&m, Command{Name: "help"})
+	if len(helpCmds) != 0 {
+		for _, c := range helpCmds {
+			if c == nil {
+				continue
+			}
+			if msg := c(); msg != nil {
+				m3, _ := m.Update(msg)
+				m = m3.(Model)
+			}
+		}
+	}
+	if v := m.View(); !strings.Contains(v, "compact") {
+		t.Errorf("/compact must appear in /help view:\n%s", v)
+	}
+
+	// Slash completion suggests /compact.
+	sc := buildSlashComplete(NewCommandRegistry()).Open().SetQuery("comp")
+	found := false
+	for _, s := range sc.Filtered() {
+		if s.Name == "compact" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("slash completion for \"comp\" must suggest compact")
+	}
+}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -201,6 +201,19 @@ type RunControlResultMsg struct {
 	Err    string
 }
 
+// CompactResultMsg carries the result of a /compact command against the
+// active run (POST /v1/runs/{id}/compact). Mode is the resolved compaction
+// mode and Summary the compaction summary for summarize/hybrid modes (empty
+// for strip); epic #817 slice 4 renders the summary as a transcript block.
+// Err is non-empty on failure.
+type CompactResultMsg struct {
+	RunID           string
+	Mode            string
+	Summary         string
+	MessagesRemoved int
+	Err             string
+}
+
 // SteerAcceptedMsg signals the server accepted a steering message for a run
 // (HTTP 202 from POST /v1/runs/{id}/steer). The steered text is injected as a
 // user message at the next step boundary; the run keeps going.

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -1992,6 +1992,21 @@ func executeCancelCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	}, false
 }
 
+// executeCompactCommand compacts the active run's context via /compact
+// [instruction] (epic #817). Any args are joined verbatim into a
+// preserve-instruction for the summarizer; the command always requests hybrid
+// mode. Requires an active run.
+func executeCompactCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	if !m.runActive || m.RunID == "" {
+		return []tea.Cmd{m.setStatusMsg("Usage: /compact [instruction] — requires an active run")}, false
+	}
+	instruction := strings.TrimSpace(strings.Join(cmd.Args, " "))
+	return []tea.Cmd{
+		m.setStatusMsg("Compacting " + m.RunID + "..."),
+		compactRunCmd(m.config.BaseURL, m.RunID, instruction, m.config.APIKey),
+	}, false
+}
+
 func executeReplayCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	if len(cmd.Args) == 0 || strings.TrimSpace(cmd.Args[0]) == "" {
 		return []tea.Cmd{m.setStatusMsg("Usage: /replay <run-id-or-rollout-path>")}, false
@@ -3549,6 +3564,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			cmds = append(cmds, m.setStatusMsg("Run command finished"))
 		}
+
+	case CompactResultMsg:
+		if msg.Err != "" {
+			cmds = append(cmds, m.setStatusMsg("compact failed: "+msg.Err))
+			return m, tea.Batch(cmds...)
+		}
+		cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Compacted context — %d messages removed", msg.MessagesRemoved)))
 
 	case SSEEventMsg:
 		if m.dashboard.peekID != "" {

--- a/cmd/harnesscli/tui/model_command_test.go
+++ b/cmd/harnesscli/tui/model_command_test.go
@@ -453,9 +453,9 @@ func TestTUI137_ModelOverlayEnterAtLevel1ClosesAndSetsModel(t *testing.T) {
 // TestTUI137_ModelAppearsInHelpCommand verifies /model appears in /help output.
 func TestTUI137_ModelAppearsInHelpCommand(t *testing.T) {
 	// A taller window is needed so /model is within the help dialog's first
-	// visible page now that /cost and /config have been added to the
-	// (alphabetically-earlier) command set.
-	m := initModel(t, 80, 30)
+	// visible page now that /cost, /config, /compact, and /fork have been added
+	// to the (alphabetically-earlier) command set.
+	m := initModel(t, 80, 40)
 	m = sendSlashCommand(m, "/help")
 
 	v := m.View()

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -612,10 +612,10 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 		"attach",
 		"cancel",
 		"clear",
+		"compact",
 		"config",
 		"context",
 		"cost",
-		"dashboard",
 	}
 	for _, cmd := range wantVisible {
 		if !strings.Contains(v, cmd) {

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -3,6 +3,7 @@ Command Registry - 120x40
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history
+/compact — Compact the active run's context (/compact [instruction])
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -3,6 +3,7 @@ Command Registry - 200x50
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history
+/compact — Compact the active run's context (/compact [instruction])
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -3,6 +3,7 @@ Command Registry - 80x24
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history
+/compact — Compact the active run's context (/compact [instruction])
 /config — View current session configuration
 /context — View context window usage
 /cost — Show running cost and token usage

--- a/docs/plans/817-compact-cmd.md
+++ b/docs/plans/817-compact-cmd.md
@@ -3,7 +3,8 @@
 Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part of #803.
 
 - Slice 1 (`feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint`): **implemented**, merged via PR #836.
-- Slice 2 (`feat(harness): return the compaction summary from the compact endpoint`): **in implementation** (branch `epic/817-compact-cmd-s2`).
+- Slice 2 (`feat(harness): return the compaction summary from the compact endpoint`): **implemented**, merged via PR #860.
+- Slice 3 (`feat(harnesscli): /compact [instruction] slash command`): **in implementation** (branch `epic/817-compact-cmd-s3`).
 
 ## Slice 1 (done)
 
@@ -100,3 +101,40 @@ Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part 
 - [ ] gofmt + go vet clean.
 - [ ] `go test ./internal/harness/ ./internal/server/ -count=1` green.
 - [ ] Commit, push `epic/817-compact-cmd-s2`, open PR (no merge).
+
+---
+
+## Slice 3 (in implementation): /compact [instruction] slash command
+
+### Context
+
+- Problem: users cannot trigger compaction from the TUI; only the raw HTTP endpoint exists (slices 1–2).
+- Constraints: `/compact` always requests `hybrid` mode (strip stays raw-API-only); requires an active run; help and slash completion are registry-driven so the registry entry covers both; the registry completeness/builtin tests (`cmd_parser_test.go`) and the auth-coverage table (`api_auth_test.go`) are the snapshots the epic mandates updating.
+
+### Scope
+
+- In scope:
+  - `compact` entry in `builtinCommandEntries()` (`cmd/harnesscli/tui/cmd_parser.go`).
+  - `executeCompactCommand` beside `executeCancelCommand` (`cmd/harnesscli/tui/model.go`): active-run guard, args joined verbatim into the instruction, fires `compactRunCmd`; `CompactResultMsg` Update case reports "Compacted context — N messages removed" / "compact failed: ...".
+  - `compactRunCmd` (`cmd/harnesscli/tui/api.go`): POST `{"mode":"hybrid","instruction":...}` to `/v1/runs/{id}/compact` via `newHarnessRequest`; decodes `{ok,messages_removed,mode,summary}` into `CompactResultMsg` (`messages.go`) — `Mode`/`Summary` carried for slice 4.
+  - Snapshot updates: `TestTUI041_BuiltinCommandsRegistered` + `TestTUI364_RegistryCompleteness` lists; `api_auth_test.go` audit comment + table case; `TestBuildCommandRegistry_SlashCompleteShowsCommands` first-window list (`compact` takes a first-window slot, pushing `dashboard` below the fold).
+- Out of scope: slice 4 (transcript block, ctrl+o, auto_compact SSE); mode selection flag; one-shot CLI UX.
+
+### Test Plan (TDD)
+
+- New failing tests first (`cmd/harnesscli/tui/compact_command_test.go`):
+  - no active run → usage/active-run status, zero HTTP requests.
+  - active run → POST hybrid + instruction joined verbatim; success status reports messages removed; msg carries mode/summary.
+  - bare `/compact` → empty instruction sent.
+  - 409 → "compact failed" status.
+  - registry/help/slash-complete visibility.
+- Updated snapshot tests: registry lists + auth table (watched red before implementation).
+- Regression: `go test ./cmd/harnesscli/... -count=1`.
+
+### Implementation Checklist
+
+- [x] Write failing tests first (watched red: build failures on undefined `executeCompactCommand`/`compactRunCmd`/`CompactResultMsg` + registry list failures).
+- [x] Implement minimal code changes.
+- [ ] gofmt + go vet clean.
+- [ ] `go test ./cmd/harnesscli/... -count=1` green.
+- [ ] Commit, push `epic/817-compact-cmd-s3`, open PR (no merge).


### PR DESCRIPTION
Parent epic: #817. Part of #803.

## What

Epic #817 slice 3 (of 4), stacked on merged slices 1–2 (PR #836, PR #860). TUI users can now compact the active run from the keyboard:

- `compact` registered in `builtinCommandEntries()` (`cmd/harnesscli/tui/cmd_parser.go`) — `/help` and slash completion pick it up automatically (both registry-driven).
- `executeCompactCommand` (`cmd/harnesscli/tui/model.go`, beside `executeCancelCommand`): requires an active run (`m.runActive && m.RunID != ""`), joins `cmd.Args` verbatim into the preserve-instruction, fires `compactRunCmd`. The `CompactResultMsg` Update case reports `Compacted context — N messages removed` on success and `compact failed: ...` on error.
- `compactRunCmd` (`cmd/harnesscli/tui/api.go`): POSTs `{"mode":"hybrid","instruction":...}` to `/v1/runs/{id}/compact` via `newHarnessRequest` (auth-covered), decodes the slice-2 response into `CompactResultMsg` (`messages.go`) — `Mode`/`Summary` ride along for slice 4's transcript block.

## Snapshot updates (mandated by the epic)

- `TestTUI041_BuiltinCommandsRegistered` + `TestTUI364_RegistryCompleteness` command lists (`cmd_parser_test.go`).
- `api_auth_test.go`: audit comment + `compactRunCmd` table case (with/without API key).
- `TestBuildCommandRegistry_SlashCompleteShowsCommands` (`model_init_test.go`): `compact` takes a first-window slot alphabetically, moving `dashboard` below the fold — expected visible list updated.

## Tests (strict TDD — failing tests written first, watched red)

New `cmd/harnesscli/tui/compact_command_test.go`:
- no active run → usage/active-run status line, zero HTTP requests issued
- active run → POST body is exactly `{"mode":"hybrid","instruction":"keep the failing test output"}` (args joined verbatim); success status reports `3 messages removed`; msg carries `Mode`/`Summary`
- bare `/compact` → empty instruction sent
- 409 → `compact failed` status
- registry lookup, `/help` view, and slash-completion `Filtered()` all surface `compact`

Red phase observed: build failures on undefined `executeCompactCommand`/`compactRunCmd`/`CompactResultMsg` plus registry-list failures before implementation.

## Verification (actually run)

- `go test ./cmd/harnesscli/tui/ -run 'TestCompactCommand|TestTUI041_BuiltinCommandsRegistered|TestTUI364_RegistryCompleteness|TestAllHarnessdCallsAuthenticate' -count=1` — ok
- `go test ./cmd/harnesscli/... -count=1` — exit 0, 27 packages ok (after the slash-complete snapshot update; the pre-update run failed only on that pinned window list)
- `gofmt` / `go vet ./cmd/harnesscli/...` — clean

## Acceptance (from epic)

In a live TUI session, `/compact keep the failing test output` compacts the run (hybrid + instruction to the slice-1/2 endpoint) and shows `Compacted context — N messages removed`; `go test ./cmd/harnesscli/...` green.

Later slice (#817): slice 4 — compaction summary transcript block + ctrl+o toggle + auto_compact SSE handling — not in this PR.