### PR TITLE
feat(tui): ctrl+g steers the active run with in-flight input

### DIFF
--- a/cmd/harnesscli/tui/keys.go
+++ b/cmd/harnesscli/tui/keys.go
@@ -26,6 +26,12 @@ type KeyMap struct {
 	Dashboard key.Binding
 	Quit      key.Binding
 	Copy      key.Binding
+	// Steer injects the input-box content into the active run as a steering
+	// message (epic #820) without cancelling it. Bound to ctrl+g: ctrl+s is
+	// taken by Copy, and ctrl+r stays reserved for a future history-search
+	// binding per terminal convention (both verified unbound under
+	// cmd/harnesscli at implementation time).
+	Steer key.Binding
 	// PasteImage attaches a clipboard image to the input as a placeholder
 	// chip (epic #818, slice 2).
 	PasteImage key.Binding
@@ -102,6 +108,10 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("ctrl+s"),
 			key.WithHelp("ctrl+s", "copy last response"),
 		),
+		Steer: key.NewBinding(
+			key.WithKeys("ctrl+g"),
+			key.WithHelp("ctrl+g", "steer run"),
+		),
 		PasteImage: key.NewBinding(
 			key.WithKeys("ctrl+v"),
 			key.WithHelp("ctrl+v", "paste image from clipboard"),
@@ -119,13 +129,13 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp implements key.Map for the help component.
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Submit, k.Interrupt, k.SlashCmd, k.Help, k.Dashboard, k.Quit, k.Newline, k.Copy}
+	return []key.Binding{k.Submit, k.Interrupt, k.Steer, k.SlashCmd, k.Help, k.Dashboard, k.Quit, k.Newline, k.Copy}
 }
 
 // FullHelp implements key.Map for the help component.
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.Submit, k.Newline, k.Interrupt, k.Quit},
+		{k.Submit, k.Newline, k.Interrupt, k.Steer, k.Quit},
 		{k.ScrollUp, k.ScrollDown, k.PageUp, k.PageDown, k.GotoTop, k.GotoBottom},
 		{k.SlashCmd, k.AtMention, k.ShellMode, k.Help, k.Dashboard},
 		{k.EditMode, k.ExpandTool},

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -531,6 +531,7 @@ func buildHelpDialog(reg *CommandRegistry, keys KeyMap) helpdialog.Model {
 		{Keys: "ctrl+e", Description: keys.EditMode.Help().Desc},
 		{Keys: "esc", Description: keys.Interrupt.Help().Desc},
 		{Keys: "ctrl+s", Description: keys.Copy.Help().Desc},
+		{Keys: "ctrl+g", Description: keys.Steer.Help().Desc},
 		{Keys: "ctrl+v", Description: keys.PasteImage.Help().Desc},
 		{Keys: "ctrl+c", Description: "interrupt run (twice) / quit when idle"},
 	}
@@ -1014,6 +1015,23 @@ func (m *Model) appendSteeringMarker(message string) {
 		Timestamp: time.Now(),
 	})
 	m.appendMessageBubble(messagebubble.RoleUser, marked)
+}
+
+// steerErrorStatusText maps a SteerErrorMsg Kind (see messages.go) to the
+// status-bar text shown when a steer attempt fails.
+func steerErrorStatusText(msg SteerErrorMsg) string {
+	switch msg.Kind {
+	case "run_not_active":
+		return "Steer failed: run already finished"
+	case "steering_buffer_full":
+		return "Steer failed: steering buffer full — try again shortly"
+	case "not_found":
+		return "Steer failed: run not found"
+	case "invalid_prompt":
+		return "Steer failed: prompt is required"
+	default:
+		return "Steer failed: " + msg.Err
+	}
 }
 
 func (m *Model) appendToolUseView(view tooluse.Model) {
@@ -2289,6 +2307,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				cmds = append(cmds, m.setStatusMsg("Copy unavailable"))
 			}
+		case key.Matches(msg, m.keys.Steer):
+			// Mid-turn steering (epic #820): send the input-box content into the
+			// active run via POST /v1/runs/{id}/steer. The run is neither
+			// cancelled nor restarted — the message lands at the next step
+			// boundary (confirmed later by a steering.received SSE event).
+			steerPrompt := strings.TrimSpace(m.input.Value())
+			switch {
+			case !m.runActive || m.RunID == "":
+				cmds = append(cmds, m.setStatusMsg("No active run to steer"))
+			case steerPrompt == "":
+				cmds = append(cmds, m.setStatusMsg("Type a message to steer into the run"))
+			default:
+				m.input = m.input.Clear()
+				cmds = append(cmds,
+					m.setStatusMsg("Steering sent"),
+					steerRunCmd(m.config.BaseURL, m.RunID, steerPrompt, m.config.APIKey),
+				)
+			}
+			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.Interrupt):
 			if m.overlayActive && m.activeOverlay == "dashboard" && m.dashboard.peekID != "" {
 				if m.dashboard.stopPeek != nil {
@@ -3571,6 +3608,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 		cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Compacted context — %d messages removed", msg.MessagesRemoved)))
+
+	// SteerAcceptedMsg: the server queued the steering message (HTTP 202). The
+	// send-time "Steering sent" status already covers the acknowledgement; the
+	// server-confirmed transcript marker arrives later as a steering.received
+	// SSE event (slice 2). Slice 4 hooks this for the local-echo lifecycle.
+	case SteerAcceptedMsg:
+
+	case SteerErrorMsg:
+		cmds = append(cmds, m.setStatusMsg(steerErrorStatusText(msg)))
 
 	case SSEEventMsg:
 		if m.dashboard.peekID != "" {

--- a/cmd/harnesscli/tui/steer_key_test.go
+++ b/cmd/harnesscli/tui/steer_key_test.go
@@ -1,0 +1,204 @@
+package tui_test
+
+// steer_key_test.go — epic #820 slice 3
+// ctrl+g steers the active run with the input-box content: one keypress POSTs
+// the text to /v1/runs/{id}/steer (steerRunCmd, slice 1), clears the input,
+// and leaves the run alive. Ungated presses (no run, empty input) are status
+// hints, never errors, and never hit the network. SteerErrorMsg kinds map to
+// human status text.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// steerKeyModel builds a model pointed at baseURL with a cancel func wired, an
+// active run (runID, when non-empty), and text typed into the input box.
+func steerKeyModel(t *testing.T, baseURL, runID, input string, cancel *bool) tui.Model {
+	t.Helper()
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = baseURL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m3 := m2.(tui.Model).WithCancelRun(func() {
+		if cancel != nil {
+			*cancel = true
+		}
+	})
+	if runID != "" {
+		m4, _ := m3.Update(tui.RunStartedMsg{RunID: runID})
+		m3 = m4.(tui.Model)
+	}
+	if input != "" {
+		m3 = typeIntoModel(m3, input)
+	}
+	return m3
+}
+
+func TestSteerKey_ActiveRunSendsInputClearsAndKeepsRunAlive(t *testing.T) {
+	var gotMethod, gotPath, gotPrompt string
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var body struct {
+			Prompt string `json:"prompt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode steer body: %v", err)
+		}
+		gotPrompt = body.Prompt
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	}))
+	defer srv.Close()
+
+	cancelCalled := false
+	model := steerKeyModel(t, srv.URL, "run-steer-key-1", "switch to approach B", &cancelCalled)
+
+	m2, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	model = m2.(tui.Model)
+
+	if cmd == nil {
+		t.Fatal("expected a non-nil command on ctrl+g during an active run with input")
+	}
+	runCmd(cmd)
+
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Fatalf("steer endpoint hits = %d, want 1", got)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/runs/run-steer-key-1/steer" {
+		t.Errorf("path = %q, want /v1/runs/run-steer-key-1/steer", gotPath)
+	}
+	if gotPrompt != "switch to approach B" {
+		t.Errorf("prompt = %q, want %q", gotPrompt, "switch to approach B")
+	}
+
+	if got := model.Input(); got != "" {
+		t.Errorf("input should be cleared after steering, got %q", got)
+	}
+	if !model.RunActive() {
+		t.Error("run must stay active after ctrl+g steer (it is not a cancel)")
+	}
+	if cancelCalled {
+		t.Error("cancelRun must NOT be called on ctrl+g steer")
+	}
+	if got := model.StatusMsg(); !strings.Contains(got, "Steering sent") {
+		t.Errorf("StatusMsg() = %q, want it to contain %q", got, "Steering sent")
+	}
+}
+
+func TestSteerKey_NoActiveRunIsStatusHintOnly(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	// No RunStartedMsg — idle model with text typed.
+	model := steerKeyModel(t, srv.URL, "", "redirect please", nil)
+
+	m2, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+	model = m2.(tui.Model)
+	runCmd(cmd)
+
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Errorf("steer endpoint hits = %d, want 0 with no active run", got)
+	}
+	if got := model.StatusMsg(); !strings.Contains(got, "No active run") {
+		t.Errorf("StatusMsg() = %q, want a 'No active run' hint", got)
+	}
+	// Input is NOT cleared when nothing was sent — the user's text is kept.
+	if got := model.Input(); got != "redirect please" {
+		t.Errorf("input must be preserved when the steer is a no-op, got %q", got)
+	}
+}
+
+func TestSteerKey_EmptyOrWhitespaceInputIsStatusHintOnly(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"whitespace", "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var hits int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer srv.Close()
+
+			model := steerKeyModel(t, srv.URL, "run-steer-key-empty", tc.input, nil)
+
+			m2, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlG})
+			model = m2.(tui.Model)
+			runCmd(cmd)
+
+			if got := atomic.LoadInt32(&hits); got != 0 {
+				t.Errorf("steer endpoint hits = %d, want 0 with %s input", got, tc.name)
+			}
+			if got := model.StatusMsg(); !strings.Contains(got, "steer") {
+				t.Errorf("StatusMsg() = %q, want a hint telling the user to type a message to steer", got)
+			}
+			if !model.RunActive() {
+				t.Error("run must stay active on a no-op ctrl+g")
+			}
+		})
+	}
+}
+
+func TestSteerErrorMsg_KindsMapToStatusText(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  tui.SteerErrorMsg
+		want string
+	}{
+		{"run not active (409)", tui.SteerErrorMsg{RunID: "run-x", Kind: "run_not_active", Err: "HTTP 409"}, "run already finished"},
+		{"buffer full (429)", tui.SteerErrorMsg{RunID: "run-x", Kind: "steering_buffer_full", Err: "HTTP 429"}, "steering buffer full"},
+		{"not found (404)", tui.SteerErrorMsg{RunID: "run-x", Kind: "not_found", Err: "HTTP 404"}, "run not found"},
+		{"transport", tui.SteerErrorMsg{RunID: "run-x", Kind: "transport", Err: "request failed: connection refused"}, "connection refused"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			model := steerKeyModel(t, "http://localhost:1", "run-x", "", nil)
+
+			m2, _ := model.Update(tc.msg)
+			model = m2.(tui.Model)
+
+			if got := model.StatusMsg(); !strings.Contains(got, tc.want) {
+				t.Errorf("StatusMsg() = %q, want it to contain %q", got, tc.want)
+			}
+			if !model.RunActive() {
+				t.Error("a failed steer must not kill the run")
+			}
+		})
+	}
+}
+
+func TestSteerAcceptedMsg_KeepsRunAlive(t *testing.T) {
+	model := steerKeyModel(t, "http://localhost:1", "run-x", "", nil)
+
+	m2, _ := model.Update(tui.SteerAcceptedMsg{RunID: "run-x"})
+	model = m2.(tui.Model)
+
+	if !model.RunActive() {
+		t.Error("run must stay active after SteerAcceptedMsg")
+	}
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -118,6 +118,14 @@
 - TDD: failing-first tests cover all three blocked signals × (non-interactive → exit 3 + stderr content + no cancel POST; simulated TTY → stream continues to the terminal event's code), plus `runContinue()` blocked → 3 and unit tables for `isBlockedEvent`/`blockedEventReason`.
 - Validation: `go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1` green; gofmt/vet clean.
 
+## 2026-07-20 (Mid-Turn Steering — Epic #820, Slice 3)
+
+- `ctrl+g` now steers the active run with the input-box content: new `Steer` binding in `cmd/harnesscli/tui/keys.go` (ctrl+s stays copy; ctrl+r stays reserved for future history search — re-grepped unbound), included in `ShortHelp`/`FullHelp` and the `buildHelpDialog` key list.
+- `cmd/harnesscli/tui/model.go` KeyMsg handler: gated on `runActive && RunID != "" && TrimSpace(input) != ""` → clears the input (`input.Clear()`, cursor/history-pos safe), sets "Steering sent", fires slice 1's `steerRunCmd`; ungated presses are status hints only ("No active run to steer" / "Type a message to steer into the run"), never errors, never HTTP. New `SteerErrorMsg` case maps kinds via `steerErrorStatusText` (409 → "run already finished", 429 → "steering buffer full — try again shortly", 404 → "run not found"); `SteerAcceptedMsg` is consumed as a documented no-op for slice 4 to hook.
+- `website/docs/cli/tui.md`: `Ctrl+G` keybinding row + a "Mid-turn steering" section (step-boundary injection, buffer-of-10 limit, `steered ⟂` marker, `harnesscli steer` one-shot).
+- Strict TDD: `steer_key_test.go` drives `tea.KeyCtrlG` through the model against an httptest daemon (POST path/body observed, input cleared, `RunActive()` true, `cancelRun` not called), plus idle/empty-input no-HTTP hints and the error-kind mapping table. The 3s per-test cost is the existing `statusTickCmd(3s)` driven synchronously by the shared `runCmd` helper — same trade the ctrl+c/cancel tests already make.
+- Validation: `go test ./cmd/harnesscli/... -count=1` all ok; regression guards (`keys_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `sse_events_test.go`) green; `go test ./internal/server/ ./internal/harness/ -count=1` ok; gofmt/vet clean.
+
 ## 2026-07-20 (Issue #875 Shell-Mode Test-Seam Coverage Fix)
 
 - Symptom: post-merge regression gate (`scripts/test-regression.sh`) failed after PR #870 landed: `coveragegate` flagged `(*Model).ShellCommandRunning` and `(*Model).WithShellExecTimeout` (cmd/harnesscli/tui/model.go) at 0.0%.

--- a/docs/plans/820-tui-steering.md
+++ b/docs/plans/820-tui-steering.md
@@ -130,3 +130,70 @@
 - [x] `go test ./cmd/harnesscli/... -count=1` green.
 - [x] Engineering-log entry.
 - [ ] Commit, push `epic/820-tui-steering-s2`, open PR (do NOT merge).
+
+---
+
+## Slice 3 — ctrl+g steers the active run with in-flight input
+
+## Context
+
+- Problem: slices 1–2 provide the client path (`steerRunCmd`) and the
+  server-confirmed transcript marker, but the user has no way to trigger a steer
+  from the TUI — kimi-code parity requires a single keypress that injects the
+  input-box content into the running turn.
+- User impact: without a binding, mid-turn correction requires cancelling the run
+  or switching to the one-shot CLI.
+- Constraints: implement ONLY slice 3 of #820. No local echo/dedupe (slice 4), no
+  e2e (slice 5). `ctrl+s` stays copy; `ctrl+r` stays reserved for a future
+  history-search binding. Re-grepped: `ctrl+g` is unbound anywhere under
+  `cmd/harnesscli` (checked again on this branch). Strict TDD.
+
+## Scope
+
+- In scope:
+  - `cmd/harnesscli/tui/keys.go`: `Steer key.Binding` on `ctrl+g` ("steer run"),
+    included in `ShortHelp`/`FullHelp`.
+  - `cmd/harnesscli/tui/model.go`: `key.Matches(msg, m.keys.Steer)` case gated on
+    `m.runActive && m.RunID != "" && strings.TrimSpace(m.input.Value()) != ""` →
+    fires `steerRunCmd`, clears the input, sets "Steering sent" status. Ungated
+    press: status hint only ("No active run to steer" / "Type a message to steer
+    into the run"), never an error. New `SteerErrorMsg` case mapping kinds to
+    status text: `run_not_active` → "run already finished", `steering_buffer_full`
+    → "steering buffer full — try again shortly", `not_found` → "run not found",
+    others → "Steer failed: <err>". `SteerAcceptedMsg` consumed as a no-op
+    (slice 4 hooks it for local echo).
+  - Help: `buildHelpDialog` key list gains `ctrl+g`;
+    `website/docs/cli/tui.md` keybinding table gains the `Ctrl+G` row.
+- Out of scope: slices 4–5; any server/harness change; remapping `ctrl+s`.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: `website/docs/cli/tui.md` keybinding table (+ steering
+  behavior note: step-boundary injection, buffer limit).
+- Implementation notes to add after code: engineering-log entry.
+
+## Test Plan (TDD)
+
+- New failing tests (`cmd/harnesscli/tui/steer_key_test.go`, package `tui_test`):
+  - ctrl+g during an active run with typed input → httptest server receives POST
+    `/v1/runs/{id}/steer` with the input text (via the existing `runCmd` batch
+    driver); input cleared; `RunActive()` still true; `cancelRun` NOT called;
+    status shows "Steering sent".
+  - ctrl+g while idle (no run) → no HTTP call, status hint.
+  - ctrl+g with empty/whitespace input during a run → no HTTP call, status hint.
+  - `SteerErrorMsg` kinds → status text (409/429/404/transport).
+  - `SteerAcceptedMsg` → no crash, run still active.
+- Regression guards: `keys_test.go`, `escape_test.go`, `cancel_test.go`,
+  `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `sse_events_test.go` stay
+  green (esc cancel and ctrl+s copy unchanged).
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests (listed above).
+- [x] Write failing tests first, watch them fail.
+- [x] Implement binding + KeyMsg case + message mapping + help/docs.
+- [x] gofmt + go vet clean.
+- [x] `go test ./cmd/harnesscli/... -count=1` green.
+- [x] Engineering-log entry.
+- [ ] Commit, push `epic/820-tui-steering-s3`, open PR (do NOT merge).

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -16,7 +16,7 @@
 - `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator + Slice 2 resume (merged), Slice 3 agent_swarm deferred tool with sole-call rule (in implementation).
 - `809-mcp-oauth.md` — Epic #809: slices 1–2 (headers/typed errors, token store) merged; slice 3 (OAuth 2.1 + PKCE flow with localhost callback) in implementation.
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
-- `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slice 1 client plumbing merged; slice 2 transcript rendering in review).
+- `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slices 1–2 merged; slice 3 ctrl+g binding in review).
 
 - `2026-07-20-codex-subscription-auth-847-plan.md` — Epic #847 ChatGPT-subscription authentication for the Codex provider (in implementation).
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -102,6 +102,7 @@ Press `?` or `Ctrl+H` at any time to open the built-in help dialog with the full
 | `Ctrl+O` | Expand/collapse active tool card, or toggle plan mode when idle |
 | `Ctrl+E` | Open `$EDITOR` for multi-line prompt editing |
 | `Ctrl+S` | Copy last assistant response to clipboard |
+| `Ctrl+G` | Steer the active run: inject the input-box text into the running turn (see below) |
 | `Ctrl+U` | Clear the input (when no overlay is open) |
 | `Ctrl+C` | Two-stage interrupt (see below) |
 | `Esc` | Multi-priority close: dropdown → overlay → cancel run → clear input |
@@ -126,6 +127,17 @@ Accidentally pressing `Ctrl+C` mid-run would be frustrating, so the TUI requires
 Pressing `Esc` when no banner is showing cancels the run directly (without the two-step confirmation).
 
 When idle (no run active), `Ctrl+C` quits the TUI immediately.
+
+### Mid-turn steering
+
+While a run is in flight, type corrective input and press `Ctrl+G` to inject it into the running turn — the run keeps going (it is not cancelled or restarted). The steered text is delivered to the agent as a user message at the **next step boundary**, not instantaneously, so the current tool call or model response finishes first.
+
+- The input box clears on send and the status bar confirms with "Steering sent".
+- The transcript shows the steered message with a `steered ⟂` marker once the server confirms it, distinguishing it from a typed prompt.
+- Steering is queued server-side with a buffer of 10 pending messages per run; if the buffer is full or the run has already finished, the status bar says so and nothing is dropped silently.
+- With no active run or an empty input box, `Ctrl+G` is a no-op with a status hint.
+- The same path is available outside the TUI as `harnesscli steer <run-id> <prompt>`.
+- `Ctrl+S` (copy) and `Esc` (cancel) are unchanged.
 
 ---
 


### PR DESCRIPTION
Parent epic: #820. Part of #803.

## What

Slice 3 of #820 (mid-turn steering): one keypress sends the input-box content into the running turn; the run continues.

- `cmd/harnesscli/tui/keys.go` — `Steer` binding on `ctrl+g` ("steer run"), in `ShortHelp`/`FullHelp` and the `buildHelpDialog` key list. Binding choice: `ctrl+s` is copy, `ctrl+r` stays reserved for a future history-search binding — re-grepped, both `ctrl+g` and `ctrl+r` unbound anywhere under `cmd/harnesscli`.
- `cmd/harnesscli/tui/model.go` — KeyMsg case gated on `runActive && RunID != "" && TrimSpace(input) != ""`: clears the input (`input.Clear()`), sets "Steering sent", fires slice 1's `steerRunCmd`. Ungated presses (no run / empty input) are status hints only ("No active run to steer" / "Type a message to steer into the run") — never an error, never an HTTP call, input preserved. New `SteerErrorMsg` case maps kinds via `steerErrorStatusText`: 409 → "run already finished", 429 → "steering buffer full — try again shortly", 404 → "run not found". `SteerAcceptedMsg` is consumed as a documented no-op that slice 4 will hook for the local-echo lifecycle.
- Help/docs: `buildHelpDialog` key list + `website/docs/cli/tui.md` keybinding table row and a new "Mid-turn steering" section (step-boundary injection, buffer-of-10 limit, `steered ⟂` marker, `harnesscli steer` one-shot).

## Tests (strict TDD — failing first)

- `cmd/harnesscli/tui/steer_key_test.go`: `tea.KeyCtrlG` during an active run with typed input → httptest daemon observes POST `/v1/runs/{id}/steer` with the input text; input cleared; `RunActive()` still true; `cancelRun` NOT called; status "Steering sent". Idle press and empty/whitespace-input press → zero HTTP hits + status hint + input preserved. `SteerErrorMsg` kind→status mapping table (409/429/404/transport). `SteerAcceptedMsg` keeps the run alive.
- The ~3s per-test cost is the existing `statusTickCmd(3s)` driven synchronously by the shared `runCmd` helper — same trade the ctrl+c/cancel tests already make.

## Verification

- `go test ./cmd/harnesscli/... -count=1` — all packages ok
- `go test ./cmd/harnesscli/tui/ -count=1 -run 'TestTUI008|Steer|Escape|Cancel|CtrlC|Clipboard|SSE'` — ok (regression guards: `keys_test.go`, `escape_test.go`, `cancel_test.go`, `ctrlc_server_cancel_test.go`, `clipboard_test.go`, `sse_events_test.go` — esc-cancel and ctrl+s-copy unchanged)
- `go test ./internal/server/ ./internal/harness/ -count=1` — ok (12.026s / 2.719s)
- gofmt / `go vet ./cmd/harnesscli/...` — clean

Manual-smoke equivalent: `TestSteerKey_ActiveRunSendsInputClearsAndKeepsRunAlive` drives exactly the acceptance path (keypress during a long run → daemon receives the steer → run continues → input clears) against a live HTTP boundary.