### PR TITLE
test(cli): cover (*runBlockedError).Error sentinel contracts (#886)

### DIFF
--- a/cmd/harnesscli/exitcodes_test.go
+++ b/cmd/harnesscli/exitcodes_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -98,6 +100,33 @@ func TestBlockedEventReason(t *testing.T) {
 		if got := blockedEventReason(tc.event); got != tc.want {
 			t.Errorf("blockedEventReason(%q) = %q, want %q", tc.event, got, tc.want)
 		}
+	}
+}
+
+// TestRunBlockedErrorMessage pins the sentinel's two contracts: Error() names
+// the blocked event type (it surfaces verbatim if the error ever escapes the
+// run()/runContinue() handlers), and errors.As detection — the mechanism
+// run()/runContinue() use to map it to exitBlocked — keeps working through
+// wrapping.
+func TestRunBlockedErrorMessage(t *testing.T) {
+	for _, tc := range blockedSignals {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &runBlockedError{eventType: harness.EventType(tc.event)}
+			msg := err.Error()
+			for _, want := range []string{"run blocked", tc.event} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Error() = %q, want it to contain %q", msg, want)
+				}
+			}
+
+			var detected *runBlockedError
+			if !errors.As(fmt.Errorf("stream: %w", err), &detected) {
+				t.Fatal("errors.As must detect runBlockedError through wrapping")
+			}
+			if detected.eventType != harness.EventType(tc.event) {
+				t.Errorf("detected.eventType = %q, want %q", detected.eventType, tc.event)
+			}
+		})
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,11 @@
 # Engineering Log
 
+## 2026-07-21 (Issue #886 runBlockedError.Error Coverage Fix)
+
+- Symptom: post-merge regression gate (`scripts/test-regression.sh`) failed after PR #882 landed: `coveragegate` flagged `(*runBlockedError).Error` (cmd/harnesscli/main.go) at 0.0% — `functions with zero coverage detected`.
+- Cause: PR #882 added `runBlockedError` as a sentinel detected via `errors.As` in `run()`/`runContinue()`; its blocked-path tests assert exit code and stderr content but never invoke `Error()`, and the PR's validation ran package tests, not the full gate. Same failure shape as #875.
+- Fix (test-only): added `TestRunBlockedErrorMessage` in `cmd/harnesscli/exitcodes_test.go` — pins both sentinel contracts across all three blocked signals: `Error()` names the blocked event type, and `errors.As` detection survives wrapping. Function now reports 100%; no production code changed.
+
 ## 2026-07-20 (OS-Service Install for harnessd — Epic #807)
 
 - Shipped `harnesscli service install|uninstall|start|stop|status` for end users: user-level launchd agent on macOS (`~/Library/LaunchAgents/com.gocode.harnessd.plist`, `RunAtLoad`+`KeepAlive`) and `systemd --user` unit on Linux (`~/.config/systemd/user/harnessd.service`, `Restart=on-failure`, `WantedBy=default.target`). Slice 1 (PR #826): install/uninstall + pure unit generators with `--binary`/`--addr`/`--log-dir`/`--dry-run`; addr resolution reuses the daemon's own stack (`HARNESS_ADDR` env or `~/.harness/config.toml`, default `:8080`) exported into the unit environment. Slice 2 (PR #866): lifecycle commands over launchctl/systemctl behind an injectable runner; `status` distinguishes not-installed / installed-not-running / running-healthy / running-unreachable via a `GET /healthz` probe.


### PR DESCRIPTION
## Problem

Post-merge regression gate failed on main after PR #882: `coveragegate` flagged `(*runBlockedError).Error` (cmd/harnesscli/main.go:236) at 0.0% — the sentinel is detected via `errors.As` and its message was never produced on any tested path.

## Fix

Test-only: `TestRunBlockedErrorMessage` in `cmd/harnesscli/exitcodes_test.go` pins both sentinel contracts across all three blocked signals (question / tool approval / plan approval):

- `Error()` names the blocked event type (surfaces verbatim if the error ever escapes the handlers)
- `errors.As` detection — the mechanism `run()`/`runContinue()` use to map it to exit 3 — survives wrapping

## Validation

- `go test ./cmd/harnesscli/ -count=1` green
- `go tool cover -func` on the package profile: `main.go:236 Error` now 100.0%
- gofmt/vet clean

Closes #886