### PR TITLE
feat(mcp): OAuth 2.1 + PKCE authorization flow with localhost callback

### DIFF
--- a/docs/plans/809-mcp-oauth.md
+++ b/docs/plans/809-mcp-oauth.md
@@ -1,13 +1,20 @@
 # Plan: MCP OAuth login flow for remote servers (epic #809)
 
-## Slice 2: file-backed OAuth token store under `~/.harness/mcp/` (in implementation)
+## Slice 3: OAuth 2.1 + PKCE authorization flow with localhost callback (in implementation)
 
-- Goal: safe persistence for OAuth tokens, reusable by the flow (slice 3) and the transport (slice 4).
-- Changes: new `internal/mcp/tokens.go` — `Token` (issuer, access/refresh tokens, type, expiry, scopes), `TokenStore` with `Get(server)` / `Put(server, token)` / `Delete(server)`; one JSON file per server under `~/.harness/mcp/`, 0600 file / 0700 dir perms and atomic temp+rename writes mirroring `internal/provider/codex/store.go`; filename derived from the server name with `url.PathEscape` (traversal-safe, injective), recorded server name verified on read.
-- Expiry classification: `Get` returns the token (refresh token included) with an error wrapping `ErrTokenExpired` when expired, so callers refresh instead of failing; `ErrTokenNotFound` when absent; `ErrTokenCorrupt` for unreadable/mismatched files. Delete is idempotent.
-- Concurrency: store is mutex-guarded, safe for concurrent use.
-- Tests (TDD, temp-dir only, no writes outside injected dir): round-trip save/load, missing file, corrupt file (garbage/missing fields/server mismatch), permission bits via `os.Stat` (including pre-existing loose dir hardened to 0700), expiry classification (expired/future/zero/boundary via injected clock), overwrite, server-name sanitization, concurrent access under `-race`.
-- Acceptance: `go test ./internal/mcp/... -count=1` green.
+- Goal: browser-based login as a library function usable by the CLI (slice 4): discover endpoints, drive the browser, complete the exchange, store tokens, refresh silently.
+- Changes: new `internal/mcp/oauth` package (imports slice 2's `mcp.TokenStore`; no cycle — `internal/mcp` does not import it).
+  - Discovery: parse `WWW-Authenticate` on a 401 probe for `resource_metadata` → fetch protected-resource metadata (RFC 9728, well-known inserted before path, bare-origin retry) → fetch AS metadata (RFC 8414); fallback to well-known probing when the header is absent, and to a co-located AS at the resource origin.
+  - PKCE: S256 verifier/challenge on `crypto/rand`; random state.
+  - Loopback `net/http` listener on `127.0.0.1:0`, path `/callback`, first request wins, ctx-cancellable.
+  - Browser open via `os/exec` (`open`/`xdg-open`/`rundll32`), injectable as `Flow.OpenURL` so tests drive the redirect in-process.
+  - RFC 8707 `resource` parameter on the authorization request.
+  - Dynamic client registration (RFC 7591) when no client ID is configured and the AS advertises `registration_endpoint`; pre-registered client ID via `LoginOptions.ClientID`.
+  - Token exchange + `Refresh(serverName)` using the stored refresh token and recorded client ID (`ClientID` added to `mcp.Token` — additive); un-rotated refresh tokens are preserved; `invalid_grant` maps to `ErrReauthRequired`.
+- Tests (TDD; in-process `httptest` mock AS + mock resource server; no real network/browser/$HOME): full code+PKCE round trip with the browser stubbed (stub GETs the auth URL, mock AS 302s into the loopback), discovery via `WWW-Authenticate`, fallback when the header is absent, dynamic registration, pre-registered ID, missing-both error, state mismatch, AS error redirect, user abort via ctx cancel, token-endpoint error, refresh (success, un-rotated, invalid_grant, no token), PKCE known vector, `resource` param asserted.
+- Acceptance: `go test ./internal/mcp/oauth/... -count=1` green; round trip completes without real network or browser.
+
+## Slice 2: file-backed OAuth token store under `~/.harness/mcp/` (implemented, PR #856)
 
 ## Slice 1: MCP HTTP static headers and typed auth errors (implemented, PR #840)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -14,7 +14,7 @@
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator (merged), Slice 2 resume via resume_agent_ids (in implementation).
-- `809-mcp-oauth.md` — Epic #809: slice 1 (static HTTP headers + typed auth errors, merged PR #840) and slice 2 (file-backed OAuth token store, in implementation).
+- `809-mcp-oauth.md` — Epic #809: slices 1–2 (headers/typed errors, token store) merged; slice 3 (OAuth 2.1 + PKCE flow with localhost callback) in implementation.
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slice 1 client plumbing merged; slice 2 transcript rendering in review).
 

--- a/internal/mcp/oauth/browser.go
+++ b/internal/mcp/oauth/browser.go
@@ -1,0 +1,26 @@
+package oauth
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// openBrowser opens url in the user's default browser using the platform
+// launcher. It returns quickly: the browser completes the flow asynchronously
+// through the loopback listener.
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("oauth: launch browser (%s): %w", runtime.GOOS, err)
+	}
+	return nil
+}

--- a/internal/mcp/oauth/browser_test.go
+++ b/internal/mcp/oauth/browser_test.go
@@ -1,0 +1,56 @@
+package oauth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestOpenBrowser_InvokesPlatformLauncher verifies that openBrowser invokes
+// the platform launcher with the authorization URL. A fake launcher placed
+// on PATH records its arguments, so no real browser is started.
+func TestOpenBrowser_InvokesPlatformLauncher(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot shadow rundll32 with a PATH executable")
+	}
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "invoked-args.txt")
+
+	launcher := "xdg-open"
+	if runtime.GOOS == "darwin" {
+		launcher = "open"
+	}
+	script := "#!/bin/sh\nprintf '%s' \"$1\" > " + logPath + "\n"
+	if err := os.WriteFile(filepath.Join(dir, launcher), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	const authURL = "http://127.0.0.1:54321/callback?code=test&state=xyz"
+	if err := openBrowser(authURL); err != nil {
+		t.Fatalf("openBrowser: %v", err)
+	}
+
+	raw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("fake launcher was not invoked: %v", err)
+	}
+	if got := string(raw); got != authURL {
+		t.Errorf("launcher received %q, want %q", got, authURL)
+	}
+}
+
+// TestOpenBrowser_LauncherMissing_ReturnsError verifies a clear error when no
+// platform launcher is available, so callers can surface the manual URL.
+func TestOpenBrowser_LauncherMissing_ReturnsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot shadow rundll32 with a PATH executable")
+	}
+	t.Setenv("PATH", t.TempDir()) // nothing on PATH
+
+	if err := openBrowser("http://example.com/authorize"); err == nil {
+		t.Fatal("expected an error when the launcher is missing, got nil")
+	}
+}

--- a/internal/mcp/oauth/discovery.go
+++ b/internal/mcp/oauth/discovery.go
@@ -1,0 +1,235 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// asMetadata is the subset of OAuth authorization-server metadata (RFC 8414)
+// the flow needs.
+type asMetadata struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	RegistrationEndpoint  string   `json:"registration_endpoint,omitempty"`
+	CodeChallengeMethods  []string `json:"code_challenge_methods_supported,omitempty"`
+}
+
+// protectedResourceMetadata is the subset of OAuth protected-resource
+// metadata (RFC 9728) the flow needs.
+type protectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+}
+
+// ParseResourceMetadataURL extracts the resource_metadata parameter from a
+// WWW-Authenticate response header (RFC 9728 §5.1). It returns an error when
+// the header does not carry the parameter.
+func ParseResourceMetadataURL(header string) (string, error) {
+	const key = "resource_metadata"
+	rest := strings.TrimSpace(header)
+	if rest == "" {
+		return "", fmt.Errorf("oauth: WWW-Authenticate header is empty")
+	}
+	// Strip the auth scheme (the first token); the rest is a comma-separated
+	// auth-param list.
+	if i := strings.IndexAny(rest, " \t"); i >= 0 {
+		rest = rest[i+1:]
+	}
+	// Split comma-separated auth-params outside of quoted strings.
+	for _, part := range splitAuthParams(rest) {
+		name, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(name) != key {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"`)
+		if value == "" {
+			break
+		}
+		return value, nil
+	}
+	return "", fmt.Errorf("oauth: WWW-Authenticate header has no %s parameter", key)
+}
+
+// splitAuthParams splits a WWW-Authenticate value on commas that are not
+// inside quoted strings.
+func splitAuthParams(s string) []string {
+	var parts []string
+	var b strings.Builder
+	inQuotes := false
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+			b.WriteRune(r)
+		case r == ',' && !inQuotes:
+			parts = append(parts, b.String())
+			b.Reset()
+		default:
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() > 0 {
+		parts = append(parts, b.String())
+	}
+	return parts
+}
+
+// discoverASMetadata resolves the authorization-server metadata for an MCP
+// resource server:
+//
+//  1. Probe the resource URL without credentials; when the 401 response
+//     carries WWW-Authenticate with a resource_metadata parameter, fetch the
+//     protected-resource document from that URL (RFC 9728).
+//  2. Otherwise fetch the well-known protected-resource document derived
+//     from the resource URL.
+//  3. Resolve the issuer from the document's authorization_servers, falling
+//     back to the resource origin (co-located AS) when no document exists.
+//  4. Fetch the AS metadata document (RFC 8414).
+func (f *Flow) discoverASMetadata(ctx context.Context, resourceURL string) (*asMetadata, error) {
+	u, err := url.Parse(resourceURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("oauth: invalid resource URL %q", resourceURL)
+	}
+	origin := u.Scheme + "://" + u.Host
+
+	var issuer string
+
+	// Step 1: probe for a WWW-Authenticate hint.
+	prURL, probeErr := f.probeResourceMetadataURL(ctx, resourceURL)
+	if probeErr != nil {
+		return nil, probeErr
+	}
+
+	// Step 2: fetch the protected-resource document, from the header-provided
+	// URL when present, otherwise from the well-known location.
+	if prURL != "" {
+		issuer, err = f.fetchAuthorizationServer(ctx, prURL)
+		if err != nil {
+			return nil, fmt.Errorf("oauth: protected resource metadata from WWW-Authenticate: %w", err)
+		}
+	} else {
+		issuer, err = f.fetchAuthorizationServer(ctx, wellKnownURL(origin, u.EscapedPath(), "oauth-protected-resource"))
+		if err != nil && u.EscapedPath() != "" && u.EscapedPath() != "/" {
+			// Some servers only serve the bare origin form; retry it.
+			issuer, err = f.fetchAuthorizationServer(ctx, wellKnownURL(origin, "", "oauth-protected-resource"))
+		}
+		if err != nil {
+			// No protected-resource document: assume a co-located AS at the
+			// resource origin.
+			issuer = origin
+		}
+	}
+
+	// Step 3: fetch the AS metadata document.
+	issuerURL, err := url.Parse(issuer)
+	if err != nil || issuerURL.Scheme == "" || issuerURL.Host == "" {
+		return nil, fmt.Errorf("oauth: invalid authorization server %q", issuer)
+	}
+	issuerOrigin := issuerURL.Scheme + "://" + issuerURL.Host
+	meta, err := f.fetchASMetadata(ctx, wellKnownURL(issuerOrigin, issuerURL.EscapedPath(), "oauth-authorization-server"))
+	if err != nil && issuer != origin {
+		// Last resort: a co-located AS at the resource origin.
+		meta, err = f.fetchASMetadata(ctx, wellKnownURL(origin, "", "oauth-authorization-server"))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("oauth: discover authorization server metadata for %q: %w", resourceURL, err)
+	}
+	if meta.AuthorizationEndpoint == "" || meta.TokenEndpoint == "" {
+		return nil, fmt.Errorf("oauth: authorization server metadata for %q is missing endpoints", resourceURL)
+	}
+	return meta, nil
+}
+
+// probeResourceMetadataURL performs an unauthenticated GET against the
+// resource URL and extracts the resource_metadata parameter from a 401
+// WWW-Authenticate header. It returns ("", nil) when the response carries no
+// usable hint, leaving discovery to the well-known fallback.
+func (f *Flow) probeResourceMetadataURL(ctx context.Context, resourceURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resourceURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("oauth: probe resource server: %w", err)
+	}
+	resp, err := f.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("oauth: probe resource server %q: %w", resourceURL, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		return "", nil
+	}
+	prURL, err := ParseResourceMetadataURL(resp.Header.Get("WWW-Authenticate"))
+	if err != nil {
+		return "", nil // header without the parameter: fall back to well-known
+	}
+	return prURL, nil
+}
+
+// fetchAuthorizationServer fetches a protected-resource metadata document and
+// returns its first authorization server.
+func (f *Flow) fetchAuthorizationServer(ctx context.Context, metadataURL string) (string, error) {
+	var doc protectedResourceMetadata
+	if err := f.getJSON(ctx, metadataURL, &doc); err != nil {
+		return "", err
+	}
+	if len(doc.AuthorizationServers) == 0 || doc.AuthorizationServers[0] == "" {
+		return "", fmt.Errorf("oauth: protected resource metadata at %q lists no authorization servers", metadataURL)
+	}
+	return doc.AuthorizationServers[0], nil
+}
+
+// fetchASMetadata fetches and validates an AS metadata document.
+func (f *Flow) fetchASMetadata(ctx context.Context, metadataURL string) (*asMetadata, error) {
+	var meta asMetadata
+	if err := f.getJSON(ctx, metadataURL, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+// getJSON performs a GET and decodes a 2xx JSON body.
+func (f *Flow) getJSON(ctx context.Context, rawURL string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("oauth: create request for %q: %w", rawURL, err)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := f.httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("oauth: fetch %q: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return fmt.Errorf("oauth: fetch %q: HTTP %d", rawURL, resp.StatusCode)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(out); err != nil {
+		return fmt.Errorf("oauth: decode %q: %w", rawURL, err)
+	}
+	return nil
+}
+
+// wellKnownURL builds a well-known URI by inserting "/.well-known/<name>"
+// between the origin and the path, per RFC 8414 §3.1 / RFC 9728 §3.1. When
+// the inserted form fails (some servers only serve the bare form), callers
+// retry with the bare origin form; wellKnownURL with an empty path yields the
+// bare form directly.
+func wellKnownURL(origin, escapedPath, name string) string {
+	base := strings.TrimSuffix(origin, "/") + "/.well-known/" + name
+	path := strings.TrimPrefix(escapedPath, "/")
+	if path != "" {
+		base += "/" + path
+	}
+	return base
+}

--- a/internal/mcp/oauth/discovery_test.go
+++ b/internal/mcp/oauth/discovery_test.go
@@ -1,0 +1,140 @@
+package oauth
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParseResourceMetadataURL covers WWW-Authenticate parsing for the
+// resource_metadata parameter (RFC 9728).
+func TestParseResourceMetadataURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		header  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "quoted value",
+			header: `Bearer resource_metadata="https://rs.example.com/.well-known/oauth-protected-resource"`,
+			want:   "https://rs.example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:   "with realm before",
+			header: `Bearer realm="mcp", resource_metadata="https://rs.example.com/pr"`,
+			want:   "https://rs.example.com/pr",
+		},
+		{
+			name:   "with realm after",
+			header: `Bearer resource_metadata="https://rs.example.com/pr", realm="mcp"`,
+			want:   "https://rs.example.com/pr",
+		},
+		{
+			name:   "unquoted token value",
+			header: `Bearer resource_metadata=https://rs.example.com/pr`,
+			want:   "https://rs.example.com/pr",
+		},
+		{
+			name:   "extra whitespace",
+			header: `Bearer   resource_metadata = "https://rs.example.com/pr" `,
+			want:   "https://rs.example.com/pr",
+		},
+		{name: "no bearer scheme", header: `Basic realm="x"`, wantErr: true},
+		{name: "no resource_metadata param", header: `Bearer realm="mcp"`, wantErr: true},
+		{name: "empty", header: ``, wantErr: true},
+		{name: "empty value", header: `Bearer resource_metadata=""`, wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseResourceMetadataURL(tc.header)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseResourceMetadataURL(%q): expected error, got %q", tc.header, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseResourceMetadataURL(%q): %v", tc.header, err)
+			}
+			if got != tc.want {
+				t.Errorf("ParseResourceMetadataURL(%q) = %q, want %q", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPKCE_KnownVector checks the S256 challenge against the RFC 7636
+// appendix B example.
+func TestPKCE_KnownVector(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	want := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if got := CodeChallengeS256(verifier); got != want {
+		t.Errorf("CodeChallengeS256(%q) = %q, want RFC 7636 vector %q", verifier, got, want)
+	}
+}
+
+// TestPKCE_VerifierProperties verifies verifier shape and uniqueness.
+func TestPKCE_VerifierProperties(t *testing.T) {
+	v1, err := GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier: %v", err)
+	}
+	v2, err := GenerateCodeVerifier()
+	if err != nil {
+		t.Fatalf("GenerateCodeVerifier: %v", err)
+	}
+	// 32 bytes base64url-encoded without padding = 43 characters.
+	if len(v1) != 43 {
+		t.Errorf("verifier length = %d, want 43", len(v1))
+	}
+	if strings.ContainsAny(v1, "+/=") {
+		t.Errorf("verifier %q is not base64url (no padding)", v1)
+	}
+	if v1 == v2 {
+		t.Error("two verifiers should not be equal")
+	}
+}
+
+// TestDiscover_CoLocatedASFallback verifies that when the resource server has
+// no protected-resource document at all, discovery falls back to AS metadata
+// at the resource origin (a co-located authorization server).
+func TestDiscover_CoLocatedASFallback(t *testing.T) {
+	// The mock AS serves its metadata at its origin; pointing the "resource"
+	// at the same origin exercises the co-located fallback.
+	as := newMockAuthorizationServer(t, nil)
+
+	flow := &Flow{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	meta, err := flow.discoverASMetadata(ctx, as.url()+"/mcp")
+	if err != nil {
+		t.Fatalf("discoverASMetadata: %v", err)
+	}
+	if meta.AuthorizationEndpoint != as.url()+"/authorize" {
+		t.Errorf("AuthorizationEndpoint = %q, want %q", meta.AuthorizationEndpoint, as.url()+"/authorize")
+	}
+	if meta.TokenEndpoint != as.url()+"/token" {
+		t.Errorf("TokenEndpoint = %q, want %q", meta.TokenEndpoint, as.url()+"/token")
+	}
+	if meta.Issuer != as.url() {
+		t.Errorf("Issuer = %q, want %q", meta.Issuer, as.url())
+	}
+}
+
+// TestDiscover_Unreachable verifies a clear error when the resource server
+// cannot be reached.
+func TestDiscover_Unreachable(t *testing.T) {
+	flow := &Flow{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Port 1 on loopback is closed.
+	_, err := flow.discoverASMetadata(ctx, "http://127.0.0.1:1/mcp")
+	if err == nil {
+		t.Fatal("expected error for unreachable server, got nil")
+	}
+}

--- a/internal/mcp/oauth/mock_test.go
+++ b/internal/mcp/oauth/mock_test.go
@@ -1,0 +1,374 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockAuthorizationServer is an in-process OAuth 2.1 authorization server for
+// tests. It serves AS metadata, an authorization endpoint that 302-redirects
+// with a code, a token endpoint that validates the PKCE verifier against the
+// challenge recorded at authorization time, and optional RFC 7591 dynamic
+// client registration.
+type mockAuthorizationServer struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu            sync.Mutex
+	authRequests  []authorizeRequest
+	tokenRequests []url.Values
+	registerHits  int
+	codes         map[string]string // code -> code_challenge
+	refreshTokens map[string]bool   // known refresh tokens
+	codeCounter   int
+	tokenCounter  int
+
+	// Behavior knobs.
+	enableRegistration bool   // advertise and serve /register
+	nextClientID       string // client ID handed out by /register
+	redirectError      string // if set, /authorize redirects with ?error=
+	redirectState      string // if set, /authorize redirects with this state instead of the client's
+	tokenError         string // if set, /token always fails with this error code
+	noRotateRefresh    bool   // if set, refresh grants do not return a new refresh_token
+	allowClientID      string // if set, /authorize and /token reject other client IDs
+}
+
+type authorizeRequest struct {
+	ClientID            string
+	RedirectURI         string
+	State               string
+	Scope               string
+	Resource            string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	ResponseType        string
+}
+
+func newMockAuthorizationServer(t *testing.T, configure func(*mockAuthorizationServer)) *mockAuthorizationServer {
+	t.Helper()
+	m := &mockAuthorizationServer{
+		t:             t,
+		codes:         make(map[string]string),
+		refreshTokens: make(map[string]bool),
+		nextClientID:  "dyn-client-1",
+	}
+	if configure != nil {
+		configure(m)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", m.handleMetadata)
+	mux.HandleFunc("/authorize", m.handleAuthorize)
+	mux.HandleFunc("/token", m.handleToken)
+	mux.HandleFunc("/register", m.handleRegister)
+	m.srv = httptest.NewServer(mux)
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *mockAuthorizationServer) url() string { return m.srv.URL }
+
+func (m *mockAuthorizationServer) handleMetadata(w http.ResponseWriter, r *http.Request) {
+	meta := map[string]any{
+		"issuer":                                m.srv.URL,
+		"authorization_endpoint":                m.srv.URL + "/authorize",
+		"token_endpoint":                        m.srv.URL + "/token",
+		"code_challenge_methods_supported":      []string{"S256"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+	}
+	if m.enableRegistration {
+		meta["registration_endpoint"] = m.srv.URL + "/register"
+	}
+	writeJSON(w, http.StatusOK, meta)
+}
+
+func (m *mockAuthorizationServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	req := authorizeRequest{
+		ClientID:            q.Get("client_id"),
+		RedirectURI:         q.Get("redirect_uri"),
+		State:               q.Get("state"),
+		Scope:               q.Get("scope"),
+		Resource:            q.Get("resource"),
+		CodeChallenge:       q.Get("code_challenge"),
+		CodeChallengeMethod: q.Get("code_challenge_method"),
+		ResponseType:        q.Get("response_type"),
+	}
+
+	m.mu.Lock()
+	m.authRequests = append(m.authRequests, req)
+	m.mu.Unlock()
+
+	redirect, err := url.Parse(req.RedirectURI)
+	if err != nil || redirect.Scheme == "" {
+		http.Error(w, "bad redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	state := req.State
+	if m.redirectState != "" {
+		state = m.redirectState
+	}
+	out := redirect.Query()
+
+	if m.redirectError != "" {
+		out.Set("error", m.redirectError)
+		out.Set("error_description", "mock AS: "+m.redirectError)
+		out.Set("state", state)
+		redirect.RawQuery = out.Encode()
+		http.Redirect(w, r, redirect.String(), http.StatusFound)
+		return
+	}
+
+	if req.ResponseType != "code" || req.ClientID == "" || req.CodeChallenge == "" {
+		out.Set("error", "invalid_request")
+		out.Set("state", state)
+		redirect.RawQuery = out.Encode()
+		http.Redirect(w, r, redirect.String(), http.StatusFound)
+		return
+	}
+	if m.allowClientID != "" && req.ClientID != m.allowClientID {
+		out.Set("error", "unauthorized_client")
+		out.Set("state", state)
+		redirect.RawQuery = out.Encode()
+		http.Redirect(w, r, redirect.String(), http.StatusFound)
+		return
+	}
+
+	m.mu.Lock()
+	m.codeCounter++
+	code := fmt.Sprintf("code-%d", m.codeCounter)
+	m.codes[code] = req.CodeChallenge
+	m.mu.Unlock()
+
+	out.Set("code", code)
+	out.Set("state", state)
+	redirect.RawQuery = out.Encode()
+	http.Redirect(w, r, redirect.String(), http.StatusFound)
+}
+
+func (m *mockAuthorizationServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request")
+		return
+	}
+	m.mu.Lock()
+	clone := make(url.Values, len(r.Form))
+	for k, vs := range r.Form {
+		clone[k] = append([]string(nil), vs...)
+	}
+	m.tokenRequests = append(m.tokenRequests, clone)
+	m.mu.Unlock()
+
+	if m.tokenError != "" {
+		writeOAuthError(w, http.StatusBadRequest, m.tokenError)
+		return
+	}
+
+	switch r.Form.Get("grant_type") {
+	case "authorization_code":
+		m.handleCodeGrant(w, r)
+	case "refresh_token":
+		m.handleRefreshGrant(w, r)
+	default:
+		writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type")
+	}
+}
+
+func (m *mockAuthorizationServer) handleCodeGrant(w http.ResponseWriter, r *http.Request) {
+	code := r.Form.Get("code")
+	verifier := r.Form.Get("code_verifier")
+	clientID := r.Form.Get("client_id")
+
+	m.mu.Lock()
+	challenge, known := m.codes[code]
+	m.mu.Unlock()
+
+	if !known {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	if m.allowClientID != "" && clientID != m.allowClientID {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client")
+		return
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	if base64.RawURLEncoding.EncodeToString(sum[:]) != challenge {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+
+	m.mu.Lock()
+	m.tokenCounter++
+	access := fmt.Sprintf("as-access-%d", m.tokenCounter)
+	refresh := fmt.Sprintf("as-refresh-%d", m.tokenCounter)
+	m.refreshTokens[refresh] = true
+	m.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  access,
+		"refresh_token": refresh,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+	})
+}
+
+func (m *mockAuthorizationServer) handleRefreshGrant(w http.ResponseWriter, r *http.Request) {
+	refresh := r.Form.Get("refresh_token")
+
+	m.mu.Lock()
+	known := m.refreshTokens[refresh]
+	m.mu.Unlock()
+	if !known {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+
+	m.mu.Lock()
+	m.tokenCounter++
+	access := fmt.Sprintf("as-access-%d", m.tokenCounter)
+	resp := map[string]any{
+		"access_token": access,
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+	}
+	if !m.noRotateRefresh {
+		newRefresh := fmt.Sprintf("as-refresh-%d", m.tokenCounter)
+		m.refreshTokens[newRefresh] = true
+		delete(m.refreshTokens, refresh)
+		resp["refresh_token"] = newRefresh
+	}
+	m.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (m *mockAuthorizationServer) handleRegister(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	m.registerHits++
+	m.mu.Unlock()
+	if !m.enableRegistration {
+		writeOAuthError(w, http.StatusNotFound, "not_found")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"client_id":   m.nextClientID,
+		"client_name": "go-agent-harness",
+	})
+}
+
+// --- accessors used by tests ---
+
+func (m *mockAuthorizationServer) lastAuthorize() authorizeRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.authRequests) == 0 {
+		return authorizeRequest{}
+	}
+	return m.authRequests[len(m.authRequests)-1]
+}
+
+func (m *mockAuthorizationServer) registerCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.registerHits
+}
+
+func (m *mockAuthorizationServer) tokenGrantTypes() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, 0, len(m.tokenRequests))
+	for _, tr := range m.tokenRequests {
+		out = append(out, tr.Get("grant_type"))
+	}
+	return out
+}
+
+// --- helpers ---
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeOAuthError(w http.ResponseWriter, status int, code string) {
+	writeJSON(w, status, map[string]any{"error": code, "error_description": "mock AS error: " + code})
+}
+
+// mockResourceServer is an in-process MCP resource server that requires
+// OAuth. Unauthenticated requests get a 401; when withMetadataHeader is set,
+// the 401 carries a WWW-Authenticate header with a resource_metadata pointer
+// (RFC 9728). The protected-resource document is served at
+// protectedResourcePath — tests move it off the well-known location to prove
+// header-driven discovery, or drop the header parameter to force the
+// well-known fallback.
+type mockResourceServer struct {
+	srv *httptest.Server
+
+	asURL                 string
+	withMetadataHeader    bool
+	protectedResourcePath string
+}
+
+func newMockResourceServer(t *testing.T, asURL string, configure func(*mockResourceServer)) *mockResourceServer {
+	t.Helper()
+	m := &mockResourceServer{
+		asURL:                 asURL,
+		withMetadataHeader:    true,
+		protectedResourcePath: "/.well-known/oauth-protected-resource",
+	}
+	if configure != nil {
+		configure(m)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", m.handleMCP)
+	mux.HandleFunc(m.protectedResourcePath, m.handleProtectedResource)
+	m.srv = httptest.NewServer(mux)
+	t.Cleanup(m.srv.Close)
+	return m
+}
+
+func (m *mockResourceServer) mcpURL() string { return m.srv.URL + "/mcp" }
+
+func (m *mockResourceServer) handleMCP(w http.ResponseWriter, r *http.Request) {
+	if m.withMetadataHeader {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata=%q`, m.srv.URL+m.protectedResourcePath))
+	} else {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp"`)
+	}
+	w.WriteHeader(http.StatusUnauthorized)
+}
+
+func (m *mockResourceServer) handleProtectedResource(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resource":              m.mcpURL(),
+		"authorization_servers": []string{m.asURL},
+	})
+}
+
+// browserViaHTTP returns an OpenURL stub that performs the user-agent step
+// in-process: it GETs the authorization URL and follows the redirect, which
+// lands on the flow's loopback callback server.
+func browserViaHTTP(t *testing.T) func(string) error {
+	t.Helper()
+	return func(rawurl string) error {
+		if !strings.HasPrefix(rawurl, "http://") && !strings.HasPrefix(rawurl, "https://") {
+			return fmt.Errorf("unexpected browser URL: %q", rawurl)
+		}
+		resp, err := http.Get(rawurl) //nolint: no real network — mock servers are loopback
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		return nil
+	}
+}

--- a/internal/mcp/oauth/oauth.go
+++ b/internal/mcp/oauth/oauth.go
@@ -1,0 +1,480 @@
+// Package oauth implements the OAuth 2.1 authorization-code flow with PKCE
+// that go-agent-harness uses to log in to remote MCP servers: metadata
+// discovery (RFC 9728 / RFC 8414), a localhost loopback redirect listener,
+// optional dynamic client registration (RFC 7591), token exchange, and
+// silent refresh. Tokens are persisted through the mcp.TokenStore from
+// epic #809 slice 2.
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/mcp"
+)
+
+// ErrReauthRequired marks failures that only a fresh interactive login can
+// fix — the AS rejected the refresh token (invalid_grant) or none is stored.
+var ErrReauthRequired = errors.New("oauth: re-authentication required")
+
+// Flow drives OAuth login and refresh for MCP servers. The zero value is
+// usable except that Store is required.
+type Flow struct {
+	// HTTPClient is used for metadata, registration, and token endpoint
+	// calls. Nil selects a default client with a 30s timeout.
+	HTTPClient *http.Client
+	// Store persists issued tokens. Required.
+	Store *mcp.TokenStore
+	// OpenURL opens the authorization URL in the user's browser. Nil selects
+	// the platform default (open / xdg-open / rundll32). Tests inject an
+	// in-process driver.
+	OpenURL func(string) error
+	// ClientName is advertised during dynamic client registration.
+	// Empty selects "go-agent-harness".
+	ClientName string
+}
+
+// LoginOptions configures one Login call.
+type LoginOptions struct {
+	// ServerName is the MCP server's configured name; the issued token is
+	// stored under this key. Required.
+	ServerName string
+	// ResourceURL is the MCP server's HTTP endpoint URL. Required.
+	ResourceURL string
+	// ClientID is a pre-registered OAuth client ID. When empty and the
+	// authorization server advertises a registration endpoint, a client is
+	// registered dynamically (RFC 7591).
+	ClientID string
+	// Scopes optionally limits the requested scopes.
+	Scopes []string
+}
+
+func (f *Flow) httpClient() *http.Client {
+	if f.HTTPClient != nil {
+		return f.HTTPClient
+	}
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func (f *Flow) clientName() string {
+	if f.ClientName != "" {
+		return f.ClientName
+	}
+	return "go-agent-harness"
+}
+
+// Login runs the full authorization-code + PKCE flow against the resource
+// server in opts: discover the authorization server, open the browser at the
+// authorization URL, wait for the loopback redirect, exchange the code, and
+// persist the token in the store. The context bounds the whole operation —
+// cancelling it (e.g. the user aborts) unblocks the wait for the browser.
+func (f *Flow) Login(ctx context.Context, opts LoginOptions) (mcp.Token, error) {
+	if f.Store == nil {
+		return mcp.Token{}, fmt.Errorf("oauth: token store is required")
+	}
+	if strings.TrimSpace(opts.ServerName) == "" {
+		return mcp.Token{}, fmt.Errorf("oauth: server name is required")
+	}
+	if strings.TrimSpace(opts.ResourceURL) == "" {
+		return mcp.Token{}, fmt.Errorf("oauth: resource URL is required")
+	}
+
+	meta, err := f.discoverASMetadata(ctx, opts.ResourceURL)
+	if err != nil {
+		return mcp.Token{}, err
+	}
+	if len(meta.CodeChallengeMethods) > 0 && !slicesContains(meta.CodeChallengeMethods, "S256") {
+		return mcp.Token{}, fmt.Errorf("oauth: authorization server %q does not support PKCE S256", meta.Issuer)
+	}
+
+	verifier, err := GenerateCodeVerifier()
+	if err != nil {
+		return mcp.Token{}, err
+	}
+	state, err := generateState()
+	if err != nil {
+		return mcp.Token{}, err
+	}
+
+	// Start the loopback listener before registration so the redirect URI is
+	// known when registering the client.
+	cb, err := startCallbackListener()
+	if err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: start loopback listener: %w", err)
+	}
+	defer cb.close()
+
+	clientID := strings.TrimSpace(opts.ClientID)
+	if clientID == "" {
+		if meta.RegistrationEndpoint == "" {
+			return mcp.Token{}, fmt.Errorf("oauth: no client ID configured for server %q and the authorization server does not support dynamic client registration; configure one in the server's headers/auth settings", opts.ServerName)
+		}
+		clientID, err = f.registerDynamicClient(ctx, meta.RegistrationEndpoint, cb.redirectURI)
+		if err != nil {
+			return mcp.Token{}, err
+		}
+	}
+
+	authURL, err := buildAuthorizationURL(meta.AuthorizationEndpoint, authorizeParams{
+		ClientID:      clientID,
+		RedirectURI:   cb.redirectURI,
+		State:         state,
+		Scope:         strings.Join(opts.Scopes, " "),
+		Resource:      opts.ResourceURL,
+		CodeChallenge: CodeChallengeS256(verifier),
+	})
+	if err != nil {
+		return mcp.Token{}, err
+	}
+
+	openURL := f.OpenURL
+	if openURL == nil {
+		openURL = openBrowser
+	}
+	if err := openURL(authURL); err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: could not open the browser: %w (open this URL manually: %s)", err, authURL)
+	}
+
+	res, err := cb.wait(ctx)
+	if err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: login for server %q aborted: %w", opts.ServerName, err)
+	}
+	if res.errCode != "" {
+		return mcp.Token{}, fmt.Errorf("oauth: authorization failed for server %q: %s (%s)", opts.ServerName, res.errCode, res.errDesc)
+	}
+	if res.state != state {
+		return mcp.Token{}, fmt.Errorf("oauth: state mismatch for server %q: the callback does not belong to this login attempt", opts.ServerName)
+	}
+	if res.code == "" {
+		return mcp.Token{}, fmt.Errorf("oauth: authorization response for server %q carried no code", opts.ServerName)
+	}
+
+	tr, err := f.postTokenRequest(ctx, meta.TokenEndpoint, url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {res.code},
+		"redirect_uri":  {cb.redirectURI},
+		"client_id":     {clientID},
+		"code_verifier": {verifier},
+	})
+	if err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: token exchange for server %q: %w", opts.ServerName, err)
+	}
+
+	tok := buildToken(meta.Issuer, clientID, opts.Scopes, mcp.Token{}, tr)
+	if err := f.Store.Put(opts.ServerName, tok); err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: store token for server %q: %w", opts.ServerName, err)
+	}
+	return tok, nil
+}
+
+// Refresh silently renews the stored token for serverName using its refresh
+// token and writes the result back to the store. When the AS does not rotate
+// the refresh token, the previous one is preserved. An invalid_grant
+// response maps to ErrReauthRequired and leaves the stored token untouched.
+func (f *Flow) Refresh(ctx context.Context, serverName string) (mcp.Token, error) {
+	if f.Store == nil {
+		return mcp.Token{}, fmt.Errorf("oauth: token store is required")
+	}
+
+	tok, err := f.Store.Get(serverName)
+	if err != nil {
+		if errors.Is(err, mcp.ErrTokenExpired) {
+			// An expired access token is exactly what Refresh is for; the
+			// returned token still carries the refresh token.
+		} else {
+			return mcp.Token{}, fmt.Errorf("oauth: load token for server %q: %w", serverName, err)
+		}
+	}
+	if tok.RefreshToken == "" {
+		return mcp.Token{}, fmt.Errorf("oauth: no refresh token stored for server %q: %w", serverName, ErrReauthRequired)
+	}
+	if tok.Issuer == "" {
+		return mcp.Token{}, fmt.Errorf("oauth: stored token for server %q has no issuer; cannot rediscover the authorization server: %w", serverName, ErrReauthRequired)
+	}
+
+	meta, err := f.discoverFromIssuer(ctx, tok.Issuer)
+	if err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: rediscover authorization server for %q: %w", serverName, err)
+	}
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tok.RefreshToken},
+	}
+	if tok.ClientID != "" {
+		form.Set("client_id", tok.ClientID)
+	}
+	tr, err := f.postTokenRequest(ctx, meta.TokenEndpoint, form)
+	if err != nil {
+		var oe *oauthError
+		if errors.As(err, &oe) && oe.Code == "invalid_grant" {
+			return mcp.Token{}, fmt.Errorf("oauth: refresh token for server %q was rejected; log in again: %w", serverName, ErrReauthRequired)
+		}
+		return mcp.Token{}, fmt.Errorf("oauth: refresh token for server %q: %w", serverName, err)
+	}
+
+	newTok := buildToken(tok.Issuer, tok.ClientID, tok.Scopes, tok, tr)
+	if err := f.Store.Put(serverName, newTok); err != nil {
+		return mcp.Token{}, fmt.Errorf("oauth: store refreshed token for server %q: %w", serverName, err)
+	}
+	return newTok, nil
+}
+
+// discoverFromIssuer fetches AS metadata starting from a known issuer.
+func (f *Flow) discoverFromIssuer(ctx context.Context, issuer string) (*asMetadata, error) {
+	u, err := url.Parse(issuer)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("oauth: invalid issuer %q", issuer)
+	}
+	origin := u.Scheme + "://" + u.Host
+	meta, err := f.fetchASMetadata(ctx, wellKnownURL(origin, u.EscapedPath(), "oauth-authorization-server"))
+	if err != nil && u.EscapedPath() != "" && u.EscapedPath() != "/" {
+		meta, err = f.fetchASMetadata(ctx, wellKnownURL(origin, "", "oauth-authorization-server"))
+	}
+	if err != nil {
+		return nil, err
+	}
+	if meta.TokenEndpoint == "" {
+		return nil, fmt.Errorf("oauth: authorization server metadata for issuer %q has no token endpoint", issuer)
+	}
+	return meta, nil
+}
+
+// authorizeParams are the query parameters of an authorization request.
+type authorizeParams struct {
+	ClientID      string
+	RedirectURI   string
+	State         string
+	Scope         string
+	Resource      string
+	CodeChallenge string
+}
+
+// buildAuthorizationURL assembles the authorization URL the browser opens.
+func buildAuthorizationURL(endpoint string, p authorizeParams) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("oauth: invalid authorization endpoint %q", endpoint)
+	}
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", p.ClientID)
+	q.Set("redirect_uri", p.RedirectURI)
+	q.Set("state", p.State)
+	q.Set("code_challenge", p.CodeChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("resource", p.Resource) // RFC 8707
+	if p.Scope != "" {
+		q.Set("scope", p.Scope)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// registerDynamicClient registers a public client per RFC 7591 and returns
+// the issued client ID.
+func (f *Flow) registerDynamicClient(ctx context.Context, endpoint, redirectURI string) (string, error) {
+	body, err := json.Marshal(map[string]any{
+		"client_name":                f.clientName(),
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	})
+	if err != nil {
+		return "", fmt.Errorf("oauth: encode registration request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(string(body)))
+	if err != nil {
+		return "", fmt.Errorf("oauth: create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("oauth: register client: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		return "", fmt.Errorf("oauth: register client: HTTP %d", resp.StatusCode)
+	}
+	var out struct {
+		ClientID string `json:"client_id"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return "", fmt.Errorf("oauth: decode registration response: %w", err)
+	}
+	if out.ClientID == "" {
+		return "", fmt.Errorf("oauth: registration response carried no client_id")
+	}
+	return out.ClientID, nil
+}
+
+// tokenResponse is the success body of a token endpoint response.
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int64  `json:"expires_in"`
+	Scope        string `json:"scope"`
+}
+
+// oauthError is an OAuth error response body (RFC 6749 §5.2).
+type oauthError struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description"`
+}
+
+func (e *oauthError) Error() string {
+	if e.Description != "" {
+		return fmt.Sprintf("%s: %s", e.Code, e.Description)
+	}
+	return e.Code
+}
+
+// postTokenRequest submits a form to the token endpoint and decodes the
+// success response; OAuth error bodies are returned as *oauthError.
+func (f *Flow) postTokenRequest(ctx context.Context, endpoint string, form url.Values) (*tokenResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("oauth: create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oauth: call token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var oe oauthError
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&oe); err == nil && oe.Code != "" {
+			return nil, &oe
+		}
+		return nil, fmt.Errorf("oauth: token endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&tr); err != nil {
+		return nil, fmt.Errorf("oauth: decode token response: %w", err)
+	}
+	if tr.AccessToken == "" {
+		return nil, fmt.Errorf("oauth: token response carried no access_token")
+	}
+	return &tr, nil
+}
+
+// buildToken merges a token endpoint response into an mcp.Token. prev carries
+// the values to preserve (refresh token, scopes) when the response omits them.
+func buildToken(issuer, clientID string, requestedScopes []string, prev mcp.Token, tr *tokenResponse) mcp.Token {
+	tok := mcp.Token{
+		Issuer:       issuer,
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		TokenType:    tr.TokenType,
+		ClientID:     clientID,
+	}
+	if tok.TokenType == "" {
+		tok.TokenType = "Bearer"
+	}
+	if tok.RefreshToken == "" {
+		tok.RefreshToken = prev.RefreshToken
+	}
+	if tr.ExpiresIn > 0 {
+		tok.Expiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	}
+	switch {
+	case tr.Scope != "":
+		tok.Scopes = strings.Fields(tr.Scope)
+	case len(prev.Scopes) > 0:
+		tok.Scopes = prev.Scopes
+	default:
+		tok.Scopes = requestedScopes
+	}
+	return tok
+}
+
+// callbackResult is the parsed loopback redirect.
+type callbackResult struct {
+	code    string
+	state   string
+	errCode string
+	errDesc string
+}
+
+// callbackListener is the loopback HTTP server that receives the redirect.
+type callbackListener struct {
+	srv         *http.Server
+	redirectURI string
+	results     chan callbackResult
+}
+
+// startCallbackListener binds an ephemeral loopback port and serves the
+// redirect handler until closed. The first /callback request wins.
+func startCallbackListener() (*callbackListener, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	cb := &callbackListener{
+		redirectURI: fmt.Sprintf("http://127.0.0.1:%d/callback", ln.Addr().(*net.TCPAddr).Port),
+		results:     make(chan callbackResult, 1),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		res := callbackResult{
+			code:    q.Get("code"),
+			state:   q.Get("state"),
+			errCode: q.Get("error"),
+			errDesc: q.Get("error_description"),
+		}
+		select {
+		case cb.results <- res:
+		default:
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, "<!doctype html><title>go-code login</title><p>Login complete — you can close this tab and return to the terminal.</p>")
+	})
+	cb.srv = &http.Server{Handler: mux}
+	go func() { _ = cb.srv.Serve(ln) }()
+	return cb, nil
+}
+
+// wait blocks until the first callback arrives or ctx is done.
+func (cb *callbackListener) wait(ctx context.Context) (callbackResult, error) {
+	select {
+	case res := <-cb.results:
+		return res, nil
+	case <-ctx.Done():
+		return callbackResult{}, ctx.Err()
+	}
+}
+
+// close shuts the listener down.
+func (cb *callbackListener) close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = cb.srv.Shutdown(ctx)
+}
+
+func slicesContains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/oauth/oauth_test.go
+++ b/internal/mcp/oauth/oauth_test.go
@@ -1,0 +1,481 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/mcp"
+)
+
+func newTestFlow(store *mcp.TokenStore, openURL func(string) error) *Flow {
+	return &Flow{Store: store, OpenURL: openURL}
+}
+
+// TestLogin_FullPKCERoundTrip_HeaderDiscovery is the slice acceptance test: a
+// full authorization-code + PKCE login against in-process mock servers,
+// discovered via the WWW-Authenticate resource_metadata header, completing
+// without a real network or browser.
+func TestLogin_FullPKCERoundTrip_HeaderDiscovery(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.enableRegistration = false
+	})
+	// The protected-resource document lives at a NON-standard location that
+	// only the WWW-Authenticate header points to; well-known probing would
+	// fail, so success proves header-driven discovery.
+	rs := newMockResourceServer(t, as.url(), func(m *mockResourceServer) {
+		m.withMetadataHeader = true
+		m.protectedResourcePath = "/custom/pr-meta"
+	})
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "demo",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+		Scopes:      []string{"mcp"},
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	if !strings.HasPrefix(tok.AccessToken, "as-access-") {
+		t.Errorf("AccessToken = %q, want mock-issued token", tok.AccessToken)
+	}
+	if tok.RefreshToken == "" {
+		t.Error("expected a refresh token")
+	}
+	if tok.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer", tok.TokenType)
+	}
+	if tok.Issuer != as.url() {
+		t.Errorf("Issuer = %q, want %q", tok.Issuer, as.url())
+	}
+	if tok.Expiry.IsZero() {
+		t.Error("expected an expiry from expires_in")
+	} else if d := time.Until(tok.Expiry); d < 55*time.Minute || d > 61*time.Minute {
+		t.Errorf("Expiry is %v away, want ~1h", d)
+	}
+	if tok.ClientID != "preregistered-client" {
+		t.Errorf("ClientID = %q, want recorded for later refresh", tok.ClientID)
+	}
+
+	// The mock AS only issues a token when S256(verifier) == the recorded
+	// challenge, so reaching this point proves the PKCE round trip. Also
+	// verify the authorization request carried the RFC 8707 resource param.
+	authReq := as.lastAuthorize()
+	if authReq.Resource != rs.mcpURL() {
+		t.Errorf("authorize resource param = %q, want %q", authReq.Resource, rs.mcpURL())
+	}
+	if authReq.CodeChallengeMethod != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", authReq.CodeChallengeMethod)
+	}
+	if authReq.Scope != "mcp" {
+		t.Errorf("scope = %q, want %q", authReq.Scope, "mcp")
+	}
+
+	// The token must be persisted in the store.
+	stored, err := store.Get("demo")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AccessToken != tok.AccessToken {
+		t.Errorf("stored AccessToken = %q, want %q", stored.AccessToken, tok.AccessToken)
+	}
+}
+
+// TestLogin_DiscoveryFallback_WellKnown covers the fallback path: the 401 has
+// no resource_metadata parameter, so discovery must probe the well-known
+// protected-resource document.
+func TestLogin_DiscoveryFallback_WellKnown(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	rs := newMockResourceServer(t, as.url(), func(m *mockResourceServer) {
+		m.withMetadataHeader = false // 401 header without resource_metadata
+	})
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "fallback",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if !strings.HasPrefix(tok.AccessToken, "as-access-") {
+		t.Errorf("AccessToken = %q, want mock-issued token", tok.AccessToken)
+	}
+}
+
+// TestLogin_DynamicClientRegistration verifies that when no client ID is
+// configured and the AS advertises a registration endpoint, the flow
+// registers a client per RFC 7591 and uses the issued client ID.
+func TestLogin_DynamicClientRegistration(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.enableRegistration = true
+		m.nextClientID = "dyn-client-42"
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "dyn",
+		ResourceURL: rs.mcpURL(),
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if as.registerCallCount() != 1 {
+		t.Errorf("register endpoint hit %d times, want 1", as.registerCallCount())
+	}
+	if got := as.lastAuthorize().ClientID; got != "dyn-client-42" {
+		t.Errorf("authorize client_id = %q, want dynamically registered %q", got, "dyn-client-42")
+	}
+	if tok.ClientID != "dyn-client-42" {
+		t.Errorf("stored ClientID = %q, want %q", tok.ClientID, "dyn-client-42")
+	}
+}
+
+// TestLogin_PreRegisteredClientID_SkipsRegistration verifies that a
+// configured client ID is used directly and dynamic registration is not
+// attempted even when the AS supports it.
+func TestLogin_PreRegisteredClientID_SkipsRegistration(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.enableRegistration = true
+		m.allowClientID = "my-preregistered-id"
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "pre",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "my-preregistered-id",
+	}); err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	if as.registerCallCount() != 0 {
+		t.Errorf("register endpoint hit %d times, want 0 for pre-registered client", as.registerCallCount())
+	}
+}
+
+// TestLogin_NoClientID_NoRegistrationEndpoint verifies the actionable error
+// when the flow has no client ID and the AS cannot register one.
+func TestLogin_NoClientID_NoRegistrationEndpoint(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.enableRegistration = false
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := flow.Login(ctx, LoginOptions{ServerName: "noc", ResourceURL: rs.mcpURL()})
+	if err == nil {
+		t.Fatal("expected error without client ID or registration endpoint, got nil")
+	}
+	if !strings.Contains(err.Error(), "client") {
+		t.Errorf("error %q should mention the missing client ID", err.Error())
+	}
+	if _, getErr := store.Get("noc"); !errors.Is(getErr, mcp.ErrTokenNotFound) {
+		t.Errorf("no token must be stored on failure, Get error = %v", getErr)
+	}
+}
+
+// TestLogin_StateMismatch verifies the flow rejects a callback whose state
+// does not match the one it generated (CSRF protection).
+func TestLogin_StateMismatch(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.redirectState = "tampered-state"
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "csrf",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err == nil {
+		t.Fatal("expected state mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "state") {
+		t.Errorf("error %q should mention state", err.Error())
+	}
+	if _, getErr := store.Get("csrf"); !errors.Is(getErr, mcp.ErrTokenNotFound) {
+		t.Errorf("no token must be stored on state mismatch, Get error = %v", getErr)
+	}
+}
+
+// TestLogin_AuthorizationError verifies that an error redirect from the AS
+// (e.g. the user denied access) fails the login without storing a token.
+func TestLogin_AuthorizationError(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.redirectError = "access_denied"
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "denied",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err == nil {
+		t.Fatal("expected authorization error, got nil")
+	}
+	if !strings.Contains(err.Error(), "access_denied") {
+		t.Errorf("error %q should carry the AS error code", err.Error())
+	}
+}
+
+// TestLogin_UserAborts verifies that cancelling the login context (the user
+// aborts instead of completing the browser flow) unblocks the flow with the
+// context error.
+func TestLogin_UserAborts(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The "browser" never completes the flow; the user aborts.
+	flow := newTestFlow(store, func(string) error {
+		cancel()
+		return nil
+	})
+
+	_, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "abort",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err == nil {
+		t.Fatal("expected error on user abort, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error = %v, want errors.Is context.Canceled", err)
+	}
+}
+
+// TestLogin_TokenEndpointError verifies that an OAuth error response from the
+// token endpoint during code exchange fails the login and surfaces the AS
+// error code.
+func TestLogin_TokenEndpointError(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.tokenError = "invalid_grant"
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "tokfail",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err == nil {
+		t.Fatal("expected token exchange error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("error %q should carry the AS error code", err.Error())
+	}
+	if _, getErr := store.Get("tokfail"); !errors.Is(getErr, mcp.ErrTokenNotFound) {
+		t.Errorf("no token must be stored on exchange failure, Get error = %v", getErr)
+	}
+}
+
+// TestRefresh_Success verifies a refresh round trip: the stored token is
+// replaced by the refreshed one, including a rotated refresh token, and the
+// issuer/client ID are preserved.
+func TestRefresh_Success(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+
+	// Seed the store with a completed login so the refresh token is known to
+	// the mock AS.
+	rs := newMockResourceServer(t, as.url(), nil)
+	flow := newTestFlow(store, browserViaHTTP(t))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	loginTok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "demo",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	refreshed, err := flow.Refresh(ctx, "demo")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if refreshed.AccessToken == loginTok.AccessToken {
+		t.Error("expected a new access token after refresh")
+	}
+	if refreshed.RefreshToken == loginTok.RefreshToken {
+		t.Error("expected a rotated refresh token")
+	}
+	if refreshed.Issuer != loginTok.Issuer {
+		t.Errorf("Issuer = %q, want preserved %q", refreshed.Issuer, loginTok.Issuer)
+	}
+	if refreshed.ClientID != loginTok.ClientID {
+		t.Errorf("ClientID = %q, want preserved %q", refreshed.ClientID, loginTok.ClientID)
+	}
+
+	// The store must hold the refreshed token.
+	stored, err := store.Get("demo")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AccessToken != refreshed.AccessToken {
+		t.Errorf("stored AccessToken = %q, want refreshed %q", stored.AccessToken, refreshed.AccessToken)
+	}
+
+	// The grant must have used the previous refresh token.
+	grants := as.tokenGrantTypes()
+	if len(grants) != 2 || grants[0] != "authorization_code" || grants[1] != "refresh_token" {
+		t.Errorf("token grant sequence = %v, want [authorization_code refresh_token]", grants)
+	}
+}
+
+// TestRefresh_UnrotatedRefreshTokenPreserved verifies that when the AS does
+// not return a new refresh token, the previous one is kept.
+func TestRefresh_UnrotatedRefreshTokenPreserved(t *testing.T) {
+	as := newMockAuthorizationServer(t, func(m *mockAuthorizationServer) {
+		m.noRotateRefresh = true
+	})
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	loginTok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "demo",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	refreshed, err := flow.Refresh(ctx, "demo")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if refreshed.RefreshToken != loginTok.RefreshToken {
+		t.Errorf("RefreshToken = %q, want original %q preserved", refreshed.RefreshToken, loginTok.RefreshToken)
+	}
+	if refreshed.AccessToken == loginTok.AccessToken {
+		t.Error("expected a new access token")
+	}
+}
+
+// TestRefresh_InvalidGrant verifies that an invalid_grant response maps to a
+// distinct re-authentication error and leaves the stored token untouched.
+func TestRefresh_InvalidGrant(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	rs := newMockResourceServer(t, as.url(), nil)
+
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	loginTok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  "demo",
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+
+	// Overwrite the stored refresh token with one the AS does not know.
+	bad := loginTok
+	bad.RefreshToken = "as-refresh-999-unknown"
+	if err := store.Put("demo", bad); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	_, err = flow.Refresh(ctx, "demo")
+	if err == nil {
+		t.Fatal("expected refresh error for unknown refresh token, got nil")
+	}
+	if !errors.Is(err, ErrReauthRequired) {
+		t.Errorf("error = %v, want errors.Is ErrReauthRequired", err)
+	}
+
+	// The stored token must remain (the CLI can point the user at login).
+	stored, getErr := store.Get("demo")
+	if getErr != nil {
+		t.Fatalf("store.Get after failed refresh: %v", getErr)
+	}
+	if stored.AccessToken != bad.AccessToken {
+		t.Errorf("stored token changed after failed refresh: %q, want %q", stored.AccessToken, bad.AccessToken)
+	}
+}
+
+// TestRefresh_NoStoredToken verifies the error when no token exists.
+func TestRefresh_NoStoredToken(t *testing.T) {
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := newTestFlow(store, browserViaHTTP(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := flow.Refresh(ctx, "ghost")
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+	if !errors.Is(err, mcp.ErrTokenNotFound) {
+		t.Errorf("error = %v, want errors.Is mcp.ErrTokenNotFound", err)
+	}
+}

--- a/internal/mcp/oauth/pkce.go
+++ b/internal/mcp/oauth/pkce.go
@@ -1,0 +1,36 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// GenerateCodeVerifier returns a PKCE code verifier: 32 cryptographically
+// random bytes, base64url-encoded without padding (43 characters, within the
+// RFC 7636 §4.1 range of 43–128).
+func GenerateCodeVerifier() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("oauth: generate code verifier: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// CodeChallengeS256 derives the PKCE S256 code challenge for a verifier:
+// base64url-no-padding of the SHA-256 digest (RFC 7636 §4.2).
+func CodeChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// generateState returns a random anti-CSRF state value for the authorization
+// request: 16 random bytes, base64url-encoded without padding.
+func generateState() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("oauth: generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/internal/mcp/tokens.go
+++ b/internal/mcp/tokens.go
@@ -37,6 +37,9 @@ type Token struct {
 	AccessToken string `json:"access_token"`
 	// RefreshToken is used to renew the access token when it expires.
 	RefreshToken string `json:"refresh_token,omitempty"`
+	// ClientID is the OAuth client ID the token was issued to. Recorded at
+	// login so refresh requests can identify the same client.
+	ClientID string `json:"client_id,omitempty"`
 	// TokenType is the token type from the OAuth response, typically "Bearer".
 	TokenType string `json:"token_type,omitempty"`
 	// Expiry is the access token's expiration time; zero means never.


### PR DESCRIPTION
Parent epic: #809. Part of #803.

## What

Slice 3 of epic #809 — the browser-based login flow as a library usable by the CLI (slice 4). New `internal/mcp/oauth` package (imports the slice 2 `mcp.TokenStore`; no import cycle):

- **Discovery**: probe the resource for a 401 `WWW-Authenticate` `resource_metadata` pointer (RFC 9728); fallback to the well-known protected-resource document (RFC-inserted form with bare-origin retry) when the header is absent; AS metadata via RFC 8414 with a co-located-AS fallback at the resource origin.
- **PKCE**: S256 verifier/challenge + random state on `crypto/rand`; RFC 8707 `resource` parameter on the authorization request.
- **Loopback**: `net/http` listener on `127.0.0.1:0`, path `/callback`, first request wins, context-cancellable; browser via `open`/`xdg-open`/`rundll32`, injectable as `Flow.OpenURL`.
- **Client registration**: pre-registered client ID via `LoginOptions.ClientID`; RFC 7591 dynamic registration when absent and the AS advertises `registration_endpoint`; actionable error when neither is available.
- **Refresh**: `Flow.Refresh(serverName)` renews via the stored refresh token and recorded client ID (`ClientID` added to `mcp.Token`, additive), preserves un-rotated refresh tokens, maps `invalid_grant` to `ErrReauthRequired` without touching the stored token.

No new third-party dependencies (`net/http` + `crypto` + `encoding/json` only, per the epic constraint).

## Tests (TDD — written first, verified failing, then implemented)

18 tests against in-process `httptest` mock authorization + resource servers; no real network, browser, or `$HOME/.harness`:

- Full code+PKCE round trip with the browser stubbed (stub GETs the auth URL, mock AS 302s into the loopback; the mock AS only issues a token when S256(verifier) matches the challenge recorded at authorize time — proving PKCE end-to-end); `resource` param asserted.
- Discovery via `WWW-Authenticate` (PR doc at a non-standard path, reachable only through the header) and fallback when the header lacks `resource_metadata`; co-located-AS fallback; unreachable server.
- Dynamic registration; pre-registered ID skips registration; missing-both error; state mismatch; AS `access_denied` redirect; user abort via ctx cancel; token-endpoint `invalid_grant`.
- Refresh: success (rotated), un-rotated refresh preserved, `invalid_grant` → `ErrReauthRequired` with store untouched, no stored token → `mcp.ErrTokenNotFound`.
- PKCE RFC 7636 appendix B known vector; `WWW-Authenticate` parsing table.

## Verification

- `go test ./internal/mcp/... -count=1` — ok (mcp 5.6s, oauth 4.7s)
- `go test ./internal/mcp/... -count=1 -race` — ok
- `gofmt` / `go vet` clean

Not merged; slice 4 (CLI commands) builds on this branch.