### PR TITLE
feat(server): runs list and run detail views in /viz

### DIFF
--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -98,4 +98,44 @@ Epic: #812 (parent #803).
 - [x] Tests green; gofmt/go vet clean.
 - [x] Update this plan.
 - [x] Run touched-package tests.
-- [ ] Commit, push `epic/812-session-visualizer-s2`, open PR against repo.
+- [x] Commit, push `epic/812-session-visualizer-s2`, open PR against repo. (Merged, PR #857.)
+
+---
+
+## Slice 3 (this branch): `feat(server): runs list and run detail views in /viz`
+
+### Context
+
+- Problem: the slice-1 shell only proves connectivity; users see placeholders, not runs.
+- User impact: list runs newest-first, click into a run's metadata + summary (tokens/cost where present) without leaving `/viz`.
+- Constraints: no new endpoints; client-side filtering only; JS stays plain (no build step); read-only GET calls only.
+- API facts verified in code:
+  - `GET /v1/runs` → `{"runs": [...]}` of serialized `store.Run` (id, conversation_id, tenant_id, agent_id, model, provider_name, prompt, status, output, error, recap, created_at, updated_at), ordered `created_at DESC` (sqlite.go:269). Cost/usage fields are `json:"-"` — never present in list payloads; the cost column renders "—" unless a field appears (`total_cost_usd`/`cost_usd` probed defensively).
+  - `GET /v1/runs/{id}` → runner state or `storeRunToHarness` map (same field names).
+  - `GET /v1/runs/{id}/summary` → `RunSummary{run_id,status,steps_taken,total_prompt_tokens,total_completion_tokens,total_cost_usd,cost_status,tool_calls,cache_hit_rate,error}` — runner in-memory only: 404 for historical runs, 409 for unfinished runs; UI renders "summary unavailable" gracefully.
+
+### Scope
+
+- In scope:
+  - `internal/server/viz/static/app.js`: hash routing `#/runs` / `#/runs/{id}`; list view (status/model/created/cost columns, prompt excerpt linking to detail); detail view (metadata + summary payload); client-side status + substring filters; 401/403 → token form; empty store / empty filter / unknown-run / summary-unavailable states.
+  - `internal/server/viz/static/index.html`: crumb text update (list/detail exist now).
+  - `internal/server/viz/static/style.css`: table, filter bar, badges, detail grid, state messages.
+  - Guard test: parse served `index.html` for `/viz/` asset refs, assert each resolves 200 under a `runs:read` key.
+- Out of scope: slices 4–6 (timeline, search, ops doc); any endpoint or payload change; client re-sorting (server order is authoritative).
+
+### Test Plan (TDD)
+
+- Note per slice spec: JS is test-light by design. The behavior change is client-side only, so there is no new Go-observable behavior to red-green; the prescribed Go test is a guard against broken embeds/paths, run before and after the JS rewrite. JS correctness is verified by `node --check` (syntax) and a seeded-daemon end-to-end smoke (curl the exact endpoints the views consume), with a scripted browser checklist in the PR.
+- New guard test (`internal/server/http_viz_test.go`): extract `/viz/...` refs from served `index.html` (`src=`/`href=`), GET each under `runs:read` → 200.
+- Existing tests to update: none.
+- Regression tests required: `go test ./internal/server/... -count=1`.
+
+### Implementation Checklist
+
+- [x] Verify API response shapes and store ordering in code.
+- [x] Add guard test; run before JS rewrite.
+- [x] Rewrite `app.js` (routing, list, detail, filters, states); update `index.html` crumbs; extend `style.css`.
+- [x] `node --check` the JS; gofmt/go vet clean.
+- [ ] Run touched-package tests.
+- [x] Seeded-daemon e2e smoke (HARNESS_RUN_DB + seeded key/runs; curl list/detail; confirm new assets served) + DOM-stubbed render smoke (15/15).
+- [ ] Commit, push `epic/812-session-visualizer-s3`, open PR against repo.

--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -136,6 +136,6 @@ Epic: #812 (parent #803).
 - [x] Add guard test; run before JS rewrite.
 - [x] Rewrite `app.js` (routing, list, detail, filters, states); update `index.html` crumbs; extend `style.css`.
 - [x] `node --check` the JS; gofmt/go vet clean.
-- [ ] Run touched-package tests.
+- [x] Run touched-package tests.
 - [x] Seeded-daemon e2e smoke (HARNESS_RUN_DB + seeded key/runs; curl list/detail; confirm new assets served) + DOM-stubbed render smoke (15/15).
-- [ ] Commit, push `epic/812-session-visualizer-s3`, open PR against repo.
+- [x] Commit, push `epic/812-session-visualizer-s3`, open PR against repo.

--- a/internal/server/http_viz_test.go
+++ b/internal/server/http_viz_test.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -196,5 +197,40 @@ func TestVizDoesNotAffectHealthz(t *testing.T) {
 	rec := vizGet(t, h, "/healthz", "")
 	if rec.Code != http.StatusOK {
 		t.Errorf("GET /healthz without token: status = %d, want %d (must stay unauthenticated)", rec.Code, http.StatusOK)
+	}
+}
+
+// vizAssetRef matches src="/viz/..." and href="/viz/..." references in the
+// served index.html.
+var vizAssetRef = regexp.MustCompile(`(?:src|href)="(/viz/[^"]+)"`)
+
+// TestVizIndexAssetReferencesResolve serves index.html under auth, extracts
+// every /viz/ asset it references (script src / link href), and asserts each
+// one resolves 200 under the same auth. This guards against broken embeds or
+// renamed static files stranding references in the shell (epic #812, slice 3:
+// the shell's markup grows while staying embed-only).
+func TestVizIndexAssetReferencesResolve(t *testing.T) {
+	t.Parallel()
+	h, tokens := vizTestServer(t)
+
+	index := vizGet(t, h, "/viz/", tokens["read"])
+	if index.Code != http.StatusOK {
+		t.Fatalf("GET /viz/: status = %d, want %d", index.Code, http.StatusOK)
+	}
+	refs := vizAssetRef.FindAllStringSubmatch(index.Body.String(), -1)
+	if len(refs) == 0 {
+		t.Fatal("index.html references no /viz/ assets; expected at least app.js and style.css")
+	}
+	seen := make(map[string]bool)
+	for _, ref := range refs {
+		path := ref[1]
+		if seen[path] {
+			continue
+		}
+		seen[path] = true
+		rec := vizGet(t, h, path, tokens["read"])
+		if rec.Code != http.StatusOK {
+			t.Errorf("index.html references %s but GET returned %d, want %d", path, rec.Code, http.StatusOK)
+		}
 	}
 }

--- a/internal/server/viz/static/app.js
+++ b/internal/server/viz/static/app.js
@@ -1,4 +1,4 @@
-/* harnessd session visualizer — slice 1 shell.
+/* harnessd session visualizer — slices 1–3.
  *
  * Token story: the API key arrives via the landing form or a ?token= query
  * param on first load, is kept in sessionStorage, and is sent only as an
@@ -6,8 +6,11 @@
  * The server never accepts tokens via query string; ?token= is consumed
  * client-side and immediately scrubbed from the address bar.
  *
- * This slice proves connectivity against GET /v1/runs and renders hash-based
- * placeholders. Real list/detail/timeline views land in later slices.
+ * Views (slice 3): hash routing between #/runs (runs list from GET /v1/runs,
+ * client-side status/text filtering) and #/runs/{id} (run detail from
+ * GET /v1/runs/{id} plus GET /v1/runs/{id}/summary when available). The
+ * event timeline (slice 4) and search (slice 5) land later. Read-only: only
+ * GET endpoints are ever called.
  */
 (function () {
   "use strict";
@@ -21,6 +24,10 @@
   var tokenError = document.getElementById("token-error");
   var viewPanel = document.getElementById("view-panel");
   var viewEl = document.getElementById("view");
+
+  // List-view client-side filter state (no new endpoints — filtering
+  // happens on the already-fetched runs array).
+  var listState = { runs: null, status: "", text: "" };
 
   function setStatus(state, label) {
     statusEl.textContent = label;
@@ -64,26 +71,321 @@
     renderRoute();
   }
 
-  function renderRoute() {
-    var hash = window.location.hash || "#/runs";
-    var match = hash.match(/^#\/runs\/(.+)$/);
-    if (match) {
-      viewEl.innerHTML =
-        "<h2>Run detail</h2><p class='muted'>Placeholder for run <code>" +
-        escapeHTML(match[1]) +
-        "</code> — metadata, summary, and the event timeline arrive in later slices.</p>";
-      return;
-    }
-    viewEl.innerHTML =
-      "<h2>Runs</h2><p class='muted'>Placeholder — the runs list arrives in a later slice. " +
-      "Connectivity check passed: the API accepted this key.</p>";
-  }
-
   function escapeHTML(s) {
-    return s.replace(/[&<>"']/g, function (c) {
+    return String(s).replace(/[&<>"']/g, function (c) {
       return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
     });
   }
+
+  // apiFetch wraps fetch with the Bearer header and uniform auth handling:
+  // 401/403 clears the stored key and returns the user to the token form.
+  // Resolves to the parsed JSON body, or null when auth handling took over.
+  function apiFetch(path) {
+    return fetch(path, {
+      headers: { Authorization: "Bearer " + currentToken() }
+    }).then(function (res) {
+      if (res.status === 401) {
+        sessionStorage.removeItem(TOKEN_KEY);
+        showTokenForm("Unauthorized — check the API key.");
+        return null;
+      }
+      if (res.status === 403) {
+        sessionStorage.removeItem(TOKEN_KEY);
+        showTokenForm("This key lacks the runs:read scope.");
+        return null;
+      }
+      if (!res.ok) {
+        var err = new Error("GET " + path + " failed: HTTP " + res.status);
+        err.status = res.status;
+        throw err;
+      }
+      return res.json();
+    });
+  }
+
+  // ---- formatting helpers ----
+
+  function formatTime(iso) {
+    if (!iso) {
+      return "—";
+    }
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) {
+      return iso;
+    }
+    return d.toLocaleString();
+  }
+
+  function formatInt(n) {
+    return Number(n).toLocaleString();
+  }
+
+  function formatUSD(n) {
+    if (typeof n !== "number" || !isFinite(n)) {
+      return "—";
+    }
+    return "$" + n.toFixed(4);
+  }
+
+  // runCost extracts a cost figure from a list-row run object when the API
+  // provides one. The current /v1/runs payload does not serialize cost
+  // fields, so this returns null and the column renders "—" until it does.
+  function runCost(run) {
+    var v = run.total_cost_usd != null ? run.total_cost_usd : run.cost_usd;
+    return typeof v === "number" && isFinite(v) ? v : null;
+  }
+
+  function statusBadge(status) {
+    var s = String(status || "unknown");
+    return '<span class="status status-' + escapeHTML(s) + '">' + escapeHTML(s) + "</span>";
+  }
+
+  function excerpt(s, max) {
+    s = String(s || "").replace(/\s+/g, " ").trim();
+    if (s.length <= max) {
+      return s;
+    }
+    return s.slice(0, max - 1) + "…";
+  }
+
+  // ---- routing ----
+
+  function renderRoute() {
+    var hash = window.location.hash || "#/runs";
+    var match = hash.match(/^#\/runs\/([^/]+)$/);
+    if (match) {
+      renderRunDetail(decodeURIComponent(match[1]));
+      return;
+    }
+    renderRunsList();
+  }
+
+  // ---- runs list view (#/runs) ----
+
+  function renderRunsList() {
+    viewEl.innerHTML = '<p class="muted">Loading runs…</p>';
+    apiFetch("/v1/runs")
+      .then(function (body) {
+        if (body === null) {
+          return; // auth handling took over
+        }
+        listState.runs = (body && body.runs) || [];
+        paintRunsList();
+      })
+      .catch(function (err) {
+        viewEl.innerHTML =
+          '<p class="error">Failed to load runs: ' + escapeHTML(err.message) + "</p>" +
+          '<p><a href="#/runs">Retry</a></p>';
+      });
+  }
+
+  function distinctStatuses(runs) {
+    var seen = {};
+    var out = [];
+    runs.forEach(function (r) {
+      var s = String(r.status || "unknown");
+      if (!seen[s]) {
+        seen[s] = true;
+        out.push(s);
+      }
+    });
+    return out.sort();
+  }
+
+  function filteredRuns() {
+    var text = listState.text.toLowerCase();
+    return listState.runs.filter(function (r) {
+      if (listState.status && String(r.status || "unknown") !== listState.status) {
+        return false;
+      }
+      if (!text) {
+        return true;
+      }
+      var hay = [r.id, r.prompt, r.model, r.conversation_id]
+        .map(function (v) { return String(v || "").toLowerCase(); })
+        .join("\n");
+      return hay.indexOf(text) !== -1;
+    });
+  }
+
+  // paintRunsList builds the filter bar and results container once per
+  // fetch; paintRunsRows re-renders only the results on filter changes so
+  // the text input keeps focus while typing.
+  function paintRunsList() {
+    var runs = listState.runs;
+    var html = "<h2>Runs</h2>";
+
+    if (runs.length === 0) {
+      viewEl.innerHTML = html +
+        '<div class="empty-state">' +
+        "<p>No runs yet.</p>" +
+        '<p class="muted">Start one with <code>harnesscli --prompt "…"</code>, then reload this page.</p>' +
+        "</div>";
+      return;
+    }
+
+    var statuses = distinctStatuses(runs);
+    html += '<div class="filter-bar">' +
+      '<select id="filter-status" aria-label="Filter by status">' +
+      '<option value="">all statuses</option>';
+    statuses.forEach(function (s) {
+      html += '<option value="' + escapeHTML(s) + '"' +
+        (listState.status === s ? " selected" : "") + ">" + escapeHTML(s) + "</option>";
+    });
+    html += "</select>" +
+      '<input id="filter-text" type="search" placeholder="filter by prompt, model, or id…" ' +
+      'aria-label="Filter runs by text" value="' + escapeHTML(listState.text) + '">' +
+      "</div>" +
+      '<div id="runs-results"></div>';
+
+    viewEl.innerHTML = html;
+
+    document.getElementById("filter-status").addEventListener("change", function (ev) {
+      listState.status = ev.target.value;
+      paintRunsRows();
+    });
+    document.getElementById("filter-text").addEventListener("input", function (ev) {
+      listState.text = ev.target.value;
+      paintRunsRows();
+    });
+
+    paintRunsRows();
+  }
+
+  function paintRunsRows() {
+    var runs = listState.runs;
+    var rows = filteredRuns();
+    var html;
+
+    if (rows.length === 0) {
+      html = '<div class="empty-state"><p>No runs match the current filters.</p></div>';
+    } else {
+      html = '<table class="runs-table"><thead><tr>' +
+        "<th>Status</th><th>Model</th><th>Prompt</th><th>Created</th><th>Cost</th>" +
+        "</tr></thead><tbody>";
+      rows.forEach(function (r) {
+        var cost = runCost(r);
+        html += "<tr>" +
+          "<td>" + statusBadge(r.status) + "</td>" +
+          "<td>" + escapeHTML(r.model || "—") + "</td>" +
+          '<td><a href="#/runs/' + encodeURIComponent(r.id) + '">' +
+          escapeHTML(excerpt(r.prompt, 80) || "(no prompt)") + "</a></td>" +
+          "<td>" + escapeHTML(formatTime(r.created_at)) + "</td>" +
+          "<td>" + (cost === null ? "—" : escapeHTML(formatUSD(cost))) + "</td>" +
+          "</tr>";
+      });
+      html += "</tbody></table>" +
+        '<p class="muted">' + rows.length + " of " + runs.length + " runs shown · newest first</p>";
+    }
+
+    document.getElementById("runs-results").innerHTML = html;
+  }
+
+  // ---- run detail view (#/runs/{id}) ----
+
+  function renderRunDetail(runID) {
+    viewEl.innerHTML = '<p class="muted">Loading run…</p>';
+
+    var run = null;
+    var summary = null;
+    var summaryNote = null;
+
+    // The summary endpoint serves runs held in the daemon's in-memory
+    // runner: 404 for historical (post-restart) runs, 409 for unfinished
+    // ones. Both are expected states, not failures of the detail view.
+    var fetchSummary = apiFetch("/v1/runs/" + encodeURIComponent(runID) + "/summary")
+      .then(function (body) {
+        summary = body;
+      })
+      .catch(function (err) {
+        if (err && err.status === 404) {
+          summaryNote = "Summary unavailable — the daemon no longer holds this run in memory (historical run).";
+        } else if (err && err.status === 409) {
+          summaryNote = "Summary unavailable — the run has not finished yet.";
+        } else {
+          summaryNote = "Summary unavailable — " + (err && err.message ? err.message : "unknown error");
+        }
+      });
+
+    apiFetch("/v1/runs/" + encodeURIComponent(runID))
+      .then(function (body) {
+        if (body === null) {
+          return null; // auth handling took over
+        }
+        run = body;
+        return fetchSummary;
+      })
+      .then(function () {
+        if (run === null) {
+          return;
+        }
+        paintRunDetail(runID, run, summary, summaryNote);
+      })
+      .catch(function (err) {
+        if (err && err.status === 404) {
+          viewEl.innerHTML =
+            '<div class="empty-state"><p>Run <code>' + escapeHTML(runID) + "</code> not found.</p>" +
+            '<p><a href="#/runs">← back to runs</a></p></div>';
+          return;
+        }
+        viewEl.innerHTML =
+          '<p class="error">Failed to load run: ' + escapeHTML(err.message) + "</p>" +
+          '<p><a href="#/runs">← back to runs</a></p>';
+      });
+  }
+
+  function paintRunDetail(runID, run, summary, summaryNote) {
+    var html = '<p><a href="#/runs">← back to runs</a></p>' +
+      "<h2>Run <code>" + escapeHTML(runID) + "</code> " + statusBadge(run.status) + "</h2>";
+
+    html += '<dl class="detail-grid">' +
+      detailRow("model", run.model) +
+      detailRow("provider", run.provider_name) +
+      detailRow("created", formatTime(run.created_at)) +
+      detailRow("updated", formatTime(run.updated_at)) +
+      detailRow("conversation", run.conversation_id) +
+      detailRow("tenant", run.tenant_id) +
+      "</dl>";
+
+    if (run.prompt) {
+      html += "<h3>Prompt</h3><pre class=\"block\">" + escapeHTML(run.prompt) + "</pre>";
+    }
+    if (run.error) {
+      html += '<h3>Error</h3><pre class="block error">' + escapeHTML(run.error) + "</pre>";
+    }
+
+    html += "<h3>Summary</h3>";
+    if (summary) {
+      html += '<dl class="detail-grid">' +
+        detailRow("steps taken", formatInt(summary.steps_taken || 0)) +
+        detailRow("prompt tokens", formatInt(summary.total_prompt_tokens || 0)) +
+        detailRow("completion tokens", formatInt(summary.total_completion_tokens || 0)) +
+        detailRow("total cost", formatUSD(summary.total_cost_usd)) +
+        detailRow("cost status", summary.cost_status) +
+        detailRow("cache hit rate", ((summary.cache_hit_rate || 0) * 100).toFixed(1) + "%") +
+        "</dl>";
+      if (summary.tool_calls && summary.tool_calls.length > 0) {
+        html += '<table class="runs-table"><thead><tr><th>Tool</th><th>Calls</th></tr></thead><tbody>';
+        summary.tool_calls.forEach(function (tc) {
+          html += "<tr><td>" + escapeHTML(tc.name || "?") + "</td><td>" +
+            escapeHTML(formatInt(tc.count || 0)) + "</td></tr>";
+        });
+        html += "</tbody></table>";
+      }
+    } else {
+      html += '<p class="muted">' + escapeHTML(summaryNote || "Summary unavailable.") + "</p>";
+    }
+
+    html += '<p class="muted">The event timeline arrives in a later slice.</p>';
+    viewEl.innerHTML = html;
+  }
+
+  function detailRow(label, value) {
+    return "<dt>" + escapeHTML(label) + "</dt><dd>" +
+      escapeHTML(value == null || value === "" ? "—" : value) + "</dd>";
+  }
+
+  // ---- bootstrap ----
 
   function connect() {
     var token = currentToken();
@@ -92,28 +394,10 @@
       return;
     }
     setStatus("idle", "connecting…");
-    fetch("/v1/runs?limit=1", {
-      headers: { Authorization: "Bearer " + token }
-    })
-      .then(function (res) {
-        if (res.status === 401) {
-          sessionStorage.removeItem(TOKEN_KEY);
-          showTokenForm("Unauthorized — check the API key.");
-          return null;
-        }
-        if (res.status === 403) {
-          sessionStorage.removeItem(TOKEN_KEY);
-          showTokenForm("This key lacks the runs:read scope.");
-          return null;
-        }
-        if (!res.ok) {
-          throw new Error("GET /v1/runs failed: HTTP " + res.status);
-        }
-        return res.json();
-      })
+    apiFetch("/v1/runs?limit=1")
       .then(function (body) {
         if (body === null) {
-          return;
+          return; // auth handling took over
         }
         setStatus("ok", "connected — read-only");
         showView();

--- a/internal/server/viz/static/index.html
+++ b/internal/server/viz/static/index.html
@@ -31,7 +31,7 @@
   <section id="view-panel" class="panel" hidden>
     <nav class="crumbs">
       <a href="#/runs">#/runs</a>
-      <span class="muted">· read-only · list, detail, and timeline views arrive in later slices</span>
+      <span class="muted">· read-only · event timeline and search arrive in later slices</span>
     </nav>
     <div id="view"></div>
   </section>

--- a/internal/server/viz/static/style.css
+++ b/internal/server/viz/static/style.css
@@ -138,3 +138,141 @@ button {
   padding: 0 20px 24px;
   font-size: 13px;
 }
+
+/* ---- slice 3: runs list + run detail views ---- */
+
+.filter-bar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.filter-bar select,
+.filter-bar input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  padding: 6px 10px;
+}
+
+.filter-bar input[type="search"] {
+  flex: 1;
+}
+
+.filter-bar select:focus,
+.filter-bar input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.runs-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 14px;
+}
+
+.runs-table th,
+.runs-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.runs-table th {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.runs-table td a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.runs-table td a:hover {
+  text-decoration: underline;
+}
+
+.status {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  display: inline-block;
+  font-size: 12px;
+  padding: 1px 10px;
+  white-space: nowrap;
+}
+
+.status-completed {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+
+.status-failed,
+.status-cancelled {
+  color: var(--err);
+  border-color: var(--err);
+}
+
+.status-running,
+.status-queued {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 16px;
+  margin: 0 0 16px;
+}
+
+.detail-grid dt {
+  color: var(--muted);
+}
+
+.detail-grid dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+pre.block {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  max-height: 320px;
+  overflow: auto;
+  padding: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+pre.block.error {
+  border-color: var(--err);
+}
+
+.empty-state {
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 24px;
+  text-align: center;
+}
+
+#view h2 {
+  font-size: 17px;
+  margin: 4px 0 14px;
+}
+
+#view h3 {
+  font-size: 14px;
+  margin: 20px 0 8px;
+}
+
+#view > p > a {
+  color: var(--accent);
+  text-decoration: none;
+}


### PR DESCRIPTION
Parent epic: #812. Part of #803.

## What

Slice 3 of #812: the embedded visualizer shell renders real data — a runs list and a run detail page — instead of the slice-1 placeholders.

- **`internal/server/viz/static/app.js`**: hash routing between `#/runs` and `#/runs/{id}`.
  - **List view**: fetches `GET /v1/runs` (server order is authoritative — `ORDER BY created_at DESC`, `internal/store/sqlite.go:269`) and renders status/model/prompt/created/cost columns; rows link to detail. Client-side filtering only (status select built from distinct statuses present + substring match over id/prompt/model/conversation id) — no new endpoints. The cost column probes for `total_cost_usd`/`cost_usd`; the current list payload does not serialize cost (`json:"-"` on the store fields), so it renders `—` until one appears.
  - **Detail view**: fetches `GET /v1/runs/{id}` (metadata, prompt, error) and `GET /v1/runs/{id}/summary` (steps, prompt/completion tokens, total cost, cost status, cache hit rate, tool-call breakdown). The summary endpoint only serves runs held in the daemon's in-memory runner, so its **404 (historical run)** and **409 (unfinished run)** responses render as deliberate "summary unavailable" notes rather than errors.
  - 401/403 on any view clears the stored key and returns to the token form; empty store, empty filter result, and unknown-run (404) states all render explicitly.
- **`index.html`**: crumb text updated (list/detail exist now; timeline/search remain later slices).
- **`style.css`**: table, filter bar, status badges, detail grid, blocks, empty states.
- **`internal/server/http_viz_test.go`**: new guard test — parse the served `index.html` for every `src=`/`href=` `/viz/...` asset reference and assert each resolves 200 under a `runs:read` key (guards broken embeds/renamed files as the shell's markup grows).

Note on TDD for this slice (per the slice spec): the behavior change is client-side JS, so there is no new Go-observable behavior to red-green; the prescribed Go test is the asset-reference guard (added first, passing before and after the JS rewrite). JS behavior is verified by the checks below.

## Verification actually run

- `go test ./internal/server/... -count=1` → ok (incl. 9 `TestViz*` tests)
- `go vet ./internal/server/ ./internal/server/viz/` → clean; `gofmt -l` on touched files → clean
- `node --check internal/server/viz/static/app.js` → syntax OK
- **DOM-stubbed render harness** (node, real app.js + real API payload shapes, 15 checks): list newest-first, all rows, status badges, cost `—` fallback, filter bar, detail links, text filter narrowing + count line, status filter, detail metadata/prompt/error, summary-404 graceful note, unknown-run state → **15/15 PASS**
- **Seeded-daemon e2e**: seeded `HARNESS_RUN_DB` sqlite with a `runs:read` key + three runs (completed/failed/running, staggered timestamps), booted real `harnessd` in tmux: `/v1/runs` returns newest-first, `/v1/runs/{id}` detail fields match what the view renders, `/summary` → 404 for historical runs (the graceful path), `/viz/app.js` serves the new views under auth, no token → 401
- `./scripts/test-regression.sh` → **PASS** (go test ./..., go test ./... -race, coverage gate 84.2% ≥ 80%)

## Manual browser checklist (reviewers)

1. `harnesscli auth login` (or reuse a `runs:read` key), start `harnessd` with `HARNESS_RUN_DB` set and a few completed runs.
2. `harnesscli viz --open` (slice 2) or open `http://ADDR/viz/?token=KEY`.
3. List shows runs newest-first; type in the filter box and switch the status select — rows narrow without reload.
4. Click a run → detail shows metadata + prompt; a run still in the daemon's memory shows the summary block (tokens/cost/tool calls); a historical run shows the "summary unavailable" note.
5. `#/runs/bogus` → "not found"; back link returns to the list.

## Out of scope (later slices)

Event timeline (4), search view (5), operations doc (6).