### PR TITLE
feat(acp): session/update notifications from the SSE stream

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,13 @@
 # Engineering Log
 
+## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
+
+- Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.
+- `RunsClient.WaitTerminal` generalized to `WatchRun(ctx, runID, onEvent)`; oversized SSE lines (cap now a test-shrinkable var) are drained and their event skipped with a logged warning instead of corrupting the stream.
+- Backpressure discipline: one bounded (256) queue per turn with a single writer goroutine, so the SSE reader never blocks on a slow editor. Coalescing/drops trigger only on a FULL queue — same-kind deltas merge into the tail, other deltas drop (counted + logged), lifecycle updates evict buffered deltas but are never dropped. (First cut coalesced whenever the writer lagged, which made healthy streams lose chunk granularity and broke the golden ordering test; coalescing is now strictly an anti-overflow mechanism.)
+- The prompt handler closes the queue at the terminal event and drains it fully before writing the `session/prompt` response, per the spec's updates-before-result rule.
+- Validation: strict TDD (red: `undefined: runEvent`/`translateRunEvent`). Golden acceptance: scripted client observes two message chunks, a thought chunk, `tool_call`, `tool_call_update` (stable `toolCallId`) in exact order before the `end_turn` result. `go test ./internal/acp/... -count=1` green.
+
 ## 2026-07-21 (Agent Swarm — Epic #808, Slice 3)
 
 - Added the deferred `agent_swarm` tool

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -42,6 +42,32 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - Scripted stdio exchange — `initialize`, `session/new`, `session/prompt` against the fake server — returns a `session/prompt` result whose `stopReason` matches the fake's terminal SSE event; cancel mid-run issues the cancel POST.
 - `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
 
+## Slice 3 — session/update notifications from the SSE stream (IN IMPLEMENTATION)
+
+### Scope (slice 3)
+
+- In scope:
+  - `internal/acp/updates.go`: translator from harness SSE events to ACP `session/update` update objects — `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content` for both), `tool.call.started` -> `tool_call` (`toolCallId` from `call_id`, `title` from `tool`, `status: "in_progress"`, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`status: "completed"`, or `"failed"` when the payload has an `error`; output included as content).
+  - Bounded per-turn notification queue: coalesce consecutive same-kind text deltas; drop deltas (counted + logged) under pressure; lifecycle updates never dropped (they evict buffered deltas first). The SSE reader never blocks on a slow editor beyond this one queue.
+  - `client.go`: `WatchRun(ctx, runID, onEvent)` generalizes `WaitTerminal` (now a nil-callback wrapper); oversized SSE lines (>16 MiB, test-shrinkable var) are drained and their event skipped with a logged warning instead of corrupting the stream.
+  - `server.go`/`jsonrpc.go`: `writeNotification("session/update", ...)`; the prompt handler drains the queue fully before writing the `session/prompt` response (spec: updates precede the turn result).
+- Out of scope: `session/request_permission` (slice 4), `agent_thought_chunk` coalescing across message/thought boundaries (different kinds never coalesce), plan/todo updates, `tool.call.delta` argument streaming.
+
+### Test Plan (TDD, slice 3)
+
+- New failing tests:
+  - Translator table (all four mappings incl. failed tool call, unmapped events, empty deltas).
+  - Tool-kind mapping table.
+  - Queue: same-kind deltas coalesce, different kinds don't, lifecycle breaks coalescing; full queue drops deltas (counted); lifecycle evicts buffered deltas; drain-after-close.
+  - Client: oversized SSE event line skipped with warning, terminal still found.
+  - Golden: scripted client performing `session/prompt` against the fake observes the exact ordered `session/update` stream (two message chunks, thought chunk, tool_call, tool_call_update with stable `toolCallId`) before the `session/prompt` result.
+- Existing tests: none modified; all slice-1/2 tests must stay green.
+
+### Acceptance (slice 3)
+
+- Scripted client performing `session/prompt` against the fake server observes `agent_message_chunk` notifications in order before the `session/prompt` result arrives.
+- `go test ./internal/acp/... -count=1` green (plus `-race`).
+
 ## Documentation Contract
 
 - Feature status: slice 1 `implemented` (PR #835); slice 2 `in implementation`.
@@ -61,6 +87,11 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - [x] Slice 2: gofmt + go vet clean; `go test ./internal/acp/... ./cmd/harnesscli/... -count=1` green.
 - [x] Slice 2: update engineering log.
 - [x] Slice 2: push branch `epic/806-acp-server-s2` and open PR (no merge) — PR #874.
+- [x] Slice 3: failing tests first (red: `undefined: runEvent`, `translateRunEvent`, `maxSSELineSize` const).
+- [x] Slice 3: translator + bounded coalescing queue + `WatchRun` + `writeNotification` + prompt wiring.
+- [x] Slice 3: gofmt + go vet clean; `go test ./internal/acp/ -count=1` (+ `-race`, `-count=3`) green; `cmd/harnesscli` green.
+- [x] Slice 3: update engineering log.
+- [ ] Slice 3: push branch `epic/806-acp-server-s3` and open PR (no merge).
 
 ## Risks and Mitigations
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -26,7 +26,7 @@
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
-- `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged) and slice 2 (session/new + session/prompt over the runs API, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
+- `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged), slice 2 (session/new + session/prompt over the runs API, merged), slice 3 (session/update notifications from the SSE stream, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
 - `805-undo-prompts.md` — Epic #805 plan: Slice 1 `ConversationStore.UndoPrompts` (merged, PR #838); Slice 2 `POST /v1/conversations/{id}/undo` route (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.

--- a/internal/acp/client.go
+++ b/internal/acp/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,8 +29,13 @@ const (
 const maxResponseBodyBytes = 8 * 1024 * 1024
 
 // maxSSELineSize bounds a single SSE line; longer lines are drained and the
-// event they belong to is skipped, mirroring the harnesscli SSE client.
-const maxSSELineSize = 16 * 1024 * 1024
+// event they belong to is skipped with a logged warning, mirroring the
+// harnesscli SSE client. It is a var so tests can shrink it.
+var maxSSELineSize = 16 * 1024 * 1024
+
+// errSSELineTruncated is returned by readSSELine when a line exceeds
+// maxSSELineSize; the caller skips the event the line belongs to.
+var errSSELineTruncated = errors.New("acp: sse line exceeded max size")
 
 // RunsClient is a minimal stdlib HTTP/SSE client for the harnessd runs API.
 // It exists so the ACP server can map one ACP session onto one go-code run
@@ -42,6 +48,9 @@ type RunsClient struct {
 	// stream is for the SSE event subscription and must have no client-level
 	// timeout: runs can legitimately stream for a long time.
 	stream *http.Client
+	// Logf receives skip/degradation warnings (e.g. oversized SSE events).
+	// Nil means quiet.
+	Logf func(format string, args ...any)
 }
 
 // NewRunsClient returns a client for the given harnessd base URL. apiKey is
@@ -125,9 +134,24 @@ type terminalOutcome struct {
 	errText   string // run.failed payload error, when present
 }
 
+// runEvent is one parsed SSE event from a run's stream: its harness event
+// type and the raw JSON of the full event object (the data: payload).
+type runEvent struct {
+	Type string
+	Data string
+}
+
 // WaitTerminal subscribes to GET /v1/runs/{id}/events and blocks until a
 // terminal run event arrives, the stream breaks, or ctx is cancelled.
 func (c *RunsClient) WaitTerminal(ctx context.Context, runID string) (terminalOutcome, error) {
+	return c.WatchRun(ctx, runID, nil)
+}
+
+// WatchRun is WaitTerminal with a callback: onEvent fires for every parsed
+// event (including the terminal one) in stream order, letting callers
+// translate the stream (e.g. into session/update notifications) while the
+// wait proceeds.
+func (c *RunsClient) WatchRun(ctx context.Context, runID string, onEvent func(runEvent)) (terminalOutcome, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/runs/"+runID+"/events", nil)
 	if err != nil {
 		return terminalOutcome{}, fmt.Errorf("build events request: %w", err)
@@ -152,6 +176,15 @@ func (c *RunsClient) WaitTerminal(ctx context.Context, runID string) (terminalOu
 	var block []string
 	for {
 		line, err := readSSELine(reader)
+		if errors.Is(err, errSSELineTruncated) {
+			// The whole event containing the oversized line is skipped; the
+			// block boundary is still respected because the line was drained.
+			if c.Logf != nil {
+				c.Logf("run %s: SSE event exceeded %d bytes; event skipped", runID, maxSSELineSize)
+			}
+			block = block[:0]
+			continue
+		}
 		if err != nil {
 			if err == io.EOF {
 				return terminalOutcome{}, fmt.Errorf("event stream ended before a terminal event")
@@ -166,6 +199,9 @@ func (c *RunsClient) WaitTerminal(ctx context.Context, runID string) (terminalOu
 			if typ == "" {
 				continue
 			}
+			if onEvent != nil {
+				onEvent(runEvent{Type: typ, Data: payload})
+			}
 			if typ == eventTypeRunCostLimitReached {
 				out.costLimit = true
 				continue
@@ -175,27 +211,41 @@ func (c *RunsClient) WaitTerminal(ctx context.Context, runID string) (terminalOu
 				out.errText = payloadError(payload)
 				return out, nil
 			}
-			continue // non-terminal event; slice 3 translates these into session/update
+		} else {
+			block = append(block, line)
 		}
-		block = append(block, line)
 	}
 }
 
-// readSSELine reads one '\n'-terminated line (without the delimiter),
-// tolerating arbitrarily long lines by draining them.
+// readSSELine reads one '\n'-terminated line (without the delimiter). A line
+// longer than maxSSELineSize is fully drained (keeping the stream aligned)
+// but reported with errSSELineTruncated so the caller can skip the event it
+// belongs to instead of processing corrupt partial data.
 func readSSELine(r *bufio.Reader) (string, error) {
 	var buf []byte
+	truncated := false
 	for {
 		frag, err := r.ReadSlice('\n')
-		if len(buf)+len(frag) <= maxSSELineSize {
-			buf = append(buf, frag...)
+		if !truncated {
+			if len(buf)+len(frag) > maxSSELineSize {
+				truncated = true
+				buf = buf[:0]
+			} else {
+				buf = append(buf, frag...)
+			}
 		}
 		switch {
 		case err == nil:
+			if truncated {
+				return "", errSSELineTruncated
+			}
 			return string(buf[:len(buf)-1]), nil
 		case err == bufio.ErrBufferFull:
 			continue
-		case err == io.EOF && len(buf) > 0:
+		case err == io.EOF && (len(buf) > 0 || truncated):
+			if truncated {
+				return "", errSSELineTruncated
+			}
 			return string(buf), nil
 		default:
 			return "", err

--- a/internal/acp/client_test.go
+++ b/internal/acp/client_test.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -217,5 +218,60 @@ func TestRunsClientWaitTerminalSkipsNonDataLines(t *testing.T) {
 	}
 	if out.eventType != "run.completed" {
 		t.Fatalf("outcome = %+v", out)
+	}
+}
+
+// TestWatchRunSkipsOversizedEventLine pins scanner-buffer overflow handling:
+// an SSE line larger than the cap is drained and its event skipped (with a
+// logged warning) instead of corrupting the stream or aborting the wait.
+func TestWatchRunSkipsOversizedEventLine(t *testing.T) {
+	old := maxSSELineSize
+	maxSSELineSize = 128 // shrink so a normal-ish event overflows
+	t.Cleanup(func() { maxSSELineSize = old })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/runs" {
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"run_id":"run-1","status":"running"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, _ := w.(http.Flusher)
+		// Oversized delta event (exceeds the 128-byte cap): must be skipped.
+		big := strings.Repeat("x", 512)
+		fmt.Fprintf(w, "id: run-1:1\nevent: assistant.message.delta\ndata: {\"type\":\"assistant.message.delta\",\"payload\":{\"content\":%q}}\n\n", big)
+		if flusher != nil {
+			flusher.Flush()
+		}
+		// Normal terminal event must still be found afterwards.
+		fmt.Fprint(w, "id: run-1:2\nevent: run.completed\ndata: {\"type\":\"run.completed\",\"payload\":{\"output\":\"ok\"}}\n\n")
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	var warnings []string
+	c := NewRunsClient(srv.URL, "")
+	c.Logf = func(format string, args ...any) { warnings = append(warnings, fmt.Sprintf(format, args...)) }
+
+	if _, err := c.StartRun(context.Background(), "hi"); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	var seen []runEvent
+	out, err := c.WatchRun(context.Background(), "run-1", func(ev runEvent) { seen = append(seen, ev) })
+	if err != nil {
+		t.Fatalf("WatchRun: %v", err)
+	}
+	if out.eventType != "run.completed" {
+		t.Fatalf("outcome = %+v, want run.completed", out)
+	}
+	for _, ev := range seen {
+		if ev.Type == "assistant.message.delta" {
+			t.Fatalf("oversized delta event must have been skipped, got %+v", ev)
+		}
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a logged warning for the skipped oversized event")
 	}
 }

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -63,3 +63,11 @@ func (e *rpcError) Error() string { return e.Message }
 
 // nullID is the response id used when the request id is unknown.
 var nullID = json.RawMessage("null")
+
+// notification is the wire shape of a JSON-RPC 2.0 notification the server
+// sends (e.g. session/update): no id, no response expected.
+type notification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -149,6 +149,12 @@ func (s *Server) writeResult(id json.RawMessage, result any) error {
 	return s.conn.WriteJSON(response{JSONRPC: "2.0", ID: id, Result: result})
 }
 
+// writeNotification sends a server-initiated notification (no id, no
+// response expected). It is safe for concurrent use with responses.
+func (s *Server) writeNotification(method string, params any) error {
+	return s.conn.WriteJSON(notification{JSONRPC: "2.0", Method: method, Params: params})
+}
+
 // writeError sends an error response.
 func (s *Server) writeError(id json.RawMessage, code int, message string) error {
 	return s.conn.WriteJSON(response{JSONRPC: "2.0", ID: id, Error: &rpcError{Code: code, Message: message}})

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -100,7 +100,7 @@ func newSessionStore() *sessionStore {
 // session/prompt, session/cancel) backed by the given harnessd runs client.
 // Without it, session methods answer -32601 like any other unknown method.
 func (s *Server) EnableSessions(client *RunsClient) {
-	ss := &sessionHandlers{client: client, store: newSessionStore(), diag: s.diag}
+	ss := &sessionHandlers{client: client, store: newSessionStore(), diag: s.diag, srv: s}
 	s.Handle("session/new", ss.handleSessionNew)
 	s.Handle("session/prompt", ss.handleSessionPrompt)
 	s.Handle("session/cancel", ss.handleSessionCancel)
@@ -111,6 +111,7 @@ type sessionHandlers struct {
 	client *RunsClient
 	store  *sessionStore
 	diag   io.Writer
+	srv    *Server // for writeNotification (session/update)
 }
 
 // handleSessionNew creates a fresh session and returns its id. The cwd and
@@ -178,7 +179,24 @@ func (h *sessionHandlers) handleSessionPrompt(ctx context.Context, params json.R
 		}
 	}
 
-	outcome, err := h.client.WaitTerminal(ctx, runID)
+	// Stream the run's events as session/update notifications. The queue and
+	// its single writer keep notifications ordered and bound the buffering a
+	// slow editor can force (deltas coalesce or drop; lifecycle updates win).
+	queue := newUpdateQueue(updateQueueCapacity)
+	writer := startUpdateWriter(queue, h.srv, req.SessionID, h.diag)
+	outcome, err := h.client.WatchRun(ctx, runID, func(ev runEvent) {
+		if update, kind, ok := translateRunEvent(ev); ok {
+			queue.push(update, kind)
+		}
+	})
+	// The terminal event has been seen: no more updates will be produced.
+	// Drain the queue fully before responding — the spec requires all
+	// session/update notifications to arrive before the session/prompt result.
+	queue.close()
+	writer.wait()
+	if dropped := queue.droppedCount(); dropped > 0 {
+		fmt.Fprintf(h.diag, "acp: session %s: dropped %d delta update(s) under backpressure\n", req.SessionID, dropped)
+	}
 	if err != nil {
 		return nil, &rpcError{Code: CodeInternalError, Message: "wait for run: " + err.Error()}
 	}

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -585,3 +585,119 @@ func TestConcurrentSessionsStayIsolated(t *testing.T) {
 		t.Fatalf("session B stopReason = %q, want end_turn", got[fmt.Sprintf("%d", idB)])
 	}
 }
+
+// readAny reads one protocol line and decodes it generically, so tests can
+// observe session/update notifications as well as responses.
+func (c *scriptedClient) readAny() map[string]any {
+	c.t.Helper()
+	type lineRes struct {
+		line string
+		err  error
+	}
+	ch := make(chan lineRes, 1)
+	go func() {
+		line, err := c.out.ReadString('\n')
+		ch <- lineRes{line, err}
+	}()
+	select {
+	case lr := <-ch:
+		if lr.err != nil {
+			c.t.Fatalf("read: %v", lr.err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(strings.TrimRight(lr.line, "\n")), &m); err != nil {
+			c.t.Fatalf("line is not JSON: %q: %v", lr.line, err)
+		}
+		return m
+	case <-time.After(15 * time.Second):
+		c.t.Fatal("timed out waiting for server output")
+		return nil
+	}
+}
+
+// TestSessionPromptStreamsUpdatesInOrder is the slice-3 acceptance test: a
+// scripted client performing session/prompt observes the exact ordered
+// session/update notification stream — agent_message_chunk deltas, a thought
+// chunk, tool_call, tool_call_update with a stable toolCallId — before the
+// session/prompt result arrives.
+func TestSessionPromptStreamsUpdatesInOrder(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	initialize(t, c)
+	sid := sessionNew(t, c)
+
+	promptID := c.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "go"}},
+	})
+	waitFor(t, "run to be created", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 1
+	})
+	run := fh.run("")
+	go func() {
+		run.emit("run.started", "{}")
+		run.emit("assistant.message.delta", `{"step":1,"content":"Hello"}`)
+		run.emit("assistant.message.delta", `{"step":1,"content":", world"}`)
+		run.emit("assistant.thinking.delta", `{"step":1,"content":"hmm"}`)
+		run.emit("tool.call.started", `{"call_id":"call-1","tool":"bash","arguments":"ls"}`)
+		run.emit("tool.call.completed", `{"call_id":"call-1","tool":"bash","output":"file.txt","duration_ms":5}`)
+		run.finish("run.completed", `{"output":"done"}`)
+	}()
+
+	type wantUpdate struct {
+		sessionUpdate string
+		toolCallID    string
+		status        string
+		text          string
+	}
+	want := []wantUpdate{
+		{sessionUpdate: "agent_message_chunk", text: "Hello"},
+		{sessionUpdate: "agent_message_chunk", text: ", world"},
+		{sessionUpdate: "agent_thought_chunk", text: "hmm"},
+		{sessionUpdate: "tool_call", toolCallID: "call-1", status: "in_progress"},
+		{sessionUpdate: "tool_call_update", toolCallID: "call-1", status: "completed"},
+	}
+
+	for i, w := range want {
+		msg := c.readAny()
+		if msg["method"] != "session/update" {
+			t.Fatalf("message %d: method = %v, want session/update (msg: %v)", i, msg["method"], msg)
+		}
+		params, _ := msg["params"].(map[string]any)
+		if params["sessionId"] != sid {
+			t.Fatalf("message %d: sessionId = %v, want %s", i, params["sessionId"], sid)
+		}
+		update, _ := params["update"].(map[string]any)
+		if update["sessionUpdate"] != w.sessionUpdate {
+			t.Fatalf("message %d: sessionUpdate = %v, want %v (update: %v)", i, update["sessionUpdate"], w.sessionUpdate, update)
+		}
+		if w.toolCallID != "" && update["toolCallId"] != w.toolCallID {
+			t.Fatalf("message %d: toolCallId = %v, want %v", i, update["toolCallId"], w.toolCallID)
+		}
+		if w.status != "" && update["status"] != w.status {
+			t.Fatalf("message %d: status = %v, want %v", i, update["status"], w.status)
+		}
+		if w.text != "" {
+			content, _ := update["content"].(map[string]any)
+			if content["text"] != w.text {
+				t.Fatalf("message %d: text = %v, want %q", i, content["text"], w.text)
+			}
+		}
+	}
+
+	// Only after every update has streamed may the prompt result arrive.
+	msg := c.readAny()
+	if msg["method"] != nil {
+		t.Fatalf("expected the prompt response after the updates, got notification: %v", msg)
+	}
+	if fmt.Sprintf("%v", msg["id"]) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id = %v, want %d", msg["id"], promptID)
+	}
+	result, _ := msg["result"].(map[string]any)
+	if result["stopReason"] != "end_turn" {
+		t.Fatalf("stopReason = %v, want end_turn (full msg: %v)", result["stopReason"], msg)
+	}
+}

--- a/internal/acp/updates.go
+++ b/internal/acp/updates.go
@@ -1,0 +1,268 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// updateKind classifies a session/update update object for queue treatment.
+type updateKind int
+
+const (
+	// kindDelta is a coalescable text delta (agent_message_chunk,
+	// agent_thought_chunk): cheap to merge and safe to drop under pressure.
+	kindDelta updateKind = iota
+	// kindLifecycle is a tool-call lifecycle update (tool_call,
+	// tool_call_update): never coalesced, dropped only in the pathological
+	// case of a queue full of lifecycle updates.
+	kindLifecycle
+)
+
+// updateQueueCapacity bounds one turn's buffered notifications. It is a var
+// so tests can shrink it.
+var updateQueueCapacity = 256
+
+// translateRunEvent converts one harness SSE event into the ACP update object
+// carried in a session/update notification's "update" member. ok is false for
+// events that have no ACP mapping in this slice (including terminal run
+// events, which the prompt handler maps to stop reasons instead).
+func translateRunEvent(ev runEvent) (map[string]any, updateKind, bool) {
+	switch ev.Type {
+	case "assistant.message.delta", "assistant.thinking.delta":
+		content := payloadString(ev.Data, "content")
+		if content == "" {
+			return nil, kindDelta, false
+		}
+		chunk := "agent_message_chunk"
+		if ev.Type == "assistant.thinking.delta" {
+			chunk = "agent_thought_chunk"
+		}
+		return map[string]any{
+			"sessionUpdate": chunk,
+			"content":       map[string]any{"type": "text", "text": content},
+		}, kindDelta, true
+
+	case "tool.call.started":
+		callID := payloadString(ev.Data, "call_id")
+		tool := payloadString(ev.Data, "tool")
+		if callID == "" {
+			return nil, kindLifecycle, false
+		}
+		return map[string]any{
+			"sessionUpdate": "tool_call",
+			"toolCallId":    callID,
+			"title":         tool,
+			"kind":          toolKind(tool),
+			"status":        "in_progress",
+		}, kindLifecycle, true
+
+	case "tool.call.completed":
+		callID := payloadString(ev.Data, "call_id")
+		if callID == "" {
+			return nil, kindLifecycle, false
+		}
+		update := map[string]any{
+			"sessionUpdate": "tool_call_update",
+			"toolCallId":    callID,
+		}
+		if errText := payloadString(ev.Data, "error"); errText != "" {
+			update["status"] = "failed"
+			update["content"] = toolOutputContent(errText)
+		} else {
+			update["status"] = "completed"
+			if out := payloadString(ev.Data, "output"); out != "" {
+				update["content"] = toolOutputContent(out)
+			}
+		}
+		return update, kindLifecycle, true
+	}
+	return nil, kindDelta, false
+}
+
+// toolOutputContent wraps tool output text in the ACP tool-call content
+// shape: a single content block of type "content".
+func toolOutputContent(text string) []map[string]any {
+	return []map[string]any{{
+		"type":    "content",
+		"content": map[string]any{"type": "text", "text": text},
+	}}
+}
+
+// payloadString extracts a string field from the "payload" member of a raw
+// harness event JSON document. Missing fields and malformed JSON yield "".
+func payloadString(data, field string) string {
+	var doc struct {
+		Payload map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(data), &doc); err != nil {
+		return ""
+	}
+	v, _ := doc.Payload[field].(string)
+	return v
+}
+
+// toolKind maps a harness tool name onto an ACP ToolCallKind.
+func toolKind(tool string) string {
+	switch tool {
+	case "bash", "exec_command", "shell", "job":
+		return "execute"
+	case "read", "read_file", "file_inspect", "ls", "glob":
+		return "read"
+	case "write", "write_file", "edit", "apply_patch":
+		return "edit"
+	case "grep", "search":
+		return "search"
+	case "web_fetch", "fetch":
+		return "fetch"
+	case "think":
+		return "think"
+	default:
+		return "other"
+	}
+}
+
+// updateQueue is one prompt turn's bounded notification buffer. It decouples
+// the SSE reader from a slow editor: pushes never block — same-kind text
+// deltas coalesce, deltas are dropped (counted) under pressure, and lifecycle
+// updates evict buffered deltas rather than being dropped themselves.
+type updateQueue struct {
+	mu      sync.Mutex
+	cond    sync.Cond
+	items   []map[string]any
+	kinds   []updateKind
+	cap     int
+	closed  bool
+	dropped int
+}
+
+func newUpdateQueue(capacity int) *updateQueue {
+	q := &updateQueue{cap: capacity}
+	q.cond.L = &q.mu
+	return q
+}
+
+// push enqueues an update without blocking. Under backpressure (a full
+// queue) same-kind text deltas coalesce into the tail item; deltas that
+// cannot coalesce are dropped (counted); lifecycle updates evict the oldest
+// buffered delta rather than being dropped themselves. A non-full queue
+// appends 1:1, so a healthy editor sees every event.
+func (q *updateQueue) push(update map[string]any, kind updateKind) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return
+	}
+	if len(q.items) < q.cap {
+		q.items = append(q.items, update)
+		q.kinds = append(q.kinds, kind)
+		q.cond.Signal()
+		return
+	}
+	// Queue full: the editor is behind.
+	if kind == kindDelta && q.kinds[len(q.kinds)-1] == kindDelta {
+		last := q.items[len(q.items)-1]
+		if last["sessionUpdate"] == update["sessionUpdate"] {
+			if lc, ok := last["content"].(map[string]any); ok {
+				if nc, ok := update["content"].(map[string]any); ok {
+					lct, _ := lc["text"].(string)
+					nct, _ := nc["text"].(string)
+					lc["text"] = lct + nct
+					return
+				}
+			}
+		}
+	}
+	if kind == kindDelta {
+		q.dropped++
+		return
+	}
+	// Lifecycle updates are precious: evict the oldest buffered delta.
+	for i, k := range q.kinds {
+		if k == kindDelta {
+			q.items = append(q.items[:i], q.items[i+1:]...)
+			q.kinds = append(q.kinds[:i], q.kinds[i+1:]...)
+			q.items = append(q.items, update)
+			q.kinds = append(q.kinds, kind)
+			q.cond.Signal()
+			return
+		}
+	}
+	q.dropped++ // pathological: queue full of lifecycle updates
+}
+
+// pop removes the oldest update, blocking while the queue is empty. ok is
+// false once the queue is closed and fully drained.
+func (q *updateQueue) pop() (map[string]any, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.items) == 0 && !q.closed {
+		q.cond.Wait()
+	}
+	if len(q.items) == 0 {
+		return nil, false
+	}
+	u := q.items[0]
+	q.items = q.items[1:]
+	q.kinds = q.kinds[1:]
+	return u, true
+}
+
+// close marks the queue finished; buffered items still drain.
+func (q *updateQueue) close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.cond.Broadcast()
+}
+
+func (q *updateQueue) len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}
+
+func (q *updateQueue) droppedCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.dropped
+}
+
+// updateWriter drains one turn's queue onto the protocol channel as
+// session/update notifications. Exactly one writer per turn keeps
+// notifications strictly ordered.
+type updateWriter struct {
+	q         *updateQueue
+	srv       *Server
+	sessionID string
+	diag      io.Writer
+	done      chan struct{}
+}
+
+func startUpdateWriter(q *updateQueue, srv *Server, sessionID string, diag io.Writer) *updateWriter {
+	w := &updateWriter{q: q, srv: srv, sessionID: sessionID, diag: diag, done: make(chan struct{})}
+	go w.run()
+	return w
+}
+
+func (w *updateWriter) run() {
+	defer close(w.done)
+	for {
+		u, ok := w.q.pop()
+		if !ok {
+			return
+		}
+		err := w.srv.writeNotification("session/update", map[string]any{
+			"sessionId": w.sessionID,
+			"update":    u,
+		})
+		if err != nil {
+			fmt.Fprintf(w.diag, "acp: write session/update: %v\n", err)
+			return
+		}
+	}
+}
+
+// wait blocks until the queue is closed and fully written out.
+func (w *updateWriter) wait() { <-w.done }

--- a/internal/acp/updates_test.go
+++ b/internal/acp/updates_test.go
@@ -1,0 +1,252 @@
+package acp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func evJSON(typ string, payload map[string]any) runEvent {
+	p, _ := json.Marshal(payload)
+	data, _ := json.Marshal(map[string]any{"id": "run-1:1", "run_id": "run-1", "type": typ, "payload": json.RawMessage(p)})
+	return runEvent{Type: typ, Data: string(data)}
+}
+
+func TestTranslateRunEvent(t *testing.T) {
+	t.Run("message delta becomes agent_message_chunk", func(t *testing.T) {
+		u, kind, ok := translateRunEvent(evJSON("assistant.message.delta", map[string]any{"step": 1, "content": "Hello"}))
+		if !ok || kind != kindDelta {
+			t.Fatalf("got ok=%v kind=%v", ok, kind)
+		}
+		if u["sessionUpdate"] != "agent_message_chunk" {
+			t.Fatalf("sessionUpdate = %v", u["sessionUpdate"])
+		}
+		content, _ := u["content"].(map[string]any)
+		if content["type"] != "text" || content["text"] != "Hello" {
+			t.Fatalf("content = %v", content)
+		}
+	})
+
+	t.Run("thinking delta becomes agent_thought_chunk", func(t *testing.T) {
+		u, kind, ok := translateRunEvent(evJSON("assistant.thinking.delta", map[string]any{"step": 1, "content": "hmm"}))
+		if !ok || kind != kindDelta {
+			t.Fatalf("got ok=%v kind=%v", ok, kind)
+		}
+		if u["sessionUpdate"] != "agent_thought_chunk" {
+			t.Fatalf("sessionUpdate = %v", u["sessionUpdate"])
+		}
+		content, _ := u["content"].(map[string]any)
+		if content["text"] != "hmm" {
+			t.Fatalf("content = %v", content)
+		}
+	})
+
+	t.Run("empty deltas are not translated", func(t *testing.T) {
+		for _, typ := range []string{"assistant.message.delta", "assistant.thinking.delta"} {
+			if _, _, ok := translateRunEvent(evJSON(typ, map[string]any{"step": 1, "content": ""})); ok {
+				t.Fatalf("empty %s delta must not produce an update", typ)
+			}
+		}
+	})
+
+	t.Run("tool.call.started becomes tool_call with stable id and in_progress", func(t *testing.T) {
+		u, kind, ok := translateRunEvent(evJSON("tool.call.started", map[string]any{"call_id": "call-1", "tool": "bash", "arguments": "ls -la"}))
+		if !ok || kind != kindLifecycle {
+			t.Fatalf("got ok=%v kind=%v", ok, kind)
+		}
+		if u["sessionUpdate"] != "tool_call" {
+			t.Fatalf("sessionUpdate = %v", u["sessionUpdate"])
+		}
+		if u["toolCallId"] != "call-1" {
+			t.Fatalf("toolCallId = %v, want call-1", u["toolCallId"])
+		}
+		if u["title"] != "bash" {
+			t.Fatalf("title = %v", u["title"])
+		}
+		if u["status"] != "in_progress" {
+			t.Fatalf("status = %v, want in_progress", u["status"])
+		}
+		if u["kind"] != "execute" {
+			t.Fatalf("kind = %v, want execute", u["kind"])
+		}
+	})
+
+	t.Run("tool.call.completed becomes tool_call_update completed with output", func(t *testing.T) {
+		u, kind, ok := translateRunEvent(evJSON("tool.call.completed", map[string]any{"call_id": "call-1", "tool": "bash", "output": "file.txt\n", "duration_ms": 12}))
+		if !ok || kind != kindLifecycle {
+			t.Fatalf("got ok=%v kind=%v", ok, kind)
+		}
+		if u["sessionUpdate"] != "tool_call_update" {
+			t.Fatalf("sessionUpdate = %v", u["sessionUpdate"])
+		}
+		if u["toolCallId"] != "call-1" {
+			t.Fatalf("toolCallId = %v, want call-1 (stable across start/complete)", u["toolCallId"])
+		}
+		if u["status"] != "completed" {
+			t.Fatalf("status = %v", u["status"])
+		}
+		content, _ := u["content"].([]map[string]any)
+		if len(content) == 0 {
+			t.Fatalf("expected tool output content, got %v", u["content"])
+		}
+	})
+
+	t.Run("tool.call.completed with error becomes failed", func(t *testing.T) {
+		u, _, ok := translateRunEvent(evJSON("tool.call.completed", map[string]any{"call_id": "call-9", "tool": "bash", "error": "sandbox violation", "duration_ms": 3}))
+		if !ok {
+			t.Fatal("expected translation")
+		}
+		if u["status"] != "failed" {
+			t.Fatalf("status = %v, want failed", u["status"])
+		}
+		if u["toolCallId"] != "call-9" {
+			t.Fatalf("toolCallId = %v", u["toolCallId"])
+		}
+	})
+
+	t.Run("unmapped events are ignored", func(t *testing.T) {
+		for _, typ := range []string{"run.started", "usage.delta", "todos.updated", "llm.turn.requested", "run.completed", "tool.call.delta"} {
+			if _, _, ok := translateRunEvent(evJSON(typ, map[string]any{"x": 1})); ok {
+				t.Fatalf("%s must not produce an update in slice 3", typ)
+			}
+		}
+	})
+}
+
+func TestToolKindMapping(t *testing.T) {
+	cases := map[string]string{
+		"bash":          "execute",
+		"exec_command":  "execute",
+		"read":          "read",
+		"read_file":     "read",
+		"ls":            "read",
+		"glob":          "read",
+		"edit":          "edit",
+		"write":         "edit",
+		"apply_patch":   "edit",
+		"grep":          "search",
+		"web_fetch":     "fetch",
+		"think":         "think",
+		"deploy":        "other",
+		"some_new_tool": "other",
+	}
+	for tool, want := range cases {
+		if got := toolKind(tool); got != want {
+			t.Errorf("toolKind(%q) = %q, want %q", tool, got, want)
+		}
+	}
+}
+
+func TestUpdateQueueCoalescesDeltas(t *testing.T) {
+	t.Run("no coalescing while the queue has room", func(t *testing.T) {
+		q := newUpdateQueue(2)
+		q.push(chunkUpdate("agent_message_chunk", "Hello"), kindDelta)
+		q.push(chunkUpdate("agent_message_chunk", ", world"), kindDelta)
+		if got := q.len(); got != 2 {
+			t.Fatalf("healthy queue must stream 1:1, got %d items", got)
+		}
+		first, _ := q.pop()
+		second, _ := q.pop()
+		if first["content"].(map[string]any)["text"] != "Hello" || second["content"].(map[string]any)["text"] != ", world" {
+			t.Fatalf("deltas mutated without backpressure: %v %v", first, second)
+		}
+	})
+
+	t.Run("full queue coalesces same-kind deltas into the tail", func(t *testing.T) {
+		q := newUpdateQueue(1)
+		q.push(chunkUpdate("agent_message_chunk", "Hello"), kindDelta)
+		q.push(chunkUpdate("agent_message_chunk", ", world"), kindDelta)
+		if got := q.len(); got != 1 {
+			t.Fatalf("full queue must coalesce same-kind deltas, got %d items", got)
+		}
+		if q.droppedCount() != 0 {
+			t.Fatalf("coalescing is not a drop, dropped = %d", q.droppedCount())
+		}
+		item, _ := q.pop()
+		if text := item["content"].(map[string]any)["text"]; text != "Hello, world" {
+			t.Fatalf("coalesced text = %q, want %q", text, "Hello, world")
+		}
+	})
+
+	t.Run("message and thought deltas never coalesce", func(t *testing.T) {
+		q := newUpdateQueue(1)
+		q.push(chunkUpdate("agent_message_chunk", "a"), kindDelta)
+		q.push(chunkUpdate("agent_thought_chunk", "t"), kindDelta)
+		if q.droppedCount() != 1 {
+			t.Fatalf("different-kind delta on a full queue must drop, dropped = %d", q.droppedCount())
+		}
+		item, _ := q.pop()
+		if item["content"].(map[string]any)["text"] != "a" {
+			t.Fatalf("queued delta was polluted: %v", item)
+		}
+	})
+}
+
+func TestUpdateQueueLifecycleBreaksCoalescing(t *testing.T) {
+	// A lifecycle update at the tail means a following delta has nothing to
+	// merge into: on a full queue it drops rather than merging across.
+	q := newUpdateQueue(2)
+	q.push(chunkUpdate("agent_message_chunk", "a"), kindDelta)
+	q.push(map[string]any{"sessionUpdate": "tool_call", "toolCallId": "c1"}, kindLifecycle)
+	q.push(chunkUpdate("agent_message_chunk", "b"), kindDelta)
+	if q.droppedCount() != 1 {
+		t.Fatalf("delta after lifecycle must drop on a full queue, dropped = %d", q.droppedCount())
+	}
+	first, _ := q.pop()
+	second, _ := q.pop()
+	if first["content"].(map[string]any)["text"] != "a" || second["sessionUpdate"] != "tool_call" {
+		t.Fatalf("unexpected queue contents: %v %v", first, second)
+	}
+}
+
+func TestUpdateQueueBackpressure(t *testing.T) {
+	t.Run("deltas are dropped (counted) when full of lifecycle updates", func(t *testing.T) {
+		q := newUpdateQueue(2)
+		q.push(map[string]any{"sessionUpdate": "tool_call", "toolCallId": "c1"}, kindLifecycle)
+		q.push(map[string]any{"sessionUpdate": "tool_call_update", "toolCallId": "c1"}, kindLifecycle)
+		q.push(chunkUpdate("agent_message_chunk", "dropped"), kindDelta)
+		if q.droppedCount() != 1 {
+			t.Fatalf("dropped = %d, want 1", q.droppedCount())
+		}
+		if got := q.len(); got != 2 {
+			t.Fatalf("queue mutated on drop, len = %d", got)
+		}
+	})
+
+	t.Run("lifecycle updates evict buffered deltas, never get dropped", func(t *testing.T) {
+		q := newUpdateQueue(2)
+		q.push(chunkUpdate("agent_message_chunk", "old"), kindDelta)
+		q.push(chunkUpdate("agent_message_chunk", "older"), kindDelta)
+		q.push(map[string]any{"sessionUpdate": "tool_call", "toolCallId": "c1"}, kindLifecycle)
+		if got := q.len(); got != 2 {
+			t.Fatalf("len = %d, want 2 (evicted oldest delta)", got)
+		}
+		first, _ := q.pop()
+		if first["sessionUpdate"] != "agent_message_chunk" {
+			t.Fatalf("oldest surviving item = %v, want the remaining delta", first["sessionUpdate"])
+		}
+		second, _ := q.pop()
+		if second["sessionUpdate"] != "tool_call" {
+			t.Fatalf("lifecycle update lost: %v", second)
+		}
+	})
+
+	t.Run("pop drains after close then reports done", func(t *testing.T) {
+		q := newUpdateQueue(4)
+		q.push(chunkUpdate("agent_message_chunk", "tail"), kindDelta)
+		q.close()
+		if _, ok := q.pop(); !ok {
+			t.Fatal("buffered item must drain after close")
+		}
+		if _, ok := q.pop(); ok {
+			t.Fatal("empty closed queue must report done")
+		}
+	})
+}
+
+// chunkUpdate builds an agent_message_chunk/agent_thought_chunk update object.
+func chunkUpdate(kind, text string) map[string]any {
+	return map[string]any{
+		"sessionUpdate": kind,
+		"content":       map[string]any{"type": "text", "text": text},
+	}
+}


### PR DESCRIPTION
Parent epic: #806. Part of #803.

## What
Slice 3 of epic #806 (ACP server mode for Zed/JetBrains): during a prompt turn the editor now sees live agent output translated from the harness SSE stream.

- `internal/acp/updates.go` (new): translator — `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk`, `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload has `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.
- Backpressure discipline: one bounded (256) per-turn notification queue with a single writer goroutine — the SSE reader never blocks on a slow editor. Coalescing/drops trigger only on a FULL queue: same-kind deltas merge into the tail, other deltas drop (counted + logged), lifecycle updates evict buffered deltas but are never dropped.
- `client.go`: `WatchRun(ctx, runID, onEvent)` generalizes `WaitTerminal` (now a nil-callback wrapper); oversized SSE lines (cap now a test-shrinkable var) are drained and their event skipped with a logged warning instead of corrupting the stream.
- `server.go`/`jsonrpc.go`: `writeNotification`; the prompt handler closes the queue at the terminal event and drains it fully before writing the `session/prompt` response (spec: updates precede the turn result).

Distinct from the SDK-based `internal/harnessacp` adapter (epic #746); untouched. Permission bridge (`session/request_permission`) lands in slice 4.

## Tests (strict TDD — failing tests first)
- Translator table (all four mappings incl. failed tool call, unmapped events, empty deltas); tool-kind table.
- Queue: no coalescing with room, full-queue same-kind coalescing, cross-kind drop, lifecycle breaks coalescing, lifecycle evicts deltas, drain-after-close.
- Client: oversized SSE event skipped with warning, terminal still found.
- Golden acceptance: scripted client performing `session/prompt` against the fake harnessd observes two `agent_message_chunk`s, an `agent_thought_chunk`, `tool_call`, `tool_call_update` (stable `toolCallId`) in exact order before the `end_turn` result.

## Validation run
- `GOCACHE=/tmp/go-build go test ./internal/acp/... -count=1` — ok
- `GOCACHE=/tmp/go-build go test ./internal/acp/... -count=1 -race` — ok
- `GOCACHE=/tmp/go-build go test ./cmd/harnesscli/ -count=1` — ok (slice-2 CLI tests unaffected)
- gofmt / go vet clean on touched files

Do not merge — slices 4–5 follow.