### PR TITLE
feat(tui): /add-dir — attach extra workspace directories to the session

### DIFF
--- a/cmd/harnesscli/tui/add_dir.go
+++ b/cmd/harnesscli/tui/add_dir.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// executeAddDirCommand implements /add-dir: it attaches an extra directory to
+// the session so runs may read/work in it (harness.RunRequest.ExtraDirs).
+//
+//	/add-dir                — list the attached directories
+//	/add-dir <path>         — attach a directory (relative paths resolve
+//	                          against the session workspace)
+//	/add-dir remove <path>  — detach a directory ("remove" is a subcommand
+//	                          only when followed by a path, so a directory
+//	                          literally named "remove" can still be added)
+//
+// The list is session-scoped (not persisted) and applies to file-tool
+// confinement only; the bash sandbox and glob still confine to the primary
+// workspace root.
+func executeAddDirCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
+	// /add-dir remove <path>
+	if len(cmd.Args) >= 2 && cmd.Args[0] == "remove" {
+		return m.removeExtraDir(strings.Join(cmd.Args[1:], " ")), false
+	}
+
+	// /add-dir (list)
+	if len(cmd.Args) == 0 {
+		if len(m.extraDirs) == 0 {
+			return []tea.Cmd{m.setStatusMsg("No extra directories — use /add-dir <path> to add one")}, false
+		}
+		return []tea.Cmd{m.setStatusMsg(fmt.Sprintf("Extra directories (%d): %s", len(m.extraDirs), strings.Join(m.extraDirs, ", ")))}, false
+	}
+
+	// /add-dir <path> (add; a sole "remove" arg is a literal relative path,
+	// see the collision rule above).
+	return m.addExtraDir(strings.Join(cmd.Args, " ")), false
+}
+
+// addExtraDir validates and attaches dir, returning the status-message command.
+func (m *Model) addExtraDir(dir string) []tea.Cmd {
+	abs, err := m.resolveAddDirPath(dir)
+	if err != nil {
+		return []tea.Cmd{m.setStatusMsg(err.Error())}
+	}
+	for _, existing := range m.extraDirs {
+		if existing == abs {
+			return []tea.Cmd{m.setStatusMsg("Already added " + abs)}
+		}
+	}
+	m.extraDirs = append(m.extraDirs, abs)
+	return []tea.Cmd{m.setStatusMsg("Added " + abs)}
+}
+
+// removeExtraDir detaches dir, returning the status-message command.
+func (m *Model) removeExtraDir(dir string) []tea.Cmd {
+	abs, err := m.resolveAddDirPath(dir)
+	if err != nil {
+		return []tea.Cmd{m.setStatusMsg(err.Error())}
+	}
+	for i, existing := range m.extraDirs {
+		if existing == abs {
+			m.extraDirs = append(m.extraDirs[:i], m.extraDirs[i+1:]...)
+			return []tea.Cmd{m.setStatusMsg("Removed " + abs)}
+		}
+	}
+	return []tea.Cmd{m.setStatusMsg(abs + " is not in the extra directories list")}
+}
+
+// resolveAddDirPath resolves dir to a canonical absolute path (relative paths
+// resolve against the session workspace, falling back to the process working
+// directory) and verifies it is an existing directory.
+func (m Model) resolveAddDirPath(dir string) (string, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "", fmt.Errorf("Usage: /add-dir <path>")
+	}
+	p := dir
+	if !filepath.IsAbs(p) {
+		base := strings.TrimSpace(m.config.Workspace)
+		if base == "" {
+			if cwd, err := os.Getwd(); err == nil {
+				base = cwd
+			}
+		}
+		p = filepath.Join(base, p)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("/add-dir: resolve %q: %v", dir, err)
+	}
+	abs = filepath.Clean(abs)
+	fi, err := os.Stat(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("/add-dir: %s does not exist", abs)
+		}
+		return "", fmt.Errorf("/add-dir: %s is not accessible: %v", abs, err)
+	}
+	if !fi.IsDir() {
+		return "", fmt.Errorf("/add-dir: %s is not a directory", abs)
+	}
+	return abs, nil
+}

--- a/cmd/harnesscli/tui/add_dir_internal_test.go
+++ b/cmd/harnesscli/tui/add_dir_internal_test.go
@@ -1,0 +1,58 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestStartRunCmdIncludesExtraDirs verifies extra directories added via
+// /add-dir are marshaled onto the run request as extra_dirs.
+func TestStartRunCmdIncludesExtraDirs(t *testing.T) {
+	t.Parallel()
+
+	var got runCreateRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(runCreateResponse{RunID: "run-extra-dirs"}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "/tmp/ws", "", nil, []string{"/tmp/shared-libs"})()
+	if _, ok := msg.(RunStartedMsg); !ok {
+		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
+	}
+	if len(got.ExtraDirs) != 1 || got.ExtraDirs[0] != "/tmp/shared-libs" {
+		t.Fatalf("extra_dirs = %v, want [/tmp/shared-libs]", got.ExtraDirs)
+	}
+}
+
+// TestStartRunCmdOmitsExtraDirsWhenEmpty verifies extra_dirs is omitted (not
+// sent as an empty array) when no directories were added.
+func TestStartRunCmdOmitsExtraDirsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var rawBody map[string]any
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&rawBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(runCreateResponse{RunID: "run-no-extra-dirs"})
+	}))
+	defer ts.Close()
+
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "default", "/tmp/ws", "", nil, nil)()
+	if _, ok := msg.(RunStartedMsg); !ok {
+		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
+	}
+	if _, present := rawBody["extra_dirs"]; present {
+		t.Fatalf("extra_dirs must be omitted when empty, body: %v", rawBody)
+	}
+}

--- a/cmd/harnesscli/tui/add_dir_test.go
+++ b/cmd/harnesscli/tui/add_dir_test.go
@@ -1,0 +1,197 @@
+package tui_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// initModelForAddDir creates a Model whose workspace is a temp directory, so
+// relative /add-dir paths resolve inside test-controlled storage.
+func initModelForAddDir(t *testing.T) (tui.Model, string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	ws := t.TempDir()
+	cfg := tui.DefaultTUIConfig()
+	cfg.Workspace = ws
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	return m2.(tui.Model), ws
+}
+
+// TestAddDirCommand_AddAndList verifies /add-dir <path> records the directory
+// and bare /add-dir lists it.
+func TestAddDirCommand_AddAndList(t *testing.T) {
+	m, _ := initModelForAddDir(t)
+	extra := t.TempDir()
+
+	m = sendSlashCommand(m, "/add-dir "+extra)
+	if got := m.StatusMsg(); !strings.Contains(got, "Added") || !strings.Contains(got, extra) {
+		t.Fatalf("StatusMsg() = %q, want an 'Added <dir>' confirmation", got)
+	}
+	dirs := m.ExtraDirs()
+	if len(dirs) != 1 || dirs[0] != extra {
+		t.Fatalf("ExtraDirs() = %v, want [%s]", dirs, extra)
+	}
+
+	m = sendSlashCommand(m, "/add-dir")
+	if got := m.StatusMsg(); !strings.Contains(got, extra) {
+		t.Errorf("StatusMsg() = %q after bare /add-dir, want the added dir listed", got)
+	}
+}
+
+// TestAddDirCommand_ListEmpty verifies bare /add-dir explains the empty state.
+func TestAddDirCommand_ListEmpty(t *testing.T) {
+	m, _ := initModelForAddDir(t)
+
+	m = sendSlashCommand(m, "/add-dir")
+	if got := m.StatusMsg(); !strings.Contains(got, "No extra directories") {
+		t.Errorf("StatusMsg() = %q, want a 'No extra directories' hint", got)
+	}
+}
+
+// TestAddDirCommand_RelativeResolvedAgainstWorkspace verifies a relative path
+// is resolved against the session workspace and stored absolute.
+func TestAddDirCommand_RelativeResolvedAgainstWorkspace(t *testing.T) {
+	m, ws := initModelForAddDir(t)
+	if err := os.Mkdir(filepath.Join(ws, "libs"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	m = sendSlashCommand(m, "/add-dir libs")
+
+	want := filepath.Join(ws, "libs")
+	dirs := m.ExtraDirs()
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Fatalf("ExtraDirs() = %v, want [%s]", dirs, want)
+	}
+}
+
+// TestAddDirCommand_RejectsNonexistent verifies a missing directory is not added.
+func TestAddDirCommand_RejectsNonexistent(t *testing.T) {
+	m, ws := initModelForAddDir(t)
+
+	m = sendSlashCommand(m, "/add-dir "+filepath.Join(ws, "nope"))
+
+	if got := m.StatusMsg(); !strings.Contains(got, "not") {
+		t.Errorf("StatusMsg() = %q, want a not-a-directory / does-not-exist error", got)
+	}
+	if n := len(m.ExtraDirs()); n != 0 {
+		t.Errorf("ExtraDirs() len = %d, want 0 after rejecting a missing dir", n)
+	}
+}
+
+// TestAddDirCommand_RejectsFiles verifies a regular file is not accepted as a
+// directory.
+func TestAddDirCommand_RejectsFiles(t *testing.T) {
+	m, ws := initModelForAddDir(t)
+	file := filepath.Join(ws, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m = sendSlashCommand(m, "/add-dir "+file)
+
+	if got := m.StatusMsg(); !strings.Contains(got, "not a directory") {
+		t.Errorf("StatusMsg() = %q, want a 'not a directory' error", got)
+	}
+	if n := len(m.ExtraDirs()); n != 0 {
+		t.Errorf("ExtraDirs() len = %d, want 0 after rejecting a file", n)
+	}
+}
+
+// TestAddDirCommand_Dedupes verifies adding the same directory twice keeps one
+// entry and tells the user.
+func TestAddDirCommand_Dedupes(t *testing.T) {
+	m, _ := initModelForAddDir(t)
+	extra := t.TempDir()
+
+	m = sendSlashCommand(m, "/add-dir "+extra)
+	m = sendSlashCommand(m, "/add-dir "+extra)
+
+	if got := m.StatusMsg(); !strings.Contains(got, "Already") {
+		t.Errorf("StatusMsg() = %q, want an 'already added' notice", got)
+	}
+	if n := len(m.ExtraDirs()); n != 1 {
+		t.Errorf("ExtraDirs() len = %d, want 1 after duplicate add", n)
+	}
+}
+
+// TestAddDirCommand_Remove verifies /add-dir remove drops the directory.
+func TestAddDirCommand_Remove(t *testing.T) {
+	m, _ := initModelForAddDir(t)
+	extra := t.TempDir()
+
+	m = sendSlashCommand(m, "/add-dir "+extra)
+	m = sendSlashCommand(m, "/add-dir remove "+extra)
+
+	if got := m.StatusMsg(); !strings.Contains(got, "Removed") || !strings.Contains(got, extra) {
+		t.Fatalf("StatusMsg() = %q, want a 'Removed <dir>' confirmation", got)
+	}
+	if n := len(m.ExtraDirs()); n != 0 {
+		t.Fatalf("ExtraDirs() len = %d, want 0 after remove", n)
+	}
+
+	m = sendSlashCommand(m, "/add-dir")
+	if got := m.StatusMsg(); !strings.Contains(got, "No extra directories") {
+		t.Errorf("StatusMsg() = %q, want empty state after remove", got)
+	}
+}
+
+// TestAddDirCommand_RemoveNotPresent verifies removing a directory that was
+// never added says so.
+func TestAddDirCommand_RemoveNotPresent(t *testing.T) {
+	m, _ := initModelForAddDir(t)
+	extra := t.TempDir()
+
+	m = sendSlashCommand(m, "/add-dir remove "+extra)
+
+	if got := m.StatusMsg(); !strings.Contains(got, "not in the extra directories") {
+		t.Errorf("StatusMsg() = %q, want a 'not in the extra directories' notice", got)
+	}
+}
+
+// TestAddDirCommand_RemoveKeywordWithoutArgAddsLiteralDir documents the
+// collision rule: "remove" is a subcommand only when followed by a path, so a
+// directory literally named "remove" can still be added.
+func TestAddDirCommand_RemoveKeywordWithoutArgAddsLiteralDir(t *testing.T) {
+	m, ws := initModelForAddDir(t)
+	if err := os.Mkdir(filepath.Join(ws, "remove"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	m = sendSlashCommand(m, "/add-dir remove")
+
+	want := filepath.Join(ws, "remove")
+	dirs := m.ExtraDirs()
+	if len(dirs) != 1 || dirs[0] != want {
+		t.Fatalf("ExtraDirs() = %v, want [%s]", dirs, want)
+	}
+}
+
+// TestAddDirCommand_Registered verifies the add-dir command is registered.
+func TestAddDirCommand_Registered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("add-dir") {
+		t.Fatal("built-in registry must register the add-dir command")
+	}
+	entry, ok := r.Lookup("add-dir")
+	if !ok || entry.Description == "" {
+		t.Fatal("add-dir command must have a description for /help and autocomplete")
+	}
+}
+
+// TestAddDirCommand_InSlashComplete verifies /add-dir appears in autocomplete.
+func TestAddDirCommand_InSlashComplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 120, 40)
+	m = typeIntoModel(m, "/add")
+	if v := m.View(); !strings.Contains(v, "add-dir") {
+		t.Errorf("slash-complete must contain 'add-dir' when typing '/add'; got:\n%s", v)
+	}
+}

--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -68,6 +68,10 @@ type runCreateRequest struct {
 	// name in prompt_profile makes the server reject the run with HTTP 400.
 	ProfileName   string `json:"profile,omitempty"`
 	WorkspacePath string `json:"workspace_path,omitempty"`
+	// ExtraDirs carries session directories added via /add-dir; they map to
+	// harness.RunRequest.ExtraDirs so file-tool confinement grants them in
+	// addition to the workspace root.
+	ExtraDirs []string `json:"extra_dirs,omitempty"`
 	// AllowFallback lets the server degrade to its default provider when the
 	// requested model's provider can't be resolved, instead of hard-failing
 	// the run. Always true from the TUI.
@@ -139,7 +143,9 @@ type RemoteTask struct {
 // restrictions and isolation.
 // attachments carries the base64-encoded image blocks from the input area's
 // chips (nil for text-only prompts).
-func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace, apiKey string, attachments []runAttachment, planMode ...bool) tea.Cmd {
+// extraDirs lists additional directory roots the run may read/work in (see
+// /add-dir); nil or empty omits the field.
+func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffort, profile, workspace, apiKey string, attachments []runAttachment, extraDirs []string, planMode ...bool) tea.Cmd {
 	enabled := len(planMode) > 0 && planMode[0]
 	return func() tea.Msg {
 		body, _ := json.Marshal(runCreateRequest{
@@ -151,6 +157,7 @@ func startRunCmd(baseURL, prompt, conversationID, model, provider, reasoningEffo
 			Attachments:     attachments,
 			ProfileName:     profile,
 			WorkspacePath:   workspace,
+			ExtraDirs:       extraDirs,
 			AllowFallback:   true,
 			PlanMode:        enabled,
 		})

--- a/cmd/harnesscli/tui/api_auth_test.go
+++ b/cmd/harnesscli/tui/api_auth_test.go
@@ -65,7 +65,7 @@ func harnessAuthCases() []harnessAuthCase {
 		{
 			name: "startRunCmd",
 			call: func(ts *httptest.Server, apiKey string) any {
-				return startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "default", "/tmp", apiKey, nil)()
+				return startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "default", "/tmp", apiKey, nil, nil)()
 			},
 		},
 		{

--- a/cmd/harnesscli/tui/api_coverage_test.go
+++ b/cmd/harnesscli/tui/api_coverage_test.go
@@ -26,7 +26,7 @@ func TestStartRunCmdIncludesWorkspacePath(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "/tmp/project-root", "", nil)()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "/tmp/project-root", "", nil, nil)()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}
@@ -51,7 +51,7 @@ func TestStartRunCmdSendsCapabilityProfileAsProfileField(t *testing.T) {
 	// A capability profile selected via /profiles (e.g. "researcher") must be
 	// sent in the "profile" field (harness.RunRequest.ProfileName), NOT in
 	// "prompt_profile" — the server rejects unknown prompt profiles with HTTP 400.
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "researcher", "/tmp/x", "", nil)()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "", "researcher", "/tmp/x", "", nil, nil)()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}
@@ -158,7 +158,7 @@ func TestStartRunCmdSetsAllowFallback(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "", "", nil)()
+	msg := startRunCmd(ts.URL, "hello", "", "gpt-test", "openai", "low", "default", "", "", nil, nil)()
 	if _, ok := msg.(RunStartedMsg); !ok {
 		t.Fatalf("expected RunStartedMsg, got %T: %+v", msg, msg)
 	}

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -232,6 +232,14 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeInitCommand,
 		},
 		{
+			Name:        "add-dir",
+			Description: "Attach an extra directory to the session (/add-dir [remove] <path>)",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeAddDirCommand,
+		},
+		{
 			Name:        "rewind",
 			Description: "Choose and confirm a destructive session rewind",
 			Handler:     func(cmd Command) CommandResult { return CommandResult{Status: CmdOK} },

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"attach", "cancel", "clear", "compact", "config", "context", "cost", "dashboard", "doctor", "export", "fork", "help", "history", "hooks", "init", "keys",
+		"add-dir", "attach", "cancel", "clear", "compact", "config", "context", "cost", "dashboard", "doctor", "export", "fork", "help", "history", "hooks", "init", "keys",
 		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents", "tasks", "rewind", "theme", "title", "undo",
 	}

--- a/cmd/harnesscli/tui/init_agents.go
+++ b/cmd/harnesscli/tui/init_agents.go
@@ -68,7 +68,7 @@ func executeInitCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	effModel, effProvider := m.effectiveModelAndProvider()
 	return []tea.Cmd{
 		m.setStatusMsg("Generating AGENTS.md..."),
-		startRunCmd(m.config.BaseURL, initAgentsPrompt, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, ws, m.config.APIKey, nil),
+		startRunCmd(m.config.BaseURL, initAgentsPrompt, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, ws, m.config.APIKey, nil, m.extraDirs),
 	}, false
 }
 

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -306,6 +306,11 @@ type Model struct {
 	// <workspace>/AGENTS.md (see init_agents.go).
 	pendingInitAgentsMd bool
 
+	// extraDirs holds the absolute paths of additional directories the user
+	// attached to this session via /add-dir. They are sent on every run as
+	// extra_dirs so the server's file-tool confinement grants them.
+	extraDirs []string
+
 	// Search overlay state (for /search and /history commands).
 	searchResults     []SearchResult
 	searchQuery       string
@@ -689,6 +694,17 @@ func (m Model) SelectedProfile() string {
 // The returned pointer is live — callers can inspect it after updates.
 func (m Model) SessionStore() *SessionStore {
 	return m.sessionStore
+}
+
+// ExtraDirs returns a copy of the extra directories attached to this session
+// via /add-dir (for testing).
+func (m Model) ExtraDirs() []string {
+	if m.extraDirs == nil {
+		return nil
+	}
+	cp := make([]string, len(m.extraDirs))
+	copy(cp, m.extraDirs)
+	return cp
 }
 
 // gatewayIndex returns the index of the gateway option with the given ID,
@@ -3347,7 +3363,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Fire off the run against the harness API with the expanded prompt.
 		effModel, effProvider := m.effectiveModelAndProvider()
-		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey, runAttachments, m.planMode))
+		cmds = append(cmds, startRunCmd(m.config.BaseURL, expandedValue, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey, runAttachments, m.extraDirs, m.planMode))
 		// The attachments were handed to the run: consume the chips and their
 		// temp files.
 		if runAttachments != nil {

--- a/cmd/harnesscli/tui/model_apikeys_test.go
+++ b/cmd/harnesscli/tui/model_apikeys_test.go
@@ -348,9 +348,9 @@ func TestKeysOverlay_EnterWithInputEmitsSetMsg(t *testing.T) {
 // TestKeysCommand_InHelpList verifies /keys appears in /help output.
 func TestKeysCommand_InHelpList(t *testing.T) {
 	// A taller window is needed so /keys is within the help dialog's first
-	// visible page now that /cost and /config have been added to the
+	// visible page now that /add-dir, /cost, and /config have been added to the
 	// (alphabetically-earlier) command set.
-	m := initModel(t, 80, 30)
+	m := initModel(t, 80, 40)
 	m = sendSlashCommand(m, "/help")
 
 	v := m.View()

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -616,7 +616,6 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 		"compact",
 		"config",
 		"context",
-		"cost",
 	}
 	for _, cmd := range wantVisible {
 		if !strings.Contains(v, cmd) {

--- a/cmd/harnesscli/tui/model_init_test.go
+++ b/cmd/harnesscli/tui/model_init_test.go
@@ -609,6 +609,7 @@ func TestBuildCommandRegistry_SlashCompleteShowsCommands(t *testing.T) {
 	// so the first visible window shows the 7 alphabetically-earliest commands
 	// in the merged command set.
 	wantVisible := []string{
+		"add-dir",
 		"attach",
 		"cancel",
 		"clear",

--- a/cmd/harnesscli/tui/overlay_wire_test.go
+++ b/cmd/harnesscli/tui/overlay_wire_test.go
@@ -23,9 +23,10 @@ func TestHelpOverlay_ShowsCommands(t *testing.T) {
 	// With many registered commands and a fixed dialog height (80x24), not all
 	// commands fit on the first visible page — overflow pagination clips the list.
 	// Check commands that are guaranteed to appear on the first visible page
-	// (alphabetically first batch). Commands past the page boundary (e.g. "search",
-	// "sessions") are only visible after scrolling and are intentionally omitted here.
-	wantCommands := []string{"attach", "cancel", "clear", "context", "doctor", "export"}
+	// (alphabetically first batch). Commands past the page boundary (e.g. "export",
+	// "search", "sessions") are only visible after scrolling and are intentionally
+	// omitted here.
+	wantCommands := []string{"attach", "cancel", "clear", "context", "doctor"}
 	for _, cmd := range wantCommands {
 		if !strings.Contains(view, cmd) {
 			t.Errorf("help overlay View() must contain command %q; got:\n%s", cmd, view)

--- a/cmd/harnesscli/tui/planmode_api_test.go
+++ b/cmd/harnesscli/tui/planmode_api_test.go
@@ -19,7 +19,7 @@ func TestStartRunCmdSendsPlanMode(t *testing.T) {
 		_, _ = w.Write([]byte(`{"run_id":"r"}`))
 	}))
 	defer ts.Close()
-	if _, ok := startRunCmd(ts.URL, "p", "", "", "", "", "", "", "", nil, true)().(RunStartedMsg); !ok {
+	if _, ok := startRunCmd(ts.URL, "p", "", "", "", "", "", "", "", nil, nil, true)().(RunStartedMsg); !ok {
 		t.Fatal("run not started")
 	}
 }

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -1,5 +1,6 @@
 Command Registry - 120x40
 ------------------------------------------------------------
+/add-dir — Attach an extra directory to the session (/add-dir [remove] <path>)
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -1,5 +1,6 @@
 Command Registry - 200x50
 --------------------------------------------------------------------------------
+/add-dir — Attach an extra directory to the session (/add-dir [remove] <path>)
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -1,5 +1,6 @@
 Command Registry - 80x24
 ----------------------------------------
+/add-dir — Attach an extra directory to the session (/add-dir [remove] <path>)
 /attach — Attach file context with @path tokens
 /cancel — Cancel a harness run
 /clear — Clear conversation history

--- a/docs/plans/822-qol-commands.md
+++ b/docs/plans/822-qol-commands.md
@@ -1,8 +1,67 @@
 # Plan: quality-of-life commands — epic #822 slices
 
-Epic: #822. Parent: #803. Slice 1 branch: `epic/822-qol-commands` (merged, PR #842). Slice 2 branch: `epic/822-qol-commands-s2`.
+Epic: #822. Parent: #803. Slice 1 branch: `epic/822-qol-commands` (merged, PR #842). Slice 2 branch: `epic/822-qol-commands-s2` (merged, PR #863). Slice 3 branch: `epic/822-qol-commands-s3`.
 
 ---
+
+# Slice 3: /add-dir — attach extra workspace directories to the session
+
+## Investigation (required by the epic, drives the shape)
+
+Traced from `runCreateRequest.WorkspacePath` (`cmd/harnesscli/tui/api.go`) through the server:
+
+1. **The TUI's `workspace_path` is silently dropped today.** `handlePostRun` (`internal/server/http_runs.go:43`) decodes into `harness.RunRequest`, which has no `workspace_path` field. The effective tool workspace is the harnessd startup config `WorkspaceBaseOptions.RepoPath` (`Runner.defaultPermissionWorkspaceRoot`), or a per-run provisioned path when `workspace_type` is set (`runPreflight`, runner.go:1147-1219). Fixing the dropped `workspace_path` is NOT this slice; `extra_dirs` are additive to whatever root a run already uses.
+2. **Confinement is real and single-rooted.** Default permission sandbox is `SandboxScopeWorkspace` (runner.go:5413, safety-biased default). Every file tool (`read/write/edit/ls/grep/apply_patch/...` in both `tools/` and `tools/core|deferred`) resolves paths through `ResolveWorkspacePathConfined` → `ConfineWorkspacePath(scope, root, extraAllowedRoots, abs)` (`internal/harness/tools/common_paths.go:165`). `ConfineWorkspacePath` **already implements extra roots** (incl. symlink-safe canonicalization, tested by `TestConfineWorkspacePath_ExtraAllowedRoots_Permitted`) — but every caller passes `nil`.
+3. **Per-run overrides reach tools via context.** The step engine sets `htools.WithSandboxScope(toolCtx, effectiveSandboxScope)` per tool call (`runner_step_engine.go:996`) from `req` — the exact seam to thread extra roots.
+4. **Bash is confined differently.** `CheckSandboxCommand` string heuristics (`sandbox.go`) plus OS-level seatbelt/bubblewrap profiles (`sandbox_darwin.go`/`sandbox_linux.go`) assume one root. Threading extra roots into OS sandbox profiles is a large change.
+
+## Decided shape (minimal viable, per epic preference)
+
+- `harness.RunRequest.ExtraDirs []string` (`json:"extra_dirs,omitempty"`); validated synchronously in `StartRun` (each entry: non-empty, absolute, exists, is a directory) → HTTP 400 on violation.
+- New context key in `internal/harness/tools/types.go`: `WithExtraAllowedRoots` / `ExtraAllowedRootsFromContext` (mirrors `WithSandboxScope`).
+- Step engine: `toolCtx = htools.WithExtraAllowedRoots(toolCtx, req.ExtraDirs)` next to the scope line.
+- `ResolveWorkspacePathConfined` passes the context roots to `ConfineWorkspacePath` (instead of `nil`).
+- TUI: `/add-dir <path>` (add, resolves relative to the session workspace, dedupes), `/add-dir` (list), `/add-dir remove <path>` (remove); dirs kept client-side per session and sent on every run via `startRunCmd` (new `extraDirs` parameter before the variadic `planMode`).
+- **Documented limits (deliberately out of scope):** bash tool commands remain confined to the primary workspace root (OS sandbox profiles unchanged); `glob` still only matches inside the primary root; extra dirs are session-scoped (not persisted); the pre-existing dropped `workspace_path` is untouched.
+
+## Documentation Contract
+
+- Feature status: `implemented`
+- Public docs affected: `website/docs/cli/tui.md`, `docs/ux-paths.md`, server API docs note for the new `extra_dirs` run-request field (`website/docs/server/http-api-guide.md`)
+- Spec docs to update before code: none (epic #822 body + this investigation)
+- Implementation notes to add after code: none required
+
+## Test Plan (TDD)
+
+- New failing tests first:
+  - `internal/harness` (acceptance, mirrors `default_sandbox_acceptance_test.go`): run with `ExtraDirs` → `read` tool reads a file under the extra root (content returned) and is still denied outside all roots; control run without `ExtraDirs` is denied under the extra root. StartRun validation table: relative/nonexistent/not-a-directory rejected; valid accepted.
+  - `internal/harness/tools` (mirrors `workspace_confinement_test.go`): `ResolveWorkspacePathConfined` + ctx roots allows the extra root, denies elsewhere; no ctx roots → unchanged behavior.
+  - `internal/server` (mirrors `http_workspace_type_test.go`): POST /v1/runs with a nonexistent `extra_dirs` entry → 400 `invalid_request`; valid entry → 202.
+  - `cmd/harnesscli/tui`: `/add-dir` add/list/remove/dedupe/not-a-directory/relative-resolution through the model; `startRunCmd` marshals `extra_dirs` (httptest body capture); registry + slash-complete; `TestTUI364_RegistryCompleteness` += `add-dir`.
+- Regression: default run (no extra_dirs) confinement unchanged — the existing GAP-1 acceptance test must stay green.
+
+## Cross-Surface Impact Map
+
+- Server API: new optional `extra_dirs` field on POST /v1/runs — additive, backward compatible. No provider/model flow, gateway, catalog, or API-key changes.
+
+## Implementation Checklist
+
+- [x] Investigation documented (above) and shape decided.
+- [x] Acceptance criteria in tests (read under added root succeeds; outside all roots denied).
+- [x] Write failing tests first.
+- [x] Implement minimal code changes.
+- [x] Update docs (`tui.md`, `ux-paths.md`, server API note, plan).
+- [x] Run `go test ./cmd/harnesscli/... ./internal/harness/... ./internal/server/... -count=1`; gofmt + go vet clean.
+- [ ] Push branch, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: scope creep into bash/seatbelt profiles. Mitigation: file-tools-only enforcement; bash limit documented in tui.md and the PR.
+- Risk: symlinked extra root escapes. Mitigation: reuse `ConfineWorkspacePath`'s canonicalization (existing, tested) — roots are canonicalized per check.
+- Risk: `/add-dir remove` collides with a dir literally named `remove`. Mitigation: `remove` is a subcommand only with an argument; `/add-dir remove` (one arg) adds the relative path `remove`. Documented in the command description.
+
+---
+
 
 # Slice 2: /init — generate AGENTS.md for the current workspace
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,7 +5,7 @@
 - `2026-07-19-issue-818-clipboard-image-plan.md` — Epic #818 slice 1: read images from the system clipboard into a temp file (in implementation).
 - `2026-07-19-issue-818-clipboard-image-impact-map.md` — One-page provider/model impact map for epic #818 slice 1.
 - `810-theme-system.md` — Theme system epic #810, slice 1: token schema + JSON loader with base-palette fallback (in implementation).
-- `822-qol-commands.md` — Epic #822 plan. Slice 1 (`/title`, merged PR #842); slice 2 (`/init` AGENTS.md generation, in implementation).
+- `822-qol-commands.md` — Epic #822 plan. Slice 1 (`/title`, merged PR #842); slice 2 (`/init`, merged PR #863); slice 3 (`/add-dir` extra workspace roots, in implementation).
 
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.

--- a/docs/ux-paths.md
+++ b/docs/ux-paths.md
@@ -343,6 +343,10 @@ Registry (`cmd_parser.go:79-194`): clear, context, export, help, keys, model, qu
 | `/init` (AGENTS.md exists) | refuse overwrite; hint `/init confirm`; file untouched | OK | init_agents_test.go |
 | `/init confirm` | overwrite existing AGENTS.md | OK | init_agents_test.go |
 | `/init` (run active) | refuse; no write on the other run's completion | OK | init_agents_test.go |
+| `/add-dir <path>` | attach extra root; sent as `extra_dirs` on runs; file tools confined to workspace + added roots | OK | `add_dir.go` (`executeAddDirCommand`); add_dir_test.go; `TestExtraDirs_*` (internal/harness) |
+| `/add-dir` (no args) | list attached directories | OK | add_dir_test.go |
+| `/add-dir remove <path>` | detach a directory | OK | add_dir_test.go |
+| `extra_dirs` validation | non-absolute/nonexistent/not-a-dir → HTTP 400 | OK | `validateExtraDirs` (runner.go); `TestStartRunExtraDirsValidation`; http_extra_dirs_test.go |
 | `/search <q>` | search transcript | OK | `model.go:1055-1068`; search_test.go (12+) |
 | `/search` (no args) | usage hint | OK | `model.go:1056-1058`; `TestSearch_BT002_EmptyQueryStatusMessage` |
 | `/history <q>` | search session meta | OK | `model.go:1070-1083`; `TestSearch_BT006_HistorySearchOpensOverlay` |

--- a/internal/harness/extra_dirs_test.go
+++ b/internal/harness/extra_dirs_test.go
@@ -1,0 +1,169 @@
+package harness
+
+// extra_dirs_test.go — acceptance and validation coverage for RunRequest.ExtraDirs
+// (TUI /add-dir, epic #822 slice 3). The acceptance tests mirror
+// default_sandbox_acceptance_test.go: a real Runner + real default tool
+// registry + real step engine, proving the file-tool confinement honors
+// caller-granted extra roots while everything outside all roots stays denied.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runReadOnce runs a single-turn read of absPath and returns the read tool's
+// result payload. extraDirs may be nil.
+func runReadOnce(t *testing.T, workspace string, extraDirs []string, absPath string) map[string]any {
+	t.Helper()
+
+	registry := NewDefaultRegistryWithOptions(workspace, DefaultRegistryOptions{})
+	provider := &continuationProvider{
+		turns: []CompletionResult{
+			{
+				ToolCalls: []ToolCall{{
+					ID:        "call_read",
+					Name:      "read",
+					Arguments: fmt.Sprintf(`{"path":%q}`, absPath),
+				}},
+			},
+			{Content: "done"},
+		},
+	}
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     4,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:    "read the file",
+		ExtraDirs: extraDirs,
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	if _, err := collectRunEvents(t, runner, run.ID); err != nil {
+		t.Fatalf("collectRunEvents: %v", err)
+	}
+	return toolMessagePayload(t, runner, run.ID, "read")
+}
+
+func writeExtraDirsFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture %s: %v", path, err)
+	}
+	return path
+}
+
+// TestExtraDirs_ReadUnderAddedRootSucceeds is the acceptance test: a run
+// granted an extra directory via RunRequest.ExtraDirs can read a file under
+// that root through the read tool.
+func TestExtraDirs_ReadUnderAddedRootSucceeds(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	extraDir := t.TempDir()
+	libPath := writeExtraDirsFixture(t, extraDir, "lib.go", "package sharedlibs\n")
+
+	payload := runReadOnce(t, workspace, []string{extraDir}, libPath)
+
+	content, _ := payload["content"].(string)
+	if !strings.Contains(content, "package sharedlibs") {
+		t.Fatalf("read under the added root must succeed; payload=%+v", payload)
+	}
+	if errMsg, _ := payload["error"].(string); errMsg != "" {
+		t.Fatalf("read under the added root returned an error: %q", errMsg)
+	}
+}
+
+// TestExtraDirs_ReadOutsideAllRootsDenied verifies that granting one extra
+// root does not open anything else: a path outside both the workspace and the
+// added root is still denied.
+func TestExtraDirs_ReadOutsideAllRootsDenied(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	extraDir := t.TempDir()
+	outsideDir := t.TempDir()
+	secretPath := writeExtraDirsFixture(t, outsideDir, "secret.txt", "TOPSECRET\n")
+
+	payload := runReadOnce(t, workspace, []string{extraDir}, secretPath)
+
+	if content, _ := payload["content"].(string); strings.Contains(content, "TOPSECRET") {
+		t.Fatalf("SECURITY REGRESSION: run read a file outside all roots: %+v", payload)
+	}
+	errMsg, _ := payload["error"].(string)
+	if !strings.Contains(errMsg, "sandbox") && !strings.Contains(errMsg, "escapes") {
+		t.Fatalf("expected a sandbox/escape violation, got: %q", errMsg)
+	}
+}
+
+// TestExtraDirs_ControlRunWithoutExtraDirsDenied verifies the added root is
+// not special: without ExtraDirs the same read is denied (the confinement
+// default is unchanged).
+func TestExtraDirs_ControlRunWithoutExtraDirsDenied(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	extraDir := t.TempDir()
+	libPath := writeExtraDirsFixture(t, extraDir, "lib.go", "package sharedlibs\n")
+
+	payload := runReadOnce(t, workspace, nil, libPath)
+
+	if content, _ := payload["content"].(string); strings.Contains(content, "package sharedlibs") {
+		t.Fatalf("run without ExtraDirs must not read outside the workspace: %+v", payload)
+	}
+	errMsg, _ := payload["error"].(string)
+	if !strings.Contains(errMsg, "sandbox") && !strings.Contains(errMsg, "escapes") {
+		t.Fatalf("expected a sandbox/escape violation, got: %q", errMsg)
+	}
+}
+
+// TestStartRunExtraDirsValidation covers the synchronous StartRun validation:
+// extra_dirs entries must be absolute paths to existing directories.
+func TestStartRunExtraDirsValidation(t *testing.T) {
+	t.Parallel()
+
+	validDir := t.TempDir()
+	aFile := writeExtraDirsFixture(t, t.TempDir(), "file.txt", "x")
+
+	cases := []struct {
+		name      string
+		extraDirs []string
+		wantErr   string
+	}{
+		{name: "nil is fine", extraDirs: nil, wantErr: ""},
+		{name: "valid directory", extraDirs: []string{validDir}, wantErr: ""},
+		{name: "two valid directories", extraDirs: []string{validDir, t.TempDir()}, wantErr: ""},
+		{name: "empty entry rejected", extraDirs: []string{""}, wantErr: "extra_dirs"},
+		{name: "relative path rejected", extraDirs: []string{"shared-libs"}, wantErr: "absolute"},
+		{name: "dot-dot relative rejected", extraDirs: []string{"../escape"}, wantErr: "absolute"},
+		{name: "nonexistent rejected", extraDirs: []string{filepath.Join(t.TempDir(), "nope")}, wantErr: "does not exist"},
+		{name: "file not directory rejected", extraDirs: []string{aFile}, wantErr: "not a directory"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runner := NewRunner(&continuationProvider{}, NewRegistry(), RunnerConfig{DefaultModel: "test-model"})
+			t.Cleanup(func() { _ = runner.Shutdown(context.Background()) })
+			_, err := runner.StartRun(RunRequest{Prompt: "hi", ExtraDirs: tc.extraDirs})
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("StartRun with extra_dirs=%v: unexpected error: %v", tc.extraDirs, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("StartRun with extra_dirs=%v: expected error containing %q, got nil", tc.extraDirs, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), "extra_dirs") || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q must name extra_dirs and contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	osuser "os/user"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -842,6 +843,12 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		if err := validateWorkspaceProvisionPreconditions(req.WorkspaceType, rc.WorkspaceBaseOptions); err != nil {
 			return Run{}, err
 		}
+	}
+
+	// Validate extra_dirs early: each entry must be an absolute path to an
+	// existing directory so the file-tool confinement can canonicalize it.
+	if err := validateExtraDirs(req.ExtraDirs); err != nil {
+		return Run{}, err
 	}
 
 	// Subagents (runs with a recorded parent) default to the "subagent" agent
@@ -5440,6 +5447,33 @@ func validateWorkspaceType(wsType string) error {
 		return nil
 	}
 	return fmt.Errorf("unsupported workspace_type %q: must be one of local, worktree, container, vm", wsType)
+}
+
+// validateExtraDirs validates RunRequest.ExtraDirs entries: each must be a
+// non-empty absolute path to an existing directory. Absolute paths are
+// required (rather than resolving relative ones server-side) so the granted
+// root is unambiguous regardless of the harnessd process working directory.
+func validateExtraDirs(dirs []string) error {
+	for i, dir := range dirs {
+		if strings.TrimSpace(dir) == "" {
+			return fmt.Errorf("invalid extra_dirs: entry %d is empty", i)
+		}
+		if !filepath.IsAbs(dir) {
+			return fmt.Errorf("invalid extra_dirs: entry %d (%q) must be an absolute path", i, dir)
+		}
+		clean := filepath.Clean(dir)
+		fi, err := os.Stat(clean)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("invalid extra_dirs: entry %d (%q) does not exist", i, dir)
+			}
+			return fmt.Errorf("invalid extra_dirs: entry %d (%q) is not accessible: %w", i, dir, err)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("invalid extra_dirs: entry %d (%q) is not a directory", i, dir)
+		}
+	}
+	return nil
 }
 
 // resolveWorkspaceType returns the effective workspace type for a run.

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -1065,6 +1065,10 @@ func (se *stepEngine) run() {
 			toolCtx = context.WithValue(toolCtx, htools.ContextKeyToolCallID, call.ID)
 			toolCtx = context.WithValue(toolCtx, htools.ContextKeyRunMetadata, meta)
 			toolCtx = htools.WithSandboxScope(toolCtx, effectiveSandboxScope)
+			// Extra directory roots granted on the run request (TUI /add-dir)
+			// ride the same per-call context so file-tool confinement permits
+			// them in addition to the workspace root.
+			toolCtx = htools.WithExtraAllowedRoots(toolCtx, req.ExtraDirs)
 			toolCtx = context.WithValue(toolCtx, htools.ContextKeyTranscriptReader, runTranscriptReader{runner: r, runID: runID})
 			toolCtx = htools.WithForkDepth(toolCtx, runForkDepth)
 			callID := call.ID

--- a/internal/harness/tools/common_paths.go
+++ b/internal/harness/tools/common_paths.go
@@ -261,13 +261,15 @@ func canonicalizePathAllowingMissing(absPath string) (string, error) {
 // ResolveWorkspacePathConfined resolves relativePath against workspaceRoot
 // exactly like ResolveWorkspacePath, then additionally enforces
 // ConfineWorkspacePath using the effective sandbox scope (context override,
-// falling back to defaultScope). This is the single call every path-resolving
-// tool handler should use going forward.
+// falling back to defaultScope) and any per-run extra allowed roots carried
+// on the context (WithExtraAllowedRoots). This is the single call every
+// path-resolving tool handler should use going forward.
 func ResolveWorkspacePathConfined(ctx context.Context, workspaceRoot, relativePath string, defaultScope SandboxScope) (string, error) {
 	absPath, err := ResolveWorkspacePath(workspaceRoot, relativePath)
 	if err != nil {
 		return "", err
 	}
 	scope := EffectiveSandboxScope(ctx, defaultScope)
-	return ConfineWorkspacePath(scope, workspaceRoot, nil, absPath)
+	extraRoots, _ := ExtraAllowedRootsFromContext(ctx)
+	return ConfineWorkspacePath(scope, workspaceRoot, extraRoots, absPath)
 }

--- a/internal/harness/tools/extra_roots_context_test.go
+++ b/internal/harness/tools/extra_roots_context_test.go
@@ -1,0 +1,78 @@
+package tools
+
+// extra_roots_context_test.go — the per-run extra allowed roots reach file-tool
+// confinement through context (TUI /add-dir, epic #822 slice 3), mirroring
+// workspace_confinement_test.go's patterns.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveWorkspacePathConfined_ExtraRootsFromContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	extra := t.TempDir()
+	other := t.TempDir()
+
+	extraFile := filepath.Join(extra, "lib.go")
+	if err := os.WriteFile(extraFile, []byte("package lib\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	otherFile := filepath.Join(other, "secret.txt")
+	if err := os.WriteFile(otherFile, []byte("secret\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	ctx := WithExtraAllowedRoots(context.Background(), []string{extra})
+
+	// A path inside the context-granted extra root is allowed...
+	if _, err := ResolveWorkspacePathConfined(ctx, root, extraFile, SandboxScopeWorkspace); err != nil {
+		t.Fatalf("path inside the extra root must be allowed: %v", err)
+	}
+	// ...while a path outside every root stays denied.
+	if _, err := ResolveWorkspacePathConfined(ctx, root, otherFile, SandboxScopeWorkspace); err == nil {
+		t.Fatal("path outside all roots must be denied even with extra roots set")
+	}
+}
+
+func TestResolveWorkspacePathConfined_NoContextRootsKeepsDefault(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	extra := t.TempDir()
+	extraFile := filepath.Join(extra, "lib.go")
+	if err := os.WriteFile(extraFile, []byte("package lib\n"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	// Without the context value nothing changes: outside the workspace is denied.
+	if _, err := ResolveWorkspacePathConfined(context.Background(), root, extraFile, SandboxScopeWorkspace); err == nil {
+		t.Fatal("path outside the workspace must be denied without context roots")
+	}
+}
+
+func TestWithExtraAllowedRoots_CopiesSlice(t *testing.T) {
+	t.Parallel()
+
+	extra := t.TempDir()
+	roots := []string{extra}
+	ctx := WithExtraAllowedRoots(context.Background(), roots)
+	roots[0] = t.TempDir() // mutate after the call
+
+	got, ok := ExtraAllowedRootsFromContext(ctx)
+	if !ok || len(got) != 1 || got[0] != extra {
+		t.Fatalf("context must hold a copy of the roots, got %v (ok=%v)", got, ok)
+	}
+}
+
+func TestExtraAllowedRootsFromContext_UnsetReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := ExtraAllowedRootsFromContext(context.Background()); ok || got != nil {
+		t.Fatalf("unset context must return (nil, false), got %v, %v", got, ok)
+	}
+}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -597,6 +597,38 @@ func WithSandboxScope(ctx context.Context, scope SandboxScope) context.Context {
 	return context.WithValue(ctx, ContextKeySandboxScope, scope)
 }
 
+// ContextKeyExtraAllowedRoots carries the per-run extra directory roots a
+// caller granted (harness.RunRequest.ExtraDirs, TUI /add-dir). File-tool
+// confinement (ConfineWorkspacePath via ResolveWorkspacePathConfined) permits
+// paths under these roots in addition to the workspace root.
+const ContextKeyExtraAllowedRoots contextKey = "extra_allowed_roots"
+
+// WithExtraAllowedRoots returns a context carrying the given extra allowed
+// roots. The slice is copied so later caller mutation cannot alter the
+// context value. Nil contexts are promoted to Background.
+func WithExtraAllowedRoots(ctx context.Context, roots []string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var cp []string
+	if roots != nil {
+		cp = make([]string, len(roots))
+		copy(cp, roots)
+	}
+	return context.WithValue(ctx, ContextKeyExtraAllowedRoots, cp)
+}
+
+// ExtraAllowedRootsFromContext retrieves the per-run extra allowed roots set
+// by WithExtraAllowedRoots. The second return value reports whether the value
+// was set at all (distinguishing unset from an explicit empty list).
+func ExtraAllowedRootsFromContext(ctx context.Context) ([]string, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	roots, ok := ctx.Value(ContextKeyExtraAllowedRoots).([]string)
+	return roots, ok
+}
+
 type RunMetadata struct {
 	RunID          string
 	TenantID       string

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -428,6 +428,13 @@ type RunRequest struct {
 	// named in ProfileName. Explicit WorkspaceType always takes precedence over
 	// the profile's IsolationMode setting.
 	WorkspaceType string `json:"workspace_type,omitempty"`
+	// ExtraDirs grants the run read/work access to additional directory roots
+	// beyond the workspace root (TUI /add-dir). Each entry must be an absolute
+	// path to an existing directory; violations are rejected synchronously at
+	// StartRun time. Entries are enforced only for file-tool path confinement
+	// (ConfineWorkspacePath): the bash tool's command sandbox and glob still
+	// confine to the primary workspace root.
+	ExtraDirs []string `json:"extra_dirs,omitempty"`
 	// ProviderName explicitly selects which catalog provider to use for this run.
 	// When set, overrides the automatic provider resolution from the model name.
 	// Must match a provider key in the model catalog (e.g. "openai", "anthropic").

--- a/internal/server/http_extra_dirs_test.go
+++ b/internal/server/http_extra_dirs_test.go
@@ -1,0 +1,103 @@
+package server
+
+// http_extra_dirs_test.go — POST /v1/runs validates extra_dirs synchronously
+// (TUI /add-dir, epic #822 slice 3): entries that are not absolute paths to
+// existing directories get a 400 at creation, not a queued run that fails
+// asynchronously. Mirrors http_workspace_type_test.go.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+)
+
+func newExtraDirsTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	runner := harness.NewRunner(
+		&staticProvider{result: harness.CompletionResult{Content: "done"}},
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "test-model", MaxSteps: 1},
+	)
+	t.Cleanup(func() { _ = runner.Shutdown(context.Background()) })
+
+	ts := httptest.NewServer(New(runner))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func postExtraDirsRun(t *testing.T, ts *httptest.Server, body string) (int, string) {
+	t.Helper()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("POST /v1/runs: %v", err)
+	}
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return res.StatusCode, string(raw)
+}
+
+func TestPostRunExtraDirsNonexistentReturns400(t *testing.T) {
+	t.Parallel()
+
+	ts := newExtraDirsTestServer(t)
+	status, raw := postExtraDirsRun(t, ts, `{"prompt":"hello","extra_dirs":["/definitely/does/not/exist"]}`)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, raw)
+	}
+	if !strings.Contains(raw, "extra_dirs") {
+		t.Fatalf("error body should name extra_dirs, got %s", raw)
+	}
+	if strings.Contains(raw, "run_id") {
+		t.Fatalf("invalid extra_dirs must not create a run: %s", raw)
+	}
+}
+
+func TestPostRunExtraDirsRelativeReturns400(t *testing.T) {
+	t.Parallel()
+
+	ts := newExtraDirsTestServer(t)
+	status, raw := postExtraDirsRun(t, ts, `{"prompt":"hello","extra_dirs":["../escape"]}`)
+
+	if status != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", status, raw)
+	}
+	if !strings.Contains(raw, "extra_dirs") {
+		t.Fatalf("error body should name extra_dirs, got %s", raw)
+	}
+}
+
+func TestPostRunExtraDirsValidAccepted(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	body := `{"prompt":"hello","extra_dirs":[` + `"` + dir + `"` + `]}`
+
+	ts := newExtraDirsTestServer(t)
+	status, raw := postExtraDirsRun(t, ts, body)
+
+	if status != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202: %s", status, raw)
+	}
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.Unmarshal([]byte(raw), &created); err != nil {
+		t.Fatalf("decode create response %q: %v", raw, err)
+	}
+	if created.RunID == "" {
+		t.Fatalf("expected run_id in create response: %s", raw)
+	}
+}

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -152,6 +152,7 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/sessions` | Browse and resume past sessions |
 | `/title [text]` | Set or show the current session's title (`/title clear` removes it). Shown in the status bar and the `/sessions` picker, persisted across restarts |
 | `/init [confirm]` | Generate an `AGENTS.md` for the current workspace via a harness run. If `AGENTS.md` already exists, run `/init confirm` to overwrite it |
+| `/add-dir [path]` | Attach an extra directory to the session so runs can read/work in it. Bare `/add-dir` lists attached directories; `/add-dir remove <path>` detaches one. See [Extra directories](#extra-directories-add-dir) |
 | `/new` | Start a fresh conversation (resets conversation ID) |
 | `/search <query>` | Search the current session transcript |
 | `/history <query>` | Search across stored session metadata |
@@ -170,6 +171,17 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/help` | Show the help dialog |
 | `/clear` | Clear the conversation history and viewport |
 | `/quit` | Quit the TUI |
+
+---
+
+## Extra directories (`/add-dir`)
+
+`/add-dir <path>` attaches an additional directory to the session. Attached directories are sent on every run as `extra_dirs` (`POST /v1/runs`), and the server's file-tool confinement (`read`, `write`, `edit`, `ls`, `grep`, …) permits paths under them in addition to the workspace root. Paths outside the workspace root and all attached directories stay denied.
+
+- Relative paths resolve against the session workspace.
+- Bare `/add-dir` lists the attached directories; `/add-dir remove <path>` detaches one. (`remove` is a subcommand only when followed by a path, so a directory literally named `remove` can still be added.)
+- The list is session-scoped — it is not persisted across restarts.
+- Current limits: the `bash` tool's command sandbox and `glob` still confine to the primary workspace root only; the server validates every entry (absolute path to an existing directory) and rejects the run with HTTP 400 otherwise.
 
 ---
 

--- a/website/docs/server/http-api-guide.md
+++ b/website/docs/server/http-api-guide.md
@@ -238,6 +238,7 @@ Fill in the fields below and copy the generated JSON body or curl command. The b
 | `model` | `string` | Model ID, e.g. `"gpt-4.1"`, `"claude-sonnet"`. Falls back to server default (`gpt-4.1-mini`). |
 | `provider_name` | `string` | Explicit provider override, e.g. `"openai"`, `"anthropic"`. When omitted, the provider is resolved from the model name. |
 | `workspace_type` | `string` | One of `""` (server default), `"local"`, `"worktree"`, `"container"`, `"vm"`. Unknown values are rejected. |
+| `extra_dirs` | `[]string` | Additional absolute directory roots the run may read/work in beyond the workspace root (TUI `/add-dir`). Each entry must be an absolute path to an existing directory; violations are rejected with HTTP 400. Applies to file-tool path confinement only — the bash sandbox and `glob` still confine to the primary workspace root. |
 | `system_prompt` | `string` | Overrides the runner's default system prompt for this run. |
 | `conversation_id` | `string` | Pin the run to an existing conversation so the agent has prior context. |
 


### PR DESCRIPTION
Parent epic: #822. Part of #803.

## Investigation (as required by the epic; full writeup in docs/plans/822-qol-commands.md)

1. **The TUI's `workspace_path` is silently dropped today**: `handlePostRun` decodes into `harness.RunRequest`, which has no `workspace_path` field. The effective tool workspace is the harnessd startup `WorkspaceBaseOptions.RepoPath` (or a per-run provisioned path). Fixing that is out of scope — `extra_dirs` are additive to whatever root a run already uses.
2. **Confinement is real and single-rooted**: default sandbox is `SandboxScopeWorkspace` (runner.go, safety-biased default); every file tool resolves paths through `ResolveWorkspacePathConfined` → `ConfineWorkspacePath(scope, root, extraAllowedRoots, abs)` — which **already implements extra roots** (symlink-safe canonicalization, tested) but every caller passed `nil`.
3. **Per-run overrides reach tools via context** (`WithSandboxScope` at runner_step_engine.go) — the exact seam used here.
4. **Bash is confined differently** (string heuristics + OS seatbelt/bubblewrap profiles, one root) — threading extra roots there is a large change.

## Decided minimal shape (the epic's preferred one)

- `harness.RunRequest.ExtraDirs` (`json:"extra_dirs,omitempty"`), validated synchronously in `StartRun` (non-empty, absolute, existing directory) → HTTP 400 on violation.
- New context key `WithExtraAllowedRoots`/`ExtraAllowedRootsFromContext` in internal/harness/tools (mirrors `WithSandboxScope`); `ResolveWorkspacePathConfined` passes the context roots to `ConfineWorkspacePath`; the step engine threads `req.ExtraDirs` onto every tool-call context.
- TUI `/add-dir <path>` (relative paths resolve against the session workspace, deduped), `/add-dir` (list), `/add-dir remove <path>` (detach; `remove` is a subcommand only with an argument, so a dir literally named `remove` can still be added). Session-scoped, sent on every run via `startRunCmd`.
- **Documented limits**: bash command sandbox and `glob` still confine to the primary workspace root; extra dirs are not persisted.

## Tests (TDD — tests written first, watched fail, then implemented)

- `internal/harness`: acceptance (real Runner + step engine, mirrors the GAP-1 test): read under the added root **succeeds**, outside all roots **denied**, control run without `ExtraDirs` **denied**; `StartRun` validation table (8 cases).
- `internal/harness/tools`: `ResolveWorkspacePathConfined` + ctx roots allows the extra root, denies elsewhere, unset ctx unchanged; slice-copy semantics.
- `internal/server`: POST /v1/runs with nonexistent/relative `extra_dirs` → 400 naming the field; valid entry → 202.
- `cmd/harnesscli/tui`: add/list/remove/dedupe/not-a-directory/file-rejection/relative-resolution dispatch through the model; `startRunCmd` marshals `extra_dirs` (and omits when empty); registry + slash-complete; inventory tests updated (`add-dir` sorts first in the dropdown window).

`go test ./cmd/harnesscli/... ./internal/harness/... ./internal/server/ -count=1` — 36 packages ok, zero FAIL. gofmt/go vet clean on touched files.

## Docs

- `website/docs/cli/tui.md`: table row + "Extra directories (`/add-dir`)" section (semantics + limits).
- `website/docs/server/http-api-guide.md`: `extra_dirs` field note in the RunRequest reference.
- `docs/ux-paths.md`: /add-dir + validation rows.
- Plan + investigation: `docs/plans/822-qol-commands.md` (+ plans index).