### PR TITLE
fix(catalog): kimi-subscription missing token_source_required

### DIFF
--- a/catalog/models.json
+++ b/catalog/models.json
@@ -541,6 +541,7 @@
       "display_name": "Kimi Code Subscription",
       "base_url": "https://api.kimi.com/coding/v1",
       "api_key_optional": true,
+      "token_source_required": true,
       "protocol": "openai_compat",
       "models_from": "kimi"
     },

--- a/internal/provider/catalog/subscription_provider_parity_test.go
+++ b/internal/provider/catalog/subscription_provider_parity_test.go
@@ -1,0 +1,41 @@
+package catalog
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSubscriptionProviderEntriesRequireTokenSource verifies that every
+// catalog provider whose name ends in "-subscription" is marked
+// TokenSourceRequired, so GET /v1/providers reports auth_type "subscription"
+// (not "api_key") and the TUI's "i" import keybinding and subscription-only
+// gating actually fire for it. Found live: kimi-subscription shipped without
+// this flag, so it was misreported as an api_key provider and its /keys "i"
+// import binding silently no-op'd.
+func TestSubscriptionProviderEntriesRequireTokenSource(t *testing.T) {
+	t.Parallel()
+
+	root := repoRoot(t)
+	cat, err := LoadCatalog(filepath.Join(root, "catalog", "models.json"))
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+
+	found := 0
+	for name, entry := range cat.Providers {
+		if !strings.HasSuffix(name, "-subscription") {
+			continue
+		}
+		found++
+		if !entry.TokenSourceRequired {
+			t.Errorf("provider %q: TokenSourceRequired = false, want true (auth_type would report \"api_key\" instead of \"subscription\")", name)
+		}
+		if !entry.APIKeyOptional {
+			t.Errorf("provider %q: APIKeyOptional = false, want true (subscription providers have no static key)", name)
+		}
+	}
+	if found == 0 {
+		t.Fatal("no *-subscription provider entries found in catalog/models.json; update this test if the naming convention changed")
+	}
+}


### PR DESCRIPTION
## Summary

Found via live TUI testing (driving the actual `go-code` TUI in tmux, not just unit tests): `kimi-subscription`'s catalog entry shipped without `token_source_required: true`, unlike its `codex-subscription` sibling. This caused `GET /v1/providers` to report `auth_type: "api_key"` instead of `"subscription"` for it.

Confirmed live, concrete downstream effects:
- The TUI's `/keys` `i` import keybinding (issue #854) only fires when `AuthType == "subscription"` — for `kimi-subscription` it silently no-op'd. I had to call `POST /v1/providers/kimi-subscription/import-subscription` directly to import it; the keyboard shortcut did nothing.
- The Enter-key gate that's supposed to disable manual key-entry for subscription-only providers didn't apply, so `/keys` incorrectly opened a "type an API key" input box for `kimi-subscription` — a provider that has no static key at all.
- `/keys` rendered a generic `● set` label for `kimi-subscription` instead of the `ChatGPT subscription ... connected`-style line `codex-subscription` correctly gets.

## Fix

One field: `catalog/models.json`'s `kimi-subscription` entry gains `"token_source_required": true`, matching `codex-subscription`.

## Regression test

Added `TestSubscriptionProviderEntriesRequireTokenSource` (`internal/provider/catalog/subscription_provider_parity_test.go`), which loads the real committed `catalog/models.json` (not a hand-built fixture — the existing subscription tests in `internal/server/http_providers_test.go` use a fixture with the field already set correctly, which is why they never caught this) and asserts every `*-subscription` provider has both `token_source_required` and `api_key_optional` set. Confirmed failing before the fix, passing after.

## Verification

- `go test ./internal/provider/catalog/... -run TestSubscriptionProviderEntriesRequireTokenSource -v` — fails on `origin/main`, passes with this change.
- `go build ./internal/... ./cmd/...` — clean.
- `gofmt -l` / `go vet` on touched files — clean.
- `bash scripts/test-regression.sh` — full run, `coveragegate: PASS (total=84.2%, min=80.0%, zero-functions=0)`. One transient run hit a known-flaky `internal/provider/anthropic` retry-timing test (`TestClientRetriesOn503`/`429`, zero diff to that package, passes 3/3 in isolation); the immediate rerun was fully green with zero failures.