### PR TITLE
feat(tools): agent_swarm deferred tool with policy integration and sole-call rule

### DIFF
--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -207,6 +207,14 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 	// Same handoff object also backs message_subagent/notify_parent — it
 	// already forwards to the runner once setRunner is called below.
 	registryOpts.RunSteerer = handoff
+	// agent_swarm (epic #808): the swarm runs on the same inline-subagent
+	// machinery (members start through the InlineManager; resume steers
+	// through the same runner handoff). Kept behind an interface in
+	// tools_default.go to avoid the harness->deferred->subagents cycle.
+	registryOpts.AgentSwarmRunner = subagents.NewToolSwarmRunner(subagents.NewSwarm(
+		registryOpts.SubagentManager,
+		subagents.WithSwarmSteerer(handoff),
+	))
 
 	tools := harness.NewDefaultRegistryWithOptions(opts.workspace, registryOpts)
 	runner := harness.NewRunner(opts.provider, tools, opts.runnerCfg)

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,39 @@
 # Engineering Log
 
+## 2026-07-21 (Agent Swarm — Epic #808, Slice 3)
+
+- Added the deferred `agent_swarm` tool
+  (`internal/harness/tools/deferred/agent_swarm.go`): `TierDeferred`,
+  `ActionExecute`, `Mutating: true`, params `prompt_template`/`items`/
+  `resume_agent_ids` plus profile/model overrides resolved exactly like
+  `start_subagent`; returns the aggregated report via `MarshalToolResult`.
+- Import-cycle design: `harness` and `deferred` cannot import `subagents`
+  (subagents imports harness). Mirror types (`SwarmRequest`/`SwarmReport`) +
+  `SwarmRunner` interface + `AgentSwarmToolName` const live in
+  `internal/harness/tools` (same pattern as `SubagentManager`); the adapter
+  `subagents.NewToolSwarmRunner` maps both directions; wiring happens in
+  `cmd/harnessd/runtime_container.go` next to the InlineManager.
+- Sole-call rule in `runner_step_engine.go`: a response containing
+  `agent_swarm` plus any other call executes the first swarm call and rejects
+  every other call with a corrective error naming the rule (a second
+  `agent_swarm` call is rejected too).
+- Nested-swarm prevention: new per-run `DeniedTools` denylist plumbed
+  `tools.SubagentRequest` -> `subagents.Request` -> `harness.RunRequest` ->
+  runState (carried over on continuation). `filteredToolsForRun` never offers
+  denied tools (even when activated) and the step-engine call gate blocks
+  them outright. The swarm sets `DeniedTools=[agent_swarm]` on every member.
+- Approval flow: no new code needed — the existing destructive-policy path
+  consults `Registry.IsMutating`, and the tool declares `Mutating: true`;
+  a test proves the call pauses for approval and runs after approval.
+- Description file `descriptions/agent_swarm.md` documents the sole-call
+  rule, the 128 cap, the 5->+1/700ms ramp, the env cap, and resume semantics.
+- TDD: tests landed first across four files (deferred tool contract, adapter
+  mapping, runner sole-call/denied/approval gates, fakeprovider full-stack
+  e2e showing a 4-item swarm and one aggregated tool result); all failed on
+  undefined symbols before implementation.
+- Validation: package tests + `-race` green for subagents, harness, tools,
+  deferred, harnessd; full regression suite (see PR body).
+
 ## 2026-07-21 (Issue #886 runBlockedError.Error Coverage Fix)
 
 - Symptom: post-merge regression gate (`scripts/test-regression.sh`) failed after PR #882 landed: `coveragegate` flagged `(*runBlockedError).Error` (cmd/harnesscli/main.go) at 0.0% — `functions with zero coverage detected`.

--- a/docs/plans/808-agent-swarm.md
+++ b/docs/plans/808-agent-swarm.md
@@ -1,4 +1,4 @@
-# Plan: agent_swarm epic #808 — Slices 1–2
+# Plan: agent_swarm epic #808 — Slices 1–3
 
 ## Context
 
@@ -8,72 +8,81 @@
 - User impact: the model must loop `start_subagent`/`wait_subagent` by hand,
   which is slow, error-prone, and burns turns.
 - Constraints: reuse `internal/subagents` Manager + `tools.SubagentManager`
-  (`InlineManager`); strict TDD. Slice 1 (core `Swarm`) merged via PR #839.
-  This PR covers ONLY Slice 2 (resume via `resume_agent_ids`).
+  (`InlineManager`); strict TDD. Slice 1 (core `Swarm`) merged via PR #839,
+  Slice 2 (resume) via PR #867. This PR covers ONLY Slice 3 (the deferred
+  tool, policy integration, and sole-call rule).
 
 ## Scope
 
-- In scope (Slice 2):
-  - Extend `internal/subagents/swarm.go`: `ResumeAgentIDs[i]` pairs with
-    `Items[i]` (first-K positional); resolve each ID upfront via
-    `tools.SubagentManager.Get`; reject unknown IDs, duplicate IDs,
-    more IDs than items, and active-incompatible statuses (only
-    `running`/`waiting_for_user` accept steered messages).
-  - Deliver the expanded prompt through the existing messaging path used by
-    `message_subagent`: `tools.RunSteerer.SteerRun(runID, prompt)`.
-  - Resumes are scheduled first in the ramp and count against the same
-    concurrency allowance; parent cancellation cancels resumed members too.
-  - Report order stays "items first, resumes later"; resumed members carry
-    `Resumed: true` and their subagent ID from the start.
-- Out of scope: `agent_swarm` deferred tool + runner sole-call rule
-  (Slice 3), TUI panel (Slice 4), new server endpoints.
+- In scope (Slice 3):
+  - Mirror types + `SwarmRunner` interface + `AgentSwarmToolName` const in
+    `internal/harness/tools` (import-cycle-safe, same pattern as
+    `SubagentManager`); adapter `NewToolSwarmRunner` in `internal/subagents`.
+  - New `internal/harness/tools/deferred/agent_swarm.go`: `TierDeferred`,
+    `ActionExecute`, `Mutating: true`; params `prompt_template`, `items`,
+    `resume_agent_ids` + profile/model overrides; returns the report via
+    `MarshalToolResult`.
+  - Description `internal/harness/tools/descriptions/agent_swarm.md`
+    (sole-call rule, 128 cap, 5→+1/700ms ramp, env cap, resume semantics).
+  - Registration in `internal/harness/tools_default.go` via new
+    `AgentSwarmRunner` option; wired in `cmd/harnessd/runtime_container.go`.
+  - Member exclusion: per-run `DeniedTools` plumbed `tools.SubagentRequest` →
+    `subagents.Request` → `harness.RunRequest` → runState; enforced in
+    `filteredToolsForRun` (never offered) and in the step-engine call gate
+    (call blocked). The swarm sets it on every member.
+  - Runner sole-call rule in `runner_step_engine.go`: a response containing
+    `agent_swarm` plus any other call executes the (first) swarm call and
+    rejects the extras with a corrective error naming the rule.
+- Out of scope: TUI panel (Slice 4), new server endpoints.
 
 ## Documentation Contract
 
 - Feature status: `in implementation`
-- Public docs affected: none (no public surface in this slice)
+- Public docs affected: `internal/harness/tools/descriptions/agent_swarm.md`
+  (tool contract, model-facing)
 - Spec docs to update before code: none
 - Implementation notes to add after code: engineering-log entry per slice.
 
 ## Test Plan (TDD)
 
-- New failing tests to add first (`internal/subagents/swarm_resume_test.go`):
-  - resume happy path against a fake manager + fake steerer (steer carries
-    the expanded prompt to the resolved run ID; mixed cohort completes)
-  - unknown ID and active-incompatible status rejection (queued/completed/
-    failed/cancelled rejected; running/waiting_for_user accepted)
-  - duplicate resume ID rejection; more resume IDs than items rejection
-  - scheduling order: resumes precede new items (deterministic with cap 1)
-  - report marking: `Resumed` flag, ID, order (items first, resumes later)
-  - steer failure captured per member without aborting the cohort
-  - cancellation cancels resumed members as well as new members
-  - missing steerer with non-empty resume_agent_ids rejected
-- Existing tests to update: drop the "resume_agent_ids rejected" case from
-  the slice-1 validation table (now supported).
-- Regression tests required: all slice-1 swarm tests stay green.
+- New failing tests to add first:
+  - `internal/harness/tools/deferred/agent_swarm_test.go`: definition shape
+    (ActionExecute/Mutating/TierDeferred/required params), arg parsing and
+    validation errors, profile resolution + override mapping, resume mapping,
+    report marshaling, runner-error propagation, nil-runner error.
+  - `internal/subagents/swarm_tool_runner_test.go`: adapter maps
+    tools.SwarmRequest ↔ subagents types both directions.
+  - `internal/harness/runner_swarm_test.go`: sole-call rule (swarm+extra →
+    corrective error, swarm alone → ok); DeniedTools gate (call blocked,
+    definitions filtered even when activated); approval flow surfaces
+    agent_swarm as mutating ActionExecute under destructive policy.
+  - `internal/subagents/swarm_e2e_test.go`: fakeprovider full-stack session —
+    find_tool activation, one `agent_swarm` call, 4 member runs with expanded
+    prompts, one aggregated tool result, run completes.
+- Existing tests to update: none.
+- Regression tests required: existing harness/deferred/subagents suites stay
+  green.
 
 ## Cross-Surface Impact Map
 
-- None — in-process orchestration only; no provider/model flow, config,
-  server API, or TUI changes in this slice.
+- None — additive tool + in-process enforcement; no provider/model flow,
+  config, or server API changes (TUI panel is Slice 4).
 
 ## Implementation Checklist
 
 - [x] Define acceptance criteria in tests.
 - [x] Write failing tests first.
-- [x] Implement minimal code changes (`swarm.go`).
+- [x] Implement minimal code changes.
 - [x] Refactor while tests remain green.
 - [x] Update docs, status ledgers, and indexes.
 - [x] Update engineering log.
-- [x] Run full test suite for touched packages.
+- [x] Run full test suite for touched packages + regression.
 
 ## Risks and Mitigations
 
-- Risk: status check races the member's own lifecycle (subagent finishes
-  between `Get` and `SteerRun`).
-- Mitigation: `SteerRun` errors are captured per member in the report; the
-  cohort is never aborted, matching slice-1 failure semantics.
-- Risk: report order confusing callers when resumes consume the first items.
-- Mitigation: deterministic documented order (non-resumed item members in
-  item order, then resumed members in resume-ID order), each entry carrying
-  its `item` and `resumed` marker.
+- Risk: import cycle between harness/deferred and subagents.
+- Mitigation: mirror types in `tools` + adapter in `subagents`, exactly the
+  existing `SubagentManager`/`InlineManager` pattern.
+- Risk: sole-call gate breaking parallel tool execution for normal calls.
+- Mitigation: gate only engages when a response contains `agent_swarm`;
+  all other responses flow unchanged; regression suite validates.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -13,7 +13,7 @@
 - `814-tasks-panel.md` — Epic #814 slice 1: `GET /v1/tasks` union endpoint for subagents, cron jobs, and delayed callbacks (in implementation).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
-- `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator (merged), Slice 2 resume via resume_agent_ids (in implementation).
+- `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator + Slice 2 resume (merged), Slice 3 agent_swarm deferred tool with sole-call rule (in implementation).
 - `809-mcp-oauth.md` — Epic #809: slices 1–2 (headers/typed errors, token store) merged; slice 3 (OAuth 2.1 + PKCE flow with localhost callback) in implementation.
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slice 1 client plumbing merged; slice 2 transcript rendering in review).

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -58,6 +58,10 @@ type runState struct {
 	// to the LLM. Skill constraints override this during skill execution.
 	// Nil or empty means no per-run restriction.
 	allowedTools []string
+	// deniedTools is the per-run tool denylist from RunRequest.DeniedTools.
+	// Denied tools are never offered (filteredToolsForRun) and never executed
+	// (step-engine call gate), even when activated or allowed.
+	deniedTools []string
 	// permissions is the effective two-axis permission configuration for this run.
 	permissions PermissionConfig
 	// permissionWorkspaceRoot is the workspace used to resolve path rules.
@@ -964,6 +968,7 @@ func (r *Runner) StartRun(req RunRequest) (Run, error) {
 		steeringCh:              make(chan string, steeringBufferSize),
 		maxCostUSD:              req.MaxCostUSD,
 		allowedTools:            req.AllowedTools,
+		deniedTools:             copyStringSlice(req.DeniedTools),
 		permissions:             effectivePerms,
 		permissionWorkspaceRoot: r.defaultPermissionWorkspaceRoot(),
 		snapshotBuilder:         sb,
@@ -1605,21 +1610,24 @@ func (r *Runner) ContinueRunWithOptions(runID string, req ContinueRunRequest) (R
 		contSB = errorchain.NewSnapshotBuilder(rc.ErrorContextDepth)
 	}
 	contState := &runState{
-		run:                      newRun,
-		config:                   &rc,
-		staticSystemPrompt:       systemPrompt,
-		promptResolved:           promptResolved,
-		usageTotals:              usageTotalsAccumulator{},
-		costTotals:               RunCostTotals{CostStatus: CostStatusPending},
-		messages:                 make([]Message, 0, 16),
-		events:                   make([]Event, 0, 32),
-		subscribers:              make(map[chan Event]struct{}),
-		steeringCh:               make(chan string, steeringBufferSize),
-		maxCostUSD:               srcMaxCostUSD,
-		permissions:              effectivePermissions,
-		permissionWorkspaceRoot:  r.defaultPermissionWorkspaceRoot(),
-		resolvedRoleModels:       srcResolvedRoleModels,
-		allowedTools:             effectiveAllowedTools,
+		run:                     newRun,
+		config:                  &rc,
+		staticSystemPrompt:      systemPrompt,
+		promptResolved:          promptResolved,
+		usageTotals:             usageTotalsAccumulator{},
+		costTotals:              RunCostTotals{CostStatus: CostStatusPending},
+		messages:                make([]Message, 0, 16),
+		events:                  make([]Event, 0, 32),
+		subscribers:             make(map[chan Event]struct{}),
+		steeringCh:              make(chan string, steeringBufferSize),
+		maxCostUSD:              srcMaxCostUSD,
+		permissions:             effectivePermissions,
+		permissionWorkspaceRoot: r.defaultPermissionWorkspaceRoot(),
+		resolvedRoleModels:      srcResolvedRoleModels,
+		allowedTools:            effectiveAllowedTools,
+		// The denylist always carries over: a continued swarm member stays a
+		// swarm member and must keep its tool exclusions.
+		deniedTools:              copyStringSlice(state.deniedTools),
 		previousRunID:            runID,
 		continuationPolicyNotice: policyNotice,
 		snapshotBuilder:          contSB,
@@ -2688,6 +2696,32 @@ func safeCallPostToolUseHook(hook PostToolUseHook, ctx context.Context, ev PostT
 func (r *Runner) filteredToolsForRun(runID string) []ToolDefinition {
 	defs := r.toolsForRun(runID).DefinitionsForRun(runID, r.activations)
 
+	r.mu.RLock()
+	state, stateOK := r.runs[runID]
+	var baseAllowed, denied []string
+	if stateOK {
+		baseAllowed = state.allowedTools
+		denied = state.deniedTools
+	}
+	r.mu.RUnlock()
+
+	// DeniedTools is an absolute per-run denylist: denied tools are never
+	// offered, whatever the activation, skill-constraint, or allowed-tools
+	// state says (keeps agent_swarm out of swarm-member runs).
+	if len(denied) > 0 {
+		blocked := make(map[string]bool, len(denied))
+		for _, name := range denied {
+			blocked[name] = true
+		}
+		kept := make([]ToolDefinition, 0, len(defs))
+		for _, def := range defs {
+			if !blocked[def.Name] {
+				kept = append(kept, def)
+			}
+		}
+		defs = kept
+	}
+
 	// Skill constraints (activated by the skill tool) take precedence over the
 	// per-run base filter. If a skill constraint is active with a non-nil
 	// AllowedTools list, apply it exclusively.
@@ -2711,14 +2745,6 @@ func (r *Runner) filteredToolsForRun(runID string) []ToolDefinition {
 
 	// No active skill constraint (or skill constraint with nil AllowedTools =
 	// unrestricted). Apply the per-run base allowed-tools list from RunRequest.
-	r.mu.RLock()
-	state, stateOK := r.runs[runID]
-	var baseAllowed []string
-	if stateOK {
-		baseAllowed = state.allowedTools
-	}
-	r.mu.RUnlock()
-
 	if len(baseAllowed) == 0 {
 		return defs // no per-run restriction either
 	}

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -745,7 +745,32 @@ func (se *stepEngine) run() {
 
 		pendingExecs := make([]pendingToolExec, 0, len(result.ToolCalls))
 
-		for _, call := range result.ToolCalls {
+		// Sole-call rule (epic #808): when a model response calls agent_swarm,
+		// that must be the response's only tool call. The first agent_swarm
+		// call proceeds; every other call in the same response is rejected
+		// below with a corrective error so the model re-issues it in a later
+		// turn.
+		agentSwarmSoleIdx := -1
+		for i, call := range result.ToolCalls {
+			if call.Name == htools.AgentSwarmToolName {
+				agentSwarmSoleIdx = i
+				break
+			}
+		}
+		enforceAgentSwarmSoleCall := agentSwarmSoleIdx >= 0 && len(result.ToolCalls) > 1
+
+		// DeniedTools is the per-run absolute denylist (swarm members deny
+		// agent_swarm to forbid nested swarms); denied calls are blocked below
+		// before any hook, permission, or approval processing.
+		var runDeniedTools map[string]bool
+		if len(stepState.deniedTools) > 0 {
+			runDeniedTools = make(map[string]bool, len(stepState.deniedTools))
+			for _, name := range stepState.deniedTools {
+				runDeniedTools[name] = true
+			}
+		}
+
+		for callIdx, call := range result.ToolCalls {
 			r.emit(runID, EventToolCallStarted, map[string]any{
 				"call_id":   call.ID,
 				"tool":      call.Name,
@@ -790,6 +815,44 @@ func (se *stepEngine) run() {
 						"step":       alert.Step,
 					})
 				}
+			}
+
+			if runDeniedTools[call.Name] {
+				deniedOutput := mustJSON(map[string]any{
+					"error": fmt.Sprintf("tool %q is not available in this run: it is denied by this run's tool policy", call.Name),
+				})
+				r.emit(runID, EventToolCallBlocked, map[string]any{
+					"call_id": call.ID,
+					"tool":    call.Name,
+					"reason":  "tool_denied_for_run",
+				})
+				messages = append(messages, Message{
+					Role:       "tool",
+					Name:       call.Name,
+					ToolCallID: call.ID,
+					Content:    deniedOutput,
+				})
+				r.stepSetMessages(runID, messages)
+				continue
+			}
+
+			if enforceAgentSwarmSoleCall && callIdx != agentSwarmSoleIdx {
+				corrective := mustJSON(map[string]any{
+					"error": fmt.Sprintf("tool %q rejected: agent_swarm must be the only tool call in a model response; re-issue it in a later turn", call.Name),
+				})
+				r.emit(runID, EventToolCallBlocked, map[string]any{
+					"call_id": call.ID,
+					"tool":    call.Name,
+					"reason":  "agent_swarm_sole_call",
+				})
+				messages = append(messages, Message{
+					Role:       "tool",
+					Name:       call.Name,
+					ToolCallID: call.ID,
+					Content:    corrective,
+				})
+				r.stepSetMessages(runID, messages)
+				continue
 			}
 
 			if !r.skillConstraints.IsToolAllowed(runID, call.Name) {

--- a/internal/harness/runner_swarm_test.go
+++ b/internal/harness/runner_swarm_test.go
@@ -1,0 +1,343 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// runnerFakeSwarmRunner implements htools.SwarmRunner for runner-level tests.
+type runnerFakeSwarmRunner struct {
+	mu     sync.Mutex
+	reqs   []htools.SwarmRequest
+	report htools.SwarmReport
+	err    error
+}
+
+func (f *runnerFakeSwarmRunner) RunSwarm(_ context.Context, req htools.SwarmRequest) (htools.SwarmReport, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reqs = append(f.reqs, req)
+	return f.report, f.err
+}
+
+func (f *runnerFakeSwarmRunner) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.reqs)
+}
+
+func swarmToolMessages(t *testing.T, r *Runner, runID string) []Message {
+	t.Helper()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	state, ok := r.runs[runID]
+	if !ok {
+		t.Fatalf("run %q not found", runID)
+	}
+	out := make([]Message, 0, len(state.messages))
+	for _, m := range state.messages {
+		if m.Role == "tool" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func toolMessageForCall(t *testing.T, r *Runner, runID, callID string) string {
+	t.Helper()
+	for _, m := range swarmToolMessages(t, r, runID) {
+		if m.ToolCallID == callID {
+			return m.Content
+		}
+	}
+	t.Fatalf("no tool message for call %q in run %q", callID, runID)
+	return ""
+}
+
+func TestAgentSwarmRegisteredAsMutatingDeferredTool(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 1, Completed: 1}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+
+	if !registry.IsMutating("agent_swarm") {
+		t.Fatal("agent_swarm IsMutating = false, want true (approval policy integration)")
+	}
+	found := false
+	for _, def := range registry.DeferredDefinitions() {
+		if def.Name == "agent_swarm" {
+			found = true
+			if !def.Mutating {
+				t.Fatal("agent_swarm Mutating = false, want true")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("agent_swarm not registered as a deferred tool")
+	}
+}
+
+func TestAgentSwarmSoleCallRuleRejectsExtras(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 2, Completed: 2}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a","b"]}`},
+			{ID: "call-extra", Name: "read", Arguments: `{"path":"x"}`},
+		}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test", DefaultSystemPrompt: "sys"})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "fan out and read"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", got)
+	}
+
+	// The swarm call itself executes.
+	if swarmRunner.callCount() != 1 {
+		t.Fatalf("swarm runner calls = %d, want 1", swarmRunner.callCount())
+	}
+	swarmResult := toolMessageForCall(t, runner, run.ID, "call-swarm")
+	if !strings.Contains(swarmResult, "\"total\":2") {
+		t.Fatalf("swarm tool result = %q, want aggregated report with total 2", swarmResult)
+	}
+
+	// The extra call is rejected with a corrective error naming the rule.
+	extraResult := toolMessageForCall(t, runner, run.ID, "call-extra")
+	if !strings.Contains(extraResult, "agent_swarm") || !strings.Contains(extraResult, "only tool call") {
+		t.Fatalf("extra call result = %q, want corrective error naming the agent_swarm sole-call rule", extraResult)
+	}
+}
+
+func TestAgentSwarmSoleCallAloneIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 1, Completed: 1}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a"]}`},
+		}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test", DefaultSystemPrompt: "sys"})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "fan out"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", got)
+	}
+	if swarmRunner.callCount() != 1 {
+		t.Fatalf("swarm runner calls = %d, want 1", swarmRunner.callCount())
+	}
+	swarmResult := toolMessageForCall(t, runner, run.ID, "call-swarm")
+	if strings.Contains(swarmResult, "only tool call") {
+		t.Fatalf("sole swarm call was rejected: %q", swarmResult)
+	}
+}
+
+func TestAgentSwarmTwoSwarmCallsKeepOnlyFirst(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 1, Completed: 1}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm-1", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a"]}`},
+			{ID: "call-swarm-2", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["b"]}`},
+		}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test", DefaultSystemPrompt: "sys"})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "two swarms"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", got)
+	}
+	if swarmRunner.callCount() != 1 {
+		t.Fatalf("swarm runner calls = %d, want 1 (second swarm call rejected)", swarmRunner.callCount())
+	}
+	second := toolMessageForCall(t, runner, run.ID, "call-swarm-2")
+	if !strings.Contains(second, "only tool call") {
+		t.Fatalf("second swarm call result = %q, want sole-call corrective error", second)
+	}
+}
+
+func TestAgentSwarmDeniedForMemberRuns(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 1, Completed: 1}}
+	activations := NewActivationTracker()
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		AgentSwarmRunner: swarmRunner,
+		Activations:      activations,
+	})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a"]}`},
+		}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel:        "test",
+		DefaultSystemPrompt: "sys",
+		Activations:         activations,
+	})
+
+	// Swarm-member runs carry DeniedTools: agent_swarm must be neither
+	// offered nor callable for them.
+	run, err := runner.StartRun(RunRequest{Prompt: "member", DeniedTools: []string{"agent_swarm"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", got)
+	}
+	if swarmRunner.callCount() != 0 {
+		t.Fatalf("swarm runner calls = %d, want 0 (member runs cannot call agent_swarm)", swarmRunner.callCount())
+	}
+	denied := toolMessageForCall(t, runner, run.ID, "call-swarm")
+	if !strings.Contains(denied, "agent_swarm") {
+		t.Fatalf("denied call result = %q, want message naming agent_swarm", denied)
+	}
+
+	// Even when activated for the run, the definition stays hidden.
+	activations.Activate(run.ID, "agent_swarm")
+	for _, def := range runner.filteredToolsForRun(run.ID) {
+		if def.Name == "agent_swarm" {
+			t.Fatal("agent_swarm visible in member run definitions despite DeniedTools")
+		}
+	}
+
+	// Control: an unrestricted run sees the activated definition.
+	run2, err := runner.StartRun(RunRequest{Prompt: "parent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activations.Activate(run2.ID, "agent_swarm")
+	seen := false
+	for _, def := range runner.filteredToolsForRun(run2.ID) {
+		if def.Name == "agent_swarm" {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatal("agent_swarm missing from unrestricted run definitions after activation")
+	}
+	waitForStatus(t, runner, run2.ID, RunStatusCompleted, RunStatusFailed)
+}
+
+func TestAgentSwarmApprovalFlowSurfacesMutatingCall(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{Total: 1, Completed: 1}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a"]}`},
+		}},
+		{Content: "done"},
+	}}
+	broker := NewInMemoryApprovalBroker()
+	runner := NewRunner(provider, registry, RunnerConfig{
+		DefaultModel:        "test",
+		DefaultSystemPrompt: "sys",
+		ApprovalBroker:      broker,
+	})
+
+	run, err := runner.StartRun(RunRequest{
+		Prompt:      "fan out",
+		Permissions: &PermissionConfig{Sandbox: SandboxScopeUnrestricted, Approval: ApprovalPolicyDestructive},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The destructive policy must pause the mutating agent_swarm call for approval.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pending, ok := broker.Pending(run.ID)
+		if ok {
+			if pending.Tool != "agent_swarm" {
+				t.Fatalf("pending approval tool = %q, want agent_swarm", pending.Tool)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("agent_swarm never surfaced for approval under the destructive policy")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := broker.Approve(run.ID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	if got := waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed); got != RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed", got)
+	}
+	if swarmRunner.callCount() != 1 {
+		t.Fatalf("swarm runner calls = %d, want 1 after approval", swarmRunner.callCount())
+	}
+}
+
+// TestAgentSwarmEndToEndReportShape guards the JSON contract returned to the
+// model for a completed swarm call.
+func TestAgentSwarmEndToEndReportShape(t *testing.T) {
+	t.Parallel()
+
+	swarmRunner := &runnerFakeSwarmRunner{report: htools.SwarmReport{
+		Total:     2,
+		Completed: 2,
+		Members: []htools.SwarmMemberReport{
+			{ID: "sub-1", Item: "a", Prompt: "do a", Status: "completed", Output: "done a"},
+			{ID: "sub-2", Item: "b", Prompt: "do b", Status: "completed", Output: "done b"},
+		},
+	}}
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{AgentSwarmRunner: swarmRunner})
+	provider := &capturingProvider{turns: []CompletionResult{
+		{ToolCalls: []ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["a","b"]}`},
+		}},
+		{Content: "done"},
+	}}
+	runner := NewRunner(provider, registry, RunnerConfig{DefaultModel: "test", DefaultSystemPrompt: "sys"})
+
+	run, err := runner.StartRun(RunRequest{Prompt: "fan out"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForStatus(t, runner, run.ID, RunStatusCompleted, RunStatusFailed)
+
+	content := toolMessageForCall(t, runner, run.ID, "call-swarm")
+	var report struct {
+		Total   int `json:"total"`
+		Members []struct {
+			ID    string `json:"id"`
+			Item  string `json:"item"`
+			Error string `json:"error"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal([]byte(content), &report); err != nil {
+		t.Fatalf("swarm tool result is not JSON: %v\n%s", err, content)
+	}
+	if report.Total != 2 || len(report.Members) != 2 {
+		t.Fatalf("report = total:%d members:%d, want 2/2", report.Total, len(report.Members))
+	}
+}

--- a/internal/harness/tools/deferred/agent_swarm.go
+++ b/internal/harness/tools/deferred/agent_swarm.go
@@ -1,0 +1,177 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	tools "go-agent-harness/internal/harness/tools"
+	"go-agent-harness/internal/harness/tools/descriptions"
+	"go-agent-harness/internal/profiles"
+)
+
+// AgentSwarmTool returns the deferred agent_swarm tool: one call fans a
+// prompt template out over an items array into up to 128 concurrent
+// subagents and returns a single aggregated report. It runs on the same
+// approval/policy path as other mutating tools (ActionExecute, Mutating).
+//
+// swarmRunner is the subagents-package swarm adapted to tools.SwarmRunner;
+// profilesDir resolves the optional per-call profile override exactly like
+// start_subagent.
+func AgentSwarmTool(swarmRunner tools.SwarmRunner, profilesDir string) tools.Tool {
+	def := tools.Definition{
+		Name:         tools.AgentSwarmToolName,
+		Description:  descriptions.Load(tools.AgentSwarmToolName),
+		Action:       tools.ActionExecute,
+		Mutating:     true,
+		ParallelSafe: false,
+		Tier:         tools.TierDeferred,
+		Tags:         []string{"agent", "subagent", "delegation", "swarm"},
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"prompt_template": map[string]any{
+					"type":        "string",
+					"description": "Prompt template for every member. Must contain the {{item}} placeholder, which is replaced with each item to produce the member prompts.",
+				},
+				"items": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Work items to fan out over (1-128). Expanded prompts must be distinct.",
+				},
+				"resume_agent_ids": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional existing subagent IDs to resume instead of creating new members. Entry i is paired with items[i] and receives its expanded prompt; targets must be running or waiting for user input. Resumed members are scheduled before new items.",
+				},
+				"profile": map[string]any{
+					"type":        "string",
+					"description": "Optional profile name for member runs (for example: full, fast, minimal). Defaults to full.",
+				},
+				"model": map[string]any{
+					"type":        "string",
+					"description": "Optional model override for member runs. Defaults to the profile's model.",
+				},
+				"max_steps": map[string]any{
+					"type":        "integer",
+					"description": "Optional step override for member runs. Defaults to the profile's max_steps.",
+				},
+				"allowed_tools": map[string]any{
+					"type":        "array",
+					"items":       map[string]any{"type": "string"},
+					"description": "Optional list of tool names to restrict every member to. Defaults to the profile's own tool set. Members never receive agent_swarm.",
+				},
+			},
+			"required": []string{"prompt_template", "items"},
+		},
+	}
+
+	handler := func(ctx context.Context, raw json.RawMessage) (string, error) {
+		var args agentSwarmArgs
+		if err := json.Unmarshal(raw, &args); err != nil {
+			return "", fmt.Errorf("parse agent_swarm args: %w", err)
+		}
+		if strings.TrimSpace(args.PromptTemplate) == "" {
+			return "", fmt.Errorf("agent_swarm: prompt_template is required")
+		}
+		if len(args.Items) == 0 {
+			return "", fmt.Errorf("agent_swarm: items is required")
+		}
+		if swarmRunner == nil {
+			return "", fmt.Errorf("agent_swarm: swarm runner is not configured")
+		}
+
+		req, err := resolveAgentSwarmRequest(ctx, args, profilesDir)
+		if err != nil {
+			return "", err
+		}
+
+		report, err := swarmRunner.RunSwarm(ctx, req)
+		if err != nil {
+			return "", fmt.Errorf("agent_swarm: %w", err)
+		}
+		return tools.MarshalToolResult(report)
+	}
+
+	return tools.Tool{Definition: def, Handler: handler}
+}
+
+type agentSwarmArgs struct {
+	PromptTemplate  string   `json:"prompt_template"`
+	Items           []string `json:"items"`
+	ResumeAgentIDs  []string `json:"resume_agent_ids,omitempty"`
+	Profile         string   `json:"profile,omitempty"`
+	Model           string   `json:"model,omitempty"`
+	MaxSteps        int      `json:"max_steps,omitempty"`
+	MaxCostUSD      float64  `json:"max_cost_usd,omitempty"`
+	AllowedTools    []string `json:"allowed_tools,omitempty"`
+	ReasoningEffort string   `json:"reasoning_effort,omitempty"`
+}
+
+// resolveAgentSwarmRequest applies the same profile-resolution semantics as
+// start_subagent: profile values are the base, per-call overrides win.
+func resolveAgentSwarmRequest(ctx context.Context, args agentSwarmArgs, profilesDir string) (tools.SwarmRequest, error) {
+	profileName := strings.TrimSpace(args.Profile)
+	if profileName == "" {
+		profileName = "full"
+	}
+
+	var p *profiles.Profile
+	var loadErr error
+	if profilesDir != "" {
+		p, loadErr = profiles.LoadProfileFromUserDir(profileName, profilesDir)
+	} else {
+		p, loadErr = profiles.LoadProfile(profileName)
+	}
+	if loadErr != nil {
+		return tools.SwarmRequest{}, fmt.Errorf("agent_swarm: profile %q could not be loaded: %w; check available profiles with list_profiles or use a built-in profile (\"full\", \"fast\", \"minimal\")", profileName, loadErr)
+	}
+	vals := p.ApplyValues()
+
+	model := vals.Model
+	if strings.TrimSpace(args.Model) != "" {
+		model = strings.TrimSpace(args.Model)
+	}
+	maxSteps := vals.MaxSteps
+	if args.MaxSteps > 0 {
+		maxSteps = args.MaxSteps
+	}
+	maxCostUSD := vals.MaxCostUSD
+	if args.MaxCostUSD > 0 {
+		maxCostUSD = args.MaxCostUSD
+	}
+	allowedTools := append([]string(nil), vals.AllowedTools...)
+	if len(args.AllowedTools) > 0 {
+		allowedTools = append([]string(nil), args.AllowedTools...)
+	}
+	reasoningEffort := vals.ReasoningEffort
+	if strings.TrimSpace(args.ReasoningEffort) != "" {
+		reasoningEffort = strings.TrimSpace(args.ReasoningEffort)
+	}
+
+	childHandoff, hasHandoff := tools.BuildParentContextHandoffFromContext(ctx)
+	var handoffRef *tools.ParentContextHandoff
+	if hasHandoff {
+		copyHandoff := childHandoff
+		handoffRef = &copyHandoff
+	}
+
+	return tools.SwarmRequest{
+		PromptTemplate:       strings.TrimSpace(args.PromptTemplate),
+		Items:                append([]string(nil), args.Items...),
+		ResumeAgentIDs:       append([]string(nil), args.ResumeAgentIDs...),
+		Model:                model,
+		SystemPrompt:         vals.SystemPrompt,
+		MaxSteps:             maxSteps,
+		MaxCostUSD:           maxCostUSD,
+		ReasoningEffort:      reasoningEffort,
+		AllowedTools:         allowedTools,
+		ProfileName:          profileName,
+		IsolationMode:        vals.IsolationMode,
+		CleanupPolicy:        vals.CleanupPolicy,
+		BaseRef:              vals.BaseRef,
+		ResultMode:           vals.ResultMode,
+		ParentContextHandoff: handoffRef,
+	}, nil
+}

--- a/internal/harness/tools/deferred/agent_swarm_test.go
+++ b/internal/harness/tools/deferred/agent_swarm_test.go
@@ -1,0 +1,272 @@
+package deferred
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// fakeSwarmRunner implements tools.SwarmRunner, capturing the request.
+type fakeSwarmRunner struct {
+	mu     sync.Mutex
+	calls  int
+	req    tools.SwarmRequest
+	report tools.SwarmReport
+	err    error
+}
+
+func (f *fakeSwarmRunner) RunSwarm(_ context.Context, req tools.SwarmRequest) (tools.SwarmReport, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.req = req
+	return f.report, f.err
+}
+
+func (f *fakeSwarmRunner) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeSwarmRunner) lastReq() tools.SwarmRequest {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.req
+}
+
+func TestAgentSwarmToolDefinition(t *testing.T) {
+	t.Parallel()
+
+	tool := AgentSwarmTool(&fakeSwarmRunner{}, "")
+	def := tool.Definition
+	if def.Name != "agent_swarm" {
+		t.Errorf("Name = %q, want agent_swarm", def.Name)
+	}
+	if def.Action != tools.ActionExecute {
+		t.Errorf("Action = %q, want ActionExecute (mutating policy path)", def.Action)
+	}
+	if !def.Mutating {
+		t.Error("Mutating = false, want true (approval policy integration)")
+	}
+	if def.Tier != tools.TierDeferred {
+		t.Errorf("Tier = %q, want TierDeferred", def.Tier)
+	}
+	if def.ParallelSafe {
+		t.Error("ParallelSafe = true, want false")
+	}
+	if def.Description == "" {
+		t.Error("Description is empty, want loaded description")
+	}
+
+	required, _ := def.Parameters["required"].([]string)
+	seen := map[string]bool{}
+	for _, name := range required {
+		seen[name] = true
+	}
+	if !seen["prompt_template"] || !seen["items"] {
+		t.Errorf("required = %v, want prompt_template and items", required)
+	}
+	props, _ := def.Parameters["properties"].(map[string]any)
+	for _, name := range []string{"prompt_template", "items", "resume_agent_ids", "profile", "model", "max_steps", "allowed_tools"} {
+		if _, ok := props[name]; !ok {
+			t.Errorf("parameters missing %q", name)
+		}
+	}
+}
+
+func TestAgentSwarmToolHandlerValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "invalid json", raw: `{not json`, wantErr: "parse"},
+		{name: "missing prompt_template", raw: `{"items":["a"]}`, wantErr: "prompt_template"},
+		{name: "blank prompt_template", raw: `{"prompt_template":"  ","items":["a"]}`, wantErr: "prompt_template"},
+		{name: "missing items", raw: `{"prompt_template":"do {{item}}"}`, wantErr: "items"},
+		{name: "empty items", raw: `{"prompt_template":"do {{item}}","items":[]}`, wantErr: "items"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			runner := &fakeSwarmRunner{}
+			tool := AgentSwarmTool(runner, "")
+			_, err := tool.Handler(context.Background(), json.RawMessage(tt.raw))
+			if err == nil {
+				t.Fatalf("handler error = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("handler error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+			if runner.callCount() != 0 {
+				t.Fatalf("invalid args reached the swarm runner %d times, want 0", runner.callCount())
+			}
+		})
+	}
+}
+
+func TestAgentSwarmToolHandlerMapsRequest(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeSwarmRunner{report: tools.SwarmReport{Total: 2, Completed: 2}}
+	tool := AgentSwarmTool(runner, "")
+	ctx := context.WithValue(context.Background(), tools.ContextKeyRunMetadata, tools.RunMetadata{RunID: "parent-run-1"})
+
+	raw := json.RawMessage(`{
+		"prompt_template": "Review {{item}} carefully",
+		"items": ["a", "b"],
+		"resume_agent_ids": ["subagent_1"],
+		"model": "gpt-swarm",
+		"max_steps": 7,
+		"allowed_tools": ["read", "bash"]
+	}`)
+	if _, err := tool.Handler(ctx, raw); err != nil {
+		t.Fatalf("handler error = %v, want nil", err)
+	}
+	if runner.callCount() != 1 {
+		t.Fatalf("swarm runner calls = %d, want 1", runner.callCount())
+	}
+	req := runner.lastReq()
+	if req.PromptTemplate != "Review {{item}} carefully" {
+		t.Errorf("PromptTemplate = %q", req.PromptTemplate)
+	}
+	if len(req.Items) != 2 || req.Items[0] != "a" || req.Items[1] != "b" {
+		t.Errorf("Items = %v, want [a b]", req.Items)
+	}
+	if len(req.ResumeAgentIDs) != 1 || req.ResumeAgentIDs[0] != "subagent_1" {
+		t.Errorf("ResumeAgentIDs = %v, want [subagent_1]", req.ResumeAgentIDs)
+	}
+	if req.Model != "gpt-swarm" {
+		t.Errorf("Model = %q, want gpt-swarm override", req.Model)
+	}
+	if req.MaxSteps != 7 {
+		t.Errorf("MaxSteps = %d, want 7 override", req.MaxSteps)
+	}
+	if len(req.AllowedTools) != 2 || req.AllowedTools[0] != "read" {
+		t.Errorf("AllowedTools = %v, want [read bash]", req.AllowedTools)
+	}
+	if req.ProfileName != "full" {
+		t.Errorf("ProfileName = %q, want default profile full", req.ProfileName)
+	}
+	if req.ParentContextHandoff == nil || req.ParentContextHandoff.ParentRunID != "parent-run-1" {
+		t.Errorf("ParentContextHandoff = %+v, want parent run id parent-run-1", req.ParentContextHandoff)
+	}
+}
+
+func TestAgentSwarmToolHandlerExplicitProfile(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeSwarmRunner{report: tools.SwarmReport{Total: 1, Completed: 1}}
+	tool := AgentSwarmTool(runner, "")
+	raw := json.RawMessage(`{"prompt_template":"do {{item}}","items":["a"],"profile":"reviewer"}`)
+	if _, err := tool.Handler(context.Background(), raw); err != nil {
+		t.Fatalf("handler error = %v, want nil", err)
+	}
+	if got := runner.lastReq().ProfileName; got != "reviewer" {
+		t.Fatalf("ProfileName = %q, want reviewer", got)
+	}
+}
+
+func TestAgentSwarmToolHandlerUnknownProfile(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeSwarmRunner{}
+	tool := AgentSwarmTool(runner, "")
+	raw := json.RawMessage(`{"prompt_template":"do {{item}}","items":["a"],"profile":"nonexistent-profile-xyz"}`)
+	_, err := tool.Handler(context.Background(), raw)
+	if err == nil {
+		t.Fatal("handler error = nil, want unknown profile error")
+	}
+	if !strings.Contains(err.Error(), "nonexistent-profile-xyz") {
+		t.Fatalf("handler error = %q, want profile name mentioned", err.Error())
+	}
+	if runner.callCount() != 0 {
+		t.Fatalf("unknown profile reached the swarm runner %d times, want 0", runner.callCount())
+	}
+}
+
+func TestAgentSwarmToolHandlerReturnsAggregatedReport(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeSwarmRunner{report: tools.SwarmReport{
+		Total:     2,
+		Completed: 1,
+		Failed:    1,
+		Members: []tools.SwarmMemberReport{
+			{ID: "sub-1", Item: "a", Prompt: "do a", Status: "completed", Output: "done a"},
+			{ID: "sub-2", Item: "b", Prompt: "do b", Status: "failed", Error: "boom"},
+		},
+	}}
+	tool := AgentSwarmTool(runner, "")
+	raw := json.RawMessage(`{"prompt_template":"do {{item}}","items":["a","b"]}`)
+	out, err := tool.Handler(context.Background(), raw)
+	if err != nil {
+		t.Fatalf("handler error = %v, want nil", err)
+	}
+
+	var decoded struct {
+		Total     int `json:"total"`
+		Completed int `json:"completed"`
+		Failed    int `json:"failed"`
+		Members   []struct {
+			ID     string `json:"id"`
+			Item   string `json:"item"`
+			Status string `json:"status"`
+			Output string `json:"output"`
+			Error  string `json:"error"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("tool result is not JSON: %v\n%s", err, out)
+	}
+	if decoded.Total != 2 || decoded.Completed != 1 || decoded.Failed != 1 {
+		t.Fatalf("counts = %d/%d/%d, want 2/1/1", decoded.Total, decoded.Completed, decoded.Failed)
+	}
+	if len(decoded.Members) != 2 {
+		t.Fatalf("members = %d, want 2", len(decoded.Members))
+	}
+	if decoded.Members[0].ID != "sub-1" || decoded.Members[0].Output != "done a" {
+		t.Errorf("member 0 = %+v", decoded.Members[0])
+	}
+	if decoded.Members[1].Status != "failed" || decoded.Members[1].Error != "boom" {
+		t.Errorf("member 1 = %+v, want failed/boom", decoded.Members[1])
+	}
+}
+
+func TestAgentSwarmToolHandlerRunnerError(t *testing.T) {
+	t.Parallel()
+
+	runner := &fakeSwarmRunner{err: errors.New("invalid swarm request: prompt_template must contain the \"{{item}}\" placeholder")}
+	tool := AgentSwarmTool(runner, "")
+	raw := json.RawMessage(`{"prompt_template":"do {{item}}","items":["a"]}`)
+	_, err := tool.Handler(context.Background(), raw)
+	if err == nil {
+		t.Fatal("handler error = nil, want swarm validation error")
+	}
+	if !strings.Contains(err.Error(), "{{item}}") {
+		t.Fatalf("handler error = %q, want the swarm validation reason", err.Error())
+	}
+}
+
+func TestAgentSwarmToolNilRunner(t *testing.T) {
+	t.Parallel()
+
+	tool := AgentSwarmTool(nil, "")
+	raw := json.RawMessage(`{"prompt_template":"do {{item}}","items":["a"]}`)
+	_, err := tool.Handler(context.Background(), raw)
+	if err == nil {
+		t.Fatal("handler error = nil, want not-configured error")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("handler error = %q, want not configured", err.Error())
+	}
+}

--- a/internal/harness/tools/descriptions/agent_swarm.md
+++ b/internal/harness/tools/descriptions/agent_swarm.md
@@ -1,0 +1,12 @@
+Fan one prompt template out over many items into concurrent subagents with a single call, and receive one aggregated report covering every member.
+
+Usage notes:
+
+- `prompt_template` must contain the `{{item}}` placeholder; each entry of `items` (1-128) is substituted in to produce one member prompt. Expanded prompts must be distinct.
+- **Sole-call rule: when you call `agent_swarm`, it must be the only tool call in that response. Any other tool call in the same response is rejected and must be re-issued in a later turn.**
+- Members run concurrently: 5 start immediately, then the in-flight allowance grows by 1 every 700ms up to `HARNESS_SWARM_MAX_CONCURRENCY` (default 128, hard-capped at 128).
+- `resume_agent_ids` reuses existing subagents instead of creating new ones: entry i is paired with `items[i]` and receives that item's expanded prompt as a follow-up message. Targets must be running or waiting for user input; resumed members are scheduled before new items.
+- Members never receive `agent_swarm` in their own tool set — nested swarms are not allowed.
+- Member failures do not abort the cohort: every member reports its own status in the aggregated report.
+- The result is a single JSON report: per-member id, item, status, output/error (resumed members marked), plus total/completed/failed/cancelled counts. Order is deterministic: new item members first (item order), then resumed members.
+- Cancelling the parent run cancels every swarm member.

--- a/internal/harness/tools/descriptions/embed_test.go
+++ b/internal/harness/tools/descriptions/embed_test.go
@@ -60,6 +60,7 @@ func TestLoadAllKnownDescriptions(t *testing.T) {
 	names := []string{
 		"AskUserQuestion",
 		"agent",
+		"agent_swarm",
 		"agentic_fetch",
 		"apply_patch",
 		"bash",
@@ -176,6 +177,7 @@ func TestEmbeddedFSAndKnownListAreInSync(t *testing.T) {
 	knownNames := map[string]bool{
 		"AskUserQuestion":         true,
 		"agent":                   true,
+		"agent_swarm":             true,
 		"agentic_fetch":           true,
 		"apply_patch":             true,
 		"bash":                    true,

--- a/internal/harness/tools/swarm.go
+++ b/internal/harness/tools/swarm.go
@@ -1,0 +1,60 @@
+package tools
+
+import "context"
+
+// AgentSwarmToolName is the name of the swarm fan-out tool. It lives here so
+// the runner's sole-call rule, the deferred tool, and the subagents package
+// (member tool-set exclusion) all share one constant without importing each
+// other.
+const AgentSwarmToolName = "agent_swarm"
+
+// SwarmRequest mirrors subagents.SwarmRequest without importing the subagents
+// package (which would create an import cycle: harness -> deferred ->
+// subagents -> harness). Field semantics are defined by subagents.SwarmRequest.
+type SwarmRequest struct {
+	PromptTemplate string   `json:"prompt_template"`
+	Items          []string `json:"items"`
+	ResumeAgentIDs []string `json:"resume_agent_ids,omitempty"`
+
+	Model                string                `json:"model,omitempty"`
+	SystemPrompt         string                `json:"system_prompt,omitempty"`
+	MaxSteps             int                   `json:"max_steps,omitempty"`
+	MaxCostUSD           float64               `json:"max_cost_usd,omitempty"`
+	ReasoningEffort      string                `json:"reasoning_effort,omitempty"`
+	AllowedTools         []string              `json:"allowed_tools,omitempty"`
+	ProfileName          string                `json:"profile,omitempty"`
+	IsolationMode        string                `json:"isolation,omitempty"`
+	CleanupPolicy        string                `json:"cleanup_policy,omitempty"`
+	BaseRef              string                `json:"base_ref,omitempty"`
+	ResultMode           string                `json:"result_mode,omitempty"`
+	ParentContextHandoff *ParentContextHandoff `json:"parent_context_handoff,omitempty"`
+}
+
+// SwarmMemberReport mirrors subagents.SwarmMemberReport.
+type SwarmMemberReport struct {
+	ID      string `json:"id,omitempty"`
+	Item    string `json:"item"`
+	Prompt  string `json:"prompt"`
+	Status  string `json:"status"`
+	Output  string `json:"output,omitempty"`
+	Error   string `json:"error,omitempty"`
+	Resumed bool   `json:"resumed,omitempty"`
+}
+
+// SwarmReport mirrors subagents.SwarmReport: one aggregated result for the
+// whole cohort, in deterministic order (new item members first, then resumed).
+type SwarmReport struct {
+	Members   []SwarmMemberReport `json:"members"`
+	Total     int                 `json:"total"`
+	Completed int                 `json:"completed"`
+	Failed    int                 `json:"failed"`
+	Cancelled int                 `json:"cancelled"`
+}
+
+// SwarmRunner fans a prompt template out over items into concurrent
+// subagents and returns the aggregated report. It is implemented by an
+// adapter in the subagents package; the interface lives here to avoid the
+// import cycle SubagentManager avoids.
+type SwarmRunner interface {
+	RunSwarm(ctx context.Context, req SwarmRequest) (SwarmReport, error)
+}

--- a/internal/harness/tools/types.go
+++ b/internal/harness/tools/types.go
@@ -299,6 +299,9 @@ type SubagentRequest struct {
 	// ResultMode controls how subagent output is formatted.
 	// Empty means inherit from defaults.
 	ResultMode string
+	// DeniedTools lists tool names the subagent must never be offered or
+	// allowed to call (e.g. swarm members never receive agent_swarm).
+	DeniedTools []string
 }
 
 // SubagentResult is a tool-layer subagent result, mirroring subagents.Subagent

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -68,6 +68,11 @@ type DefaultRegistryOptions struct {
 	MessageSummarizer   htools.MessageSummarizer   // optional: enables summarize/hybrid modes in compact_history
 	// SubagentManager enables the run_agent tool for profile-based subagent delegation.
 	SubagentManager htools.SubagentManager
+	// AgentSwarmRunner enables the agent_swarm tool: a single-call template
+	// fan-out over items into concurrent subagents (epic #808). Implemented by
+	// the subagents package adapter (subagents.NewToolSwarmRunner); kept as an
+	// interface here to avoid an import cycle.
+	AgentSwarmRunner htools.SwarmRunner
 	// RunSteerer enables message_subagent (parent -> running subagent) and
 	// notify_parent (subagent -> spawning agent), both built on the same
 	// steer-a-live-run primitive in each direction.
@@ -386,6 +391,13 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 		if opts.RunSteerer != nil {
 			deferredTools = append(deferredTools, deferred.MessageSubagentTool(opts.SubagentManager, opts.RunSteerer))
 		}
+	}
+
+	// agent_swarm: one-call template fan-out into concurrent subagents.
+	// Registered next to the subagent tools; the swarm itself denies members
+	// agent_swarm via RunRequest.DeniedTools (no nested swarms).
+	if opts.AgentSwarmRunner != nil {
+		deferredTools = append(deferredTools, deferred.AgentSwarmTool(opts.AgentSwarmRunner, opts.ProfilesDir))
 	}
 
 	// notify_parent: the reverse direction of message_subagent (subagent ->

--- a/internal/harness/types.go
+++ b/internal/harness/types.go
@@ -454,6 +454,10 @@ type RunRequest struct {
 	// available. Skill constraints activated during execution override this
 	// base filter for the duration of the skill.
 	AllowedTools []string `json:"allowed_tools,omitempty"`
+	// DeniedTools lists tool names that must never be offered to or callable
+	// from this run, even when activated or granted by AllowedTools. Used to
+	// keep agent_swarm out of swarm-member runs (no nested swarms).
+	DeniedTools []string `json:"denied_tools,omitempty"`
 	// MCPServers specifies per-run MCP server configurations. Each entry
 	// describes an MCP server to connect for this run only. The per-run servers
 	// shadow any global MCP servers with the same name. When the run completes,

--- a/internal/subagents/inline_manager.go
+++ b/internal/subagents/inline_manager.go
@@ -59,6 +59,7 @@ func (im *InlineManager) Start(ctx context.Context, req tools.SubagentRequest) (
 		MaxCostUSD:           req.MaxCostUSD,
 		ReasoningEffort:      req.ReasoningEffort,
 		AllowedTools:         append([]string(nil), req.AllowedTools...),
+		DeniedTools:          append([]string(nil), req.DeniedTools...),
 		ProfileName:          req.ProfileName,
 		ParentContextHandoff: req.ParentContextHandoff,
 		Isolation:            isolation,

--- a/internal/subagents/manager.go
+++ b/internal/subagents/manager.go
@@ -51,11 +51,14 @@ type Request struct {
 	// AgentIntent selects a named prompt overlay (e.g. "code_review",
 	// "autonomous") for this subagent, forwarded to RunRequest.AgentIntent.
 	// SystemPrompt (a full override) takes precedence over an intent overlay.
-	AgentIntent          string                      `json:"agent_intent,omitempty"`
-	MaxSteps             int                         `json:"max_steps,omitempty"`
-	MaxCostUSD           float64                     `json:"max_cost_usd,omitempty"`
-	ReasoningEffort      string                      `json:"reasoning_effort,omitempty"`
-	AllowedTools         []string                    `json:"allowed_tools,omitempty"`
+	AgentIntent     string   `json:"agent_intent,omitempty"`
+	MaxSteps        int      `json:"max_steps,omitempty"`
+	MaxCostUSD      float64  `json:"max_cost_usd,omitempty"`
+	ReasoningEffort string   `json:"reasoning_effort,omitempty"`
+	AllowedTools    []string `json:"allowed_tools,omitempty"`
+	// DeniedTools lists tool names the subagent must never be offered or
+	// allowed to call; swarm members always deny agent_swarm (no nesting).
+	DeniedTools          []string                    `json:"denied_tools,omitempty"`
 	ProfileName          string                      `json:"profile,omitempty"`
 	Permissions          *harness.PermissionConfig   `json:"permissions,omitempty"`
 	Isolation            IsolationMode               `json:"isolation,omitempty"`
@@ -231,6 +234,7 @@ func (m *manager) Create(ctx context.Context, req Request) (Subagent, error) {
 		MaxCostUSD:           req.MaxCostUSD,
 		ReasoningEffort:      strings.TrimSpace(req.ReasoningEffort),
 		AllowedTools:         append([]string(nil), req.AllowedTools...),
+		DeniedTools:          append([]string(nil), req.DeniedTools...),
 		ProfileName:          strings.TrimSpace(req.ProfileName),
 		Permissions:          req.Permissions,
 		AgentID:              id,

--- a/internal/subagents/swarm.go
+++ b/internal/subagents/swarm.go
@@ -251,6 +251,8 @@ func (r SwarmRequest) expandedPrompts() ([]string, error) {
 }
 
 // memberRequest builds the per-member tool-layer request from the overrides.
+// Every member is denied agent_swarm: nested swarms are out of scope, so the
+// tool is neither offered to nor callable from a member run.
 func (r SwarmRequest) memberRequest(prompt string) tools.SubagentRequest {
 	return tools.SubagentRequest{
 		Prompt:               prompt,
@@ -259,6 +261,7 @@ func (r SwarmRequest) memberRequest(prompt string) tools.SubagentRequest {
 		MaxSteps:             r.MaxSteps,
 		MaxCostUSD:           r.MaxCostUSD,
 		AllowedTools:         append([]string(nil), r.AllowedTools...),
+		DeniedTools:          []string{tools.AgentSwarmToolName},
 		ProfileName:          r.ProfileName,
 		ReasoningEffort:      r.ReasoningEffort,
 		IsolationMode:        r.IsolationMode,

--- a/internal/subagents/swarm_e2e_test.go
+++ b/internal/subagents/swarm_e2e_test.go
@@ -1,0 +1,178 @@
+package subagents
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// waitSwarmE2ETerminal polls until the run reaches a terminal status.
+func waitSwarmE2ETerminal(t *testing.T, r *harness.Runner, runID string) harness.Run {
+	t.Helper()
+	deadline := time.Now().Add(60 * time.Second)
+	for time.Now().Before(deadline) {
+		run, ok := r.GetRun(runID)
+		if !ok {
+			t.Fatalf("run %q not found", runID)
+		}
+		switch run.Status {
+		case harness.RunStatusCompleted, harness.RunStatusFailed, harness.RunStatusCancelled:
+			return run
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("run %q did not reach terminal state", runID)
+	return harness.Run{}
+}
+
+// swarmE2EHandoff forwards subagents.RunEngine and tools.RunSteerer to the
+// runner under construction, mirroring cmd/harnessd's subagentRunnerHandoff.
+type swarmE2EHandoff struct {
+	runner atomic.Pointer[harness.Runner]
+}
+
+func (h *swarmE2EHandoff) setRunner(r *harness.Runner) { h.runner.Store(r) }
+
+func (h *swarmE2EHandoff) StartRun(req harness.RunRequest) (harness.Run, error) {
+	return h.runner.Load().StartRun(req)
+}
+
+func (h *swarmE2EHandoff) GetRun(runID string) (harness.Run, bool) {
+	return h.runner.Load().GetRun(runID)
+}
+
+func (h *swarmE2EHandoff) Subscribe(runID string) ([]harness.Event, <-chan harness.Event, func(), error) {
+	return h.runner.Load().Subscribe(runID)
+}
+
+func (h *swarmE2EHandoff) CancelRun(runID string) error {
+	return h.runner.Load().CancelRun(runID)
+}
+
+func (h *swarmE2EHandoff) SteerRun(runID, message string) error {
+	return h.runner.Load().SteerRun(runID, message)
+}
+
+func (h *swarmE2EHandoff) ParentRunID(string) (string, bool) { return "", false }
+
+// TestAgentSwarmEndToEndFanOut drives the production wiring shape —
+// fakeprovider → registry(agent_swarm) → runner → handoff → manager →
+// InlineManager → Swarm — and asserts a 4-item swarm produces four member
+// runs and exactly one aggregated tool result returned to the parent run.
+func TestAgentSwarmEndToEndFanOut(t *testing.T) {
+	provider := fakeprovider.New([]fakeprovider.Turn{
+		{ToolCalls: []harness.ToolCall{
+			{ID: "call-find", Name: "find_tool", Arguments: `{"query":"select:agent_swarm"}`},
+		}},
+		{ToolCalls: []harness.ToolCall{
+			{ID: "call-swarm", Name: "agent_swarm", Arguments: `{"prompt_template":"do {{item}}","items":["i1","i2","i3","i4"]}`},
+		}},
+		{Content: "member done"},
+		{Content: "member done"},
+		{Content: "member done"},
+		{Content: "member done"},
+		{Content: "all done"},
+	})
+
+	handoff := &swarmE2EHandoff{}
+	mgr, err := NewManager(Options{InlineRunner: handoff})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	swarm := NewSwarm(NewInlineManager(mgr), WithSwarmSteerer(handoff))
+	registry := harness.NewDefaultRegistryWithOptions(t.TempDir(), harness.DefaultRegistryOptions{
+		AgentSwarmRunner: NewToolSwarmRunner(swarm),
+	})
+	runner := harness.NewRunner(provider, registry, harness.RunnerConfig{
+		DefaultModel:        "test-model",
+		DefaultSystemPrompt: "You are helpful.",
+	})
+	handoff.setRunner(runner)
+
+	run, err := runner.StartRun(harness.RunRequest{Prompt: "fan out please"})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	final := waitSwarmE2ETerminal(t, runner, run.ID)
+	if final.Status != harness.RunStatusCompleted {
+		t.Fatalf("run status = %q, want completed (output %q, error %q)", final.Status, final.Output, final.Error)
+	}
+
+	invocations := provider.Invocations()
+	// Four member runs each consume exactly one provider turn with their
+	// expanded item prompt.
+	memberPrompts := map[string]bool{}
+	for _, inv := range invocations {
+		for _, msg := range inv.Request.Messages {
+			if msg.Role == "user" && strings.HasPrefix(msg.Content, "do i") {
+				memberPrompts[msg.Content] = true
+			}
+		}
+	}
+	for _, want := range []string{"do i1", "do i2", "do i3", "do i4"} {
+		if !memberPrompts[want] {
+			t.Fatalf("no member run saw prompt %q; saw %v", want, memberPrompts)
+		}
+	}
+
+	// The parent's final provider turn must carry exactly one agent_swarm
+	// tool result: the aggregated report covering all four members.
+	last := invocations[len(invocations)-1]
+	swarmResults := 0
+	var report struct {
+		Total     int `json:"total"`
+		Completed int `json:"completed"`
+		Failed    int `json:"failed"`
+		Members   []struct {
+			ID     string `json:"id"`
+			Item   string `json:"item"`
+			Status string `json:"status"`
+			Output string `json:"output"`
+		} `json:"members"`
+	}
+	for _, msg := range last.Request.Messages {
+		if msg.Role == "tool" && msg.Name == "agent_swarm" {
+			swarmResults++
+			if err := json.Unmarshal([]byte(msg.Content), &report); err != nil {
+				t.Fatalf("agent_swarm tool result is not JSON: %v\n%s", err, msg.Content)
+			}
+		}
+	}
+	if swarmResults != 1 {
+		t.Fatalf("agent_swarm tool results in final turn = %d, want exactly 1", swarmResults)
+	}
+	if report.Total != 4 || report.Completed != 4 || report.Failed != 0 {
+		t.Fatalf("report counts = total:%d completed:%d failed:%d, want 4/4/0", report.Total, report.Completed, report.Failed)
+	}
+	if len(report.Members) != 4 {
+		t.Fatalf("report members = %d, want 4", len(report.Members))
+	}
+	for i, want := range []string{"i1", "i2", "i3", "i4"} {
+		m := report.Members[i]
+		if m.Item != want {
+			t.Errorf("member %d item = %q, want %q (deterministic order)", i, m.Item, want)
+		}
+		if m.Status != string(harness.RunStatusCompleted) {
+			t.Errorf("member %d status = %q, want completed", i, m.Status)
+		}
+		if m.ID == "" {
+			t.Errorf("member %d has no subagent id", i)
+		}
+	}
+
+	// Every member is an ordinary subagent visible through the manager.
+	items, err := mgr.List(context.Background())
+	if err != nil {
+		t.Fatalf("manager List: %v", err)
+	}
+	if len(items) != 4 {
+		t.Fatalf("manager tracks %d subagents, want 4", len(items))
+	}
+}

--- a/internal/subagents/swarm_test.go
+++ b/internal/subagents/swarm_test.go
@@ -681,6 +681,34 @@ func TestSwarmMemberStartFailureIsCaptured(t *testing.T) {
 	}
 }
 
+func TestSwarmMembersExcludeAgentSwarmFromToolSet(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.release()
+	swarm := NewSwarm(fake)
+	res := awaitSwarmRun(t, runSwarmAsync(swarm, context.Background(), SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b"},
+	}))
+	if res.err != nil {
+		t.Fatalf("Run error = %v, want nil", res.err)
+	}
+	// Swarm members must never receive agent_swarm in their own tool set
+	// (nested swarms are out of scope), regardless of profile tool grants.
+	for i, req := range fake.started {
+		found := false
+		for _, name := range req.DeniedTools {
+			if name == "agent_swarm" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("member %d DeniedTools = %v, want agent_swarm excluded", i, req.DeniedTools)
+		}
+	}
+}
+
 func TestSwarmRunWithInlineManager(t *testing.T) {
 	t.Parallel()
 

--- a/internal/subagents/swarm_tool_runner.go
+++ b/internal/subagents/swarm_tool_runner.go
@@ -1,0 +1,62 @@
+package subagents
+
+import (
+	"context"
+
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// toolSwarmRunner adapts *Swarm to the tools.SwarmRunner interface so the
+// deferred agent_swarm tool can run swarms without the harness packages
+// importing this one (import cycle: harness -> deferred -> subagents).
+type toolSwarmRunner struct {
+	swarm *Swarm
+}
+
+// NewToolSwarmRunner wraps a Swarm as a tools.SwarmRunner.
+func NewToolSwarmRunner(s *Swarm) tools.SwarmRunner {
+	return toolSwarmRunner{swarm: s}
+}
+
+func (a toolSwarmRunner) RunSwarm(ctx context.Context, req tools.SwarmRequest) (tools.SwarmReport, error) {
+	report, err := a.swarm.Run(ctx, SwarmRequest{
+		PromptTemplate:       req.PromptTemplate,
+		Items:                append([]string(nil), req.Items...),
+		ResumeAgentIDs:       append([]string(nil), req.ResumeAgentIDs...),
+		Model:                req.Model,
+		SystemPrompt:         req.SystemPrompt,
+		MaxSteps:             req.MaxSteps,
+		MaxCostUSD:           req.MaxCostUSD,
+		ReasoningEffort:      req.ReasoningEffort,
+		AllowedTools:         append([]string(nil), req.AllowedTools...),
+		ProfileName:          req.ProfileName,
+		IsolationMode:        req.IsolationMode,
+		CleanupPolicy:        req.CleanupPolicy,
+		BaseRef:              req.BaseRef,
+		ResultMode:           req.ResultMode,
+		ParentContextHandoff: req.ParentContextHandoff,
+	})
+	if err != nil {
+		return tools.SwarmReport{}, err
+	}
+
+	out := tools.SwarmReport{
+		Total:     report.Total,
+		Completed: report.Completed,
+		Failed:    report.Failed,
+		Cancelled: report.Cancelled,
+		Members:   make([]tools.SwarmMemberReport, len(report.Members)),
+	}
+	for i, m := range report.Members {
+		out.Members[i] = tools.SwarmMemberReport{
+			ID:      m.ID,
+			Item:    m.Item,
+			Prompt:  m.Prompt,
+			Status:  m.Status,
+			Output:  m.Output,
+			Error:   m.Error,
+			Resumed: m.Resumed,
+		}
+	}
+	return out, nil
+}

--- a/internal/subagents/swarm_tool_runner_test.go
+++ b/internal/subagents/swarm_tool_runner_test.go
@@ -1,0 +1,125 @@
+package subagents
+
+import (
+	"context"
+	"testing"
+
+	"go-agent-harness/internal/harness"
+	tools "go-agent-harness/internal/harness/tools"
+)
+
+// TestToolSwarmRunnerMapsRequestIntoSwarm verifies the tools.SwarmRunner
+// adapter translates every request field into the subagents swarm and that
+// members are created with the mapped overrides.
+func TestToolSwarmRunnerMapsRequestIntoSwarm(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.release()
+	steerer := &fakeRunSteerer{}
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+	runner := NewToolSwarmRunner(swarm)
+
+	report, err := runner.RunSwarm(context.Background(), tools.SwarmRequest{
+		PromptTemplate:  "do {{item}}",
+		Items:           []string{"a", "b"},
+		Model:           "gpt-swarm",
+		MaxSteps:        7,
+		MaxCostUSD:      1.5,
+		ReasoningEffort: "high",
+		AllowedTools:    []string{"read"},
+		ProfileName:     "explorer",
+		IsolationMode:   "inline",
+		CleanupPolicy:   "delete",
+		BaseRef:         "main",
+		ResultMode:      "summary",
+	})
+	if err != nil {
+		t.Fatalf("RunSwarm error = %v, want nil", err)
+	}
+	if fake.startCount() != 2 {
+		t.Fatalf("started %d members, want 2", fake.startCount())
+	}
+	for i := 0; i < 2; i++ {
+		req := fake.started[i]
+		if req.Model != "gpt-swarm" || req.MaxSteps != 7 || req.MaxCostUSD != 1.5 {
+			t.Errorf("member %d overrides = model:%q steps:%d cost:%v", i, req.Model, req.MaxSteps, req.MaxCostUSD)
+		}
+		if req.ReasoningEffort != "high" || req.ProfileName != "explorer" {
+			t.Errorf("member %d effort/profile = %q/%q", i, req.ReasoningEffort, req.ProfileName)
+		}
+		if len(req.AllowedTools) != 1 || req.AllowedTools[0] != "read" {
+			t.Errorf("member %d AllowedTools = %v, want [read]", i, req.AllowedTools)
+		}
+		if req.IsolationMode != "inline" || req.CleanupPolicy != "delete" || req.BaseRef != "main" || req.ResultMode != "summary" {
+			t.Errorf("member %d runtime fields = %q/%q/%q/%q", i, req.IsolationMode, req.CleanupPolicy, req.BaseRef, req.ResultMode)
+		}
+	}
+
+	if report.Total != 2 || report.Completed != 2 {
+		t.Fatalf("report counts = total:%d completed:%d, want 2/2", report.Total, report.Completed)
+	}
+	if len(report.Members) != 2 {
+		t.Fatalf("report members = %d, want 2", len(report.Members))
+	}
+	for i, item := range []string{"a", "b"} {
+		m := report.Members[i]
+		if m.Item != item || m.Status != string(harness.RunStatusCompleted) {
+			t.Errorf("member %d = item:%q status:%q, want %q completed", i, m.Item, m.Status, item)
+		}
+		if m.Resumed {
+			t.Errorf("member %d Resumed = true, want false (new member)", i)
+		}
+	}
+}
+
+// TestToolSwarmRunnerMapsResume verifies resume_agent_ids pass through the
+// adapter into steering and that the resumed marker survives the round trip.
+func TestToolSwarmRunnerMapsResume(t *testing.T) {
+	t.Parallel()
+
+	fake := newFakeSwarmManager()
+	fake.seed("sub-1", "run-1", string(harness.RunStatusRunning))
+	fake.release()
+	steerer := &fakeRunSteerer{}
+	swarm := NewSwarm(fake, WithSwarmSteerer(steerer))
+	runner := NewToolSwarmRunner(swarm)
+
+	report, err := runner.RunSwarm(context.Background(), tools.SwarmRequest{
+		PromptTemplate: "do {{item}}",
+		Items:          []string{"a", "b"},
+		ResumeAgentIDs: []string{"sub-1"},
+	})
+	if err != nil {
+		t.Fatalf("RunSwarm error = %v, want nil", err)
+	}
+	if steerer.callCount() != 1 || steerer.call(0).message != "do a" {
+		t.Fatalf("steer calls = %d, want 1 with expanded prompt", steerer.callCount())
+	}
+	if len(report.Members) != 2 {
+		t.Fatalf("report members = %d, want 2", len(report.Members))
+	}
+	resumed := report.Members[1]
+	if !resumed.Resumed || resumed.ID != "sub-1" || resumed.Item != "a" {
+		t.Fatalf("resumed member = id:%q resumed:%v item:%q, want sub-1/true/a", resumed.ID, resumed.Resumed, resumed.Item)
+	}
+	if report.Members[0].Resumed {
+		t.Fatal("new member marked resumed, want false")
+	}
+}
+
+// TestToolSwarmRunnerPropagatesValidationError verifies swarm validation
+// failures surface through the adapter untouched.
+func TestToolSwarmRunnerPropagatesValidationError(t *testing.T) {
+	t.Parallel()
+
+	swarm := NewSwarm(newFakeSwarmManager())
+	runner := NewToolSwarmRunner(swarm)
+	_, err := runner.RunSwarm(context.Background(), tools.SwarmRequest{
+		PromptTemplate: "no placeholder",
+		Items:          []string{"a"},
+	})
+	if err == nil {
+		t.Fatal("RunSwarm error = nil, want validation error")
+	}
+}


### PR DESCRIPTION
Parent epic: #808. Part of #803.

## Slice 3 of #808

Exposes the Slice 1–2 swarm to the model as one deferred tool with the kimi-code sole-call constraint.

### What landed

- **Tool** `internal/harness/tools/deferred/agent_swarm.go` — `TierDeferred`, `ActionExecute`, `Mutating: true`; params `prompt_template`, `items`, `resume_agent_ids` + profile/model overrides resolved like `start_subagent`; aggregated report via `MarshalToolResult`.
- **Cycle-safe wiring** — mirror types + `SwarmRunner` interface + `AgentSwarmToolName` in `internal/harness/tools` (same pattern as `SubagentManager`); `subagents.NewToolSwarmRunner` adapter; registration in `tools_default.go`; production wiring in `cmd/harnessd/runtime_container.go`.
- **Sole-call rule** (`runner_step_engine.go`) — a response containing `agent_swarm` plus any other call executes the first swarm call; every other call (including a second `agent_swarm`) is rejected with a corrective error naming the rule.
- **Nested-swarm prevention** — new per-run `DeniedTools` denylist (`SubagentRequest` → `subagents.Request` → `RunRequest` → runState, carried on continuation); `filteredToolsForRun` never offers denied tools even when activated, and the step-engine call gate blocks them. The swarm sets `DeniedTools=[agent_swarm]` on every member.
- **Approval flow** — the tool rides the existing mutating-tools policy path (`Registry.IsMutating` under destructive policy); test proves the call pauses for approval and runs after approval.
- **Description** `descriptions/agent_swarm.md` — sole-call rule, 128 cap, 5→+1/700ms ramp, `HARNESS_SWARM_MAX_CONCURRENCY`, resume semantics. Sync-registered in `embed_test.go`.

### Tests (TDD — all failed on undefined symbols before implementation)

- `deferred/agent_swarm_test.go`: definition shape, arg validation, profile/override mapping, resume mapping, report marshaling, error propagation, nil runner.
- `subagents/swarm_tool_runner_test.go`: adapter mapping both directions incl. resume + validation errors.
- `harness/runner_swarm_test.go`: registration shape; sole-call (swarm+extra → corrective error; swarm alone → ok; two swarm calls → first only); DeniedTools (call blocked, definitions hidden even when activated, unrestricted control); approval flow under destructive policy.
- `subagents/swarm_e2e_test.go`: fakeprovider full-stack session — find_tool activation, one `agent_swarm` call, 4 member runs with expanded prompts, exactly one aggregated tool result (4/4 completed, deterministic order), members visible via the manager.

### Verification

- `go test ./internal/subagents/ ./internal/harness/tools/ ./internal/harness/tools/deferred/ ./cmd/harnessd/ -count=1` — ok
- `go test ./internal/harness/ -count=1` — ok
- `go test ./internal/subagents/ ./internal/harness/ ./internal/harness/tools/deferred/ -count=1 -race` — ok
- `gofmt`, `go vet` on touched packages — clean
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — PASS: `coveragegate: PASS (total=84.3%, min=80.0%, zero-functions=0)`