### PR TITLE
docs(cli): document /fork command and fork endpoint

### DIFF
--- a/docs/plans/816-session-fork.md
+++ b/docs/plans/816-session-fork.md
@@ -1,6 +1,35 @@
 # Plan: /fork — fork live conversations (epic #816)
 
-## Slice 3: `feat(harnesscli): /fork TUI command` (branch epic/816-session-fork-s3)
+## Slice 4: `docs(cli): document /fork command and fork endpoint` (branch epic/816-session-fork-s4)
+
+### Context
+
+- Problem: slices 1–3 shipped the store primitive, endpoint, and TUI command; the public docs do not mention either surface.
+- User impact: users cannot discover `/fork` semantics or the endpoint contract without reading code.
+- Constraints: docs-only; anti-ghost-feature rule — every documented behavior verified against the merged implementation (`cmd/harnesscli/tui` fork command, `internal/server` fork endpoint).
+
+### Scope
+
+- In scope:
+  - `website/docs/cli/tui.md` — `/fork` row in the slash-command table + a "Forking a session" subsection (full-history copy at fork time, independent divergence, shared workspace, session-store entry, error behavior, distinction from `harnesscli replay -mode fork -fork-step`).
+  - `website/docs/reference/http-routes.md` — `POST /v1/conversations/{id}/fork` row (scope, request/response, 404/405/501, tenant guard).
+  - `docs/plans/INDEX.md` — refresh the now-stale "slice-1" description of this plan.
+- Out of scope: code changes; pre-existing doc drift unrelated to fork (e.g. cleanup-route scope, `?token=` note).
+
+### Verification
+
+- `cd website && npm run build` succeeds; both pages render the new entries.
+
+### Checklist
+
+- [x] tui.md `/fork` documented (table row + semantics section; verified against merged TUI implementation).
+- [x] http-routes.md fork endpoint documented (verified against merged endpoint).
+- [x] Website build green (`npm run build` → SUCCESS; both built pages contain the new entries).
+- [x] Plan/index maintenance; commit, push, PR.
+
+---
+
+## Slice 3: `feat(harnesscli): /fork TUI command` (merged via PR #883)
 
 ### Context
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -31,7 +31,7 @@
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.
 
-- `816-session-fork.md` — Slice-1 plan for epic #816 (`/fork`): `ConversationStore.ForkConversation` store primitive with TDD fork-integrity, divergence-isolation, and metadata-inheritance tests (in implementation).
+- `816-session-fork.md` — Full four-slice plan for epic #816 (`/fork`): store primitive, `POST /v1/conversations/{id}/fork`, TUI `/fork` command, and user/API docs (slices 1–3 implemented; slice 4 in implementation).
 - `PLAN_TEMPLATE.md`: Required template for pre-implementation planning with checklist.
 - `IMPACT_MAP_TEMPLATE.md`: One-page cross-surface impact map template for provider/model flow changes.
 - `active-plan.md`: Current active plan tracker.

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -154,6 +154,7 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/init [confirm]` | Generate an `AGENTS.md` for the current workspace via a harness run. If `AGENTS.md` already exists, run `/init confirm` to overwrite it |
 | `/add-dir [path]` | Attach an extra directory to the session so runs can read/work in it. Bare `/add-dir` lists attached directories; `/add-dir remove <path>` detaches one. See [Extra directories](#extra-directories-add-dir) |
 | `/new` | Start a fresh conversation (resets conversation ID) |
+| `/fork` | Fork the current session into a new conversation with the full history, and switch into the copy (see [Forking a session](#forking-a-session-fork)) |
 | `/search <query>` | Search the current session transcript |
 | `/history <query>` | Search across stored session metadata |
 | `/export` | Export the conversation to a Markdown file |
@@ -267,6 +268,28 @@ Sessions are persisted to `~/.config/harnesscli/sessions.json`.
 |---|---|
 | `/sessions` | Opens a picker of saved sessions. Press `D` to delete one. |
 | `/new` | Resets the conversation ID and clears the viewport, starting a fresh session. |
+| `/fork` | Duplicates the current session under a new conversation ID and switches into the copy. |
+
+---
+
+## Forking a session (`/fork`)
+
+`/fork` duplicates the live conversation — **full message history included** — into a new, server-minted conversation ID, then switches you into the copy. Use it to explore an alternative direction mid-task (a different prompt, a different plan) without abandoning or polluting the original session.
+
+Semantics:
+
+- **Snapshot at fork time.** The fork contains the full message history as it is at the moment you run `/fork`; when the server's in-memory view is newer than the last persisted state, the fork captures the newer view. From then on the two conversations **diverge independently** — turns in one never appear in the other.
+- **You land in the fork.** The status bar confirms with `Forked <src> → <new>; you are now in the fork`. The transcript stays in place because the fork holds identical history. The original session is untouched and remains resumable via `/sessions`.
+- **Session store.** The fork is registered in `~/.config/harnesscli/sessions.json` with a `forked from <src-id>` hint, so it survives a TUI restart.
+- **Workspace is shared.** Only messages are copied — the fork keeps the same workspace path. File state, rewind points, and the pinned flag are **not** carried over, and token/cost counters start at zero for the fork.
+- **Errors keep you put.** When the fork fails (unknown conversation, server without conversation persistence, network error), the status bar shows the server error and you stay in the current conversation.
+- With no active conversation (before the first message), `/fork` shows a "send a message first" hint instead of calling the server.
+
+<Callout type="info">
+`/fork` always copies the **entire current history**. To branch a *recorded* run from a specific mid-history step, use `harnesscli replay -mode fork -fork-step N` instead — that is a different feature with its own semantics.
+</Callout>
+
+Under the hood `/fork` calls `POST /v1/conversations/{id}/fork` — see the [HTTP route reference](/docs/reference/http-routes).
 
 ---
 

--- a/website/docs/reference/http-routes.md
+++ b/website/docs/reference/http-routes.md
@@ -91,6 +91,7 @@ Runs are the core unit of execution in `harnessd`. A run accepts a prompt, invok
 | `GET` | `/v1/conversations/{id}/runs` | `runs:read` | All runs for a conversation. |
 | `GET` | `/v1/conversations/{id}/export` | `runs:read` | JSONL (ndjson) export of all messages. |
 | `POST` | `/v1/conversations/{id}/compact` | `runs:write` | Replace early messages with a summary. Body: `{"keep_from_step":N,"summary":"…","role":"system"}`. Auto-generates summary via LLM when `summary` is omitted. |
+| `POST` | `/v1/conversations/{id}/fork` | `runs:write` | Duplicate the conversation — full message history included — under a server-minted ID. No body. Returns `{"conversation_id":"…","forked_from":"…","message_count":N}`. The fork inherits the source's workspace and tenant (cross-tenant requests are rejected with 404); pinned flag and token/cost counters start at zero. Works for persisted conversations and ones held only in server memory (mid-run), capturing the latest in-memory view. 404 unknown source; 405 for non-POST; 501 when conversation persistence is not configured. Afterwards the two conversations diverge independently. |
 | `POST` | `/v1/conversations/cleanup` | `runs:write` | Bulk-delete old conversations. Body: `{"max_age_days":30}`. Returns `{"deleted":N}`. |
 | `DELETE` | `/v1/conversations/{id}` | `runs:write` | Delete a conversation. |
 


### PR DESCRIPTION
Parent epic: #816. Part of #803.