### PR TITLE
feat(tui): /feedback — bundle local diagnostics into a zip

### DIFF
--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -240,6 +240,14 @@ func builtinCommandEntries() []CommandEntry {
 			Execute: executeAddDirCommand,
 		},
 		{
+			Name:        "feedback",
+			Description: "Bundle local diagnostics (rollouts, redacted config, runtime info) into a zip",
+			Handler: func(cmd Command) CommandResult {
+				return CommandResult{Status: CmdOK}
+			},
+			Execute: executeFeedbackCommand,
+		},
+		{
 			Name:        "rewind",
 			Description: "Choose and confirm a destructive session rewind",
 			Handler:     func(cmd Command) CommandResult { return CommandResult{Status: CmdOK} },

--- a/cmd/harnesscli/tui/cmd_parser_test.go
+++ b/cmd/harnesscli/tui/cmd_parser_test.go
@@ -396,7 +396,7 @@ func TestTUI041_BuiltinCommandsRegistered(t *testing.T) {
 func TestTUI364_RegistryCompleteness(t *testing.T) {
 	// These are the exact built-in slash commands the TUI exposes.
 	knownCommands := []string{
-		"add-dir", "attach", "cancel", "clear", "compact", "config", "context", "cost", "dashboard", "doctor", "export", "fork", "help", "history", "hooks", "init", "keys",
+		"add-dir", "attach", "cancel", "clear", "compact", "config", "context", "cost", "dashboard", "doctor", "export", "feedback", "fork", "help", "history", "hooks", "init", "keys",
 		"model", "new", "permissions", "plugins", "profiles", "quit", "replay", "resume", "runs", "search",
 		"sessions", "stats", "subagents", "tasks", "rewind", "theme", "title", "undo",
 	}

--- a/cmd/harnesscli/tui/feedback.go
+++ b/cmd/harnesscli/tui/feedback.go
@@ -1,0 +1,259 @@
+package tui
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	harnessconfig "go-agent-harness/cmd/harnesscli/config"
+	"go-agent-harness/internal/forensics/redaction"
+)
+
+// maxFeedbackRollouts caps how many of the newest rollout JSONL files go into
+// a feedback bundle.
+const maxFeedbackRollouts = 5
+
+// feedbackInput carries everything buildFeedbackBundle needs; it is a plain
+// value so the write path is testable without a TUI model.
+type feedbackInput struct {
+	// CLIConfig is the persistent harnesscli config (nil tolerated).
+	CLIConfig *harnessconfig.Config
+	// RolloutDir is the harness rollout directory ("" means not configured).
+	RolloutDir string
+	BaseURL    string
+	Model      string
+	// Version is the harnesscli build version stamp; "" means unstamped.
+	Version string
+	// Notes are extra human-readable caveats recorded in version.json.
+	Notes []string
+	// Now overrides the timestamp (zero → time.Now()).
+	Now time.Time
+}
+
+// executeFeedbackCommand implements /feedback: it bundles recent rollout
+// JSONL, the redacted CLI config, and version/runtime info into a zip under
+// <config-dir>/feedback/ and prints the path. The bundle is local-only —
+// nothing is uploaded; the user attaches it to a bug report manually.
+func executeFeedbackCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
+	var notes []string
+	cfg, err := harnessconfig.Load()
+	if err != nil {
+		cfg = nil
+		notes = append(notes, "cli config unreadable: "+err.Error())
+	}
+	rolloutDir := strings.TrimSpace(os.Getenv("HARNESS_ROLLOUT_DIR"))
+
+	outDir := filepath.Join(defaultSessionConfigDir(), "feedback")
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return []tea.Cmd{m.setStatusMsg("Could not create feedback dir: " + err.Error())}, false
+	}
+	outPath := filepath.Join(outDir, "go-code-feedback-"+time.Now().Format("20060102-150405")+".zip")
+
+	err = buildFeedbackBundle(outPath, feedbackInput{
+		CLIConfig:  cfg,
+		RolloutDir: rolloutDir,
+		BaseURL:    m.config.BaseURL,
+		Model:      m.selectedModel,
+		Notes:      notes,
+	})
+	if err != nil {
+		return []tea.Cmd{m.setStatusMsg("Could not write feedback bundle: " + err.Error())}, false
+	}
+	return []tea.Cmd{m.setStatusMsg("Feedback bundle written to " + outPath)}, false
+}
+
+// buildFeedbackBundle writes the diagnostics zip to outPath. The bundle never
+// contains secrets: the CLI config passes through exact-value replacement of
+// every stored api_keys value plus the forensics redaction patterns, and
+// rollout files pass through the same redactor.
+func buildFeedbackBundle(outPath string, in feedbackInput) error {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	redactor := redaction.NewRedactor(nil)
+	notes := append([]string{}, in.Notes...)
+
+	zf, err := os.Create(outPath)
+	if err != nil {
+		return fmt.Errorf("create bundle: %w", err)
+	}
+	zw := zip.NewWriter(zf)
+
+	// version.json — version/runtime info plus caveats.
+	version := in.Version
+	if version == "" {
+		version = "unstamped"
+	}
+	rolloutFiles, rolloutNote := collectFeedbackRollouts(in.RolloutDir, maxFeedbackRollouts)
+	if rolloutNote != "" {
+		notes = append(notes, rolloutNote)
+	}
+	info := map[string]any{
+		"harnesscli_version": version,
+		"go_version":         runtime.Version(),
+		"goos":               runtime.GOOS,
+		"goarch":             runtime.GOARCH,
+		"base_url":           in.BaseURL,
+		"model":              in.Model,
+		"generated_at":       now.UTC().Format(time.RFC3339),
+		"notes":              notes,
+	}
+	infoJSON, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		zw.Close()
+		zf.Close()
+		return fmt.Errorf("marshal version.json: %w", err)
+	}
+	if err := writeZipMember(zw, "version.json", infoJSON); err != nil {
+		zw.Close()
+		zf.Close()
+		return err
+	}
+
+	// config.json — redacted CLI config.
+	if err := writeZipMember(zw, "config.json", redactCLIConfigJSON(in.CLIConfig, redactor)); err != nil {
+		zw.Close()
+		zf.Close()
+		return err
+	}
+
+	// rollouts/ — newest rollout files, redacted; absence marker otherwise.
+	if len(rolloutFiles) == 0 {
+		marker := "no rollout files included: " + rolloutNote + "\n"
+		if rolloutNote == "" {
+			marker = "no rollout files included\n"
+		}
+		if err := writeZipMember(zw, "rollouts/NOT_PRESENT.txt", []byte(marker)); err != nil {
+			zw.Close()
+			zf.Close()
+			return err
+		}
+	}
+	for _, rf := range rolloutFiles {
+		if err := writeZipMember(zw, rf.member, redactFileBytes(rf.absPath, redactor)); err != nil {
+			zw.Close()
+			zf.Close()
+			return err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		zf.Close()
+		return fmt.Errorf("finalize bundle: %w", err)
+	}
+	return zf.Close()
+}
+
+// rolloutFile pairs an on-disk rollout JSONL path with its intended zip
+// member name.
+type rolloutFile struct {
+	absPath string
+	member  string
+}
+
+// collectFeedbackRollouts returns the newest max .jsonl files under dir
+// (layout <dir>/<YYYY-MM-DD>/<run_id>.jsonl) as zip members preserving the
+// dated subdirectory. The second return value explains an empty result:
+// "" when files were found, otherwise a human-readable reason.
+func collectFeedbackRollouts(dir string, max int) ([]rolloutFile, string) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, "rollout dir not configured (HARNESS_ROLLOUT_DIR unset)"
+	}
+	fi, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, "rollout dir " + dir + " does not exist"
+		}
+		return nil, "rollout dir " + dir + " is not accessible: " + err.Error()
+	}
+	if !fi.IsDir() {
+		return nil, "rollout dir " + dir + " is not a directory"
+	}
+
+	type candidate struct {
+		absPath string
+		member  string
+		modTime time.Time
+	}
+	var found []candidate
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		found = append(found, candidate{absPath: path, member: "rollouts/" + filepath.ToSlash(rel), modTime: info.ModTime()})
+		return nil
+	})
+	if len(found) == 0 {
+		return nil, "no rollout files found under " + dir
+	}
+
+	// Newest first, then cap.
+	sort.Slice(found, func(i, j int) bool { return found[i].modTime.After(found[j].modTime) })
+	if len(found) > max {
+		found = found[:max]
+	}
+	out := make([]rolloutFile, len(found))
+	for i, c := range found {
+		out[i] = rolloutFile{absPath: c.absPath, member: c.member}
+	}
+	return out, ""
+}
+
+// redactCLIConfigJSON marshals cfg and scrubs it: every stored api_keys value
+// is replaced exactly (format-agnostic), then the forensics redaction
+// patterns run over the whole document (catches secrets pasted into history).
+func redactCLIConfigJSON(cfg *harnessconfig.Config, r *redaction.Redactor) []byte {
+	if cfg == nil {
+		cfg = &harnessconfig.Config{}
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		data = []byte("{}")
+	}
+	text := string(data)
+	for _, v := range cfg.APIKeys {
+		if v != "" {
+			text = strings.ReplaceAll(text, v, "[REDACTED:api_key]")
+		}
+	}
+	return []byte(r.Redact(text))
+}
+
+// redactFileBytes reads path and returns its content with the redaction
+// patterns applied. Unreadable files yield an explanatory placeholder rather
+// than failing the whole bundle.
+func redactFileBytes(path string, r *redaction.Redactor) []byte {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []byte("could not read file: " + err.Error())
+	}
+	return []byte(r.Redact(string(data)))
+}
+
+func writeZipMember(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("create member %s: %w", name, err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write member %s: %w", name, err)
+	}
+	return nil
+}

--- a/cmd/harnesscli/tui/feedback_internal_test.go
+++ b/cmd/harnesscli/tui/feedback_internal_test.go
@@ -1,0 +1,300 @@
+package tui
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	harnessconfig "go-agent-harness/cmd/harnesscli/config"
+)
+
+// ─── zip test helpers ─────────────────────────────────────────────────────────
+
+func zipMemberNames(t *testing.T, path string) []string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", path, err)
+	}
+	defer r.Close()
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func readZipMember(t *testing.T, path, name string) string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", path, err)
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open member %s: %v", name, err)
+			}
+			defer rc.Close()
+			buf := new(strings.Builder)
+			if _, err := io.Copy(buf, rc); err != nil {
+				t.Fatalf("read member %s: %v", name, err)
+			}
+			return buf.String()
+		}
+	}
+	t.Fatalf("member %s not found in %s", name, path)
+	return ""
+}
+
+func writeRolloutFile(t *testing.T, dir, date, name, content string, mod time.Time) string {
+	t.Helper()
+	dateDir := filepath.Join(dir, date)
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dateDir, err)
+	}
+	p := filepath.Join(dateDir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	if err := os.Chtimes(p, mod, mod); err != nil {
+		t.Fatalf("chtimes %s: %v", p, err)
+	}
+	return p
+}
+
+// ─── Bundle members ───────────────────────────────────────────────────────────
+
+// TestBuildFeedbackBundle_ContainsExpectedMembers verifies the bundle holds
+// version.json, config.json, and the newest rollout files under rollouts/,
+// capped at five.
+func TestBuildFeedbackBundle_ContainsExpectedMembers(t *testing.T) {
+	t.Parallel()
+
+	rolloutDir := t.TempDir()
+	base := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	// Seven files with strictly increasing modtimes; the two oldest (run-1,
+	// run-2) must be excluded by the newest-5 cap.
+	for i := 1; i <= 7; i++ {
+		date := "2026-07-01"
+		if i > 4 {
+			date = "2026-07-02"
+		}
+		writeRolloutFile(t, rolloutDir, date, "run-"+string(rune('0'+i))+".jsonl", `{"event":"run.started"}`+"\n", base.Add(time.Duration(i)*time.Hour))
+	}
+
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+	err := buildFeedbackBundle(out, feedbackInput{
+		CLIConfig:  &harnessconfig.Config{StarredModels: []string{"gpt-4o"}},
+		RolloutDir: rolloutDir,
+		BaseURL:    "http://localhost:8080",
+		Model:      "gpt-4o",
+	})
+	if err != nil {
+		t.Fatalf("buildFeedbackBundle: %v", err)
+	}
+
+	names := zipMemberNames(t, out)
+	has := func(want string) bool {
+		for _, n := range names {
+			if n == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("version.json") {
+		t.Errorf("bundle missing version.json: %v", names)
+	}
+	if !has("config.json") {
+		t.Errorf("bundle missing config.json: %v", names)
+	}
+	rolloutCount := 0
+	for _, n := range names {
+		if strings.HasPrefix(n, "rollouts/") && strings.HasSuffix(n, ".jsonl") {
+			rolloutCount++
+		}
+	}
+	if rolloutCount != 5 {
+		t.Errorf("bundle must contain the newest 5 rollout files, got %d: %v", rolloutCount, names)
+	}
+	if has("rollouts/2026-07-01/run-1.jsonl") || has("rollouts/2026-07-01/run-2.jsonl") {
+		t.Errorf("oldest rollout files must be excluded by the cap: %v", names)
+	}
+
+	// version.json content.
+	var info struct {
+		HarnesscliVersion string   `json:"harnesscli_version"`
+		GoVersion         string   `json:"go_version"`
+		GOOS              string   `json:"goos"`
+		GOARCH            string   `json:"goarch"`
+		BaseURL           string   `json:"base_url"`
+		Model             string   `json:"model"`
+		Notes             []string `json:"notes"`
+	}
+	if err := json.Unmarshal([]byte(readZipMember(t, out, "version.json")), &info); err != nil {
+		t.Fatalf("version.json does not parse: %v", err)
+	}
+	if info.HarnesscliVersion != "unstamped" {
+		t.Errorf("harnesscli_version = %q, want unstamped (no version stamp landed yet)", info.HarnesscliVersion)
+	}
+	if info.GoVersion != runtime.Version() || info.GOOS != runtime.GOOS || info.GOARCH != runtime.GOARCH {
+		t.Errorf("runtime info wrong: %+v", info)
+	}
+	if info.BaseURL != "http://localhost:8080" || info.Model != "gpt-4o" {
+		t.Errorf("base_url/model not carried through: %+v", info)
+	}
+
+	// config.json content.
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(readZipMember(t, out, "config.json")), &cfg); err != nil {
+		t.Fatalf("config.json does not parse: %v", err)
+	}
+	if !strings.Contains(readZipMember(t, out, "config.json"), "gpt-4o") {
+		t.Errorf("config.json should carry non-secret fields: %v", cfg)
+	}
+}
+
+// ─── Redaction canaries ───────────────────────────────────────────────────────
+
+// TestBuildFeedbackBundle_RedactsConfigSecrets is the canary table: no secret
+// placed anywhere in the CLI config may survive into the bundled config.json.
+func TestBuildFeedbackBundle_RedactsConfigSecrets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		cfg    *harnessconfig.Config
+		canary string
+	}{
+		{
+			name:   "sk- API key in api_keys",
+			cfg:    &harnessconfig.Config{APIKeys: map[string]string{"openai": "sk-testcanary1234567890abcdef"}},
+			canary: "sk-testcanary1234567890abcdef",
+		},
+		{
+			name:   "short non-pattern key caught by exact-value replace",
+			cfg:    &harnessconfig.Config{APIKeys: map[string]string{"weird": "sh0rt"}},
+			canary: "sh0rt",
+		},
+		{
+			name:   "JWT in api_keys",
+			cfg:    &harnessconfig.Config{APIKeys: map[string]string{"svc": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c"}},
+			canary: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJVadQssw5c",
+		},
+		{
+			name:   "AWS access key id in history",
+			cfg:    &harnessconfig.Config{HistoryEntries: []string{"aws configure set AKIAIOSFODNN7EXAMPLE"}},
+			canary: "AKIAIOSFODNN7EXAMPLE",
+		},
+		{
+			name:   "postgres connection string in history",
+			cfg:    &harnessconfig.Config{HistoryEntries: []string{"psql postgres://admin:hunter2@db.internal:5432/prod"}},
+			canary: "postgres://admin:hunter2@db.internal:5432/prod",
+		},
+		{
+			name:   "sk- key pasted into history",
+			cfg:    &harnessconfig.Config{HistoryEntries: []string{"/keys openai sk-pastedcanary1234567890"}},
+			canary: "sk-pastedcanary1234567890",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := filepath.Join(t.TempDir(), "bundle.zip")
+			if err := buildFeedbackBundle(out, feedbackInput{CLIConfig: tc.cfg}); err != nil {
+				t.Fatalf("buildFeedbackBundle: %v", err)
+			}
+			configJSON := readZipMember(t, out, "config.json")
+			if strings.Contains(configJSON, tc.canary) {
+				t.Errorf("canary secret survived into bundled config.json: %q\n%s", tc.canary, configJSON)
+			}
+			if !strings.Contains(configJSON, "[REDACTED") {
+				t.Errorf("expected a redaction marker in bundled config.json: %s", configJSON)
+			}
+		})
+	}
+}
+
+// TestBuildFeedbackBundle_RedactsRolloutContent verifies rollout files are
+// redacted before bundling too.
+func TestBuildFeedbackBundle_RedactsRolloutContent(t *testing.T) {
+	t.Parallel()
+
+	rolloutDir := t.TempDir()
+	writeRolloutFile(t, rolloutDir, "2026-07-19", "run-x.jsonl",
+		`{"event":"tool.result","output":"key was sk-rolloutcanary1234567890 ok"}`+"\n", time.Now())
+
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+	if err := buildFeedbackBundle(out, feedbackInput{RolloutDir: rolloutDir}); err != nil {
+		t.Fatalf("buildFeedbackBundle: %v", err)
+	}
+	bundled := readZipMember(t, out, "rollouts/2026-07-19/run-x.jsonl")
+	if strings.Contains(bundled, "sk-rolloutcanary1234567890") {
+		t.Errorf("rollout secret survived into the bundle:\n%s", bundled)
+	}
+}
+
+// ─── Rollout dir absence ──────────────────────────────────────────────────────
+
+// TestBuildFeedbackBundle_RolloutDirUnset verifies the bundle still builds
+// when no rollout dir is configured, noting the absence.
+func TestBuildFeedbackBundle_RolloutDirUnset(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+	if err := buildFeedbackBundle(out, feedbackInput{RolloutDir: ""}); err != nil {
+		t.Fatalf("buildFeedbackBundle with unset rollout dir: %v", err)
+	}
+
+	names := zipMemberNames(t, out)
+	foundMarker := false
+	for _, n := range names {
+		if strings.HasPrefix(n, "rollouts/") {
+			foundMarker = true
+		}
+	}
+	if !foundMarker {
+		t.Fatalf("bundle must note the absent rollouts (rollouts/ marker member), got %v", names)
+	}
+	marker := readZipMember(t, out, "rollouts/NOT_PRESENT.txt")
+	if !strings.Contains(marker, "rollout") {
+		t.Errorf("absence marker should explain the missing rollouts, got: %q", marker)
+	}
+
+	var info struct {
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal([]byte(readZipMember(t, out, "version.json")), &info); err != nil {
+		t.Fatalf("version.json does not parse: %v", err)
+	}
+	joined := strings.Join(info.Notes, " ")
+	if !strings.Contains(joined, "rollout") {
+		t.Errorf("version.json notes should mention the rollout dir absence, got %v", info.Notes)
+	}
+}
+
+// TestBuildFeedbackBundle_RolloutDirMissing verifies a configured-but-missing
+// rollout dir degrades the same way.
+func TestBuildFeedbackBundle_RolloutDirMissing(t *testing.T) {
+	t.Parallel()
+
+	out := filepath.Join(t.TempDir(), "bundle.zip")
+	missing := filepath.Join(t.TempDir(), "no-such-dir")
+	if err := buildFeedbackBundle(out, feedbackInput{RolloutDir: missing}); err != nil {
+		t.Fatalf("buildFeedbackBundle with missing rollout dir: %v", err)
+	}
+	marker := readZipMember(t, out, "rollouts/NOT_PRESENT.txt")
+	if !strings.Contains(marker, "rollout") {
+		t.Errorf("absence marker should explain the missing rollouts, got: %q", marker)
+	}
+}

--- a/cmd/harnesscli/tui/feedback_test.go
+++ b/cmd/harnesscli/tui/feedback_test.go
@@ -1,0 +1,138 @@
+package tui_test
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	harnessconfig "go-agent-harness/cmd/harnesscli/config"
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+// findFeedbackZip returns the single zip under the feedback dir of the given
+// HOME, failing the test otherwise.
+func findFeedbackZip(t *testing.T, home string) string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(home, ".config", "harnesscli", "feedback", "*.zip"))
+	if err != nil {
+		t.Fatalf("glob feedback zips: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one feedback zip under %s, got %v", home, matches)
+	}
+	return matches[0]
+}
+
+func readZipText(t *testing.T, path, name string) string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		if f.Name == name {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open member: %v", err)
+			}
+			defer rc.Close()
+			buf := new(strings.Builder)
+			if _, err := io.Copy(buf, rc); err != nil {
+				t.Fatalf("read member: %v", err)
+			}
+			return buf.String()
+		}
+	}
+	t.Fatalf("member %s not found", name)
+	return ""
+}
+
+// TestFeedbackCommand_WritesBundleAndReportsPath is the acceptance-level test:
+// /feedback writes a zip under <config-dir>/feedback/, prints its path, and
+// the bundled config contains no secrets.
+func TestFeedbackCommand_WritesBundleAndReportsPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Seed a CLI config holding a canary API key.
+	if err := harnessconfig.Save(&harnessconfig.Config{
+		APIKeys: map[string]string{"openai": "sk-feedbackcanary1234567890"},
+	}); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// Point HARNESS_ROLLOUT_DIR at a temp rollout dir with one dated file.
+	rolloutDir := t.TempDir()
+	t.Setenv("HARNESS_ROLLOUT_DIR", rolloutDir)
+	dateDir := filepath.Join(rolloutDir, "2026-07-19")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dateDir, "run-1.jsonl"), []byte(`{"event":"run.started"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/feedback")
+
+	got := m.StatusMsg()
+	if !strings.Contains(got, ".zip") || !strings.Contains(got, filepath.Join(".config", "harnesscli", "feedback")) {
+		t.Fatalf("StatusMsg() = %q, want the feedback zip path under the config dir", got)
+	}
+
+	bundle := findFeedbackZip(t, home)
+	configJSON := readZipText(t, bundle, "config.json")
+	if strings.Contains(configJSON, "sk-feedbackcanary1234567890") {
+		t.Fatalf("canary API key survived into the bundled config:\n%s", configJSON)
+	}
+	rollout := readZipText(t, bundle, "rollouts/2026-07-19/run-1.jsonl")
+	if !strings.Contains(rollout, "run.started") {
+		t.Errorf("bundled rollout missing its content: %q", rollout)
+	}
+}
+
+// TestFeedbackCommand_WorksWithoutRolloutDir verifies /feedback still writes a
+// bundle when HARNESS_ROLLOUT_DIR is unset.
+func TestFeedbackCommand_WorksWithoutRolloutDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("HARNESS_ROLLOUT_DIR", "")
+
+	m := initModel(t, 80, 24)
+	m = sendSlashCommand(m, "/feedback")
+
+	if got := m.StatusMsg(); !strings.Contains(got, ".zip") {
+		t.Fatalf("StatusMsg() = %q, want the bundle path even without a rollout dir", got)
+	}
+	bundle := findFeedbackZip(t, home)
+	marker := readZipText(t, bundle, "rollouts/NOT_PRESENT.txt")
+	if !strings.Contains(marker, "rollout") {
+		t.Errorf("bundle must note the missing rollouts, marker: %q", marker)
+	}
+}
+
+// TestFeedbackCommand_Registered verifies the feedback command is registered.
+func TestFeedbackCommand_Registered(t *testing.T) {
+	r := tui.NewCommandRegistry()
+	if !r.IsRegistered("feedback") {
+		t.Fatal("built-in registry must register the feedback command")
+	}
+	entry, ok := r.Lookup("feedback")
+	if !ok || entry.Description == "" {
+		t.Fatal("feedback command must have a description for /help and autocomplete")
+	}
+}
+
+// TestFeedbackCommand_InSlashComplete verifies /feedback appears in autocomplete.
+func TestFeedbackCommand_InSlashComplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := initModel(t, 120, 40)
+	m = typeIntoModel(m, "/fee")
+	if v := m.View(); !strings.Contains(v, "feedback") {
+		t.Errorf("slash-complete must contain 'feedback' when typing '/fee'; got:\n%s", v)
+	}
+}

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -11,6 +11,7 @@ Command Registry - 120x40
 /dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
+/feedback — Bundle local diagnostics (rollouts, redacted config, runtime info) into a zip
 /fork — Fork the current session into a new conversation and switch to it
 /help — Show help dialog
 /history — Search across stored session metadata

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -11,6 +11,7 @@ Command Registry - 200x50
 /dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
+/feedback — Bundle local diagnostics (rollouts, redacted config, runtime info) into a zip
 /fork — Fork the current session into a new conversation and switch to it
 /help — Show help dialog
 /history — Search across stored session metadata

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -11,6 +11,7 @@ Command Registry - 80x24
 /dashboard — View and control all runs
 /doctor — Show local harness diagnostic commands
 /export — Export conversation to markdown
+/feedback — Bundle local diagnostics (rollouts, redacted config, runtime info) into a zip
 /fork — Fork the current session into a new conversation and switch to it
 /help — Show help dialog
 /history — Search across stored session metadata

--- a/docs/plans/822-qol-commands.md
+++ b/docs/plans/822-qol-commands.md
@@ -1,6 +1,59 @@
 # Plan: quality-of-life commands — epic #822 slices
 
-Epic: #822. Parent: #803. Slice 1 branch: `epic/822-qol-commands` (merged, PR #842). Slice 2 branch: `epic/822-qol-commands-s2` (merged, PR #863). Slice 3 branch: `epic/822-qol-commands-s3`.
+Epic: #822. Parent: #803. Slice 1 branch: `epic/822-qol-commands` (merged, PR #842). Slice 2 branch: `epic/822-qol-commands-s2` (merged, PR #863). Slice 3 branch: `epic/822-qol-commands-s3` (merged, PR #894). Slice 4 branch: `epic/822-qol-commands-s4`.
+
+---
+
+# Slice 4: /feedback — bundle local diagnostics into a zip
+
+## Context
+
+- Problem: bug reports lack a one-command way to gather diagnostics (rollouts, config, runtime info).
+- User impact: `/feedback` writes `<config-dir>/feedback/go-code-feedback-<timestamp>.zip` and prints the path; the user attaches it manually.
+- Constraints: local-only (no upload/telemetry); no secrets in the bundle (canary-tested); strict TDD.
+
+## Decided shape
+
+- New `cmd/harnesscli/tui/feedback.go`: `executeFeedbackCommand` + pure builder `buildFeedbackBundle(outPath, feedbackInput)`.
+- Bundle members:
+  - `version.json` — `harnesscli_version` (slice 5 stamp when it exists; `"unstamped"` today), `go_version` (`runtime.Version()`), `goos`, `goarch`, `base_url`, `model`, `generated_at`, `notes` (e.g. rollout-dir absence).
+  - `config.json` — the persistent CLI config (`harnessconfig.Load()`), redacted two ways: (1) exact-string replacement of every stored `api_keys` value (format-agnostic guarantee), then (2) `internal/forensics/redaction` pattern pass (catches secrets pasted into history).
+  - `rollouts/<date>/<run>.jsonl` — newest 5 `.jsonl` files (by modtime) from the rollout dir, each run through the redactor; `rollouts/NOT_PRESENT.txt` marker + note when the rollout dir is unset/missing/empty.
+- Rollout dir resolution: `HARNESS_ROLLOUT_DIR` env (the same wiring harnessd uses, `cmd/harnessd/main.go:429`); unset → absence note (per epic fallback).
+- Output: `<defaultSessionConfigDir()>/feedback/go-code-feedback-<yyyymmdd-HHMMSS>.zip`; status message reports the path (pattern after `executeExportCommand`).
+
+## Documentation Contract
+
+- Feature status: `implemented`
+- Public docs affected: `website/docs/cli/tui.md`, `docs/ux-paths.md`
+- Spec docs to update before code: none (epic #822 body is the contract)
+- Implementation notes to add after code: none required
+
+## Test Plan (TDD)
+
+- New failing tests first:
+  - `feedback_internal_test.go` (package tui): bundle members against a temp rollout dir (newest-5 cap, paths under `rollouts/`); redaction canary table (`sk-…` in api_keys value AND pasted into history, JWT, AWS `AKIA…`, postgres connection string, bearer token, short non-pattern key covered by exact-value replace); rollout content redaction canary; unset/missing rollout dir → `NOT_PRESENT.txt` + note, no error.
+  - `feedback_test.go` (package tui_test): `/feedback` writes the zip under `<HOME>/.config/harnesscli/feedback/`, prints the path, canary key absent from the bundled config; works with no rollout dir; registry + slash-complete; `TestTUI364_RegistryCompleteness` += `feedback`.
+- Regression: none beyond the above (additive change).
+
+## Cross-Surface Impact Map
+
+- None required: reads local files only; no run-request schema, server routes, or provider/model flows touched.
+
+## Implementation Checklist
+
+- [x] Acceptance criteria in tests (zip exists with JSONL + redacted config; canary secret never survives).
+- [x] Write failing tests first.
+- [x] Implement minimal code changes.
+- [x] Update docs (`tui.md`, `ux-paths.md`, plan).
+- [x] Run `go test ./cmd/harnesscli/... -count=1`; gofmt + go vet clean.
+- [ ] Push branch, open PR (no merge).
+
+## Risks and Mitigations
+
+- Risk: a stored API key in a format the regexes miss → mitigated by exact-string replacement of every `api_keys` value before the pattern pass (canary-tested).
+- Risk: tests touching the developer's real `~/.config/harnesscli` → every test sets `t.Setenv("HOME", t.TempDir())`.
+- Risk: huge rollout files bloat the zip → capped at newest 5 files.
 
 ---
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -5,7 +5,7 @@
 - `2026-07-19-issue-818-clipboard-image-plan.md` — Epic #818 slice 1: read images from the system clipboard into a temp file (in implementation).
 - `2026-07-19-issue-818-clipboard-image-impact-map.md` — One-page provider/model impact map for epic #818 slice 1.
 - `810-theme-system.md` — Theme system epic #810, slice 1: token schema + JSON loader with base-palette fallback (in implementation).
-- `822-qol-commands.md` — Epic #822 plan. Slice 1 (`/title`, merged PR #842); slice 2 (`/init`, merged PR #863); slice 3 (`/add-dir` extra workspace roots, in implementation).
+- `822-qol-commands.md` — Epic #822 plan. Slice 1 (`/title`, merged PR #842); slice 2 (`/init`, merged PR #863); slice 3 (`/add-dir`, merged PR #894); slice 4 (`/feedback`, in implementation).
 
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.

--- a/docs/ux-paths.md
+++ b/docs/ux-paths.md
@@ -347,6 +347,9 @@ Registry (`cmd_parser.go:79-194`): clear, context, export, help, keys, model, qu
 | `/add-dir` (no args) | list attached directories | OK | add_dir_test.go |
 | `/add-dir remove <path>` | detach a directory | OK | add_dir_test.go |
 | `extra_dirs` validation | non-absolute/nonexistent/not-a-dir → HTTP 400 | OK | `validateExtraDirs` (runner.go); `TestStartRunExtraDirsValidation`; http_extra_dirs_test.go |
+| `/feedback` | zip rollouts + redacted config + runtime info; print path | OK | `feedback.go` (`executeFeedbackCommand`); feedback_test.go |
+| `/feedback` redaction | canary secret never survives into the bundle | OK | feedback_internal_test.go (table: sk-, JWT, AWS, conn-string, pasted keys) |
+| `/feedback` (no rollout dir) | bundle notes absence (`rollouts/NOT_PRESENT.txt`) | OK | feedback_internal_test.go |
 | `/search <q>` | search transcript | OK | `model.go:1055-1068`; search_test.go (12+) |
 | `/search` (no args) | usage hint | OK | `model.go:1056-1058`; `TestSearch_BT002_EmptyQueryStatusMessage` |
 | `/history <q>` | search session meta | OK | `model.go:1070-1083`; `TestSearch_BT006_HistorySearchOpensOverlay` |

--- a/website/docs/cli/tui.md
+++ b/website/docs/cli/tui.md
@@ -153,6 +153,7 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 | `/title [text]` | Set or show the current session's title (`/title clear` removes it). Shown in the status bar and the `/sessions` picker, persisted across restarts |
 | `/init [confirm]` | Generate an `AGENTS.md` for the current workspace via a harness run. If `AGENTS.md` already exists, run `/init confirm` to overwrite it |
 | `/add-dir [path]` | Attach an extra directory to the session so runs can read/work in it. Bare `/add-dir` lists attached directories; `/add-dir remove <path>` detaches one. See [Extra directories](#extra-directories-add-dir) |
+| `/feedback` | Bundle local diagnostics into a zip for bug reports and print its path. See [Feedback bundles](#feedback-bundles-feedback) |
 | `/new` | Start a fresh conversation (resets conversation ID) |
 | `/search <query>` | Search the current session transcript |
 | `/history <query>` | Search across stored session metadata |
@@ -182,6 +183,16 @@ Type `/` to open the autocomplete dropdown. `Tab` completes to the common prefix
 - Bare `/add-dir` lists the attached directories; `/add-dir remove <path>` detaches one. (`remove` is a subcommand only when followed by a path, so a directory literally named `remove` can still be added.)
 - The list is session-scoped — it is not persisted across restarts.
 - Current limits: the `bash` tool's command sandbox and `glob` still confine to the primary workspace root only; the server validates every entry (absolute path to an existing directory) and rejects the run with HTTP 400 otherwise.
+
+---
+
+## Feedback bundles (`/feedback`)
+
+`/feedback` writes `~/.config/harnesscli/feedback/go-code-feedback-<timestamp>.zip` and prints the path. The bundle is local-only — nothing is uploaded; attach it to a bug report manually. It contains:
+
+- `version.json` — harnesscli version (`unstamped` until version stamping lands), Go version, GOOS/GOARCH, server URL, model, and caveats (e.g. rollouts not configured).
+- `config.json` — the CLI config with secrets scrubbed: every stored `api_keys` value is replaced exactly, then the forensics redaction patterns run over the whole file (also covering keys pasted into command history).
+- `rollouts/<date>/<run>.jsonl` — the newest five rollout files, redacted, when `HARNESS_ROLLOUT_DIR` is set (the same env var `harnessd` uses); otherwise a `rollouts/NOT_PRESENT.txt` marker explains the absence.
 
 ---
 


### PR DESCRIPTION
Parent epic: #822. Part of #803.

## What

Adds the `/feedback` slash command (slice 4 of #822): one command writes `~/.config/harnesscli/feedback/go-code-feedback-<timestamp>.zip` and prints the path. Local-only — nothing is uploaded; the user attaches the zip to a bug report manually.

Bundle contents:

- `version.json` — `harnesscli_version` (`unstamped` until slice 5's version stamping lands), `runtime.Version()`, GOOS/GOARCH, server URL, model, generated-at, and caveats (e.g. rollout dir unset).
- `config.json` — the persistent CLI config scrubbed **two ways**: (1) exact-string replacement of every stored `api_keys` value (format-agnostic guarantee), then (2) the `internal/forensics/redaction` pattern pass (catches secrets pasted into command history).
- `rollouts/<date>/<run>.jsonl` — the newest 5 rollout files from `HARNESS_ROLLOUT_DIR` (same env wiring `harnessd` uses), each run through the redactor; when the dir is unset/missing/empty, a `rollouts/NOT_PRESENT.txt` marker plus a `version.json` note explains the absence.

Implementation: pure `buildFeedbackBundle(outPath, feedbackInput)` in `cmd/harnesscli/tui/feedback.go` (testable without a model), thin `executeFeedbackCommand`, registered in `builtinCommandEntries()` (autocomplete + `/help` come free).

## Tests (TDD — tests written first, watched fail, then implemented)

- Internal (package tui): bundle members + newest-5 cap with staggered modtimes; version.json/config.json content; **canary redaction table** (sk- key, short non-pattern key, JWT, AWS `AKIA…`, postgres connection string, sk- pasted into history — none survive, redaction markers present); rollout content redaction; unset/missing rollout dir → absence marker + note, no error.
- Model-level (package tui_test): `/feedback` writes the zip under the config dir, prints the path, canary key absent from the bundled config; works with no rollout dir; registry + slash-complete. `TestTUI364_RegistryCompleteness` += `feedback`.

`go test ./cmd/harnesscli/... -count=1` — 29 packages ok, zero FAIL. gofmt/go vet clean on touched files.

## Docs

- `website/docs/cli/tui.md`: table row + "Feedback bundles (`/feedback`)" section (contents, redaction, rollout-dir wiring).
- `docs/ux-paths.md`: /feedback rows incl. redaction + no-rollout-dir paths.
- Plan updated: `docs/plans/822-qol-commands.md` (+ plans index).