### PR TITLE
feat(harnesscli): harnesscli mcp login/logout/status commands and 401 re-auth guidance

### DIFF
--- a/cmd/harnesscli/auth.go
+++ b/cmd/harnesscli/auth.go
@@ -197,6 +197,8 @@ func dispatch(args []string) int {
 		return runPlugin(args[1:])
 	case "auth":
 		return runAuth(args[1:])
+	case "mcp":
+		return runMCP(args[1:])
 	case "hooks":
 		return runHooks(args[1:])
 	case "service":

--- a/cmd/harnesscli/mcp.go
+++ b/cmd/harnesscli/mcp.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"go-agent-harness/internal/config"
+	"go-agent-harness/internal/mcp"
+	"go-agent-harness/internal/mcp/oauth"
+)
+
+// mcpOpenURL is the browser opener used by "mcp login". Nil selects the
+// platform default inside oauth.Flow. Tests replace it with an in-process
+// driver.
+var mcpOpenURL func(string) error
+
+// newMCPOAuthFlow builds the login/refresh flow over the default token store
+// (~/.harness/mcp).
+func newMCPOAuthFlow() *oauth.Flow {
+	return &oauth.Flow{Store: mcp.DefaultTokenStore(), OpenURL: mcpOpenURL}
+}
+
+// configuredMCPServer is one MCP server entry as seen by the CLI, resolved
+// from the same config sources the daemon uses.
+type configuredMCPServer struct {
+	Name          string
+	Transport     string
+	URL           string
+	HasStaticAuth bool
+}
+
+// loadConfiguredMCPServers resolves MCP server configs from
+// ~/.harness/config.toml, .harness/config.toml (project), and
+// HARNESS_MCP_SERVERS, with TOML taking precedence on name collisions —
+// mirroring cmd/harnessd registration. The result is sorted by name.
+func loadConfiguredMCPServers() ([]configuredMCPServer, error) {
+	var userCfgPath string
+	if home, err := os.UserHomeDir(); err == nil {
+		userCfgPath = filepath.Join(home, ".harness", "config.toml")
+	}
+	cfg, err := config.Load(config.LoadOptions{
+		UserConfigPath:    userCfgPath,
+		ProjectConfigPath: filepath.Join(".harness", "config.toml"),
+		Getenv:            os.Getenv,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]configuredMCPServer)
+	for name, srv := range cfg.MCPServers {
+		transport := srv.Transport
+		if transport == "" {
+			if srv.URL != "" {
+				transport = "http"
+			} else {
+				transport = "stdio"
+			}
+		}
+		byName[name] = configuredMCPServer{
+			Name:          name,
+			Transport:     transport,
+			URL:           srv.URL,
+			HasStaticAuth: hasAuthorizationHeader(srv.Headers),
+		}
+	}
+
+	envServers, err := mcp.ParseMCPServersEnv()
+	if err != nil {
+		return nil, err
+	}
+	for _, sc := range envServers {
+		if _, exists := byName[sc.Name]; exists {
+			continue // TOML wins, mirroring the daemon
+		}
+		byName[sc.Name] = configuredMCPServer{
+			Name:          sc.Name,
+			Transport:     sc.Transport,
+			URL:           sc.URL,
+			HasStaticAuth: hasAuthorizationHeader(sc.Headers),
+		}
+	}
+
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]configuredMCPServer, 0, len(names))
+	for _, name := range names {
+		out = append(out, byName[name])
+	}
+	return out, nil
+}
+
+// hasAuthorizationHeader reports whether headers configure Authorization
+// (any casing).
+func hasAuthorizationHeader(headers map[string]string) bool {
+	for k := range headers {
+		if strings.EqualFold(k, "Authorization") {
+			return true
+		}
+	}
+	return false
+}
+
+func findConfiguredServer(servers []configuredMCPServer, name string) (configuredMCPServer, bool) {
+	for _, s := range servers {
+		if s.Name == name {
+			return s, true
+		}
+	}
+	return configuredMCPServer{}, false
+}
+
+// runMCP dispatches "harnesscli mcp <subcommand>" commands.
+func runMCP(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "harnesscli mcp: subcommand required (try: login, logout, status)")
+		return 1
+	}
+	switch args[0] {
+	case "login":
+		return runMCPLogin(args[1:])
+	case "logout":
+		return runMCPLogout(args[1:])
+	case "status":
+		return runMCPStatus(args[1:])
+	default:
+		fmt.Fprintf(stderr, "harnesscli mcp: unknown subcommand %q (try: login, logout, status)\n", args[0])
+		return 1
+	}
+}
+
+// runMCPLogin implements "harnesscli mcp login <server>": it runs the OAuth
+// 2.1 + PKCE flow against the named server's configured URL and stores the
+// token under ~/.harness/mcp.
+func runMCPLogin(args []string) int {
+	fs := flag.NewFlagSet("mcp login", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	clientID := fs.String("client-id", "", "pre-registered OAuth client ID (dynamic registration is used when omitted and supported)")
+	scope := fs.String("scope", "", "space-separated OAuth scopes to request")
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+	if fs.NArg() != 1 {
+		fmt.Fprintln(stderr, "harnesscli mcp login: server name required (usage: harnesscli mcp login [--client-id ID] [--scope \"a b\"] <server>)")
+		return 1
+	}
+	name := fs.Arg(0)
+
+	servers, err := loadConfiguredMCPServers()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli mcp login: load config: %v\n", err)
+		return 1
+	}
+	srv, ok := findConfiguredServer(servers, name)
+	if !ok {
+		fmt.Fprintf(stderr, "harnesscli mcp login: server %q not found in config (checked ~/.harness/config.toml, .harness/config.toml, and %s)\n", name, mcp.EnvVarMCPServers)
+		return 1
+	}
+	if srv.Transport != "http" {
+		fmt.Fprintf(stderr, "harnesscli mcp login: server %q uses the stdio transport; OAuth login only applies to http servers\n", name)
+		return 1
+	}
+
+	flow := newMCPOAuthFlow()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	fmt.Fprintf(stdout, "Opening browser to authorize MCP server %q...\n", name)
+	tok, err := flow.Login(ctx, oauth.LoginOptions{
+		ServerName:  name,
+		ResourceURL: srv.URL,
+		ClientID:    *clientID,
+		Scopes:      strings.Fields(*scope),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli mcp login %s: %v\n", name, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Logged in to MCP server %q (issuer %s); token stored in %s\n", name, tok.Issuer, flow.Store.Dir())
+	return 0
+}
+
+// runMCPLogout implements "harnesscli mcp logout <server>": it deletes the
+// stored token. Logout is idempotent.
+func runMCPLogout(args []string) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "harnesscli mcp logout: server name required (usage: harnesscli mcp logout <server>)")
+		return 1
+	}
+	name := args[0]
+	if err := mcp.DefaultTokenStore().Delete(name); err != nil {
+		fmt.Fprintf(stderr, "harnesscli mcp logout %s: %v\n", name, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Removed stored token for MCP server %q (if any existed).\n", name)
+	return 0
+}
+
+// runMCPStatus implements "harnesscli mcp status": it prints the configured
+// MCP servers with their per-server auth state for HTTP servers.
+func runMCPStatus(args []string) int {
+	servers, err := loadConfiguredMCPServers()
+	if err != nil {
+		fmt.Fprintf(stderr, "harnesscli mcp status: load config: %v\n", err)
+		return 1
+	}
+	if len(servers) == 0 {
+		fmt.Fprintln(stdout, "No MCP servers configured.")
+		return 0
+	}
+
+	store := mcp.DefaultTokenStore()
+	for _, srv := range servers {
+		url := srv.URL
+		if url == "" {
+			url = "-"
+		}
+		fmt.Fprintf(stdout, "%s %s %s %s\n", srv.Name, srv.Transport, url, mcpAuthState(store, srv))
+	}
+	return 0
+}
+
+// mcpAuthState renders the auth state for one configured server.
+func mcpAuthState(store *mcp.TokenStore, srv configuredMCPServer) string {
+	if srv.Transport != "http" {
+		return "-"
+	}
+	if srv.HasStaticAuth {
+		return "static Authorization header"
+	}
+	tok, err := store.Get(srv.Name)
+	switch {
+	case err == nil:
+		if tok.Expiry.IsZero() {
+			return "token valid (no expiry)"
+		}
+		return "token valid (expires " + tok.Expiry.Format(time.RFC3339) + ")"
+	case errors.Is(err, mcp.ErrTokenNotFound):
+		return "no token (run `harnesscli mcp login " + srv.Name + "`)"
+	case errors.Is(err, mcp.ErrTokenExpired):
+		return "token expired (run `harnesscli mcp login " + srv.Name + "`)"
+	case errors.Is(err, mcp.ErrTokenCorrupt):
+		return "token corrupt (run `harnesscli mcp login " + srv.Name + "`)"
+	default:
+		return fmt.Sprintf("error reading token: %v", err)
+	}
+}

--- a/cmd/harnesscli/mcp_test.go
+++ b/cmd/harnesscli/mcp_test.go
@@ -1,0 +1,501 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/mcp"
+)
+
+// --- combined in-process OAuth authorization server + MCP resource server ---
+
+// oauthMCPStack is one httptest server playing both roles: an OAuth 2.1
+// authorization server (metadata, authorize, token) and an MCP resource
+// server gated on the bearer tokens it issues.
+type oauthMCPStack struct {
+	srv *httptest.Server
+
+	mu             sync.Mutex
+	challenges     map[string]string
+	accessTokens   map[string]bool
+	refreshTokens  map[string]bool
+	codeN          int
+	tokenN         int
+	lastAuthClient string
+}
+
+func newOAuthMCPStack(t *testing.T) *oauthMCPStack {
+	t.Helper()
+	s := &oauthMCPStack{
+		challenges:    make(map[string]string),
+		accessTokens:  make(map[string]bool),
+		refreshTokens: make(map[string]bool),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/oauth-authorization-server", s.handleASMetadata)
+	mux.HandleFunc("/.well-known/oauth-protected-resource", s.handleProtectedResource)
+	mux.HandleFunc("/authorize", s.handleAuthorize)
+	mux.HandleFunc("/token", s.handleToken)
+	mux.HandleFunc("/mcp", s.handleMCP)
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *oauthMCPStack) baseURL() string { return s.srv.URL }
+func (s *oauthMCPStack) mcpURL() string  { return s.srv.URL + "/mcp" }
+
+func (s *oauthMCPStack) handleASMetadata(w http.ResponseWriter, _ *http.Request) {
+	stackWriteJSON(w, http.StatusOK, map[string]any{
+		"issuer":                           s.srv.URL,
+		"authorization_endpoint":           s.srv.URL + "/authorize",
+		"token_endpoint":                   s.srv.URL + "/token",
+		"code_challenge_methods_supported": []string{"S256"},
+	})
+}
+
+func (s *oauthMCPStack) handleProtectedResource(w http.ResponseWriter, _ *http.Request) {
+	stackWriteJSON(w, http.StatusOK, map[string]any{
+		"resource":              s.mcpURL(),
+		"authorization_servers": []string{s.srv.URL},
+	})
+}
+
+func (s *oauthMCPStack) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	redirect, err := url.Parse(q.Get("redirect_uri"))
+	if err != nil || redirect.Scheme == "" {
+		http.Error(w, "bad redirect_uri", http.StatusBadRequest)
+		return
+	}
+	s.mu.Lock()
+	s.lastAuthClient = q.Get("client_id")
+	s.codeN++
+	code := fmt.Sprintf("stack-code-%d", s.codeN)
+	s.challenges[code] = q.Get("code_challenge")
+	s.mu.Unlock()
+
+	out := redirect.Query()
+	out.Set("code", code)
+	out.Set("state", q.Get("state"))
+	redirect.RawQuery = out.Encode()
+	http.Redirect(w, r, redirect.String(), http.StatusFound)
+}
+
+func (s *oauthMCPStack) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		stackWriteJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_request"})
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch r.Form.Get("grant_type") {
+	case "authorization_code":
+		challenge, ok := s.challenges[r.Form.Get("code")]
+		if !ok {
+			stackWriteJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_grant"})
+			return
+		}
+		sum := sha256.Sum256([]byte(r.Form.Get("code_verifier")))
+		if base64.RawURLEncoding.EncodeToString(sum[:]) != challenge {
+			stackWriteJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_grant"})
+			return
+		}
+	case "refresh_token":
+		if !s.refreshTokens[r.Form.Get("refresh_token")] {
+			stackWriteJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid_grant"})
+			return
+		}
+	default:
+		stackWriteJSON(w, http.StatusBadRequest, map[string]any{"error": "unsupported_grant_type"})
+		return
+	}
+
+	s.tokenN++
+	access := fmt.Sprintf("stack-access-%d", s.tokenN)
+	refresh := fmt.Sprintf("stack-refresh-%d", s.tokenN)
+	s.accessTokens[access] = true
+	s.refreshTokens[refresh] = true
+	stackWriteJSON(w, http.StatusOK, map[string]any{
+		"access_token":  access,
+		"refresh_token": refresh,
+		"token_type":    "Bearer",
+		"expires_in":    3600,
+	})
+}
+
+func (s *oauthMCPStack) handleMCP(w http.ResponseWriter, r *http.Request) {
+	auth := r.Header.Get("Authorization")
+	s.mu.Lock()
+	allowed := strings.HasPrefix(auth, "Bearer ") && s.accessTokens[strings.TrimPrefix(auth, "Bearer ")]
+	s.mu.Unlock()
+	if !allowed {
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer resource_metadata=%q`, s.srv.URL+"/.well-known/oauth-protected-resource"))
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		Method string          `json:"method"`
+		ID     json.RawMessage `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	resp := map[string]any{"jsonrpc": "2.0", "id": req.ID}
+	switch req.Method {
+	case "initialize":
+		resp["result"] = map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"serverInfo":      map[string]any{"name": "stack", "version": "1.0"},
+		}
+	case "tools/list":
+		resp["result"] = map[string]any{"tools": []map[string]any{
+			{"name": "stack-tool", "description": "A gated tool", "inputSchema": map[string]any{"type": "object"}},
+		}}
+	default:
+		resp["error"] = map[string]any{"code": -32601, "message": "method not found"}
+	}
+	stackWriteJSON(w, http.StatusOK, resp)
+}
+
+func (s *oauthMCPStack) lastClientID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastAuthClient
+}
+
+func stackWriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// --- test helpers ---
+
+func captureCLI(t *testing.T) (out, errOut *bytes.Buffer) {
+	t.Helper()
+	origOut, origErr := stdout, stderr
+	out = &bytes.Buffer{}
+	errOut = &bytes.Buffer{}
+	stdout, stderr = out, errOut
+	t.Cleanup(func() { stdout, stderr = origOut, origErr })
+	return out, errOut
+}
+
+// isolateMCPHome points HOME at a temp dir and clears HARNESS_MCP_SERVERS.
+func isolateMCPHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(mcp.EnvVarMCPServers, "")
+	return home
+}
+
+func writeUserConfig(t *testing.T, home, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".harness")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func stackOpenURL(t *testing.T) func(string) error {
+	t.Helper()
+	return func(rawurl string) error {
+		resp, err := http.Get(rawurl) // follows the redirect into the loopback listener
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+		return nil
+	}
+}
+
+func stubMCPOpenURL(t *testing.T, fn func(string) error) {
+	t.Helper()
+	orig := mcpOpenURL
+	mcpOpenURL = fn
+	t.Cleanup(func() { mcpOpenURL = orig })
+}
+
+// --- dispatch tests ---
+
+func TestRunMCP_NoSubcommand(t *testing.T) {
+	_, errOut := captureCLI(t)
+	if code := runMCP(nil); code != 1 {
+		t.Fatalf("runMCP(nil) = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "subcommand") {
+		t.Errorf("stderr %q should print usage", errOut.String())
+	}
+}
+
+func TestRunMCP_UnknownSubcommand(t *testing.T) {
+	_, errOut := captureCLI(t)
+	if code := runMCP([]string{"bogus"}); code != 1 {
+		t.Fatalf("runMCP(bogus) = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "unknown") {
+		t.Errorf("stderr %q should report the unknown subcommand", errOut.String())
+	}
+}
+
+func TestDispatch_MCPCase(t *testing.T) {
+	captureCLI(t)
+	if code := dispatch([]string{"mcp"}); code != 1 {
+		t.Fatalf("dispatch(mcp) = %d, want 1 (usage)", code)
+	}
+	if code := dispatch([]string{"mcp", "bogus"}); code != 1 {
+		t.Fatalf("dispatch(mcp bogus) = %d, want 1", code)
+	}
+}
+
+// --- login/logout/status behavior tests ---
+
+// TestMCPLogin_Logout_Status_EndToEnd is the slice acceptance test: against
+// an in-process OAuth+MCP stack, `mcp login` stores a token, the transport
+// then reaches the gated server with the bearer attached, `mcp status`
+// reports the token state, and `mcp logout` removes it.
+func TestMCPLogin_Logout_Status_EndToEnd(t *testing.T) {
+	home := isolateMCPHome(t)
+	stack := newOAuthMCPStack(t)
+	writeUserConfig(t, home, fmt.Sprintf(`
+[mcp_servers.demo]
+transport = "http"
+url = %q
+`, stack.mcpURL()))
+	stubMCPOpenURL(t, stackOpenURL(t))
+
+	// login
+	out, errOut := captureCLI(t)
+	if code := runMCPLogin([]string{"--client-id", "e2e-client", "demo"}); code != 0 {
+		t.Fatalf("runMCPLogin = %d, stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "demo") {
+		t.Errorf("login output %q should name the server", out.String())
+	}
+	if got := stack.lastClientID(); got != "e2e-client" {
+		t.Errorf("authorize client_id = %q, want the --client-id flag value", got)
+	}
+
+	// token stored under the isolated home with restrictive permissions
+	tokenDir := filepath.Join(home, ".harness", "mcp")
+	entries, err := os.ReadDir(tokenDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 token file in %s: entries=%v err=%v", tokenDir, entries, err)
+	}
+	fi, err := entries[0].Info()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fi.Mode().Perm(); got != 0o600 {
+		t.Errorf("token file perms = %o, want 600", got)
+	}
+
+	// the transport uses the stored token automatically
+	cm := mcp.NewClientManager()
+	defer cm.Close()
+	flow := newMCPOAuthFlow()
+	cm.SetTokenProvider(flow.TokenProvider())
+	if err := cm.AddServer(mcp.ServerConfig{Name: "demo", Transport: "http", URL: stack.mcpURL()}); err != nil {
+		t.Fatalf("AddServer: %v", err)
+	}
+	tools, err := cm.DiscoverTools(t.Context(), "demo")
+	if err != nil {
+		t.Fatalf("DiscoverTools with stored token: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "stack-tool" {
+		t.Fatalf("unexpected tools: %v", tools)
+	}
+
+	// status reports the valid token
+	out, _ = captureCLI(t)
+	if code := runMCPStatus(nil); code != 0 {
+		t.Fatalf("runMCPStatus = %d", code)
+	}
+	line := out.String()
+	if !strings.Contains(line, "demo") || !strings.Contains(line, "valid") {
+		t.Errorf("status output %q should show demo with a valid token", line)
+	}
+
+	// logout deletes the token
+	out, errOut = captureCLI(t)
+	if code := runMCPLogout([]string{"demo"}); code != 0 {
+		t.Fatalf("runMCPLogout = %d, stderr: %s", code, errOut.String())
+	}
+	if _, err := mcp.NewTokenStore(tokenDir).Get("demo"); err == nil {
+		t.Error("token still present after logout")
+	}
+
+	// status now reports no token
+	out, _ = captureCLI(t)
+	if code := runMCPStatus(nil); code != 0 {
+		t.Fatalf("runMCPStatus = %d", code)
+	}
+	if !strings.Contains(out.String(), "no token") {
+		t.Errorf("status output %q should show no token after logout", out.String())
+	}
+}
+
+func TestRunMCPLogin_ServerNotConfigured(t *testing.T) {
+	isolateMCPHome(t)
+	_, errOut := captureCLI(t)
+	if code := runMCPLogin([]string{"ghost"}); code != 1 {
+		t.Fatalf("runMCPLogin = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "ghost") {
+		t.Errorf("stderr %q should name the unknown server", errOut.String())
+	}
+}
+
+func TestRunMCPLogin_StdioServerRejected(t *testing.T) {
+	home := isolateMCPHome(t)
+	writeUserConfig(t, home, `
+[mcp_servers.local-tool]
+transport = "stdio"
+command = "/usr/local/bin/tool"
+`)
+	_, errOut := captureCLI(t)
+	if code := runMCPLogin([]string{"local-tool"}); code != 1 {
+		t.Fatalf("runMCPLogin = %d, want 1", code)
+	}
+	if !strings.Contains(errOut.String(), "stdio") {
+		t.Errorf("stderr %q should explain OAuth login does not apply to stdio", errOut.String())
+	}
+}
+
+func TestRunMCPLogin_RequiresServerName(t *testing.T) {
+	isolateMCPHome(t)
+	captureCLI(t)
+	if code := runMCPLogin(nil); code != 1 {
+		t.Fatalf("runMCPLogin(nil) = %d, want 1", code)
+	}
+}
+
+func TestRunMCPLogout_Idempotent(t *testing.T) {
+	isolateMCPHome(t)
+	captureCLI(t)
+	if code := runMCPLogout([]string{"never-logged-in"}); code != 0 {
+		t.Fatalf("runMCPLogout for unknown token = %d, want 0 (idempotent)", code)
+	}
+}
+
+func TestRunMCPLogout_RequiresServerName(t *testing.T) {
+	captureCLI(t)
+	if code := runMCPLogout(nil); code != 1 {
+		t.Fatalf("runMCPLogout(nil) = %d, want 1", code)
+	}
+}
+
+// TestRunMCPStatus_States covers the per-server auth-state matrix.
+func TestRunMCPStatus_States(t *testing.T) {
+	home := isolateMCPHome(t)
+	writeUserConfig(t, home, `
+[mcp_servers.with-static]
+transport = "http"
+url = "https://static.example.com/mcp"
+
+[mcp_servers.with-static.headers]
+Authorization = "Bearer configured-token"
+
+[mcp_servers.valid-tok]
+transport = "http"
+url = "https://valid.example.com/mcp"
+
+[mcp_servers.expired-tok]
+transport = "http"
+url = "https://expired.example.com/mcp"
+
+[mcp_servers.plain]
+transport = "http"
+url = "https://plain.example.com/mcp"
+
+[mcp_servers.local-tool]
+transport = "stdio"
+command = "/usr/local/bin/tool"
+`)
+
+	store := mcp.NewTokenStore(filepath.Join(home, ".harness", "mcp"))
+	if err := store.Put("valid-tok", mcp.Token{
+		Issuer: "https://as.example.com", AccessToken: "a", RefreshToken: "r",
+		Expiry: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Put("expired-tok", mcp.Token{
+		Issuer: "https://as.example.com", AccessToken: "a", RefreshToken: "r",
+		Expiry: time.Now().Add(-time.Hour),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	out, errOut := captureCLI(t)
+	if code := runMCPStatus(nil); code != 0 {
+		t.Fatalf("runMCPStatus = %d, stderr: %s", code, errOut.String())
+	}
+	got := out.String()
+
+	assertLine := func(server, want string) {
+		t.Helper()
+		for _, line := range strings.Split(got, "\n") {
+			if strings.HasPrefix(line, server+" ") || strings.HasPrefix(line, server+"\t") {
+				if !strings.Contains(line, want) {
+					t.Errorf("status line for %q = %q, want it to contain %q\nfull output:\n%s", server, line, want, got)
+				}
+				return
+			}
+		}
+		t.Errorf("no status line for %q\nfull output:\n%s", server, got)
+	}
+	assertLine("with-static", "static")
+	assertLine("valid-tok", "valid")
+	assertLine("expired-tok", "expired")
+	assertLine("plain", "no token")
+	assertLine("local-tool", "stdio")
+}
+
+// TestRunMCPStatus_EnvServer verifies servers from HARNESS_MCP_SERVERS appear
+// in status output.
+func TestRunMCPStatus_EnvServer(t *testing.T) {
+	home := isolateMCPHome(t)
+	t.Setenv(mcp.EnvVarMCPServers, `[{"name":"env-srv","url":"https://env.example.com/mcp","headers":{"Authorization":"Bearer env-token"}}]`)
+	_ = home
+
+	out, errOut := captureCLI(t)
+	if code := runMCPStatus(nil); code != 0 {
+		t.Fatalf("runMCPStatus = %d, stderr: %s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "env-srv") {
+		t.Errorf("status output %q should list the env-configured server", out.String())
+	}
+}
+
+func TestRunMCPStatus_NoServers(t *testing.T) {
+	isolateMCPHome(t)
+	out, _ := captureCLI(t)
+	if code := runMCPStatus(nil); code != 0 {
+		t.Fatalf("runMCPStatus = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "No MCP servers") {
+		t.Errorf("status output %q should say no servers are configured", out.String())
+	}
+}

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -28,6 +28,7 @@ import (
 	htools "go-agent-harness/internal/harness/tools"
 	"go-agent-harness/internal/harness/tools/deferred"
 	"go-agent-harness/internal/mcp"
+	"go-agent-harness/internal/mcp/oauth"
 	"go-agent-harness/internal/networks"
 	om "go-agent-harness/internal/observationalmemory"
 	"go-agent-harness/internal/plugins"
@@ -612,6 +613,9 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	// var entries with the same name.
 	mcpManager := mcp.NewClientManager()
 	defer func() { _ = mcpManager.Close() }() // safety-net defer; explicit close is in shutdown sequence below
+	// Attach OAuth tokens from ~/.harness/mcp to HTTP MCP requests, with
+	// silent refresh; static per-server Authorization headers take precedence.
+	mcpManager.SetTokenProvider((&oauth.Flow{Store: mcp.DefaultTokenStore()}).TokenProvider())
 	{
 		// Load config WITHOUT a profile so the global ClientManager only gets
 		// layers 1-3 (user global + project); profile-specific servers are

--- a/docs/plans/809-mcp-oauth.md
+++ b/docs/plans/809-mcp-oauth.md
@@ -1,18 +1,21 @@
 # Plan: MCP OAuth login flow for remote servers (epic #809)
 
-## Slice 3: OAuth 2.1 + PKCE authorization flow with localhost callback (in implementation)
+## Slice 4: harnesscli mcp login/logout/status and 401 re-auth guidance (in implementation)
 
-- Goal: browser-based login as a library function usable by the CLI (slice 4): discover endpoints, drive the browser, complete the exchange, store tokens, refresh silently.
-- Changes: new `internal/mcp/oauth` package (imports slice 2's `mcp.TokenStore`; no cycle — `internal/mcp` does not import it).
-  - Discovery: parse `WWW-Authenticate` on a 401 probe for `resource_metadata` → fetch protected-resource metadata (RFC 9728, well-known inserted before path, bare-origin retry) → fetch AS metadata (RFC 8414); fallback to well-known probing when the header is absent, and to a co-located AS at the resource origin.
-  - PKCE: S256 verifier/challenge on `crypto/rand`; random state.
-  - Loopback `net/http` listener on `127.0.0.1:0`, path `/callback`, first request wins, ctx-cancellable.
-  - Browser open via `os/exec` (`open`/`xdg-open`/`rundll32`), injectable as `Flow.OpenURL` so tests drive the redirect in-process.
-  - RFC 8707 `resource` parameter on the authorization request.
-  - Dynamic client registration (RFC 7591) when no client ID is configured and the AS advertises `registration_endpoint`; pre-registered client ID via `LoginOptions.ClientID`.
-  - Token exchange + `Refresh(serverName)` using the stored refresh token and recorded client ID (`ClientID` added to `mcp.Token` — additive); un-rotated refresh tokens are preserved; `invalid_grant` maps to `ErrReauthRequired`.
-- Tests (TDD; in-process `httptest` mock AS + mock resource server; no real network/browser/$HOME): full code+PKCE round trip with the browser stubbed (stub GETs the auth URL, mock AS 302s into the loopback), discovery via `WWW-Authenticate`, fallback when the header is absent, dynamic registration, pre-registered ID, missing-both error, state mismatch, AS error redirect, user abort via ctx cancel, token-endpoint error, refresh (success, un-rotated, invalid_grant, no token), PKCE known vector, `resource` param asserted.
-- Acceptance: `go test ./internal/mcp/oauth/... -count=1` green; round trip completes without real network or browser.
+- Goal: user-facing entrypoint; the transport automatically uses stored tokens; auth failures tell the user how to fix them.
+- Changes:
+  - `internal/mcp`: `TokenProviderFunc` + optional `ServerConfig.TokenProvider`; `ClientManager.SetTokenProvider` as the manager-level default injected at lazy-connect (`getConn` → `dialServer`). `httpConn.sendRequest` consults the provider only when no static `Authorization` header is configured; `("", nil)` means send unauthenticated. The 401 error message gains ``run `harnesscli mcp login <server>` `` (still wrapping `ErrUnauthorized`).
+  - `internal/mcp/oauth`: `Flow.TokenProvider()` adapts store + silent refresh into an `mcp.TokenProviderFunc` (expired → `Refresh`; not-found → `("", nil)`; refresh failures surface).
+  - `cmd/harnessd/main.go`: wire `mcpManager.SetTokenProvider((&oauth.Flow{Store: mcp.DefaultTokenStore()}).TokenProvider())` at startup.
+  - `cmd/harnesscli/mcp.go`: `mcp login <server> [--client-id id] [--scope "a b"]` (resolves the server's URL from `~/.harness/config.toml` + `.harness/config.toml` + `HARNESS_MCP_SERVERS`, runs the slice 3 flow), `mcp logout <server>` (idempotent token delete), `mcp status` (per-server auth state: static header / token valid / expired / corrupt / no token, for HTTP servers). New `mcp` case in `dispatch`. Browser opener injectable via package var for tests.
+  - Auth state is reported in the CLI status output (the epic's "or" option); `/v1/mcp/servers` is unchanged.
+- Tests (TDD; temp HOME, in-process mocks, no real browser/network):
+  - `internal/mcp`: 401 error contains `harnesscli mcp login <name>`; provider attaches bearer (end-to-end gated mock); `("", nil)` → no header; static header beats provider; provider error surfaces; `ClientManager.SetTokenProvider` used at lazy connect.
+  - `internal/mcp/oauth`: `Flow.TokenProvider` — valid, expired→refreshed, not-found→empty, invalid_grant→`ErrReauthRequired`.
+  - `cmd/harnesscli`: dispatch routing; login e2e (mock OAuth+MCP, browser stubbed, token stored, then `tools/list` via a manager succeeds with bearer attached); login errors (not configured, stdio); logout idempotent; status reports all states; status with no servers.
+- Acceptance: `go test ./cmd/harnesscli/... ./internal/mcp/... -count=1` green.
+
+## Slice 3: OAuth 2.1 + PKCE authorization flow with localhost callback (implemented, PR #888)
 
 ## Slice 2: file-backed OAuth token store under `~/.harness/mcp/` (implemented, PR #856)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -14,7 +14,7 @@
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator + Slice 2 resume (merged), Slice 3 agent_swarm deferred tool with sole-call rule (in implementation).
-- `809-mcp-oauth.md` — Epic #809: slices 1–2 (headers/typed errors, token store) merged; slice 3 (OAuth 2.1 + PKCE flow with localhost callback) in implementation.
+- `809-mcp-oauth.md` — Epic #809: slices 1–3 (headers/typed errors, token store, OAuth flow) merged; slice 4 (`harnesscli mcp login/logout/status` + 401 re-auth guidance) in implementation.
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slices 1–2 merged; slice 3 ctrl+g binding in review).
 

--- a/internal/mcp/http_conn.go
+++ b/internal/mcp/http_conn.go
@@ -31,10 +31,11 @@ var (
 // httpConn implements Conn over HTTP using JSON-RPC 2.0.
 // It supports both application/json and text/event-stream (SSE) responses.
 type httpConn struct {
-	name     string
-	endpoint string
-	headers  map[string]string
-	client   *http.Client
+	name          string
+	endpoint      string
+	headers       map[string]string
+	tokenProvider TokenProviderFunc
+	client        *http.Client
 
 	idCounter         atomic.Int64
 	negotiatedVersion string
@@ -56,10 +57,11 @@ func dialHTTP(cfg ServerConfig) (Conn, error) {
 		return nil, fmt.Errorf("mcp: server %q URL must use http or https scheme (got %q)", cfg.Name, u.Scheme)
 	}
 	return &httpConn{
-		name:     cfg.Name,
-		endpoint: cfg.URL,
-		headers:  cfg.Headers,
-		client:   &http.Client{Timeout: 30 * time.Second},
+		name:          cfg.Name,
+		endpoint:      cfg.URL,
+		headers:       cfg.Headers,
+		tokenProvider: cfg.TokenProvider,
+		client:        &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
@@ -220,6 +222,17 @@ func (c *httpConn) sendRequest(ctx context.Context, method string, params any) (
 	for k, v := range c.headers {
 		httpReq.Header.Set(k, v)
 	}
+	// Resolve a bearer token only when no static Authorization header is
+	// configured; static credentials always win.
+	if c.tokenProvider != nil && httpReq.Header.Get("Authorization") == "" {
+		token, err := c.tokenProvider(ctx, c.name)
+		if err != nil {
+			return nil, fmt.Errorf("mcp: resolve token for %q: %w", c.name, err)
+		}
+		if token != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -230,7 +243,7 @@ func (c *httpConn) sendRequest(ctx context.Context, method string, params any) (
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		switch resp.StatusCode {
 		case http.StatusUnauthorized:
-			return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s: %w", c.name, resp.StatusCode, resp.Status, ErrUnauthorized)
+			return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s: %w; run `harnesscli mcp login %s` to authenticate", c.name, resp.StatusCode, resp.Status, ErrUnauthorized, c.name)
 		case http.StatusForbidden:
 			return nil, fmt.Errorf("mcp: server %q returned HTTP %d %s: %w", c.name, resp.StatusCode, resp.Status, ErrForbidden)
 		}

--- a/internal/mcp/http_conn_test.go
+++ b/internal/mcp/http_conn_test.go
@@ -1149,3 +1149,239 @@ func TestClientManager_HTTP_BearerGatedServer_WithoutHeaders_Unauthorized(t *tes
 		t.Errorf("errors.Is(err, ErrUnauthorized) = false for error %q", err.Error())
 	}
 }
+
+// --- Slice 4 (epic #809): token provider and 401 re-auth guidance ---
+
+// TestHTTPConn_UnauthorizedError_ContainsLoginHint verifies that a 401
+// response produces an error that names the server and the exact remediation
+// command, while still wrapping ErrUnauthorized.
+func TestHTTPConn_UnauthorizedError_ContainsLoginHint(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockMCPHTTPServer(t, mockHTTPMCPServerOpts{non2xxStatus: http.StatusUnauthorized})
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "hinted",
+		Transport: "http",
+		URL:       srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = conn.Initialize(ctx)
+	if err == nil {
+		t.Fatal("expected error from 401 response, got nil")
+	}
+	if !errors.Is(err, mcp.ErrUnauthorized) {
+		t.Errorf("errors.Is(err, ErrUnauthorized) = false for %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "harnesscli mcp login hinted") {
+		t.Errorf("error %q does not contain the re-auth hint %q", err.Error(), "harnesscli mcp login hinted")
+	}
+}
+
+// TestHTTPConn_TokenProvider_AttachesBearer verifies that a configured token
+// provider supplies the Authorization header end to end: a bearer-gated
+// server becomes reachable.
+func TestHTTPConn_TokenProvider_AttachesBearer(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := newHeaderRecordingServer(t, "Bearer provided-tok")
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "provided",
+		Transport: "http",
+		URL:       srv.URL,
+		TokenProvider: func(context.Context, string) (string, error) {
+			return "provided-tok", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := conn.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize with token provider: %v", err)
+	}
+	if _, err := conn.ListTools(ctx); err != nil {
+		t.Fatalf("ListTools with token provider: %v", err)
+	}
+	for _, method := range []string{"initialize", "tools/list"} {
+		if got := rec.headerForMethod(method, "Authorization"); got != "Bearer provided-tok" {
+			t.Errorf("%s: Authorization = %q, want %q", method, got, "Bearer provided-tok")
+		}
+	}
+}
+
+// TestHTTPConn_TokenProvider_EmptyMeansNoHeader verifies that a provider
+// returning ("", nil) leaves the request unauthenticated.
+func TestHTTPConn_TokenProvider_EmptyMeansNoHeader(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := newHeaderRecordingServer(t, "")
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "no-token",
+		Transport: "http",
+		URL:       srv.URL,
+		TokenProvider: func(context.Context, string) (string, error) {
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := conn.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := rec.headerForMethod("initialize", "Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty", got)
+	}
+}
+
+// TestHTTPConn_TokenProvider_StaticHeaderWins verifies that a statically
+// configured Authorization header takes precedence over the token provider.
+func TestHTTPConn_TokenProvider_StaticHeaderWins(t *testing.T) {
+	t.Parallel()
+
+	srv, rec := newHeaderRecordingServer(t, "Bearer static-tok")
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "static-wins",
+		Transport: "http",
+		URL:       srv.URL,
+		Headers:   map[string]string{"Authorization": "Bearer static-tok"},
+		TokenProvider: func(context.Context, string) (string, error) {
+			return "provided-tok", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := conn.Initialize(ctx); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if got := rec.headerForMethod("initialize", "Authorization"); got != "Bearer static-tok" {
+		t.Errorf("Authorization = %q, want static header %q", got, "Bearer static-tok")
+	}
+}
+
+// TestHTTPConn_TokenProvider_ErrorSurfaces verifies that a provider failure
+// fails the request with the provider's error.
+func TestHTTPConn_TokenProvider_ErrorSurfaces(t *testing.T) {
+	t.Parallel()
+
+	srv := newMockMCPServer(t, nil)
+	defer srv.Close()
+
+	conn, err := mcp.DialHTTPForTest(mcp.ServerConfig{
+		Name:      "provider-fails",
+		Transport: "http",
+		URL:       srv.URL,
+		TokenProvider: func(context.Context, string) (string, error) {
+			return "", errors.New("token store exploded")
+		},
+	})
+	if err != nil {
+		t.Fatalf("DialHTTPForTest: %v", err)
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = conn.Initialize(ctx)
+	if err == nil {
+		t.Fatal("expected provider error, got nil")
+	}
+	if !strings.Contains(err.Error(), "token store exploded") {
+		t.Errorf("error %q does not contain the provider failure", err.Error())
+	}
+}
+
+// TestClientManager_SetTokenProvider verifies the manager-level default
+// provider is used by servers registered without an explicit one, and that an
+// explicit per-server provider takes precedence.
+func TestClientManager_SetTokenProvider(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default used when server has none", func(t *testing.T) {
+		t.Parallel()
+
+		srv, _ := newHeaderRecordingServer(t, "Bearer x")
+		defer srv.Close()
+
+		cm := mcp.NewClientManager()
+		defer cm.Close()
+		cm.SetTokenProvider(func(context.Context, string) (string, error) { return "x", nil })
+
+		if err := cm.AddServer(mcp.ServerConfig{Name: "gated", Transport: "http", URL: srv.URL}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if _, err := cm.DiscoverTools(ctx, "gated"); err != nil {
+			t.Fatalf("DiscoverTools with manager default provider: %v", err)
+		}
+	})
+
+	t.Run("explicit provider overrides default", func(t *testing.T) {
+		t.Parallel()
+
+		srv, _ := newHeaderRecordingServer(t, "Bearer x")
+		defer srv.Close()
+
+		cm := mcp.NewClientManager()
+		defer cm.Close()
+		cm.SetTokenProvider(func(context.Context, string) (string, error) { return "x", nil })
+
+		if err := cm.AddServer(mcp.ServerConfig{
+			Name:      "gated-explicit",
+			Transport: "http",
+			URL:       srv.URL,
+			TokenProvider: func(context.Context, string) (string, error) {
+				return "wrong-token", nil
+			},
+		}); err != nil {
+			t.Fatalf("AddServer: %v", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		// The explicit (wrong) provider is used, not the manager default that
+		// would succeed — so the call must fail with 401.
+		_, err := cm.DiscoverTools(ctx, "gated-explicit")
+		if err == nil {
+			t.Fatal("expected 401 with the explicit wrong-token provider, got nil")
+		}
+		if !errors.Is(err, mcp.ErrUnauthorized) {
+			t.Errorf("errors.Is(err, ErrUnauthorized) = false for %q", err.Error())
+		}
+	})
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -56,7 +56,19 @@ type ServerConfig struct {
 	// after the transport's own protocol headers, so an explicitly configured
 	// header wins on collision. Ignored on the stdio transport.
 	Headers map[string]string
+
+	// TokenProvider, when set, resolves a bearer token for this server at
+	// request time (e.g. from the OAuth token store with silent refresh).
+	// It is consulted on the http transport only when no static
+	// Authorization header is configured; returning ("", nil) sends the
+	// request without credentials. Not serialized — set programmatically.
+	TokenProvider TokenProviderFunc `json:"-"`
 }
+
+// TokenProviderFunc resolves a bearer token for the named server at request
+// time. Returning ("", nil) means no credentials are available and the
+// request is sent unauthenticated.
+type TokenProviderFunc func(ctx context.Context, serverName string) (string, error)
 
 // Conn represents an active connection to an MCP server.
 type Conn interface {
@@ -110,6 +122,8 @@ type serverEntry struct {
 type ClientManager struct {
 	mu      sync.RWMutex
 	servers map[string]*serverEntry
+
+	tokenProvider TokenProviderFunc // default for servers registered without one
 }
 
 // NewClientManager returns a new, empty ClientManager.
@@ -117,6 +131,15 @@ func NewClientManager() *ClientManager {
 	return &ClientManager{
 		servers: make(map[string]*serverEntry),
 	}
+}
+
+// SetTokenProvider sets the default token provider applied to servers
+// registered without an explicit ServerConfig.TokenProvider. Call it before
+// the first connect (the provider is captured at dial time).
+func (m *ClientManager) SetTokenProvider(p TokenProviderFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tokenProvider = p
 }
 
 // AddServer registers a server from a config. The connection is not established
@@ -274,7 +297,13 @@ func (m *ClientManager) getConn(ctx context.Context, serverName string) (Conn, e
 	if entry.factory != nil {
 		conn, err = entry.factory()
 	} else {
-		conn, err = dialServer(entry.config)
+		cfg := entry.config
+		if cfg.TokenProvider == nil {
+			m.mu.RLock()
+			cfg.TokenProvider = m.tokenProvider
+			m.mu.RUnlock()
+		}
+		conn, err = dialServer(cfg)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("mcp: connect %q: %w", serverName, err)

--- a/internal/mcp/oauth/provider.go
+++ b/internal/mcp/oauth/provider.go
@@ -1,0 +1,35 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+
+	"go-agent-harness/internal/mcp"
+)
+
+// TokenProvider adapts the flow's token store into an mcp.TokenProviderFunc
+// suitable for ServerConfig.TokenProvider or ClientManager.SetTokenProvider:
+// valid stored tokens are returned as-is, expired tokens are silently
+// refreshed through Refresh, and a missing token yields ("", nil) so the
+// transport sends the request unauthenticated and the server's own 401
+// guides the user to `harnesscli mcp login`. Refresh failures (including
+// ErrReauthRequired) are surfaced to the caller.
+func (f *Flow) TokenProvider() mcp.TokenProviderFunc {
+	return func(ctx context.Context, serverName string) (string, error) {
+		tok, err := f.Store.Get(serverName)
+		switch {
+		case errors.Is(err, mcp.ErrTokenNotFound):
+			return "", nil
+		case errors.Is(err, mcp.ErrTokenExpired):
+			refreshed, rerr := f.Refresh(ctx, serverName)
+			if rerr != nil {
+				return "", rerr
+			}
+			return refreshed.AccessToken, nil
+		case err != nil:
+			return "", err
+		default:
+			return tok.AccessToken, nil
+		}
+	}
+}

--- a/internal/mcp/oauth/provider_test.go
+++ b/internal/mcp/oauth/provider_test.go
@@ -1,0 +1,138 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/mcp"
+)
+
+// loginForProviderTest completes a full login against the mocks so the store
+// holds a token known to the mock AS.
+func loginForProviderTest(t *testing.T, as *mockAuthorizationServer, store *mcp.TokenStore, serverName string) mcp.Token {
+	t.Helper()
+	rs := newMockResourceServer(t, as.url(), nil)
+	flow := &Flow{Store: store, OpenURL: browserViaHTTP(t)}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	tok, err := flow.Login(ctx, LoginOptions{
+		ServerName:  serverName,
+		ResourceURL: rs.mcpURL(),
+		ClientID:    "preregistered-client",
+	})
+	if err != nil {
+		t.Fatalf("Login: %v", err)
+	}
+	return tok
+}
+
+// TestTokenProvider_ValidToken verifies the provider returns the stored
+// access token without hitting the token endpoint again.
+func TestTokenProvider_ValidToken(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	store := mcp.NewTokenStore(t.TempDir())
+	tok := loginForProviderTest(t, as, store, "demo")
+
+	flow := &Flow{Store: store}
+	provider := flow.TokenProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	access, err := provider(ctx, "demo")
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if access != tok.AccessToken {
+		t.Errorf("provider returned %q, want stored %q", access, tok.AccessToken)
+	}
+	if grants := as.tokenGrantTypes(); len(grants) != 1 || grants[0] != "authorization_code" {
+		t.Errorf("token endpoint grants = %v, want only the login exchange (no refresh)", grants)
+	}
+}
+
+// TestTokenProvider_ExpiredToken_Refreshes verifies the silent-refresh path:
+// an expired stored token is renewed and the fresh access token returned.
+func TestTokenProvider_ExpiredToken_Refreshes(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	store := mcp.NewTokenStore(t.TempDir())
+	tok := loginForProviderTest(t, as, store, "demo")
+
+	// Force the stored token to be expired.
+	expired := tok
+	expired.Expiry = time.Now().Add(-time.Minute)
+	if err := store.Put("demo", expired); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	flow := &Flow{Store: store}
+	provider := flow.TokenProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	access, err := provider(ctx, "demo")
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if access == tok.AccessToken {
+		t.Error("expected a refreshed access token, got the expired one")
+	}
+
+	// The refreshed token must be persisted with a future expiry.
+	stored, err := store.Get("demo")
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if stored.AccessToken != access {
+		t.Errorf("stored AccessToken = %q, want refreshed %q", stored.AccessToken, access)
+	}
+}
+
+// TestTokenProvider_NoToken verifies that a missing token means "no
+// credentials" — the transport sends the request unauthenticated and the
+// server's own 401 guides the user.
+func TestTokenProvider_NoToken(t *testing.T) {
+	store := mcp.NewTokenStore(t.TempDir())
+	flow := &Flow{Store: store}
+	provider := flow.TokenProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	access, err := provider(ctx, "ghost")
+	if err != nil {
+		t.Fatalf("provider: %v", err)
+	}
+	if access != "" {
+		t.Errorf("provider returned %q, want empty for missing token", access)
+	}
+}
+
+// TestTokenProvider_RefreshRejected verifies that an invalid_grant during
+// refresh surfaces as ErrReauthRequired so the user is sent back to login.
+func TestTokenProvider_RefreshRejected(t *testing.T) {
+	as := newMockAuthorizationServer(t, nil)
+	store := mcp.NewTokenStore(t.TempDir())
+	tok := loginForProviderTest(t, as, store, "demo")
+
+	// Expire the token and break its refresh token.
+	broken := tok
+	broken.Expiry = time.Now().Add(-time.Minute)
+	broken.RefreshToken = "as-refresh-999-unknown"
+	if err := store.Put("demo", broken); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	flow := &Flow{Store: store}
+	provider := flow.TokenProvider()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := provider(ctx, "demo")
+	if err == nil {
+		t.Fatal("expected an error for a rejected refresh, got nil")
+	}
+	if !errors.Is(err, ErrReauthRequired) {
+		t.Errorf("error = %v, want errors.Is ErrReauthRequired", err)
+	}
+}


### PR DESCRIPTION
Parent epic: #809. Part of #803.

## What

Slice 4 of epic #809 — the user-facing OAuth entrypoint for remote MCP servers:

- **`harnesscli mcp login <server> [--client-id ID] [--scope "a b"]`** — resolves the server's URL from `~/.harness/config.toml`, `.harness/config.toml`, or `HARNESS_MCP_SERVERS` (TOML wins on collisions, mirroring harnessd) and runs the slice 3 OAuth 2.1 + PKCE flow; rejects stdio servers and unknown names with actionable errors.
- **`harnesscli mcp logout <server>`** — deletes the stored token (idempotent).
- **`harnesscli mcp status`** — per-server auth state for HTTP servers: static Authorization header / token valid (with expiry) / token expired / token corrupt / no token, each with the `harnesscli mcp login <name>` remediation where relevant.
- **Transport uses stored tokens automatically**: `mcp.ServerConfig.TokenProvider` (pluggable, `json:"-"`) + `ClientManager.SetTokenProvider` default applied at lazy connect; `httpConn` resolves a bearer only when no static `Authorization` header is configured (static wins). `oauth.Flow.TokenProvider()` adapts the store + silent refresh; harnessd wires it as the default at startup.
- **401 re-auth guidance**: the `ErrUnauthorized`-wrapping error message now includes `run ` + "harnesscli mcp login <server>" + ` to authenticate`.

Auth state is reported in the CLI status output (the epic's "or" option); `/v1/mcp/servers` is unchanged.

## Tests (TDD — written first, verified failing, then implemented)

- `internal/mcp`: 401 error contains `harnesscli mcp login <name>` + still `errors.Is ErrUnauthorized`; provider attaches bearer end-to-end against a gated mock; `("", nil)` → no header; static header beats provider; provider error surfaces; `SetTokenProvider` default used at lazy connect; explicit provider overrides the default.
- `internal/mcp/oauth`: `Flow.TokenProvider` — valid token returned without a refresh call, expired → silently refreshed + persisted, not-found → `("", nil)`, invalid_grant → `ErrReauthRequired`.
- `cmd/harnesscli`: dispatch routing; **end-to-end acceptance**: in-process OAuth+MCP stack, `login --client-id` (browser stubbed), token stored at 0600 under a temp HOME, then `tools/list` via a manager with the default provider succeeds with the bearer attached, `status` shows valid, `logout` removes it, `status` shows no token; login errors (not configured / stdio / missing arg); logout idempotent; status state matrix incl. env-configured server; status with no servers. All tests use temp HOME — no real browser/network/$HOME.

## Verification

- `go test ./cmd/harnesscli/... ./internal/mcp/... ./cmd/harnessd/... -count=1` — ok
- `go test ./cmd/harnesscli/ ./internal/mcp/ ./internal/mcp/oauth/ ./cmd/harnessd/ -count=1 -race` — ok
- `gofmt` / `go vet` clean

Not merged; slice 5 (docs) builds on this branch.