### PR TITLE
feat(tui): compaction summary block in the transcript with ctrl+o toggle

### DIFF
--- a/cmd/harnesscli/tui/compaction_block.go
+++ b/cmd/harnesscli/tui/compaction_block.go
@@ -1,0 +1,145 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// compaction_block.go — epic #817 slice 4: compaction summary blocks in the
+// transcript. Manual /compact results (CompactResultMsg) and auto_compact.*
+// SSE events both render a collapsed-by-default block; ctrl+o toggles the most
+// recent block between the collapsed title line and the expanded detail view,
+// reusing the tool-card pattern of in-place viewport replacement with tracked
+// line offsets.
+
+// compactionBlock tracks one rendered compaction block in the viewport.
+type compactionBlock struct {
+	id        string
+	title     string   // collapsed one-liner, e.g. "Compacted context — 3 messages removed"
+	details   []string // revealed when expanded (mode, token counts, summary text)
+	expanded  bool
+	lineStart int // absolute viewport line offset of the block's first line
+	lineCount int // number of viewport lines the block currently occupies
+}
+
+// compactionToggleIndicators mirror the tool-card expand/collapse affordance.
+const (
+	compactionCollapsedPrefix = "▸ "
+	compactionExpandedPrefix  = "▾ "
+	compactionDetailPrefix    = "⎿  "
+)
+
+// render produces the block's viewport lines at the given width.
+func (b *compactionBlock) render(width int) []string {
+	if !b.expanded {
+		return []string{compactionCollapsedPrefix + b.title}
+	}
+	lines := []string{compactionExpandedPrefix + b.title}
+	detailWidth := width - len([]rune(compactionDetailPrefix)) - 1
+	for _, d := range b.details {
+		for _, w := range wrapCompactionText(d, detailWidth) {
+			lines = append(lines, compactionDetailPrefix+w)
+		}
+	}
+	return lines
+}
+
+// wrapCompactionText greedily wraps plain text to width runes per line,
+// preserving existing newlines. Widths <= 0 fall back to 76.
+func wrapCompactionText(text string, width int) []string {
+	if width <= 0 {
+		width = 76
+	}
+	var out []string
+	for _, para := range strings.Split(text, "\n") {
+		words := strings.Fields(para)
+		if len(words) == 0 {
+			out = append(out, "")
+			continue
+		}
+		line := words[0]
+		for _, w := range words[1:] {
+			if len([]rune(line))+1+len([]rune(w)) > width {
+				out = append(out, line)
+				line = w
+			} else {
+				line += " " + w
+			}
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+// addCompactionBlock appends a collapsed compaction block at the viewport tail
+// and returns it.
+func (m *Model) addCompactionBlock(title string, details []string) *compactionBlock {
+	m.compactionSeq++
+	b := &compactionBlock{
+		id:        fmt.Sprintf("compact-%d", m.compactionSeq),
+		title:     title,
+		details:   details,
+		lineStart: m.vp.LineCount(),
+	}
+	lines := b.render(m.width)
+	b.lineCount = len(lines)
+	m.vp.AppendLines(lines)
+	m.compactionBlocks = append(m.compactionBlocks, b)
+	return b
+}
+
+// findCompactionBlock returns the block with the given id, or nil.
+func (m *Model) findCompactionBlock(id string) *compactionBlock {
+	if id == "" {
+		return nil
+	}
+	for _, b := range m.compactionBlocks {
+		if b.id == id {
+			return b
+		}
+	}
+	return nil
+}
+
+// updateCompactionBlock re-renders a block in place after its title, details,
+// or expanded state changed. When the line count changes, the tracked start
+// offsets of tool cards and compaction blocks below it are shifted, mirroring
+// appendToolUseView's in-place update.
+func (m *Model) updateCompactionBlock(b *compactionBlock) {
+	lines := b.render(m.width)
+	delta := len(lines) - b.lineCount
+	m.vp.ReplaceLineRange(b.lineStart, b.lineCount, lines)
+	b.lineCount = len(lines)
+	if delta == 0 {
+		return
+	}
+	for id, start := range m.toolLineStarts {
+		if start > b.lineStart {
+			m.toolLineStarts[id] = start + delta
+		}
+	}
+	for _, ob := range m.compactionBlocks {
+		if ob != b && ob.lineStart > b.lineStart {
+			ob.lineStart += delta
+		}
+	}
+}
+
+// toggleLatestCompactionBlock flips the expanded state of the most recent
+// compaction block and re-renders it. Returns false when no block exists.
+func (m *Model) toggleLatestCompactionBlock() bool {
+	if len(m.compactionBlocks) == 0 {
+		return false
+	}
+	b := m.compactionBlocks[len(m.compactionBlocks)-1]
+	b.expanded = !b.expanded
+	m.updateCompactionBlock(b)
+	return true
+}
+
+// clearCompactionBlocks drops all compaction block tracking. Must be called
+// wherever the viewport is rebuilt (new session, /clear, session switch).
+func (m *Model) clearCompactionBlocks() {
+	m.compactionBlocks = nil
+	m.pendingAutoCompactID = ""
+}

--- a/cmd/harnesscli/tui/compaction_block_test.go
+++ b/cmd/harnesscli/tui/compaction_block_test.go
@@ -1,0 +1,185 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Tests in this file cover epic #817 slice 4: compaction summary blocks in the
+// transcript with a ctrl+o expand/collapse toggle, for both manual /compact
+// results (CompactResultMsg) and auto_compact.* SSE events.
+// Helper testRunControlModel lives in run_control_command_test.go.
+
+// TestCompactResultMsg_RendersCollapsedBlock verifies a successful /compact
+// result renders a collapsed-by-default transcript block: the one-line title
+// is visible while the summary stays hidden, and the slice-3 status line is
+// unchanged.
+func TestCompactResultMsg_RendersCollapsedBlock(t *testing.T) {
+	m := testRunControlModel("http://localhost:8080")
+
+	m2, _ := m.Update(CompactResultMsg{
+		RunID:           "run-1",
+		Mode:            "hybrid",
+		Summary:         "kept the SQL schema",
+		MessagesRemoved: 3,
+	})
+	m = m2.(Model)
+
+	view := m.View()
+	if !strings.Contains(view, "Compacted context — 3 messages removed") {
+		t.Errorf("view missing collapsed compaction title:\n%s", view)
+	}
+	if strings.Contains(view, "kept the SQL schema") {
+		t.Errorf("summary must be hidden while collapsed:\n%s", view)
+	}
+	// Slice-3 status line is preserved.
+	if !strings.Contains(m.StatusMsg(), "3 messages removed") {
+		t.Errorf("StatusMsg() = %q, want messages-removed report", m.StatusMsg())
+	}
+
+	if len(m.compactionBlocks) != 1 {
+		t.Fatalf("expected 1 compaction block, got %d", len(m.compactionBlocks))
+	}
+	if m.compactionBlocks[0].expanded {
+		t.Error("block must start collapsed")
+	}
+}
+
+// TestCompactionBlock_CtrlOTogglesExpandCollapse verifies ctrl+o expands the
+// collapsed block to reveal the summary, then collapses it again — and that
+// with a block present, ctrl+o toggles the block rather than plan mode.
+func TestCompactionBlock_CtrlOTogglesExpandCollapse(t *testing.T) {
+	m := testRunControlModel("http://localhost:8080")
+
+	m2, _ := m.Update(CompactResultMsg{
+		RunID:           "run-1",
+		Mode:            "hybrid",
+		Summary:         "kept the SQL schema",
+		MessagesRemoved: 3,
+	})
+	m = m2.(Model)
+
+	// Expand.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m3.(Model)
+	if !m.compactionBlocks[0].expanded {
+		t.Fatal("expected block expanded after first ctrl+o")
+	}
+	if v := m.View(); !strings.Contains(v, "kept the SQL schema") {
+		t.Errorf("expanded view must show the summary:\n%s", v)
+	}
+	if m.PlanMode() {
+		t.Error("ctrl+o must toggle the compaction block, not plan mode, when a block exists")
+	}
+
+	// Collapse again.
+	m4, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m4.(Model)
+	if m.compactionBlocks[0].expanded {
+		t.Fatal("expected block collapsed after second ctrl+o")
+	}
+	if v := m.View(); strings.Contains(v, "kept the SQL schema") {
+		t.Errorf("collapsed view must hide the summary again:\n%s", v)
+	}
+}
+
+// TestAutoCompactEventsRenderAndUpdateBlock verifies auto_compact.started
+// renders an in-progress block and auto_compact.completed updates that same
+// block (not a duplicate) with before/after token counts.
+func TestAutoCompactEventsRenderAndUpdateBlock(t *testing.T) {
+	m := testRunControlModel("http://localhost:8080")
+
+	m2, _ := m.Update(SSEEventMsg{
+		EventType: "auto_compact.started",
+		Raw:       []byte(`{"estimated_tokens":1200,"context_window":2000,"threshold":0.8,"ratio":0.9,"mode":"hybrid"}`),
+	})
+	m = m2.(Model)
+
+	if v := m.View(); !strings.Contains(v, "Auto-compacting context") {
+		t.Fatalf("view missing auto-compact started block:\n%s", v)
+	}
+	if len(m.compactionBlocks) != 1 {
+		t.Fatalf("expected 1 block after started, got %d", len(m.compactionBlocks))
+	}
+
+	m3, _ := m.Update(SSEEventMsg{
+		EventType: "auto_compact.completed",
+		Raw:       []byte(`{"before_tokens":1200,"after_tokens":300,"mode":"hybrid"}`),
+	})
+	m = m3.(Model)
+
+	if len(m.compactionBlocks) != 1 {
+		t.Fatalf("completed must update the started block, not append: got %d blocks", len(m.compactionBlocks))
+	}
+	if v := m.View(); !strings.Contains(v, "Auto-compacted context — 1200 → 300 tokens (hybrid)") {
+		t.Errorf("view missing completed title with token counts:\n%s", v)
+	}
+
+	// Expanded details carry the token counts.
+	m4, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m4.(Model)
+	v := m.View()
+	for _, want := range []string{"Before: 1200 tokens", "After: 300 tokens"} {
+		if !strings.Contains(v, want) {
+			t.Errorf("expanded auto-compact block missing %q:\n%s", want, v)
+		}
+	}
+}
+
+// TestAutoCompactCompletedWithoutStartedAppendsBlock verifies a completed
+// event that arrives without a matching started (e.g. after an SSE reconnect)
+// still renders a block.
+func TestAutoCompactCompletedWithoutStartedAppendsBlock(t *testing.T) {
+	m := testRunControlModel("http://localhost:8080")
+
+	m2, _ := m.Update(SSEEventMsg{
+		EventType: "auto_compact.completed",
+		Raw:       []byte(`{"before_tokens":900,"after_tokens":200,"mode":"strip"}`),
+	})
+	m = m2.(Model)
+
+	if len(m.compactionBlocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(m.compactionBlocks))
+	}
+	if v := m.View(); !strings.Contains(v, "Auto-compacted context — 900 → 200 tokens (strip)") {
+		t.Errorf("view missing completed title:\n%s", v)
+	}
+}
+
+// TestCompactionBlock_CtrlOPrefersActiveToolOverBlock is a precedence
+// regression guard: with an active tool call in flight, ctrl+o expands the
+// tool card and leaves the compaction block collapsed.
+func TestCompactionBlock_CtrlOPrefersActiveToolOverBlock(t *testing.T) {
+	m := testRunControlModel("http://localhost:8080")
+	m = m.WithCancelRun(func() {})
+
+	m2, _ := m.Update(RunStartedMsg{RunID: "run-compact-reg"})
+	m = m2.(Model)
+	m3, _ := m.Update(SSEEventMsg{
+		EventType: "tool.call.started",
+		Raw:       []byte(`{"tool":"bash","call_id":"call-compactreg","arguments":"echo hi"}`),
+	})
+	m = m3.(Model)
+	m4, _ := m.Update(CompactResultMsg{
+		RunID:           "run-compact-reg",
+		Mode:            "hybrid",
+		Summary:         "kept the SQL schema",
+		MessagesRemoved: 2,
+	})
+	m = m4.(Model)
+
+	m5, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	m = m5.(Model)
+
+	if m.compactionBlocks[0].expanded {
+		t.Error("active tool expansion must keep priority: block must stay collapsed")
+	}
+	if !m.toolExpanded["call-compactreg"] {
+		t.Error("expected the active tool call to be expanded by ctrl+o")
+	}
+	if m.PlanMode() {
+		t.Error("ctrl+o with an active tool must not toggle plan mode")
+	}
+}

--- a/cmd/harnesscli/tui/keys.go
+++ b/cmd/harnesscli/tui/keys.go
@@ -129,7 +129,7 @@ func DefaultKeyMap() KeyMap {
 		),
 		ExpandTool: key.NewBinding(
 			key.WithKeys("ctrl+o"),
-			key.WithHelp("ctrl+o", "expand tool"),
+			key.WithHelp("ctrl+o", "expand tool / compaction"),
 		),
 	}
 }

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -139,6 +139,16 @@ type Model struct {
 	// tool call ID. True = expanded, absent/false = collapsed.
 	toolExpanded map[string]bool
 
+	// compactionBlocks tracks rendered compaction summary blocks in append
+	// order (epic #817 slice 4). ctrl+o toggles the most recent one.
+	compactionBlocks []*compactionBlock
+	// compactionSeq numbers blocks as they are created (id compact-N).
+	compactionSeq int
+	// pendingAutoCompactID is the block id of an in-flight auto-compaction
+	// (auto_compact.started seen, completed not yet received), so the
+	// completed event updates that block in place instead of appending.
+	pendingAutoCompactID string
+
 	// activeToolCallID is the ID of the currently active/selected tool call,
 	// used when toggling expansion via Ctrl+O.
 	activeToolCallID string
@@ -610,7 +620,7 @@ func buildHelpDialog(reg *CommandRegistry, keys KeyMap) helpdialog.Model {
 		{Keys: "@", Description: keys.AtMention.Help().Desc},
 		{Keys: "!", Description: keys.ShellMode.Help().Desc},
 		{Keys: "? / ctrl+h", Description: keys.Help.Help().Desc},
-		{Keys: "ctrl+o", Description: "plan mode / expand active tool"},
+		{Keys: "ctrl+o", Description: "plan mode / expand active tool / compaction"},
 		{Keys: "ctrl+e", Description: keys.EditMode.Help().Desc},
 		{Keys: "esc", Description: keys.Interrupt.Help().Desc},
 		{Keys: "ctrl+s", Description: keys.Copy.Help().Desc},
@@ -1829,6 +1839,7 @@ func (m *Model) resetTranscriptView() {
 	m.toolLineOrder = nil
 	m.clearPendingSteers()
 	m.clearThinkingBar()
+	m.clearCompactionBlocks()
 }
 
 func executeClearCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
@@ -2219,6 +2230,7 @@ func executeNewSessionCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	m.activeAssistantLineCount = 0
 	m.clearPendingSteers()
 	m.clearThinkingBar()
+	m.clearCompactionBlocks()
 	// A fresh session has no title; drop it from the status bar.
 	m.statusBar.SetTitle("")
 	return []tea.Cmd{m.setStatusMsg("New session started")}, false
@@ -2791,11 +2803,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// No-op.
 			return m, tea.Batch(cmds...)
 		case key.Matches(msg, m.keys.ExpandTool):
-			// Dual-purpose ctrl+o with precedence (highest first):
+			// Multi-purpose ctrl+o with precedence (highest first):
 			// 1. Active tool call present → expand/collapse it (UNCHANGED behavior).
-			// 2. Idle (no run, no active tool) → toggle plan mode.
-			// This ordering ensures a later tool-card expansion ticket can add
-			// completed-card expansion between (1) and (2) without conflict.
+			// 2. Compaction block present → toggle the most recent one (epic #817 slice 4).
+			// 3. Idle (no run, no active tool, no block) → toggle plan mode (UNCHANGED).
 			if m.activeToolCallID != "" {
 				// Highest priority: expand/collapse the active tool call.
 				if m.toolExpanded == nil {
@@ -2803,6 +2814,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.toolExpanded[m.activeToolCallID] = !m.toolExpanded[m.activeToolCallID]
 				m.rerenderActiveToolView()
+			} else if len(m.compactionBlocks) > 0 {
+				// Next: expand/collapse the most recent compaction summary block.
+				m.toggleLatestCompactionBlock()
 			} else if !m.runActive {
 				// Idle (no run active, no active tool): toggle plan mode.
 				m.planMode = !m.planMode
@@ -3899,6 +3913,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.toolLineStarts = make(map[string]int)
 		m.toolLineOrder = nil
 		m.clearThinkingBar()
+		m.clearCompactionBlocks()
 
 	case ExportTranscriptMsg:
 		if msg.FilePath != "" {
@@ -4075,7 +4090,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, m.setStatusMsg("compact failed: "+msg.Err))
 			return m, tea.Batch(cmds...)
 		}
-		cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Compacted context — %d messages removed", msg.MessagesRemoved)))
+		// Render the collapsed compaction block (epic #817 slice 4); ctrl+o
+		// expands it to reveal the mode and summary.
+		title := fmt.Sprintf("Compacted context — %d messages removed", msg.MessagesRemoved)
+		details := []string{"Mode: " + msg.Mode}
+		if strings.TrimSpace(msg.Summary) != "" {
+			details = append(details, msg.Summary)
+		}
+		m.addCompactionBlock(title, details)
+		cmds = append(cmds, m.setStatusMsg(title))
 
 	// SteerAcceptedMsg: the server queued the steering message (HTTP 202). The
 	// send-time "Steering sent" status already covers the acknowledgement; the
@@ -4201,6 +4224,53 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "plan.approval_granted", "plan.approval_denied":
 			m.planApproval = planApprovalState{}
+		case "auto_compact.started":
+			// Render an in-progress compaction block (epic #817 slice 4); the
+			// completed event updates this same block in place.
+			var p struct {
+				EstimatedTokens int     `json:"estimated_tokens"`
+				ContextWindow   int     `json:"context_window"`
+				Threshold       float64 `json:"threshold"`
+				Mode            string  `json:"mode"`
+			}
+			if err := json.Unmarshal(msg.Raw, &p); err == nil {
+				title := fmt.Sprintf("Auto-compacting context — ~%d tokens (%s)…", p.EstimatedTokens, p.Mode)
+				details := []string{
+					fmt.Sprintf("Estimated tokens: %d", p.EstimatedTokens),
+					fmt.Sprintf("Context window: %d", p.ContextWindow),
+					fmt.Sprintf("Threshold: %.0f%%", p.Threshold*100),
+					"Mode: " + p.Mode,
+				}
+				b := m.addCompactionBlock(title, details)
+				m.pendingAutoCompactID = b.id
+			}
+		case "auto_compact.completed":
+			var p struct {
+				BeforeTokens int    `json:"before_tokens"`
+				AfterTokens  int    `json:"after_tokens"`
+				Mode         string `json:"mode"`
+				Error        string `json:"error"`
+			}
+			if err := json.Unmarshal(msg.Raw, &p); err == nil {
+				title := fmt.Sprintf("Auto-compacted context — %d → %d tokens (%s)", p.BeforeTokens, p.AfterTokens, p.Mode)
+				details := []string{
+					fmt.Sprintf("Before: %d tokens", p.BeforeTokens),
+					fmt.Sprintf("After: %d tokens", p.AfterTokens),
+					"Mode: " + p.Mode,
+				}
+				if p.Error != "" {
+					title = fmt.Sprintf("Auto-compaction failed (%s)", p.Mode)
+					details = append(details, "Error: "+p.Error)
+				}
+				if b := m.findCompactionBlock(m.pendingAutoCompactID); b != nil {
+					b.title = title
+					b.details = details
+					m.updateCompactionBlock(b)
+				} else {
+					m.addCompactionBlock(title, details)
+				}
+				m.pendingAutoCompactID = ""
+			}
 		case "usage.delta":
 			var p struct {
 				CumulativeUsage struct {
@@ -4624,6 +4694,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.responseStarted = false
 		m.activeAssistantLineCount = 0
 		m.clearPendingSteers()
+		m.clearCompactionBlocks()
 		// Show a system message so the user knows the session switch happened.
 		m.vp.AppendLine("↩ Resumed session " + msg.SessionID + ". Previous messages are on the server.")
 		m.vp.AppendLine("")

--- a/docs/plans/817-compact-cmd.md
+++ b/docs/plans/817-compact-cmd.md
@@ -4,7 +4,8 @@ Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part 
 
 - Slice 1 (`feat(harness): accept a preserve-instruction in CompactRun and the compact endpoint`): **implemented**, merged via PR #836.
 - Slice 2 (`feat(harness): return the compaction summary from the compact endpoint`): **implemented**, merged via PR #860.
-- Slice 3 (`feat(harnesscli): /compact [instruction] slash command`): **in implementation** (branch `epic/817-compact-cmd-s3`).
+- Slice 3 (`feat(harnesscli): /compact [instruction] slash command`): **implemented**, merged via PR #884.
+- Slice 4 (`feat(tui): compaction summary block in the transcript with ctrl+o toggle`): **in implementation** (branch `epic/817-compact-cmd-s4`).
 
 ## Slice 1 (done)
 
@@ -138,3 +139,38 @@ Parent epic: #817 (`/compact [instruction]` + visible compaction summary), part 
 - [ ] gofmt + go vet clean.
 - [ ] `go test ./cmd/harnesscli/... -count=1` green.
 - [ ] Commit, push `epic/817-compact-cmd-s3`, open PR (no merge).
+
+---
+
+## Slice 4 (in implementation): compaction summary block in the transcript with ctrl+o toggle
+
+### Context
+
+- Problem: compactions are invisible — slice 3's `/compact` shows only a transient status line, and `auto_compact.*` SSE events are unhandled in the TUI dispatch.
+- Constraints: ctrl+o is already dual-purpose (active-tool expansion, then idle plan-mode toggle at `model.go` `keys.ExpandTool`); the compaction toggle must slot between them, never rebind. Block rendering reuses the tool-card in-place update pattern (tracked line offsets + `ReplaceLineRange` + start shifting), not the tooluse component itself (it is tool-call-specific).
+
+### Scope
+
+- In scope:
+  - `cmd/harnesscli/tui/compaction_block.go` (new): `compactionBlock` (title/details/expanded/lineStart/lineCount), collapsed `▸` / expanded `▾` + `⎿` detail rendering with width-wrapped details, model helpers `addCompactionBlock` / `findCompactionBlock` / `updateCompactionBlock` (shifts `toolLineStarts` and later blocks on line-count delta) / `toggleLatestCompactionBlock` / `clearCompactionBlocks`.
+  - `model.go`: `CompactResultMsg` success renders a collapsed block (`Compacted context — N messages removed`, details = mode + summary); SSE dispatch handles `auto_compact.started` (in-progress block, remembered via `pendingAutoCompactID`) and `auto_compact.completed` (updates the pending block in place, or appends when missed; error payload renders a failure title); ctrl+o chain gains the block toggle between active-tool and plan-mode; `clearCompactionBlocks()` called at every viewport rebuild (`resetTranscriptView`, `ClearMsg`, `executeNewSessionCommand`, `SessionPickerSelectedMsg`); help entries updated.
+  - `keys.go`: ExpandTool help text mentions compaction.
+- Out of scope: persisting blocks to the store / resumed sessions; toggling older (non-latest) blocks; changing auto-compact behavior itself.
+
+### Test Plan (TDD)
+
+- New failing tests first (`cmd/harnesscli/tui/compaction_block_test.go`):
+  - manual result renders collapsed block (title visible, summary hidden, slice-3 status line preserved).
+  - ctrl+o expands then collapses; with a block present ctrl+o does NOT toggle plan mode.
+  - auto_compact started→completed renders one block updated in place with before/after tokens; completed-without-started appends.
+  - precedence regression: active tool + block → ctrl+o expands the tool, block stays collapsed.
+  - plan-mode idle toggle regression: covered by existing `planmode_test.go` (unmodified, must stay green).
+- Regression: `go test ./cmd/harnesscli/... -count=1`.
+
+### Implementation Checklist
+
+- [x] Write failing tests first (watched red: `m.compactionBlocks undefined`).
+- [x] Implement minimal code changes.
+- [ ] gofmt + go vet clean.
+- [ ] `go test ./cmd/harnesscli/... -count=1` green.
+- [ ] Commit, push `epic/817-compact-cmd-s4`, open PR (no merge).


### PR DESCRIPTION
Parent epic: #817. Part of #803.

## What

Epic #817 slice 4 (final), stacked on merged slices 1–3 (PR #836, #860, #884). Compactions are now visible in the TUI transcript:

- **Manual `/compact` results** (`CompactResultMsg`, slice 3 msg carrying the slice-2 summary) render a collapsed-by-default block: one line `▸ Compacted context — N messages removed`, with mode + summary hidden until toggled.
- **Auto-compaction SSE events** — previously unhandled in the TUI dispatch (verified) — now render an equivalent block: `auto_compact.started` appends an in-progress block (`Auto-compacting context — ~N tokens (mode)…`, details = estimated/window/threshold/mode); `auto_compact.completed` updates that same block in place (`Auto-compacted context — before → after tokens (mode)`), appending instead when the started event was missed (e.g. SSE reconnect); `error` payloads render a failure title with the error in details.
- **ctrl+o joins the existing precedence chain without rebinding** (`keys.ExpandTool`): active tool expansion keeps top priority → most recent compaction block toggles → plan-mode idle toggle unchanged.
- New `compactionBlock` type (`cmd/harnesscli/tui/compaction_block.go`) follows the tool-card in-place update pattern: tracked line offsets, `ReplaceLineRange`, and start shifting of `toolLineStarts`/later blocks on line-count delta. Details are width-wrapped (`⎿` prefix, mirroring tool cards). Viewport rebuilds (new session, `/clear`, `ClearMsg`, session switch) clear block tracking.
- `keys.go` help (`expand tool / compaction`) and the help-dialog entry (`plan mode / expand active tool / compaction`) updated.

## Tests (strict TDD — failing tests written first, watched red on undefined `m.compactionBlocks`)

New `cmd/harnesscli/tui/compaction_block_test.go`:
- manual result renders collapsed block: title visible, summary hidden, slice-3 status line preserved
- ctrl+o expands (summary visible) then collapses; with a block present ctrl+o does NOT toggle plan mode
- `auto_compact.started`→`completed` yields ONE block updated in place with before/after tokens; completed-without-started appends
- precedence regression: active tool + block → ctrl+o expands the tool, block stays collapsed, plan mode untouched

Regressions (unmodified, green): `planmode_test.go` idle ctrl+o toggle, tool-expansion tests, slice-3 `compact_command_test.go`.

## Verification (actually run)

- `go test ./cmd/harnesscli/tui/ -run 'TestCompactResultMsg_RendersCollapsedBlock|TestCompactionBlock|TestAutoCompact' -count=1 -v` — 5/5 PASS
- `go test ./cmd/harnesscli/tui/ -run 'TestPlanMode|TestCompactCommand|TestCompactEndpoint' -count=1` — ok
- `go test ./cmd/harnesscli/... -count=1` — exit 0, 29 packages ok, zero FAIL lines
- `gofmt` / `go vet ./cmd/harnesscli/...` — clean

## Acceptance (from epic)

`/compact` (or crossing the auto-compact threshold) drops a collapsed block in the transcript; ctrl+o reveals the summary/token counts; tool-expansion and plan-mode ctrl+o behavior unchanged. This completes epic #817's four slices.