### PR TITLE
test(e2e): end-to-end exit-code assertions per terminal outcome

### DIFF
--- a/cmd/harnesscli/go_code_script_test.go
+++ b/cmd/harnesscli/go_code_script_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,5 +65,83 @@ func writeExecutable(t *testing.T, path, body string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
 		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+// TestGoCodeScriptPropagatesHarnessCLIExitCode pins the wrapper's exit-code
+// contract (website/docs/reference/exit-codes.md): the harnesscli invocation
+// is the last command of main for both prompt and cli modes, so its exit
+// status must surface unchanged through `go-code` — including when the
+// wrapper started the server itself and the stop_server EXIT trap runs.
+func TestGoCodeScriptPropagatesHarnessCLIExitCode(t *testing.T) {
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "go-code.sh"))
+	if err != nil {
+		t.Fatalf("resolve go-code script path: %v", err)
+	}
+
+	binDir := t.TempDir()
+	// curl: fail the first health check when CURL_FAIL_FIRST=1 (forces the
+	// wrapper down the start-server path so the EXIT trap is armed), then
+	// succeed. A per-subtest counter file tracks call count.
+	writeExecutable(t, filepath.Join(binDir, "curl"), "#!/usr/bin/env bash\nf=\"$CURL_COUNT_FILE\"\nn=0\nif [ -f \"$f\" ]; then n=$(cat \"$f\"); fi\nn=$((n+1))\necho \"$n\" > \"$f\"\nif [ \"${CURL_FAIL_FIRST:-0}\" = \"1\" ] && [ \"$n\" -eq 1 ]; then exit 1; fi\nexit 0\n")
+	// harnessd: never actually contacted beyond being started in the
+	// background (it exits immediately; the health check is stubbed).
+	writeExecutable(t, filepath.Join(binDir, "harnessd"), "#!/usr/bin/env bash\nexit 0\n")
+	// harnesscli: record that it ran and exit with the injected code.
+	writeExecutable(t, filepath.Join(binDir, "harnesscli"), "#!/usr/bin/env bash\nprintf 'called\\n' >> \"$RECORD_FILE\"\nexit \"${STUB_EXIT_CODE:-0}\"\n")
+
+	cases := []struct {
+		name         string
+		args         []string
+		stubExitCode int
+		startServer  bool // CURL_FAIL_FIRST=1 → wrapper starts harnessd and arms the EXIT trap
+	}{
+		{name: "prompt mode with pre-existing server", args: []string{"hello world"}, stubExitCode: 2},
+		{name: "prompt mode with wrapper-started server (trap armed)", args: []string{"hello world"}, stubExitCode: 2, startServer: true},
+		{name: "prompt mode cancelled run with wrapper-started server", args: []string{"hello world"}, stubExitCode: 6, startServer: true},
+		{name: "prompt mode blocked run with wrapper-started server", args: []string{"hello world"}, stubExitCode: 3, startServer: true},
+		{name: "cli mode with pre-existing server", args: []string{"runs"}, stubExitCode: 2},
+		{name: "cli mode with wrapper-started server (trap armed)", args: []string{"runs"}, stubExitCode: 6, startServer: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			recordFile := filepath.Join(tmp, "harnesscli.called")
+			countFile := filepath.Join(tmp, "curl.count")
+			failFirst := "0"
+			if tc.startServer {
+				failFirst = "1"
+			}
+			cmd := exec.Command("bash", append([]string{scriptPath}, tc.args...)...)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"HARNESS_ADDR=:19181",
+				"RECORD_FILE="+recordFile,
+				"CURL_COUNT_FILE="+countFile,
+				"CURL_FAIL_FIRST="+failFirst,
+				fmt.Sprintf("STUB_EXIT_CODE=%d", tc.stubExitCode),
+			)
+			out, runErr := cmd.CombinedOutput()
+
+			if tc.stubExitCode == 0 && runErr != nil {
+				t.Fatalf("go-code %v: unexpected failure: %v\n%s", tc.args, runErr, out)
+			}
+			gotExit := 0
+			if runErr != nil {
+				var exitErr *exec.ExitError
+				if !errors.As(runErr, &exitErr) {
+					t.Fatalf("go-code %v: %v (not an exit-code error)\n%s", tc.args, runErr, out)
+				}
+				gotExit = exitErr.ExitCode()
+			}
+			if gotExit != tc.stubExitCode {
+				t.Fatalf("go-code %v exit code = %d, want %d (harnesscli exit code must propagate unchanged)\n%s", tc.args, gotExit, tc.stubExitCode, out)
+			}
+			raw, err := os.ReadFile(recordFile)
+			if err != nil || !strings.Contains(string(raw), "called") {
+				t.Fatalf("harnesscli stub was not invoked (record=%q, err=%v) — the test proves nothing\n%s", raw, err, out)
+			}
+		})
 	}
 }

--- a/docs/plans/823-exit-codes.md
+++ b/docs/plans/823-exit-codes.md
@@ -4,10 +4,22 @@
 
 - Slice 1 (docs contract): **merged** (PR #824, branch `epic/823-exit-codes`).
 - Slice 2 (map terminal events to exit codes): **merged** (PR #861, branch `epic/823-exit-codes-s2`).
-- Slice 3 (exit 3 on blocked headless runs): **this branch** (`epic/823-exit-codes-s3`), branched from `origin/main` after the Slice 2 merge.
-- Slice 4 (e2e assertions + per-command docs): future branch.
+- Slice 3 (exit 3 on blocked headless runs): **merged** (PR #882, branch `epic/823-exit-codes-s3`).
+- Slice 4 (e2e assertions + per-command docs): **this branch** (`epic/823-exit-codes-s4`), branched from `origin/main` after the Slice 3 merge.
 
-## Slice 3 scope
+## Slice 4 scope
+
+- New `test/e2e/exit_codes_test.go`: builds the real `harnesscli` binary once (`go build`) and drives it over real HTTP+SSE against the in-process harnessd (`newTestServer` patterns from `helpers_test.go`) backed by `internal/fakeprovider` — content turn → exit 0 (`run.completed`); `ExhaustError` → exit 2 (`run.failed`); `Hang` turn + `POST /v1/runs/{id}/cancel` mid-run → exit 6 (`run.cancelled`); plus an unreachable-server client-error pin (exit 1). Assertions are on the process exit code (`$?`), not stdout text.
+- Wrapper propagation: `TestGoCodeScriptPropagatesHarnessCLIExitCode` in `cmd/harnesscli/go_code_script_test.go` — stubbed `harnesscli` exits 2/6/3 in prompt and cli modes, with and without the wrapper-started-server `EXIT` trap armed; the script's exit code must equal the stub's, and the stub must actually have run.
+- Docs: per-command exit-code table in `website/docs/cli/harnesscli.md` (streaming mode + non-streaming 0/1 note), headless-scripting `$?` section in `website/docs/cli/go-code-wrapper.md`, exit-code note + `-no-stream` clarification in `website/docs/reference/cli-flags.md` — all linking the contract page.
+- Out of scope per the slice spec: blocked (exit 3) e2e — the CLI has no permissions flag, so approval-blocked runs cannot be driven through `harnesscli`; blocked coverage stays with the Slice 3 unit tests. No code changes.
+
+## Slice 4 test plan
+
+- The e2e assertions are the tests; they validate already-merged Slice 2/3 behavior over the real binary (a red result would mean the contract is broken, not that a test needs adjusting).
+- `go test ./test/e2e/... -count=1` and `go test ./cmd/harnesscli/... -count=1` green; `go test ./internal/harness/... -count=1` green; gofmt/vet clean; `npm run build` green for the edited docs pages.
+
+## Slice 3 record (completed)
 
 - `cmd/harnesscli/exitcodes.go`: `isBlockedEvent` (run.waiting_for_user, tool.approval_required, plan.approval_required) and `blockedEventReason` (question-blocked vs approval-blocked wording). The contract's blocked signals, in the same single-source-of-truth file as the code table.
 - `cmd/harnesscli/main.go`: `runBlockedError`; `processSSEBlock` returns it when a blocked signal arrives while `stdinIsTerminal()` is false (interactive stdin: stream unchanged, stays open — ask-user wiring is the other epic's scope); `run()` maps it to `exitBlocked` after `reportRunBlocked` prints the run ID, reason, and `harnesscli continue <run-id>` resume command to stderr. Terminal detection reuses the existing injectable `stdinIsTerminal` double (`cmd/harnesscli/plugins.go:107`); no new TTY dependency.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -22,7 +22,7 @@
 - `2026-07-20-codex-subscription-auth-847-impact-map.md` — Cross-surface impact map for Epic #847 Codex subscription routing.
 - `2026-07-20-subscription-auth-foundation-846-plan.md` — Epic #846 subscription-auth foundation: token-source, dynamic request auth, refresh cache, and registry plumbing (in implementation).
 - `2026-07-20-subscription-auth-foundation-846-impact-map.md` — Cross-surface impact map for Epic #846 provider credential plumbing.
-- `823-exit-codes.md` — Epic #823 headless CLI exit-code contract: Slices 1–2 merged (docs contract; terminal-event mapping); Slice 3 (blocked exit 3) in implementation.
+- `823-exit-codes.md` — Epic #823 headless CLI exit-code contract: Slices 1–3 merged (contract, mapping, blocked exit 3); Slice 4 (e2e assertions + per-command docs) in implementation.
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).

--- a/test/e2e/exit_codes_test.go
+++ b/test/e2e/exit_codes_test.go
@@ -1,0 +1,219 @@
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+)
+
+// This file proves the headless exit-code contract
+// (website/docs/reference/exit-codes.md, epic #823) end to end: the real
+// harnesscli binary, built from source, streaming real HTTP+SSE from a real
+// in-process harnessd, must exit 0 on run.completed, 2 on run.failed, and 6
+// on run.cancelled. The assertions are on the process exit code itself — the
+// same $? a shell script or CI job would branch on.
+
+var (
+	cliBuildOnce sync.Once
+	cliPath      string
+	cliBuildErr  error
+)
+
+// harnesscliPath builds the real harnesscli binary once per test binary run
+// and returns its path. Building from source (rather than relying on an
+// installed binary) keeps the suite hermetic and pinned to the current tree.
+func harnesscliPath(t *testing.T) string {
+	t.Helper()
+	cliBuildOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "harnesscli-e2e-*")
+		if err != nil {
+			cliBuildErr = err
+			return
+		}
+		cliPath = filepath.Join(dir, "harnesscli")
+		out, err := exec.Command("go", "build", "-o", cliPath, "go-agent-harness/cmd/harnesscli").CombinedOutput()
+		if err != nil {
+			cliBuildErr = fmt.Errorf("build harnesscli: %v\n%s", err, out)
+		}
+	})
+	if cliBuildErr != nil {
+		t.Fatalf("%v", cliBuildErr)
+	}
+	return cliPath
+}
+
+// cliResult captures the outcome of one harnesscli invocation.
+type cliResult struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+// runHarnessCLI runs the real binary to completion and returns its process
+// exit code. A non-zero exit is a normal outcome here, not a test failure.
+func runHarnessCLI(t *testing.T, args ...string) cliResult {
+	t.Helper()
+	cmd := exec.Command(harnesscliPath(t), args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	res := cliResult{stdout: stdout.String(), stderr: stderr.String()}
+	if err == nil {
+		return res
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run harnesscli %v: %v (not an exit-code error)", args, err)
+	}
+	res.exitCode = exitErr.ExitCode()
+	return res
+}
+
+// TestE2E_ExitCodeCompleted drives a one-shot run whose provider answers
+// immediately and asserts the CLI process exits 0 (run.completed).
+func TestE2E_ExitCodeCompleted(t *testing.T) {
+	t.Parallel()
+
+	provider := fakeprovider.New([]fakeprovider.Turn{{Content: "hello from the fake model"}})
+	ts := newTestServer(t, provider, nil, nil)
+
+	res := runHarnessCLI(t, "-base-url", ts.URL, "-prompt", "say hi")
+	if res.exitCode != 0 {
+		t.Fatalf("exit code = %d, want 0 for run.completed (stderr=%s)", res.exitCode, res.stderr)
+	}
+}
+
+// TestE2E_ExitCodeFailed drives a one-shot run whose provider errors on every
+// turn and asserts the CLI process exits 2 (run.failed).
+func TestE2E_ExitCodeFailed(t *testing.T) {
+	t.Parallel()
+
+	provider := fakeprovider.New(nil, fakeprovider.WithExhaustedBehavior(fakeprovider.ExhaustError))
+	ts := newTestServer(t, provider, nil, nil)
+
+	res := runHarnessCLI(t, "-base-url", ts.URL, "-prompt", "this will fail")
+	if res.exitCode != 2 {
+		t.Fatalf("exit code = %d, want 2 for run.failed (stderr=%s)", res.exitCode, res.stderr)
+	}
+}
+
+// TestE2E_ExitCodeCancelled cancels an in-flight run exactly as an operator
+// would (POST /v1/runs/{id}/cancel) while the real CLI streams it, and
+// asserts the CLI process exits 6 (run.cancelled). The run ID is read from
+// the CLI's own run_id= stdout contract line — the in-process test server has
+// no run store, so the list route (GET /v1/runs) is not available here.
+func TestE2E_ExitCodeCancelled(t *testing.T) {
+	t.Parallel()
+
+	provider := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+	ts := newTestServer(t, provider, nil, nil)
+
+	cmd := exec.Command(harnesscliPath(t), "-base-url", ts.URL, "-prompt", "do something slow")
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start harnesscli: %v", err)
+	}
+	// The child must never outlive the test: while it runs it holds an SSE
+	// connection that blocks httptest.Server.Close during cleanup.
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		select {
+		case <-waitDone:
+		case <-time.After(5 * time.Second):
+		}
+	})
+
+	// Read the run ID from the CLI's run_id= stdout line as it streams.
+	runIDCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdoutPipe)
+		for scanner.Scan() {
+			if line := scanner.Text(); strings.HasPrefix(line, "run_id=") {
+				runIDCh <- strings.TrimPrefix(line, "run_id=")
+				return
+			}
+		}
+	}()
+	var runID string
+	select {
+	case runID = <-runIDCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("CLI never printed the run_id= line")
+	}
+
+	// Wait until the provider is actually inside its Hang turn so the cancel
+	// lands mid-run rather than before the run starts.
+	deadline := time.Now().Add(5 * time.Second)
+	for provider.Calls() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("provider never entered the hanging turn")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	res, err := ts.Client().Post(ts.URL+"/v1/runs/"+runID+"/cancel", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST cancel: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("POST cancel: expected 200, got %d", res.StatusCode)
+	}
+
+	select {
+	case waitErr := <-waitDone:
+		if waitErr == nil {
+			t.Fatalf("exit code = 0, want 6 for run.cancelled")
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatalf("wait harnesscli: %v (not an exit-code error)", waitErr)
+		}
+		if exitErr.ExitCode() != 6 {
+			t.Fatalf("exit code = %d, want 6 for run.cancelled (stderr=%s)", exitErr.ExitCode(), stderr.String())
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("CLI did not exit after the run was cancelled")
+	}
+}
+
+// TestE2E_ExitCodeClientError drives the CLI against an unreachable server
+// and asserts the conventional client-error exit 1 (unchanged behavior,
+// pinned here so the transport-error path cannot drift into the run-outcome
+// codes).
+func TestE2E_ExitCodeClientError(t *testing.T) {
+	t.Parallel()
+
+	// Bind then immediately close a listener to obtain an address that is
+	// guaranteed to refuse connections.
+	ts := newTestServer(t, fakeprovider.New(nil), nil, nil)
+	url := ts.URL
+	ts.Close()
+
+	res := runHarnessCLI(t, "-base-url", url, "-prompt", "no server listening")
+	if res.exitCode != 1 {
+		t.Fatalf("exit code = %d, want 1 for client/transport error (stderr=%s)", res.exitCode, res.stderr)
+	}
+	if !strings.Contains(res.stderr, "harnesscli") {
+		t.Errorf("expected a client error message on stderr, got %q", res.stderr)
+	}
+}

--- a/website/docs/cli/go-code-wrapper.md
+++ b/website/docs/cli/go-code-wrapper.md
@@ -125,6 +125,24 @@ go-code improve [--target seam]         # run the self-improvement test loop
 
 ---
 
+## Headless scripting and exit codes
+
+The wrapper propagates the `harnesscli` exit code unchanged, so shell scripts and CI can branch on `$?` exactly as they would when calling `harnesscli` directly — including when the wrapper started the server itself (the auto-stop `EXIT` trap does not override the exit status):
+
+```bash
+go-code "summarize the diff"
+case $? in
+  0) echo "run completed" ;;
+  2) echo "run failed" ;;
+  3) echo "run blocked on input — resume interactively" ;;
+  6) echo "run cancelled — resumable via go-code continue <run-id> ..." ;;
+esac
+```
+
+The full code table (`0` completed, `1` client error, `2` failed, `3` blocked, `6` cancelled, `130` interrupted) and its per-command coverage are documented in [Exit Codes](/docs/reference/exit-codes).
+
+---
+
 ## Subcommand reference
 
 <Callout type="info">

--- a/website/docs/cli/harnesscli.md
+++ b/website/docs/cli/harnesscli.md
@@ -42,7 +42,20 @@ When you invoke `harnesscli` with no recognized subcommand — typically just `-
 
 Terminal events are `run.completed`, `run.failed`, and `run.cancelled`. Every non-terminal event is printed as a single line: `<event_type> <full_event_json>`.
 
-The process exit code reports the run's outcome for scripts and CI — see [Exit Codes](/docs/reference/exit-codes) for the headless exit-code contract (which terminal event maps to which code, plus blocked and interrupted runs).
+### Exit codes
+
+The process exit code reports the run's outcome, so scripts and CI can branch on `$?`:
+
+| Code | Meaning |
+|---|---|
+| `0` | `run.completed` — the run finished successfully |
+| `1` | Client-side error: bad flags, missing prompt, connection/HTTP/stream failure |
+| `2` | `run.failed` — a turn failed server-side |
+| `3` | Blocked — the run needs input it will never get headlessly (`run.waiting_for_user`, `tool.approval_required`, or `plan.approval_required` observed while stdin is non-interactive) |
+| `6` | `run.cancelled` — interrupted but resumable via `harnesscli continue <run-id> <prompt>` |
+| `130` | SIGINT/SIGTERM while streaming |
+
+The `run_id=` / `terminal_event=` stdout lines are unchanged by this mapping. See [Exit Codes](/docs/reference/exit-codes) for the full contract — blocked-signal details, goal-status reservations, and per-command coverage.
 
 ### Flags
 
@@ -106,6 +119,8 @@ The CLI maintains two separate `http.Client` instances:
 ---
 
 ## Run-management subcommands
+
+The non-streaming subcommands below (`list`, `cancel`, `status`, `replay`, `search`) exit `0` on success and `1` on error — the terminal-event exit-code mapping does not apply to them since they never observe an event stream. Streaming `continue` follows the same [exit-code contract](/docs/reference/exit-codes) as the one-shot mode.
 
 ### list / runs
 

--- a/website/docs/reference/cli-flags.md
+++ b/website/docs/reference/cli-flags.md
@@ -94,6 +94,8 @@ run_id=<uuid>
 terminal_event=<run.completed|run.failed|run.cancelled>
 ```
 
+**Exit codes (non-TUI streaming):** `0` on `run.completed`, `2` on `run.failed`, `6` on `run.cancelled`, `3` when the run blocks on input while stdin is non-interactive, `1` on client/transport errors, `130` on SIGINT/SIGTERM. Full contract: [Exit Codes](/docs/reference/exit-codes).
+
 ### `list` / `runs` subcommand
 
 Both `list` and `runs` tokens route to `runList`. Calls `GET /v1/runs`.
@@ -135,7 +137,7 @@ Takes a run ID as the first positional argument and the continuation prompt as t
 | Flag | Default | Description |
 |---|---|---|
 | `-base-url` | `http://localhost:8080` | Harness API base URL. |
-| `-no-stream` | `false` | Create the continuation run without streaming events. Prints only `run_id=<id>` and exits. |
+| `-no-stream` | `false` | Create the continuation run without streaming events. Prints only `run_id=<id>` and exits `0` (`1` on error); no terminal event is observed, so the exit-code mapping does not apply. |
 
 Source: `cmd/harnesscli/runctl.go:260-264`
 


### PR DESCRIPTION
Parent epic: #823. Part of #803.

## What

Final slice of #823: proves the exit-code contract end to end with the real `harnesscli` binary over real HTTP+SSE, pins wrapper propagation, and publishes the per-command docs. No production code changes.

- **New `test/e2e/exit_codes_test.go`** — builds the real binary once via `go build` and drives it against the in-process harnessd (`newTestServer` patterns) backed by `internal/fakeprovider`:
  - content turn → exit **0** (`run.completed`)
  - `ExhaustError` → exit **2** (`run.failed`)
  - `Hang` turn + `POST /v1/runs/{id}/cancel` mid-run → exit **6** (`run.cancelled`); the run ID is read from the CLI's own `run_id=` stdout contract line (the store-less test server returns 501 for `GET /v1/runs`), and the child is always reaped in cleanup so its SSE connection cannot block `httptest.Server.Close`
  - unreachable server → exit **1** (client/transport pin)
  
  Assertions are on the process exit code, never on stdout text.
- **Wrapper propagation** (`cmd/harnesscli/go_code_script_test.go`) — `TestGoCodeScriptPropagatesHarnessCLIExitCode`: stubbed `harnesscli` exits 2/6/3 in prompt and cli modes, with and without the wrapper-started-server `EXIT` trap armed (stub `curl` fails the first health check to force the start-server path); asserts `go-code` surfaces the code unchanged **and** that the stub actually ran.
- **Docs** — per-command exit-code table in `website/docs/cli/harnesscli.md` (streaming mode + non-streaming 0/1 note), headless-scripting `$?` section in `website/docs/cli/go-code-wrapper.md`, exit-code note + `-no-stream` clarification in `website/docs/reference/cli-flags.md`; all link `website/docs/reference/exit-codes.md` and match its table.

Scope note: blocked (exit 3) e2e is intentionally absent — the CLI has no permissions flag, so approval-blocked runs can't be driven through `harnesscli` headlessly; blocked coverage stays with the Slice 3 unit tests (per the slice spec, which calls for 0/2/6 e2e).

## Tests run

- `go test ./test/e2e/ -run 'TestE2E_ExitCode' -count=1 -timeout 120s -v` — all 4 pass (8.0s). (First draft hung on `GET /v1/runs` → 501; fixed by reading `run_id=` from the CLI stdout and adding kill-on-cleanup.)
- `GOCACHE=/tmp/go-build go test ./cmd/harnesscli/... ./internal/harness/... ./test/e2e/... -count=1` — **green** (no failures across all three trees).
- `gofmt -l test/e2e/ cmd/harnesscli/` clean; `go vet ./test/e2e/ ./cmd/harnesscli/` clean.
- `cd website && npm run build` — `[SUCCESS]` with `onBrokenLinks: 'throw'`.

## Epic status after this slice

All four slices delivered: contract doc (slice 1), terminal-event mapping (slice 2), blocked exit 3 (slice 3), e2e assertions + per-command docs (slice 4).