### PR TITLE
feat(plugins): markdown command files as namespaced slash commands with $ARGUMENTS

### DIFF
--- a/cmd/harnesscli/tui/installable_plugins.go
+++ b/cmd/harnesscli/tui/installable_plugins.go
@@ -7,23 +7,43 @@ import (
 	"go-agent-harness/internal/plugins"
 )
 
-func installablePluginCommandDirs() []string {
+// BundleCommandSource identifies one trusted bundle's commands directory for
+// slash-command loading (legacy JSON PluginDef files and markdown command
+// files).
+type BundleCommandSource struct {
+	BundleName string
+	Dir        string
+}
+
+// installablePluginCommandSources returns the commands directories of all
+// enabled AND trusted bundles. Command definitions may invoke a shell; unlike
+// skills, load them only after the bundle has been explicitly trusted.
+func installablePluginCommandSources() []BundleCommandSource {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
 	}
 	root := filepath.Join(home, ".go-harness", "plugins")
-	// Command definitions may invoke a shell; unlike skills, load them only
-	// after the bundle has been explicitly trusted.
 	bundles, err := plugins.TrustedBundles(root, plugins.NewStateStore(filepath.Join(root, "state.json")))
 	if err != nil {
 		return nil
 	}
-	var dirs []string
+	var sources []BundleCommandSource
 	for _, bundle := range bundles {
 		if bundle.CommandsDir != "" {
-			dirs = append(dirs, bundle.CommandsDir)
+			sources = append(sources, BundleCommandSource{BundleName: bundle.Manifest.Name, Dir: bundle.CommandsDir})
 		}
+	}
+	return sources
+}
+
+// installablePluginCommandDirs returns only the directories, for the legacy
+// JSON PluginDef loading path.
+func installablePluginCommandDirs() []string {
+	sources := installablePluginCommandSources()
+	dirs := make([]string, 0, len(sources))
+	for _, s := range sources {
+		dirs = append(dirs, s.Dir)
 	}
 	return dirs
 }

--- a/cmd/harnesscli/tui/markdown_command_test.go
+++ b/cmd/harnesscli/tui/markdown_command_test.go
@@ -1,0 +1,238 @@
+package tui
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/inputarea"
+	tuiplugin "go-agent-harness/cmd/harnesscli/tui/plugin"
+	"go-agent-harness/internal/plugins"
+)
+
+// Slice 4 (epic #821): bundle markdown command files as namespaced slash
+// commands with skills argument expansion.
+
+func writeMarkdownCommand(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExpandMarkdownCommand_MatchesSkillsSemantics(t *testing.T) {
+	def := tuiplugin.MarkdownCommand{
+		Name:        "greet",
+		Description: "Greet someone",
+		Body:        "Hello $0! All: $ARGUMENTS. Literal: $HOME. Dir: $SKILL_DIR",
+		FilePath:    "/bundles/greeter/commands/greet.md",
+	}
+	// Quotes are preserved in the raw args string; $0 uses SplitArgs
+	// tokenization, $ARGUMENTS is verbatim, unknown $HOME stays literal.
+	cmd := Command{Name: "greet", Args: []string{`"hello`, `world"`}, Raw: `/greet "hello world"`}
+	got := expandMarkdownCommand(def, "/ws", cmd)
+	want := `Hello hello world! All: "hello world". Literal: $HOME. Dir: /bundles/greeter/commands`
+	if got != want {
+		t.Fatalf("expandMarkdownCommand() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestExpandMarkdownCommand_ArgumentsFallback(t *testing.T) {
+	def := tuiplugin.MarkdownCommand{
+		Name:     "summarize",
+		Body:     "Summarize the notes.",
+		FilePath: "/b/commands/summarize.md",
+	}
+	cmd := Command{Name: "summarize", Args: []string{"these", "notes"}, Raw: "/summarize these notes"}
+	got := expandMarkdownCommand(def, "/ws", cmd)
+	want := "Summarize the notes.\nARGUMENTS: these notes"
+	if got != want {
+		t.Fatalf("expandMarkdownCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadAndRegisterBundleCommands_RegistersMarkdownCommands(t *testing.T) {
+	dir := t.TempDir()
+	writeMarkdownCommand(t, dir, "greet.md", "---\nname: greet\ndescription: Greet someone\n---\nSay hello to $ARGUMENTS.\n")
+
+	registry := NewCommandRegistry()
+	warnings := LoadAndRegisterBundleCommands(registry, BundleCommandSource{BundleName: "greeter", Dir: dir})
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	entry, ok := registry.Lookup("greet")
+	if !ok {
+		t.Fatal("greet command not registered")
+	}
+	if entry.Description != "Greet someone" {
+		t.Fatalf("Description = %q", entry.Description)
+	}
+	// Markdown commands submit through the built-in Execute path, not the
+	// async plugin-handler path.
+	if entry.Execute == nil {
+		t.Fatal("markdown command must set Execute (submits the expanded prompt)")
+	}
+}
+
+func TestLoadAndRegisterBundleCommands_CollisionNamespaces(t *testing.T) {
+	dirA := t.TempDir()
+	writeMarkdownCommand(t, dirA, "greet.md", "---\nname: greet\ndescription: From bundle alpha\n---\nalpha\n")
+	dirB := t.TempDir()
+	writeMarkdownCommand(t, dirB, "greet.md", "---\nname: greet\ndescription: From bundle beta\n---\nbeta\n")
+	dirHelp := t.TempDir()
+	writeMarkdownCommand(t, dirHelp, "help.md", "---\nname: help\ndescription: Bundle help\n---\nbundle help\n")
+
+	registry := NewCommandRegistry() // includes the built-in help command
+	warnings := LoadAndRegisterBundleCommands(registry,
+		BundleCommandSource{BundleName: "alpha", Dir: dirA},
+		BundleCommandSource{BundleName: "beta", Dir: dirB},
+		BundleCommandSource{BundleName: "helpertools", Dir: dirHelp},
+	)
+
+	// First bundle keeps the plain name; the second is namespaced.
+	if _, ok := registry.Lookup("greet"); !ok {
+		t.Fatal("plain greet not registered")
+	}
+	if _, ok := registry.Lookup("beta:greet"); !ok {
+		t.Fatal("beta:greet not registered")
+	}
+	// A collision with a built-in namespaces too, leaving the built-in intact.
+	if _, ok := registry.Lookup("helpertools:help"); !ok {
+		t.Fatal("helpertools:help not registered")
+	}
+	if entry, _ := registry.Lookup("help"); entry.Description == "Bundle help" {
+		t.Fatal("built-in help was replaced by the bundle command")
+	}
+	// Both namespacings are logged via the warnings slice.
+	joined := strings.Join(warnings, "\n")
+	if !strings.Contains(joined, "beta:greet") || !strings.Contains(joined, "helpertools:help") {
+		t.Fatalf("expected namespacing warnings, got %v", warnings)
+	}
+}
+
+func TestLoadAndRegisterBundleCommands_DoubleCollisionSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeMarkdownCommand(t, dir, "dup.md", "---\nname: dup\ndescription: Duplicate\n---\nbody\n")
+
+	registry := NewCommandRegistry()
+	registry.Register(CommandEntry{Name: "dup", Description: "pre-existing"})
+	registry.Register(CommandEntry{Name: "beta:dup", Description: "pre-existing namespaced"})
+
+	warnings := LoadAndRegisterBundleCommands(registry, BundleCommandSource{BundleName: "beta", Dir: dir})
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "skipped") {
+		t.Fatalf("expected one skip warning, got %v", warnings)
+	}
+	if entry, _ := registry.Lookup("dup"); entry.Description != "pre-existing" {
+		t.Fatal("pre-existing dup command was replaced")
+	}
+}
+
+func TestInstallablePluginCommandSources_UntrustedBundlesExcluded(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	home, _ := os.UserHomeDir()
+	root := filepath.Join(home, ".go-harness", "plugins")
+	bundleDir := filepath.Join(root, "greeter", "1.0.0")
+	writeMarkdownCommand(t, filepath.Join(bundleDir, "commands"), "greet.md", "---\nname: greet\ndescription: x\n---\nbody\n")
+	if err := os.WriteFile(filepath.Join(bundleDir, "plugin.json"), []byte(`{"schema_version":1,"name":"greeter","version":"1.0.0","commands":"commands"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := plugins.NewStateStore(filepath.Join(root, "state.json"))
+	// Remote bundle: installed untrusted — its commands dir must not appear.
+	if err := store.RecordInstall(plugins.InstalledPlugin{Name: "greeter", Version: "1.0.0", Source: "https://example.com/x.git", Remote: true}); err != nil {
+		t.Fatal(err)
+	}
+	if sources := installablePluginCommandSources(); len(sources) != 0 {
+		t.Fatalf("untrusted bundle contributed sources: %v", sources)
+	}
+
+	// Trusting the bundle exposes its commands dir under the bundle name.
+	if err := store.SetTrusted("greeter", true); err != nil {
+		t.Fatal(err)
+	}
+	sources := installablePluginCommandSources()
+	if len(sources) != 1 || sources[0].BundleName != "greeter" || sources[0].Dir != filepath.Join(bundleDir, "commands") {
+		t.Fatalf("sources = %+v", sources)
+	}
+
+	// Disabled bundles contribute nothing even when trusted.
+	if err := store.SetEnabled("greeter", false); err != nil {
+		t.Fatal(err)
+	}
+	if sources := installablePluginCommandSources(); len(sources) != 0 {
+		t.Fatalf("disabled bundle contributed sources: %v", sources)
+	}
+}
+
+// Acceptance: install + trust a bundle with commands/greet.md, submit
+// "/greet hello world" in the TUI, and the expanded prompt is POSTed as a run.
+func TestMarkdownCommandSubmitsExpandedPrompt(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	home, _ := os.UserHomeDir()
+	root := filepath.Join(home, ".go-harness", "plugins")
+	bundleDir := filepath.Join(root, "greeter", "1.0.0")
+	writeMarkdownCommand(t, filepath.Join(bundleDir, "commands"), "greet.md",
+		"---\nname: greet\ndescription: Greet someone\n---\nSay hi to $0. Everyone: $ARGUMENTS\n")
+	if err := os.WriteFile(filepath.Join(bundleDir, "plugin.json"), []byte(`{"schema_version":1,"name":"greeter","version":"1.0.0","commands":"commands"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := plugins.NewStateStore(filepath.Join(root, "state.json"))
+	// Local source: trusted by default.
+	if err := store.RecordInstall(plugins.InstalledPlugin{Name: "greeter", Version: "1.0.0", Source: bundleDir, Remote: false}); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotPrompt string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/runs" {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+				gotPrompt, _ = body["prompt"].(string)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"run_id":"run_1"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	cfg := DefaultTUIConfig()
+	cfg.BaseURL = srv.URL
+	m := New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m2.(Model)
+
+	// The command is registered (which also feeds /help and slash completion,
+	// both built from the same registry).
+	if _, ok := m.commandRegistry.Lookup("greet"); !ok {
+		t.Fatal("greet not registered from the trusted bundle")
+	}
+
+	updated, cmd := m.Update(inputarea.CommandSubmittedMsg{Value: "/greet hello world"})
+	m = updated.(Model)
+	if cmd == nil {
+		t.Fatal("expected a run command for the markdown slash command")
+	}
+	if msg := cmd(); msg != nil {
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, c := range batch {
+				c()
+			}
+		}
+	}
+
+	want := "Say hi to hello. Everyone: hello world"
+	if gotPrompt != want {
+		t.Fatalf("submitted prompt = %q, want %q", gotPrompt, want)
+	}
+}

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -465,7 +465,16 @@ func New(cfg TUIConfig) Model {
 	if m.pluginsDir == "" {
 		m.pluginsDir = defaultPluginsDir()
 	}
-	m.pluginWarnings = LoadAndRegisterPlugins(m.commandRegistry, append([]string{m.pluginsDir}, installablePluginCommandDirs()...)...)
+	commandSources := installablePluginCommandSources()
+	jsonDirs := make([]string, 0, len(commandSources)+1)
+	jsonDirs = append(jsonDirs, m.pluginsDir)
+	for _, source := range commandSources {
+		jsonDirs = append(jsonDirs, source.Dir)
+	}
+	m.pluginWarnings = LoadAndRegisterPlugins(m.commandRegistry, jsonDirs...)
+	// Markdown command files from trusted bundles register as slash commands
+	// whose expanded bodies are submitted as prompts (epic #821 slice 4).
+	m.pluginWarnings = append(m.pluginWarnings, LoadAndRegisterBundleCommands(m.commandRegistry, commandSources...)...)
 	if warning := legacyPluginsDirWarning(m.pluginsDir); warning != "" {
 		m.pluginWarnings = append(m.pluginWarnings, warning)
 	}

--- a/cmd/harnesscli/tui/plugin/markdown.go
+++ b/cmd/harnesscli/tui/plugin/markdown.go
@@ -1,0 +1,124 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MarkdownCommand is a slash command declared by a bundle markdown file: a
+// YAML frontmatter block (name, description) and a prompt-template body that
+// is expanded at invocation with internal/skills argument semantics
+// ($ARGUMENTS, positional $0..$n, $WORKSPACE, $SKILL_DIR, ARGUMENTS fallback).
+type MarkdownCommand struct {
+	Name        string
+	Description string
+	Body        string
+	FilePath    string
+}
+
+// markdownFrontmatter is the YAML frontmatter of a bundle markdown command
+// file. Unknown fields are rejected so typos fail loading instead of being
+// silently ignored (matching the plugin.json manifest contract).
+type markdownFrontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// LoadMarkdownCommands reads all *.md files from dir, parses and validates
+// each as a MarkdownCommand, and returns valid commands plus per-file errors
+// that name the offending file. A missing directory is not an error (both
+// return values are nil), mirroring LoadPlugins.
+func LoadMarkdownCommands(dir string) ([]MarkdownCommand, []error) {
+	_, err := os.Stat(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, []error{fmt.Errorf("stat %s: %w", dir, err)}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, []error{fmt.Errorf("read dir %s: %w", dir, err)}
+	}
+
+	var commands []MarkdownCommand
+	var errs []error
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) != ".md" {
+			continue
+		}
+		fullPath := filepath.Join(dir, name)
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: read error: %w", name, err))
+			continue
+		}
+		def, err := ParseMarkdownCommand(data, fullPath)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+			continue
+		}
+		commands = append(commands, def)
+	}
+	return commands, errs
+}
+
+// ParseMarkdownCommand parses one markdown command file's content.
+func ParseMarkdownCommand(data []byte, path string) (MarkdownCommand, error) {
+	fm, body, err := splitCommandFrontmatter(string(data))
+	if err != nil {
+		return MarkdownCommand{}, err
+	}
+	var meta markdownFrontmatter
+	dec := yaml.NewDecoder(strings.NewReader(fm))
+	dec.KnownFields(true)
+	if err := dec.Decode(&meta); err != nil {
+		return MarkdownCommand{}, fmt.Errorf("frontmatter: %w", err)
+	}
+	if meta.Name == "" {
+		return MarkdownCommand{}, fmt.Errorf("frontmatter name is required")
+	}
+	if !validName.MatchString(meta.Name) {
+		return MarkdownCommand{}, fmt.Errorf("frontmatter name %q is invalid: must match ^[a-z][a-z0-9-]*$", meta.Name)
+	}
+	if meta.Description == "" {
+		return MarkdownCommand{}, fmt.Errorf("frontmatter description is required")
+	}
+	if body == "" {
+		return MarkdownCommand{}, fmt.Errorf("command body is empty")
+	}
+	return MarkdownCommand{
+		Name:        meta.Name,
+		Description: meta.Description,
+		Body:        body,
+		FilePath:    path,
+	}, nil
+}
+
+// splitCommandFrontmatter splits a markdown command file into YAML
+// frontmatter and body, requiring the --- delimiters like SKILL.md files.
+func splitCommandFrontmatter(content string) (string, string, error) {
+	const delimiter = "---"
+	trimmed := strings.TrimSpace(content)
+	if !strings.HasPrefix(trimmed, delimiter) {
+		return "", "", fmt.Errorf("must start with --- frontmatter delimiter")
+	}
+	rest := trimmed[len(delimiter):]
+	idx := strings.Index(rest, "\n"+delimiter)
+	if idx < 0 {
+		return "", "", fmt.Errorf("missing closing --- frontmatter delimiter")
+	}
+	fm := rest[:idx]
+	body := strings.TrimSpace(rest[idx+len("\n"+delimiter):])
+	return fm, body, nil
+}

--- a/cmd/harnesscli/tui/plugin/markdown_test.go
+++ b/cmd/harnesscli/tui/plugin/markdown_test.go
@@ -1,0 +1,109 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Bundle markdown command files (epic #821 slice 4): a <name>.md file with
+// YAML frontmatter (name, description) and a prompt-template body.
+
+func TestParseMarkdownCommand_Valid(t *testing.T) {
+	content := "---\nname: greet\ndescription: Greet someone\n---\nSay hello to $ARGUMENTS.\n"
+	def, err := ParseMarkdownCommand([]byte(content), "/x/commands/greet.md")
+	if err != nil {
+		t.Fatalf("ParseMarkdownCommand() error = %v", err)
+	}
+	if def.Name != "greet" {
+		t.Fatalf("Name = %q", def.Name)
+	}
+	if def.Description != "Greet someone" {
+		t.Fatalf("Description = %q", def.Description)
+	}
+	if def.Body != "Say hello to $ARGUMENTS." {
+		t.Fatalf("Body = %q", def.Body)
+	}
+	if def.FilePath != "/x/commands/greet.md" {
+		t.Fatalf("FilePath = %q", def.FilePath)
+	}
+}
+
+func TestParseMarkdownCommand_ValidationErrors(t *testing.T) {
+	cases := map[string]struct {
+		content string
+		wantErr string
+	}{
+		"missing frontmatter": {
+			content: "Say hello\n",
+			wantErr: "frontmatter",
+		},
+		"missing closing delimiter": {
+			content: "---\nname: greet\ndescription: x\n",
+			wantErr: "frontmatter",
+		},
+		"missing name": {
+			content: "---\ndescription: Greet someone\n---\nbody\n",
+			wantErr: "name",
+		},
+		"invalid name": {
+			content: "---\nname: Greet_Me!\ndescription: x\n---\nbody\n",
+			wantErr: "name",
+		},
+		"missing description": {
+			content: "---\nname: greet\n---\nbody\n",
+			wantErr: "description",
+		},
+		"empty body": {
+			content: "---\nname: greet\ndescription: x\n---\n",
+			wantErr: "body",
+		},
+		"unknown frontmatter field": {
+			content: "---\nname: greet\ndescription: x\nbogus: 1\n---\nbody\n",
+			wantErr: "bogus",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseMarkdownCommand([]byte(tc.content), "/x/commands/x.md")
+			if err == nil {
+				t.Fatalf("ParseMarkdownCommand() succeeded, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want it to mention %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadMarkdownCommands(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("greet.md", "---\nname: greet\ndescription: Greet someone\n---\nSay hello to $ARGUMENTS.\n")
+	write("review.md", "---\nname: review\ndescription: Review code\n---\nReview $0.\n")
+	write("broken.md", "---\nname: broken\n---\nmissing description\n")
+	// JSON PluginDef files and other files coexist and are ignored by the
+	// markdown loader (the JSON path loads them separately).
+	write("legacy.json", `{"name":"legacy","description":"x","handler":"prompt","prompt_template":"y"}`)
+	write("notes.txt", "not a command")
+
+	defs, errs := LoadMarkdownCommands(dir)
+	if len(defs) != 2 {
+		t.Fatalf("LoadMarkdownCommands() defs = %d, want 2 (%v); errs = %v", len(defs), defs, errs)
+	}
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "broken.md") {
+		t.Fatalf("LoadMarkdownCommands() errs = %v, want one naming broken.md", errs)
+	}
+
+	// A missing directory is not an error, mirroring LoadPlugins.
+	defs, errs = LoadMarkdownCommands(filepath.Join(t.TempDir(), "does-not-exist"))
+	if defs != nil || errs != nil {
+		t.Fatalf("missing dir: defs = %v, errs = %v, want both nil", defs, errs)
+	}
+}

--- a/cmd/harnesscli/tui/plugin_loader.go
+++ b/cmd/harnesscli/tui/plugin_loader.go
@@ -4,8 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/messagebubble"
+	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
 	tuiplugin "go-agent-harness/cmd/harnesscli/tui/plugin"
+	"go-agent-harness/internal/skills"
 )
 
 // LoadAndRegisterPlugins loads plugin command definitions from dir and registers
@@ -34,6 +41,93 @@ func LoadAndRegisterPlugins(registry *CommandRegistry, dirs ...string) []string 
 		return nil
 	}
 	return warnings
+}
+
+// LoadAndRegisterBundleCommands loads markdown command files (*.md) from each
+// trusted bundle's commands directory and registers them as slash commands
+// whose expanded bodies are submitted as prompts (unlike legacy JSON prompt
+// plugins, which display their output). A name that collides with an existing
+// command is registered as "<bundle>:<name>" instead; if that is taken too,
+// the command is skipped. Namespacings and skips are returned as warnings.
+func LoadAndRegisterBundleCommands(registry *CommandRegistry, sources ...BundleCommandSource) []string {
+	if registry == nil {
+		return nil
+	}
+
+	var warnings []string
+	for _, source := range sources {
+		defs, errs := tuiplugin.LoadMarkdownCommands(source.Dir)
+		for _, err := range errs {
+			warnings = append(warnings, err.Error())
+		}
+		for _, def := range defs {
+			name := def.Name
+			if registry.IsRegistered(name) {
+				namespaced := source.BundleName + ":" + def.Name
+				if registry.IsRegistered(namespaced) {
+					warnings = append(warnings, fmt.Sprintf("plugin command %q from bundle %q skipped: %q and %q are both registered", def.Name, source.BundleName, def.Name, namespaced))
+					continue
+				}
+				warnings = append(warnings, fmt.Sprintf("plugin command %q from bundle %q registered as %q: plain name already registered", def.Name, source.BundleName, namespaced))
+				name = namespaced
+			}
+			registry.Register(markdownCommandEntry(name, def))
+		}
+	}
+	if len(warnings) == 0 {
+		return nil
+	}
+	return warnings
+}
+
+// markdownCommandEntry builds the registry entry for a bundle markdown
+// command. The Handler is a no-op like the built-in commands; Execute expands
+// the body template with skills argument semantics and submits the result as
+// a user prompt, mirroring the normal submit path (transcript, bubble, run).
+func markdownCommandEntry(name string, def tuiplugin.MarkdownCommand) CommandEntry {
+	return CommandEntry{
+		Name:        name,
+		Description: def.Description,
+		Handler:     func(Command) CommandResult { return CommandResult{Status: CmdOK} },
+		Execute: func(m *Model, cmd Command) ([]tea.Cmd, bool) {
+			prompt := expandMarkdownCommand(def, m.config.Workspace, cmd)
+			// Reset assistant text accumulator for the new user turn.
+			m.lastAssistantText = ""
+			m.responseStarted = false
+			m.activeAssistantLineCount = 0
+			m.clearThinkingBar()
+			m.pendingLastMsg = truncateStr(prompt, 60)
+			m.transcript = append(m.transcript, transcriptexport.TranscriptEntry{
+				Role:      "user",
+				Content:   prompt,
+				Timestamp: time.Now(),
+			})
+			m.appendMessageBubble(messagebubble.RoleUser, prompt)
+			effModel, effProvider := m.effectiveModelAndProvider()
+			return []tea.Cmd{startRunCmd(m.config.BaseURL, prompt, m.conversationID, effModel, effProvider, m.selectedReasoningEffort, m.selectedProfile, m.config.Workspace, m.config.APIKey, nil, m.extraDirs, m.planMode)}, false
+		},
+	}
+}
+
+// expandMarkdownCommand expands a markdown command's body template with the
+// shared skills argument-expansion contract: $ARGUMENTS is the raw argument
+// text as typed, $0..$n are SplitArgs tokens, $WORKSPACE is the session
+// workspace, $SKILL_DIR is the command file's directory, and args are
+// appended as a trailing "ARGUMENTS: <args>" line when the body references no
+// placeholder.
+func expandMarkdownCommand(def tuiplugin.MarkdownCommand, workspace string, cmd Command) string {
+	return skills.ExpandTemplate(def.Body, nil, rawCommandArgs(cmd), workspace, filepath.Dir(def.FilePath))
+}
+
+// rawCommandArgs returns the argument text exactly as typed after the command
+// name, preserving quotes, so markdown command expansion tokenizes with the
+// same SplitArgs semantics as skill invocation.
+func rawCommandArgs(cmd Command) string {
+	rest := strings.TrimPrefix(cmd.Raw, "/")
+	if idx := strings.IndexAny(rest, " \t"); idx >= 0 {
+		return strings.TrimSpace(rest[idx+1:])
+	}
+	return ""
 }
 
 // legacyPluginsDirWarning returns a deprecation warning when dir (the legacy

--- a/docs/design/installable-plugin-bundles.md
+++ b/docs/design/installable-plugin-bundles.md
@@ -1,6 +1,6 @@
 # Installable Plugin Bundles
 
-Status: implemented (Epic #748). Manifest v1 authoring contract and plugin-home decision published under Epic #821 (slice 1); trust grant/revoke CLI and install-time confirmation (slice 2) and zip/GitHub-archive install sources (slice 3) implemented. Items marked **planned** are later slices of Epic #821 and are not implemented yet.
+Status: implemented (Epic #748). Manifest v1 authoring contract and plugin-home decision published under Epic #821 (slice 1); trust grant/revoke CLI and install-time confirmation (slice 2), zip/GitHub-archive install sources (slice 3), and markdown command files with `$ARGUMENTS` (slice 4) implemented. Items marked **planned** are later slices of Epic #821 and are not implemented yet.
 
 An installable bundle is a directory with a `plugin.json` manifest declaring optional `skills`, `commands`, `agents`, `hooks`, and `mcp` components. Bundles are installed from a local directory, git URL, or GitHub shorthand, validated without executing their content, and atomically promoted into a versioned plugin home. This document is the stable v1 authoring contract for that manifest and the lifecycle around it.
 
@@ -34,7 +34,7 @@ The manifest is a single JSON object at the bundle root. Unknown fields are reje
 | `version` | string | yes | Safe path segment: `^[A-Za-z0-9][A-Za-z0-9._+-]*$`, never `.`, `..`, or absolute. Becomes the versioned install directory name. |
 | `description` | string | no | Free text shown in listings. |
 | `skills` | string | no | Relative path to a **directory** of skills (`SKILL.md` trees), loaded by the standard skills loader. |
-| `commands` | string | no | Relative path to a **directory** of slash-command definitions. Today each `*.json` file uses the legacy `PluginDef` schema (`name`, `description`, `handler` = `bash`/`prompt`, `command` or `prompt_template`). Markdown command files with `$ARGUMENTS` are **planned** (Epic #821, slice 4). |
+| `commands` | string | no | Relative path to a **directory** of slash-command definitions. `*.json` files use the legacy `PluginDef` schema (`name`, `description`, `handler` = `bash`/`prompt`, `command` or `prompt_template`). `*.md` files are markdown commands (see below). Both kinds coexist. |
 | `agents` | string | no | Relative path to a **directory** of agent TOML profiles, searched when resolving `--profile`. |
 | `hooks` | string | no | Relative path to a hook **file** (`*.json`, config-driven hooks schema: `event`, `kind` = `command`/`http`, `command`/`url`, optional `matcher`, `timeout_seconds`; see `docs/design/plugins.md`). Every `*.json` file in the declared file's directory is loaded. |
 | `mcp` | string | no | Relative path to an MCP servers **file**: a JSON array of `{name, transport, command, args, url}` entries (`transport` = `stdio` or `http`; `command`/`args` for stdio, `url` for http), validated by the same parser as `HARNESS_MCP_SERVERS`. |
@@ -74,6 +74,24 @@ release-helper/
 │   └── hooks.json            # config-driven hook definition(s)
 └── mcp.json                  # [{"name":"gh","transport":"stdio","command":"gh-mcp","args":["serve"]}]
 ```
+
+### Markdown command files (`commands/<name>.md`)
+
+A `*.md` file in the `commands` directory declares a slash command with a YAML frontmatter block and a prompt-template body:
+
+```markdown
+---
+name: greet
+description: Greet someone
+---
+Say hello to $0. Everyone: $ARGUMENTS
+```
+
+- Frontmatter fields are exactly `name` (`^[a-z][a-z0-9-]*$`) and `description`; both are required and unknown fields are rejected (same discipline as `plugin.json`). The body must be non-empty.
+- At invocation the body expands with the shared `internal/skills` argument contract: `$ARGUMENTS` is the raw argument text as typed, `$0..$n` are quote-aware `SplitArgs` tokens, `$WORKSPACE` is the session workspace, `$SKILL_DIR` is the command file's directory, and unknown `$VARS` stay literal. When the body references no placeholder and arguments were given, they are appended verbatim as a trailing `ARGUMENTS: <args>` line.
+- The expanded body is **submitted as a prompt** (unlike legacy JSON `prompt` plugins, which display their output in the viewport).
+- Registration needs an enabled **and trusted** bundle, same as JSON command defs. A name colliding with an existing command (built-in or another plugin's) is registered as `<bundle>:<name>`; if that is taken too, the command is skipped. Namespacings and skips are logged via the plugin warnings slice.
+- `/help` and slash completion pick registered markdown commands up automatically.
 
 ## 3. Install layout and lifecycle
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -29,6 +29,13 @@
 - 501 no-broker: `ApproveRun`/`DenyRun` map harnessd's 501 to `ErrApprovalNotConfigured`, surfaced as an `agent_message_chunk` note instead of a hang until the deadline.
 - Validation: strict TDD (red: `undefined: permissionParams`, `srv.callClient`). Flows via scripted io.Pipe client + fake harnessd (new `/approve`/`/deny` routes with 501 mode): grant -> approve + `end_turn`; reject -> deny; `cancelled` -> deny; client error -> deny; deadline expiry -> no POST and a late answer ignored; 501 -> note, no hang.
 
+## 2026-07-19 (Plugin Markdown Command Files with $ARGUMENTS — Epic #821 Slice 4)
+
+- Bundle `commands/*.md` files now register as TUI slash commands: YAML frontmatter (`name`, `description`; unknown fields rejected, body required) plus a prompt-template body. The expanded body is SUBMITTED as a prompt (transcript + message bubble + `startRunCmd`), unlike legacy JSON `prompt` plugins, which display their output — the acceptance is `/greet hello world` POSTing the expansion to `/v1/runs`, covered by a model-level test driving `inputarea.CommandSubmittedMsg`.
+- Expansion reuses epic #813's merged engine: `internal/skills` now exports `BuildTemplateVars` + `ExpandTemplate` + `HasArgPlaceholder`, with the skill invocation path (`buildVars`/`expandBody`/`hasArgPlaceholder`) delegating unchanged. `$ARGUMENTS` is the raw typed args (quotes preserved via `rawCommandArgs` from `cmd.Raw`), `$0..$n` use `SplitArgs`, `$WORKSPACE`/`$SKILL_DIR` resolve, and the `ARGUMENTS: <args>` fallback applies when the body references no placeholder.
+- Collision rule: plain name if free, else `<bundle>:<name>`, else skip — namespacings and skips surface through the plugin warnings slice. JSON `PluginDef` files in bundle `commands/` dirs keep loading through the unchanged legacy path; untrusted/disabled bundles contribute nothing (TrustedBundles gating, pinned by `installablePluginCommandSources` tests).
+- TDD: failing-first tests cover the exported expansion contract, frontmatter parse/validation matrix, loader file handling, registration + namespacing + double-collision skip, trust gating, and the end-to-end submission.
+
 ## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
 
 - Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.

--- a/docs/plans/821-plugin-system.md
+++ b/docs/plans/821-plugin-system.md
@@ -171,3 +171,54 @@
 
 - Risk: zip-slip via crafted prefixes (e.g. all entries under `../`).
 - Mitigation: every original entry name is validated (no `..` element, not absolute, no backslash) BEFORE the shared-prefix is computed and stripped; symlink entries rejected pre-extraction; pinned by tests.
+
+---
+
+# Plan: Epic #821 Slice 4 — markdown command files as namespaced slash commands with $ARGUMENTS
+
+## Context
+
+- Problem: A bundle's `commands/` dir only loads legacy JSON `PluginDef` files; kimi-code's markdown command files with frontmatter and `$ARGUMENTS` expansion are unsupported.
+- User impact: Bundle authors cannot write markdown slash commands.
+- Constraints: Reuse epic #813's merged argument expansion in `internal/skills` (SplitArgs tokenizer, $0..$n, named args, `ARGUMENTS:` fallback) — do not re-implement. JSON `PluginDef` files keep working unchanged. Trusted bundles only (existing gating). Strict TDD.
+
+## Scope
+
+- In scope:
+  - `internal/skills`: export the shared expansion engine — `BuildTemplateVars(namedArgs, args, workspace, dir)` + `ExpandTemplate(body, namedArgs, args, workspace, dir)` + `HasArgPlaceholder(body, namedArgs)` — with existing `buildVars`/`expandBody`/`hasArgPlaceholder` delegating (behavior unchanged, covered by existing tests).
+  - `cmd/harnesscli/tui/plugin`: `MarkdownCommand` + `LoadMarkdownCommands(dir)` parsing `*.md` files with strict YAML frontmatter (`name`, `description`; unknown fields rejected); body is the prompt template.
+  - `cmd/harnesscli/tui/plugin_loader.go`: `LoadAndRegisterBundleCommands(registry, sources...)` — registers each markdown command as a slash command whose expanded body is SUBMITTED as a prompt (unlike legacy JSON prompt plugins, which display output); collision rule: plain name if free, else `<bundle>:<name>`, else skip — namespacing and skips logged via the warnings slice.
+  - `cmd/harnesscli/tui/installable_plugins.go`: `installablePluginCommandSources()` returning `{BundleName, Dir}` per trusted bundle (TrustedBundles gating unchanged); model wiring registers JSON defs (unchanged path) plus markdown commands.
+  - Docs: design doc commands section, engineering log, this plan.
+- Out of scope: `/plugins` TUI manager + reload (slice 5), e2e (slice 6), `arguments` frontmatter for commands (spec is name+description only; the shared engine supports named args, and the loader passes none).
+
+## Test Plan (TDD)
+
+- New failing tests first:
+  - `internal/skills`: `ExpandTemplate` covers $ARGUMENTS/$0..$n/$WORKSPACE/$SKILL_DIR expansion, SplitArgs quote handling, unknown `$HOME` left literal, and the `ARGUMENTS:` fallback; existing skill tests pin the delegation.
+  - `tui/plugin`: frontmatter parse/validation (missing name/description, invalid name, empty body, unknown field, missing delimiters); `LoadMarkdownCommands` skips non-`.md`, collects per-file errors, missing dir is not an error.
+  - `tui`: registration + expansion matches skills semantics (quoted tokens, raw `$ARGUMENTS`); collision → `<bundle>:<name>` + warning, double collision → skip + warning; JSON defs unaffected; `installablePluginCommandSources` returns nothing for untrusted bundles; model-level: `/greet hello world` via `inputarea.CommandSubmittedMsg` POSTs the expanded prompt to `/v1/runs` (acceptance).
+- Existing tests to update: none (wiring is additive).
+
+## Cross-Surface Impact Map
+
+- None. TUI command registration + a thin exported wrapper over the existing skills expansion.
+
+## Implementation Checklist
+
+- [x] Write failing tests first; watch them fail (`ExpandTemplate`/`MarkdownCommand`/`LoadAndRegisterBundleCommands` undefined).
+- [x] Export skills expansion engine; delegate existing internals.
+- [x] Implement markdown loader, registration, namespacing, submission.
+- [x] Update design doc, plan, engineering log.
+- [x] `go test ./cmd/harnesscli/... ./internal/plugins/... ./internal/skills/... -count=1` green; gofmt + go vet clean. **Green (32 packages ok).**
+- [x] Push `epic/821-plugin-system-s4`, open PR (no merge).
+
+## Slice 4 Verification Results
+
+- `GOCACHE=/tmp/go-build go test ./cmd/harnesscli/... ./internal/plugins/... ./internal/skills/... -count=1` — PASS, all 32 packages `ok` (incl. existing skills hook/resolver tests pinning the delegation, and the JSON plugin registration tests).
+- `gofmt -l` on changed Go files — clean; `go vet` on touched packages — clean.
+
+## Risks and Mitigations
+
+- Risk: divergence between skill and command expansion semantics.
+- Mitigation: one engine (`ExpandTemplate`) serves both; skills' own tests pin the delegation, command tests assert identical outcomes.

--- a/internal/skills/hook.go
+++ b/internal/skills/hook.go
@@ -79,13 +79,16 @@ func AutoInvokeHook(registry *Registry) func(lastUserMessage string) *SkillActiv
 	}
 }
 
-// buildVars creates the variable map for skill body interpolation.
-// Positional variables are 0-based: $0 is the first argument token.
-func buildVars(skill *Skill, args, workspace string) map[string]string {
+// BuildTemplateVars creates the variable map for prompt-template expansion,
+// shared by skill invocation and bundle markdown commands. Positional
+// variables are 0-based: $0 is the first argument token (SplitArgs
+// tokenization). Named arguments are bound to tokens in declaration order;
+// names with no corresponding token expand empty.
+func BuildTemplateVars(namedArgs []string, args, workspace, dir string) map[string]string {
 	vars := map[string]string{
 		"$ARGUMENTS": args,
 		"$WORKSPACE": workspace,
-		"$SKILL_DIR": filepath.Dir(skill.FilePath),
+		"$SKILL_DIR": dir,
 	}
 	fields, err := SplitArgs(args)
 	if err != nil {
@@ -97,9 +100,8 @@ func buildVars(skill *Skill, args, workspace string) map[string]string {
 	for i, field := range fields {
 		vars[fmt.Sprintf("$%d", i)] = field
 	}
-	// Bind named arguments declared in frontmatter to tokens in declaration
-	// order. Names with no corresponding token expand empty.
-	for i, name := range skill.Arguments {
+	// Bind named arguments to tokens in declaration order.
+	for i, name := range namedArgs {
 		if i < len(fields) {
 			vars["$"+name] = fields[i]
 		} else {
@@ -109,6 +111,26 @@ func buildVars(skill *Skill, args, workspace string) map[string]string {
 	return vars
 }
 
+// ExpandTemplate interpolates a prompt-template body with the shared
+// expansion contract used by every invocation path (AutoInvokeHook,
+// Resolver.ResolveSkill, and bundle markdown commands): when the body
+// references no argument placeholder ($ARGUMENTS, $N, or a declared named
+// argument) and the raw args are non-empty, the raw args are appended
+// verbatim as a trailing "ARGUMENTS: <args>" line instead of being dropped.
+func ExpandTemplate(body string, namedArgs []string, args, workspace, dir string) string {
+	content := Interpolate(body, BuildTemplateVars(namedArgs, args, workspace, dir))
+	if args != "" && !HasArgPlaceholder(body, namedArgs) {
+		content += "\nARGUMENTS: " + args
+	}
+	return content
+}
+
+// buildVars creates the variable map for skill body interpolation.
+// Positional variables are 0-based: $0 is the first argument token.
+func buildVars(skill *Skill, args, workspace string) map[string]string {
+	return BuildTemplateVars(skill.Arguments, args, workspace, filepath.Dir(skill.FilePath))
+}
+
 // expandBody interpolates the skill body with the given arguments and
 // workspace, applying the shared expansion contract used by every invocation
 // path (AutoInvokeHook and Resolver.ResolveSkill): when the body references
@@ -116,10 +138,5 @@ func buildVars(skill *Skill, args, workspace string) map[string]string {
 // the raw args are non-empty, the raw args are appended verbatim as a
 // trailing "ARGUMENTS: <args>" line instead of being dropped.
 func expandBody(skill *Skill, args, workspace string) string {
-	vars := buildVars(skill, args, workspace)
-	content := Interpolate(skill.Body, vars)
-	if args != "" && !hasArgPlaceholder(skill) {
-		content += "\nARGUMENTS: " + args
-	}
-	return content
+	return ExpandTemplate(skill.Body, skill.Arguments, args, workspace, filepath.Dir(skill.FilePath))
 }

--- a/internal/skills/interpolate.go
+++ b/internal/skills/interpolate.go
@@ -57,19 +57,18 @@ func Interpolate(body string, vars map[string]string) string {
 	return result
 }
 
-// hasArgPlaceholder reports whether a skill body references any argument
-// placeholder: $ARGUMENTS, a positional $N, or a named argument declared in
-// the skill's frontmatter arguments field.
-func hasArgPlaceholder(skill *Skill) bool {
-	body := skill.Body
+// HasArgPlaceholder reports whether a prompt-template body references any
+// argument placeholder: $ARGUMENTS, a positional $N, or a named argument in
+// namedArgs.
+func HasArgPlaceholder(body string, namedArgs []string) bool {
 	if strings.Contains(body, "$ARGUMENTS") || positionalVarPattern.MatchString(body) {
 		return true
 	}
-	if len(skill.Arguments) == 0 {
+	if len(namedArgs) == 0 {
 		return false
 	}
-	declared := make(map[string]bool, len(skill.Arguments))
-	for _, name := range skill.Arguments {
+	declared := make(map[string]bool, len(namedArgs))
+	for _, name := range namedArgs {
 		declared["$"+name] = true
 	}
 	for _, ref := range namedVarPattern.FindAllString(body, -1) {
@@ -78,4 +77,11 @@ func hasArgPlaceholder(skill *Skill) bool {
 		}
 	}
 	return false
+}
+
+// hasArgPlaceholder reports whether a skill body references any argument
+// placeholder: $ARGUMENTS, a positional $N, or a named argument declared in
+// the skill's frontmatter arguments field.
+func hasArgPlaceholder(skill *Skill) bool {
+	return HasArgPlaceholder(skill.Body, skill.Arguments)
 }

--- a/internal/skills/template_test.go
+++ b/internal/skills/template_test.go
@@ -1,0 +1,100 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+// ExpandTemplate is the shared argument-expansion engine for skill invocation
+// and bundle markdown commands (epic #821 slice 4). These tests pin the
+// exported contract; the existing hook/resolver tests pin the delegating
+// wrappers.
+
+func TestExpandTemplate_PositionalAndBuiltinVars(t *testing.T) {
+	body := "First: $0. Second: $1. Missing: $5. All: $ARGUMENTS. Workspace: $WORKSPACE. Dir: $SKILL_DIR. Shell var: $HOME."
+	got := ExpandTemplate(body, nil, `one "two words"`, "/ws", "/bundles/demo/commands")
+	want := `First: one. Second: two words. Missing: . All: one "two words". Workspace: /ws. Dir: /bundles/demo/commands. Shell var: $HOME.`
+	if got != want {
+		t.Fatalf("ExpandTemplate() =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestExpandTemplate_NamedArgumentsBindInDeclarationOrder(t *testing.T) {
+	got := ExpandTemplate("Hello $who, you are $mood.", []string{"who", "mood"}, "world", "/ws", "/dir")
+	want := "Hello world, you are ."
+	if got != want {
+		t.Fatalf("ExpandTemplate() = %q, want %q", got, want)
+	}
+}
+
+func TestExpandTemplate_ArgumentsFallback(t *testing.T) {
+	t.Run("appends raw args when no placeholder is referenced", func(t *testing.T) {
+		got := ExpandTemplate("Summarize the notes.", nil, "these specific notes", "/ws", "/dir")
+		want := "Summarize the notes.\nARGUMENTS: these specific notes"
+		if got != want {
+			t.Fatalf("ExpandTemplate() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no fallback line without args", func(t *testing.T) {
+		if got := ExpandTemplate("Summarize.", nil, "", "/ws", "/dir"); got != "Summarize." {
+			t.Fatalf("ExpandTemplate() = %q", got)
+		}
+	})
+
+	t.Run("no fallback when a placeholder is referenced", func(t *testing.T) {
+		got := ExpandTemplate("Summarize $ARGUMENTS.", nil, "x", "/ws", "/dir")
+		if got != "Summarize x." {
+			t.Fatalf("ExpandTemplate() = %q", got)
+		}
+	})
+
+	t.Run("no fallback when a declared named argument is referenced", func(t *testing.T) {
+		got := ExpandTemplate("Summarize $topic.", []string{"topic"}, "x", "/ws", "/dir")
+		if got != "Summarize x." {
+			t.Fatalf("ExpandTemplate() = %q", got)
+		}
+	})
+}
+
+func TestHasArgPlaceholder(t *testing.T) {
+	cases := []struct {
+		body      string
+		namedArgs []string
+		want      bool
+	}{
+		{"$ARGUMENTS here", nil, true},
+		{"positional $2", nil, true},
+		{"plain text", nil, false},
+		{"uses $topic", []string{"topic"}, true},
+		{"uses $other", []string{"topic"}, false},
+		{"shell $HOME", nil, false},
+	}
+	for _, tc := range cases {
+		if got := HasArgPlaceholder(tc.body, tc.namedArgs); got != tc.want {
+			t.Errorf("HasArgPlaceholder(%q, %v) = %t, want %t", tc.body, tc.namedArgs, got, tc.want)
+		}
+	}
+}
+
+func TestBuildTemplateVars(t *testing.T) {
+	vars := BuildTemplateVars([]string{"who"}, `world "bright new"`, "/ws", "/dir")
+	for key, want := range map[string]string{
+		"$ARGUMENTS": `world "bright new"`,
+		"$0":         "world",
+		"$1":         "bright new",
+		"$who":       "world",
+		"$WORKSPACE": "/ws",
+		"$SKILL_DIR": "/dir",
+	} {
+		if vars[key] != want {
+			t.Errorf("vars[%q] = %q, want %q", key, vars[key], want)
+		}
+	}
+	if _, ok := vars["$2"]; ok {
+		t.Errorf("unexpected $2 binding: %q", vars["$2"])
+	}
+	if !strings.HasPrefix(vars["$ARGUMENTS"], "world") {
+		t.Errorf("$ARGUMENTS = %q", vars["$ARGUMENTS"])
+	}
+}


### PR DESCRIPTION
Parent epic: #821. Part of #803.