### PR TITLE
feat(tui): live swarm progress panel with per-member status

### DIFF
--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -118,6 +118,9 @@ type RemoteSubagent struct {
 	BaseRef          string `json:"base_ref,omitempty"`
 	Output           string `json:"output,omitempty"`
 	Error            string `json:"error,omitempty"`
+	// CreatedAt is the subagent creation time reported by the server; used by
+	// the swarm panel to match members to a swarm's creation window.
+	CreatedAt time.Time `json:"created_at,omitempty"`
 }
 
 // RemoteTask is one entry of the GET /v1/tasks union (epic #814): a single
@@ -527,6 +530,21 @@ func loadSubagentsCmd(baseURL, apiKey string) tea.Cmd {
 			return SubagentsLoadFailedMsg{Err: err.Error()}
 		}
 		return SubagentsLoadedMsg{Subagents: payload.Subagents}
+	}
+}
+
+// pollSwarmSubagentsCmd fetches /v1/subagents for the swarm panel's poll
+// loop and marks the resulting message so the update handler refreshes the
+// live panel in place (see SubagentsLoadedMsg.SwarmPoll).
+func pollSwarmSubagentsCmd(baseURL, apiKey string) tea.Cmd {
+	fetch := loadSubagentsCmd(baseURL, apiKey)
+	return func() tea.Msg {
+		msg := fetch()
+		if loaded, ok := msg.(SubagentsLoadedMsg); ok {
+			loaded.SwarmPoll = true
+			return loaded
+		}
+		return msg
 	}
 }
 

--- a/cmd/harnesscli/tui/api_coverage_test.go
+++ b/cmd/harnesscli/tui/api_coverage_test.go
@@ -170,7 +170,7 @@ func TestStartRunCmdSetsAllowFallback(t *testing.T) {
 func TestFormatSubagentsLinesRendersSummaryAndDetails(t *testing.T) {
 	t.Parallel()
 
-	if got := formatSubagentsLines(nil); len(got) != 1 || got[0] != "No managed subagents." {
+	if got := formatSubagentsLines(nil, nil); len(got) != 1 || got[0] != "No managed subagents." {
 		t.Fatalf("unexpected empty-state lines: %v", got)
 	}
 
@@ -183,7 +183,7 @@ func TestFormatSubagentsLinesRendersSummaryAndDetails(t *testing.T) {
 		BranchName:       "codex/coverage-fix",
 		BaseRef:          "main",
 		WorkspacePath:    "/tmp/sub-1",
-	}})
+	}}, nil)
 	joined := strings.Join(lines, "\n")
 
 	if !strings.Contains(joined, "sub-1 [completed] worktree (destroy) cleaned") {

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -157,7 +157,14 @@ type ModelSelectedMsg struct {
 	ReasoningEffort string // "" | "low" | "medium" | "high"
 }
 
-type SubagentsLoadedMsg struct{ Subagents []RemoteSubagent }
+// SubagentsLoadedMsg carries the GET /v1/subagents listing. SwarmPoll marks
+// responses to the swarm panel's poll loop (as opposed to a user-invoked
+// /subagents listing) so the update handler refreshes the live panel in
+// place instead of appending a new listing.
+type SubagentsLoadedMsg struct {
+	Subagents []RemoteSubagent
+	SwarmPoll bool
+}
 
 type SubagentsLoadFailedMsg struct{ Err string }
 

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -395,6 +395,10 @@ type Model struct {
 	// (e.g. load errors, name collisions with builtins).
 	pluginWarnings []string
 	pluginBrowser  pluginBrowserState
+
+	// swarm tracks the current run's agent_swarm call (epic #808 slice 4) so
+	// the /subagents view can group and live-update swarm members.
+	swarm swarmTracker
 }
 
 // New creates a new root Model.
@@ -974,6 +978,12 @@ func runPluginCommandCmd(entry CommandEntry, cmd Command) tea.Cmd {
 }
 
 // statusTickCmd returns a tea.Cmd that fires statusTickMsg after duration d.
+// swarmPollTickCmd schedules the next swarm panel poll (1s cadence while a
+// swarm is active).
+func swarmPollTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(time.Time) tea.Msg { return SwarmPollTickMsg{} })
+}
+
 func statusTickCmd(d time.Duration) tea.Cmd {
 	return tea.Tick(d, func(time.Time) tea.Msg { return statusTickMsg{} })
 }
@@ -3611,11 +3621,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.input = m.input.SetValue(edited)
 
 	case SubagentsLoadedMsg:
-		for _, line := range formatSubagentsLines(msg.Subagents) {
+		if msg.SwarmPoll {
+			// Swarm poll response: refresh the live panel in place. A stale
+			// response after completion is ignored (the panel is frozen).
+			if m.swarm.active {
+				panel := m.swarm.resolvePanel(msg.Subagents)
+				m.renderSwarmPanel(panel)
+				if swarmPanelAllTerminal(panel) {
+					m.swarm.active = false
+				}
+			}
+			break
+		}
+		var panel *swarmPanel
+		if m.swarm.hasData() {
+			p := m.swarm.resolvePanel(msg.Subagents)
+			panel = &p
+		}
+		for _, line := range formatSubagentsLines(msg.Subagents, panel) {
 			m.vp.AppendLine(line)
 		}
 		m.vp.AppendLine("")
 		cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Loaded %d subagent(s)", len(msg.Subagents))))
+
+	case SwarmPollTickMsg:
+		// Poll loop (epic #808 slice 4): refresh while the swarm is active,
+		// then re-tick. Completion or all-terminal members stops the loop.
+		if m.swarm.active {
+			cmds = append(cmds,
+				pollSwarmSubagentsCmd(m.config.BaseURL, m.config.APIKey),
+				swarmPollTickCmd(),
+			)
+		}
 
 	case SubagentsLoadFailedMsg:
 		cmds = append(cmds, m.setStatusMsg("Load subagents failed: "+msg.Err))
@@ -3761,6 +3798,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if err := json.Unmarshal(msg.Raw, &p); err == nil {
 				m.handleToolStart(p.CallID, p.Tool, p.Arguments)
+				if p.Tool == swarmToolName {
+					cmds = append(cmds, m.startSwarmTracking(p.CallID, p.Arguments)...)
+				}
 			}
 		case "tool.output.delta":
 			var p struct {
@@ -3784,6 +3824,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.handleToolError(p.CallID, p.Error, p.DurationMS)
 				} else {
 					m.handleToolResult(p.CallID, p.Output, p.DurationMS)
+				}
+				if p.Tool == swarmToolName {
+					m.completeSwarmTracking(p.CallID, p.Output)
 				}
 			}
 		case "tool.approval_required":
@@ -4513,12 +4556,70 @@ func formatTUIRunLines(runs []tuiRunRecord) []string {
 	return lines
 }
 
-func formatSubagentsLines(items []RemoteSubagent) []string {
+// startSwarmTracking begins tracking an agent_swarm call: parse the item
+// list, render the initial all-pending panel, and kick the poll loop.
+func (m *Model) startSwarmTracking(callID string, args json.RawMessage) []tea.Cmd {
+	items, resumeIDs := parseSwarmToolArgs(unwrapToolInput(args))
 	if len(items) == 0 {
+		return nil
+	}
+	m.swarm = swarmTracker{
+		active:      true,
+		callID:      callID,
+		items:       items,
+		resumeCount: len(resumeIDs),
+		startedAt:   time.Now(),
+		panelStart:  -1,
+	}
+	m.renderSwarmPanel(m.swarm.resolvePanel(nil))
+	return []tea.Cmd{
+		pollSwarmSubagentsCmd(m.config.BaseURL, m.config.APIKey),
+		swarmPollTickCmd(),
+	}
+}
+
+// completeSwarmTracking freezes the panel with the exact member statuses from
+// the aggregated report and stops the poll loop.
+func (m *Model) completeSwarmTracking(callID, output string) {
+	if !m.swarm.active || m.swarm.callID != callID {
+		return
+	}
+	m.swarm.active = false
+	if members := parseSwarmReport(output); members != nil {
+		m.swarm.report = members
+		m.swarm.reportSet = true
+	}
+	m.renderSwarmPanel(m.swarm.resolvePanel(nil))
+}
+
+// renderSwarmPanel writes the panel into the viewport, replacing the previous
+// block in place when one is already rendered. While the swarm runs the
+// parent run is blocked inside the tool call, so nothing interleaves into
+// the panel's line range; the block freezes once the swarm completes.
+func (m *Model) renderSwarmPanel(panel swarmPanel) {
+	lines := formatSwarmPanelLines(panel)
+	if m.swarm.panelCount > 0 && m.swarm.panelStart >= 0 {
+		m.vp.ReplaceLineRange(m.swarm.panelStart, m.swarm.panelCount, lines)
+	} else {
+		m.swarm.panelStart = m.vp.LineCount()
+		m.vp.AppendLines(lines)
+	}
+	m.swarm.panelCount = len(lines)
+}
+
+func formatSubagentsLines(items []RemoteSubagent, panel *swarmPanel) []string {
+	lines := []string{}
+	if panel != nil && len(panel.Members) > 0 {
+		lines = append(lines, formatSwarmPanelLines(*panel)...)
+		lines = append(lines, "")
+	}
+	if len(items) == 0 {
+		if len(lines) > 0 {
+			return append(lines, "No other managed subagents.")
+		}
 		return []string{"No managed subagents."}
 	}
 
-	lines := make([]string, 0, len(items)*2)
 	for _, item := range items {
 		summary := fmt.Sprintf("%s [%s] %s (%s)", item.ID, item.Status, item.Isolation, item.CleanupPolicy)
 		if item.WorkspaceCleaned {

--- a/cmd/harnesscli/tui/swarm_panel.go
+++ b/cmd/harnesscli/tui/swarm_panel.go
@@ -1,0 +1,179 @@
+package tui
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// swarmToolName is the wire name of the swarm fan-out tool (kept as a local
+// literal the same way the SSE switch matches event types as literals).
+const swarmToolName = "agent_swarm"
+
+// swarmMemberCap is the hard cap on swarm members from the agent_swarm tool
+// contract (subagents.SwarmMaxMembers). Duplicated as a literal to avoid a
+// TUI -> subagents package dependency for one constant.
+const swarmMemberCap = 128
+
+// swarmMatchSkew is the small margin subtracted from the swarm start time
+// when matching member subagents by creation window, absorbing clock jitter
+// between the tool-call event and subagent creation.
+const swarmMatchSkew = 2 * time.Second
+
+// SwarmPollTickMsg drives the /v1/subagents poll loop while a swarm is active.
+type SwarmPollTickMsg struct{}
+
+// swarmPanelMember is one rendered swarm member row.
+type swarmPanelMember struct {
+	Item   string
+	ID     string
+	Status string
+}
+
+// swarmPanel is the view model for the live swarm section: a summary line
+// plus one row per member.
+type swarmPanel struct {
+	Active  bool
+	Members []swarmPanelMember
+}
+
+// swarmTracker tracks the current run's in-flight (or most recently
+// completed) agent_swarm call so the /subagents view can group and live-update
+// its members. agent_swarm is a sole-call, blocking tool, so at most one
+// swarm per run is ever active.
+type swarmTracker struct {
+	active      bool
+	callID      string
+	items       []string
+	resumeCount int
+	startedAt   time.Time
+	// report holds the exact members parsed from the aggregated report once
+	// the tool call completes; until then members are matched heuristically.
+	report    []swarmPanelMember
+	reportSet bool
+	// panelStart/panelCount locate the live panel block in the viewport so
+	// poll refreshes replace it in place instead of appending duplicates.
+	panelStart int
+	panelCount int
+}
+
+// hasData reports whether the tracker holds anything renderable.
+func (t *swarmTracker) hasData() bool {
+	return len(t.items) > 0 || t.reportSet
+}
+
+// resolvePanel builds the panel view model. Before the aggregated report
+// arrives, members are matched by creation window in schedule order (item i
+// pairs with the i-th subagent created after the swarm started); resume
+// entries render as "resumed" until the report provides exact statuses.
+func (t *swarmTracker) resolvePanel(remote []RemoteSubagent) swarmPanel {
+	p := swarmPanel{Active: t.active}
+	if t.reportSet {
+		p.Members = append([]swarmPanelMember(nil), t.report...)
+		return p
+	}
+	candidates := make([]RemoteSubagent, 0, len(t.items))
+	for _, sa := range remote {
+		if sa.CreatedAt.IsZero() {
+			continue
+		}
+		if sa.CreatedAt.Before(t.startedAt.Add(-swarmMatchSkew)) {
+			continue
+		}
+		candidates = append(candidates, sa)
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].CreatedAt.Before(candidates[j].CreatedAt) })
+
+	p.Members = make([]swarmPanelMember, 0, len(t.items))
+	for i, item := range t.items {
+		m := swarmPanelMember{Item: item, Status: "pending"}
+		switch {
+		case i < t.resumeCount:
+			// Resumed members are pre-existing subagents; creation-window
+			// matching cannot see them, and the exact status arrives with
+			// the aggregated report.
+			m.Status = "resumed"
+		default:
+			if cand := i - t.resumeCount; cand < len(candidates) {
+				m.ID = candidates[cand].ID
+				m.Status = candidates[cand].Status
+			}
+		}
+		p.Members = append(p.Members, m)
+	}
+	return p
+}
+
+// formatSwarmPanelLines renders the summary line and per-member rows.
+func formatSwarmPanelLines(p swarmPanel) []string {
+	launched, completed := 0, 0
+	for _, m := range p.Members {
+		if m.ID != "" {
+			launched++
+		}
+		if m.Status == "completed" {
+			completed++
+		}
+	}
+	lines := []string{
+		fmt.Sprintf("Swarm: %d launched, %d/%d completed (cap %d)", launched, completed, len(p.Members), swarmMemberCap),
+	}
+	for _, m := range p.Members {
+		row := fmt.Sprintf("  [%-9s] %s", m.Status, m.Item)
+		if m.ID != "" {
+			row += " (" + m.ID + ")"
+		}
+		lines = append(lines, row)
+	}
+	return lines
+}
+
+// swarmPanelAllTerminal reports whether every member reached a terminal
+// state, which stops the poll loop even without the tool-call completion.
+func swarmPanelAllTerminal(p swarmPanel) bool {
+	if len(p.Members) == 0 {
+		return false
+	}
+	for _, m := range p.Members {
+		switch m.Status {
+		case "completed", "failed", "cancelled":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// parseSwarmToolArgs extracts items and resume_agent_ids from agent_swarm
+// call arguments (already unwrapped by the caller's handleToolStart path).
+func parseSwarmToolArgs(args json.RawMessage) (items []string, resumeIDs []string) {
+	var parsed struct {
+		Items          []string `json:"items"`
+		ResumeAgentIDs []string `json:"resume_agent_ids"`
+	}
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return nil, nil
+	}
+	return parsed.Items, parsed.ResumeAgentIDs
+}
+
+// parseSwarmReport extracts per-member results from the aggregated report
+// JSON returned by the agent_swarm tool call.
+func parseSwarmReport(output string) []swarmPanelMember {
+	var report struct {
+		Members []struct {
+			ID     string `json:"id"`
+			Item   string `json:"item"`
+			Status string `json:"status"`
+		} `json:"members"`
+	}
+	if err := json.Unmarshal([]byte(output), &report); err != nil || len(report.Members) == 0 {
+		return nil
+	}
+	members := make([]swarmPanelMember, 0, len(report.Members))
+	for _, m := range report.Members {
+		members = append(members, swarmPanelMember{Item: m.Item, ID: m.ID, Status: m.Status})
+	}
+	return members
+}

--- a/cmd/harnesscli/tui/swarm_panel_internal_test.go
+++ b/cmd/harnesscli/tui/swarm_panel_internal_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatSwarmPanelLinesMultiStatus(t *testing.T) {
+	t.Parallel()
+
+	p := swarmPanel{
+		Active: true,
+		Members: []swarmPanelMember{
+			{Item: "alpha", ID: "sub-1", Status: "completed"},
+			{Item: "beta", ID: "sub-2", Status: "running"},
+			{Item: "gamma", Status: "pending"},
+			{Item: "delta", ID: "sub-4", Status: "failed"},
+		},
+	}
+	lines := formatSwarmPanelLines(p)
+	want := []string{
+		"Swarm: 3 launched, 1/4 completed (cap 128)",
+		"  [completed] alpha (sub-1)",
+		"  [running  ] beta (sub-2)",
+		"  [pending  ] gamma",
+		"  [failed   ] delta (sub-4)",
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("lines = %v, want %v", lines, want)
+	}
+	for i := range want {
+		if lines[i] != want[i] {
+			t.Fatalf("line %d = %q, want %q (all: %v)", i, lines[i], want[i], lines)
+		}
+	}
+}
+
+func TestResolveSwarmPanelMatchesByCreationWindow(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	tr := &swarmTracker{
+		active:    true,
+		items:     []string{"a", "b", "c"},
+		startedAt: start,
+	}
+	remote := []RemoteSubagent{
+		// Created before the swarm started: not a member.
+		{ID: "old", Status: "completed", CreatedAt: start.Add(-time.Minute)},
+		// Members, deliberately out of order to prove CreatedAt sorting.
+		{ID: "s2", Status: "completed", CreatedAt: start.Add(2 * time.Second)},
+		{ID: "s1", Status: "running", CreatedAt: start.Add(time.Second)},
+	}
+	p := tr.resolvePanel(remote)
+	if !p.Active {
+		t.Fatal("panel Active = false, want true")
+	}
+	if len(p.Members) != 3 {
+		t.Fatalf("members = %d, want 3", len(p.Members))
+	}
+	want := []swarmPanelMember{
+		{Item: "a", ID: "s1", Status: "running"},
+		{Item: "b", ID: "s2", Status: "completed"},
+		{Item: "c", ID: "", Status: "pending"},
+	}
+	for i, w := range want {
+		if p.Members[i] != w {
+			t.Errorf("member %d = %+v, want %+v", i, p.Members[i], w)
+		}
+	}
+}
+
+func TestResolveSwarmPanelResumeEntries(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	tr := &swarmTracker{
+		active:      true,
+		items:       []string{"a", "b"},
+		resumeCount: 1,
+		startedAt:   start,
+	}
+	remote := []RemoteSubagent{
+		{ID: "s1", Status: "running", CreatedAt: start.Add(time.Second)},
+	}
+	p := tr.resolvePanel(remote)
+	if len(p.Members) != 2 {
+		t.Fatalf("members = %d, want 2", len(p.Members))
+	}
+	if p.Members[0].Status != "resumed" || p.Members[0].ID != "" {
+		t.Errorf("resume entry = %+v, want status resumed with no id pre-report", p.Members[0])
+	}
+	if p.Members[1].ID != "s1" || p.Members[1].Status != "running" {
+		t.Errorf("new entry = %+v, want s1 running", p.Members[1])
+	}
+}
+
+func TestResolveSwarmPanelReportSetUsesExactMembers(t *testing.T) {
+	t.Parallel()
+
+	tr := &swarmTracker{
+		items: []string{"a"},
+		report: []swarmPanelMember{
+			{Item: "a", ID: "sub-9", Status: "failed"},
+		},
+		reportSet: true,
+	}
+	p := tr.resolvePanel(nil)
+	if len(p.Members) != 1 || p.Members[0].ID != "sub-9" || p.Members[0].Status != "failed" {
+		t.Fatalf("members = %+v, want exact report member sub-9 failed", p.Members)
+	}
+}
+
+func TestFormatSubagentsLinesNoSwarmRegression(t *testing.T) {
+	t.Parallel()
+
+	if got := formatSubagentsLines(nil, nil); len(got) != 1 || got[0] != "No managed subagents." {
+		t.Fatalf("empty listing = %v, want [No managed subagents.]", got)
+	}
+
+	items := []RemoteSubagent{{ID: "sub-1", Status: "running", Isolation: "inline", CleanupPolicy: "preserve"}}
+	got := formatSubagentsLines(items, nil)
+	if len(got) != 1 || got[0] != "sub-1 [running] inline (preserve)" {
+		t.Fatalf("listing = %v, want legacy single-line format", got)
+	}
+}
+
+func TestFormatSubagentsLinesWithSwarmGroup(t *testing.T) {
+	t.Parallel()
+
+	panel := &swarmPanel{Members: []swarmPanelMember{
+		{Item: "alpha", ID: "sub-1", Status: "completed"},
+		{Item: "beta", Status: "pending"},
+	}}
+	items := []RemoteSubagent{{ID: "other", Status: "queued", Isolation: "inline", CleanupPolicy: "preserve"}}
+	got := formatSubagentsLines(items, panel)
+
+	if len(got) < 5 {
+		t.Fatalf("listing too short: %v", got)
+	}
+	if got[0] != "Swarm: 1 launched, 1/2 completed (cap 128)" {
+		t.Errorf("summary line = %q", got[0])
+	}
+	if got[1] != "  [completed] alpha (sub-1)" || got[2] != "  [pending  ] beta" {
+		t.Errorf("member rows = %q, %q", got[1], got[2])
+	}
+	// The regular listing follows the swarm group.
+	last := got[len(got)-1]
+	if last != "other [queued] inline (preserve)" {
+		t.Errorf("last line = %q, want regular subagent entry", last)
+	}
+}

--- a/cmd/harnesscli/tui/swarm_panel_test.go
+++ b/cmd/harnesscli/tui/swarm_panel_test.go
@@ -1,0 +1,187 @@
+package tui_test
+
+// swarm_panel_test.go — epic #808 slice 4: the /subagents live swarm panel.
+// Drives the public model surface: agent_swarm tool events start/stop the
+// tracked panel, poll responses update it in place, and completion freezes
+// it with the exact aggregated statuses.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tui "go-agent-harness/cmd/harnesscli/tui"
+)
+
+func countOccurrences(haystack, needle string) int {
+	return strings.Count(haystack, needle)
+}
+
+func TestAgentSwarmLivePanelFlow(t *testing.T) {
+	m := initModel(t, 120, 40)
+	m = m.WithCancelRun(func() {})
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-swarm-1"})
+	model := m2.(tui.Model)
+
+	// The model calls agent_swarm with two items: the panel appears with both
+	// items pending.
+	m3, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.started",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","arguments":{"prompt_template":"do {{item}}","items":["alpha","beta"]}}`),
+	})
+	model = m3.(tui.Model)
+	view := model.View()
+	if !strings.Contains(view, "Swarm:") {
+		t.Fatalf("view has no swarm panel after agent_swarm start:\n%s", view)
+	}
+	if !strings.Contains(view, "alpha") || !strings.Contains(view, "beta") {
+		t.Fatalf("panel missing item labels:\n%s", view)
+	}
+
+	// A poll response matches the first member by creation window; the panel
+	// updates in place (still exactly one block).
+	m4, _ := model.Update(tui.SubagentsLoadedMsg{
+		SwarmPoll: true,
+		Subagents: []tui.RemoteSubagent{
+			{ID: "sub-1", Status: "running", Isolation: "inline", CleanupPolicy: "preserve", CreatedAt: time.Now().Add(2 * time.Second)},
+		},
+	})
+	model = m4.(tui.Model)
+	view = model.View()
+	if !strings.Contains(view, "running") || !strings.Contains(view, "sub-1") {
+		t.Fatalf("panel did not pick up the running member:\n%s", view)
+	}
+	if got := countOccurrences(view, "Swarm:"); got != 1 {
+		t.Fatalf("view contains %d swarm panels, want exactly 1 (in-place update):\n%s", got, view)
+	}
+
+	// Completion delivers the aggregated report: exact statuses, and the
+	// panel freezes.
+	report := `{"members":[` +
+		`{"id":"sub-1","item":"alpha","prompt":"do alpha","status":"completed","output":"done"},` +
+		`{"id":"sub-2","item":"beta","prompt":"do beta","status":"failed","error":"boom"}` +
+		`],"total":2,"completed":1,"failed":1}`
+	m5, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.completed",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","output":` + jsonString(report) + `}`),
+	})
+	model = m5.(tui.Model)
+	view = model.View()
+	if !strings.Contains(view, "[completed]") || !strings.Contains(view, "[failed") {
+		t.Fatalf("panel missing exact report statuses:\n%s", view)
+	}
+	if !strings.Contains(view, "sub-2") {
+		t.Fatalf("panel missing the failed member's id from the report:\n%s", view)
+	}
+	if got := countOccurrences(view, "Swarm:"); got != 1 {
+		t.Fatalf("view contains %d swarm panels after completion, want 1:\n%s", got, view)
+	}
+
+	// A stale poll after completion must not resurrect or duplicate the panel.
+	m6, _ := model.Update(tui.SubagentsLoadedMsg{SwarmPoll: true})
+	model = m6.(tui.Model)
+	if got := countOccurrences(model.View(), "Swarm:"); got != 1 {
+		t.Fatalf("stale poll changed the frozen panel (count %d):\n%s", got, model.View())
+	}
+}
+
+// TestAgentSwarmPollTickStopsWithSwarm verifies the poll loop only ticks
+// while a swarm is active.
+func TestAgentSwarmPollTickStopsWithSwarm(t *testing.T) {
+	m := initModel(t, 120, 40)
+	m = m.WithCancelRun(func() {})
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-swarm-2"})
+	model := m2.(tui.Model)
+
+	// No swarm active: the tick is a no-op.
+	_, cmd := model.Update(tui.SwarmPollTickMsg{})
+	if cmd != nil {
+		t.Fatal("tick without an active swarm returned commands, want nil")
+	}
+
+	// Start a swarm: the tick must schedule a poll and the next tick.
+	m3, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.started",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","arguments":{"prompt_template":"do {{item}}","items":["a"]}}`),
+	})
+	model = m3.(tui.Model)
+	_, cmd = model.Update(tui.SwarmPollTickMsg{})
+	if cmd == nil {
+		t.Fatal("tick with an active swarm returned nil, want poll + re-tick")
+	}
+
+	// Complete it: the tick stops.
+	report := `{"members":[{"id":"sub-1","item":"a","prompt":"do a","status":"completed"}],"total":1,"completed":1}`
+	m4, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.completed",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","output":` + jsonString(report) + `}`),
+	})
+	model = m4.(tui.Model)
+	_, cmd = model.Update(tui.SwarmPollTickMsg{})
+	if cmd != nil {
+		t.Fatal("tick after swarm completion returned commands, want nil")
+	}
+}
+
+// TestSubagentsListingGroupsSwarm verifies the user-invoked /subagents
+// listing embeds the swarm group when a swarm is tracked, and omits it when
+// nothing was ever tracked.
+func TestSubagentsListingGroupsSwarm(t *testing.T) {
+	m := initModel(t, 120, 40)
+	m = m.WithCancelRun(func() {})
+	m2, _ := m.Update(tui.RunStartedMsg{RunID: "run-swarm-3"})
+	model := m2.(tui.Model)
+
+	// Plain listing with no swarm tracked: no swarm section.
+	m3, _ := model.Update(tui.SubagentsLoadedMsg{
+		Subagents: []tui.RemoteSubagent{{ID: "other", Status: "queued", Isolation: "inline", CleanupPolicy: "preserve"}},
+	})
+	model = m3.(tui.Model)
+	if strings.Contains(model.View(), "Swarm:") {
+		t.Fatalf("listing shows a swarm group with nothing tracked:\n%s", model.View())
+	}
+
+	// Track a swarm and complete it so the tracker holds exact members.
+	m4, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.started",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","arguments":{"prompt_template":"do {{item}}","items":["alpha"]}}`),
+	})
+	model = m4.(tui.Model)
+	report := `{"members":[{"id":"sub-1","item":"alpha","prompt":"do alpha","status":"completed"}],"total":1,"completed":1}`
+	m5, _ := model.Update(tui.SSEEventMsg{
+		EventType: "tool.call.completed",
+		Raw:       []byte(`{"tool":"agent_swarm","call_id":"c1","output":` + jsonString(report) + `}`),
+	})
+	model = m5.(tui.Model)
+
+	// A user-invoked listing afterwards groups the swarm members.
+	m6, _ := model.Update(tui.SubagentsLoadedMsg{
+		Subagents: []tui.RemoteSubagent{{ID: "other", Status: "queued", Isolation: "inline", CleanupPolicy: "preserve"}},
+	})
+	model = m6.(tui.Model)
+	view := model.View()
+	if !strings.Contains(view, "Swarm:") || !strings.Contains(view, "[completed] alpha (sub-1)") {
+		t.Fatalf("listing missing the swarm group:\n%s", view)
+	}
+	if !strings.Contains(view, "other [queued]") {
+		t.Fatalf("listing missing the regular subagent entry:\n%s", view)
+	}
+}
+
+// jsonString wraps s as a JSON string literal (for embedding in event payloads).
+func jsonString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -36,6 +36,34 @@
 - Collision rule: plain name if free, else `<bundle>:<name>`, else skip — namespacings and skips surface through the plugin warnings slice. JSON `PluginDef` files in bundle `commands/` dirs keep loading through the unchanged legacy path; untrusted/disabled bundles contribute nothing (TrustedBundles gating, pinned by `installablePluginCommandSources` tests).
 - TDD: failing-first tests cover the exported expansion contract, frontmatter parse/validation matrix, loader file handling, registration + namespacing + double-collision skip, trust gating, and the end-to-end submission.
 
+## 2026-07-21 (Agent Swarm — Epic #808, Slice 4)
+
+- Added the TUI live swarm progress panel (`cmd/harnesscli/tui/swarm_panel.go`):
+  the model's `agent_swarm` tool call is tracked from SSE events
+  (`tool.call.started` parses the item list, `tool.call.completed` parses the
+  aggregated report), and a grouped panel renders in the viewport with a
+  summary line (launched/completed counts, cap 128) plus per-member
+  pending/running/completed/failed rows with the item label.
+- Poll loop: while a swarm is active, `/v1/subagents` is re-fetched every 1s
+  (`SwarmPollTickMsg`); poll responses refresh the panel block in place
+  (keyed line-range replacement) and stop on completion or when every member
+  is terminal. No server changes: `RemoteSubagent` only gained the
+  already-sent `created_at` field for creation-window member matching.
+- Before the report arrives, members are matched to items by creation window
+  in schedule order (resumed entries render as `resumed`); the aggregated
+  report at completion replaces the heuristic with exact member IDs/statuses.
+  Single-run tracking is sound because agent_swarm is sole-call and blocks
+  the parent run.
+- `/subagents` listing groups the swarm section first via an extended
+  `formatSubagentsLines(items, panel)`; no-swarm output is unchanged.
+- TDD: internal rendering/matching tests (multi-status rows, creation window,
+  resume entries, exact report members, grouping, no-swarm regression) and an
+  external SSE-flow test (panel appears, updates in place on poll, freezes
+  with exact statuses, stale poll ignored, tick starts/stops) landed first
+  and failed on undefined symbols before implementation.
+- Validation: `go test ./cmd/harnesscli/... -count=1` (29 packages) and
+  `-race` green; full regression suite (see PR body).
+
 ## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
 
 - Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.

--- a/docs/plans/808-agent-swarm.md
+++ b/docs/plans/808-agent-swarm.md
@@ -1,4 +1,4 @@
-# Plan: agent_swarm epic #808 — Slices 1–3
+# Plan: agent_swarm epic #808 — Slices 1–4
 
 ## Context
 
@@ -8,65 +8,52 @@
 - User impact: the model must loop `start_subagent`/`wait_subagent` by hand,
   which is slow, error-prone, and burns turns.
 - Constraints: reuse `internal/subagents` Manager + `tools.SubagentManager`
-  (`InlineManager`); strict TDD. Slice 1 (core `Swarm`) merged via PR #839,
-  Slice 2 (resume) via PR #867. This PR covers ONLY Slice 3 (the deferred
-  tool, policy integration, and sole-call rule).
+  (`InlineManager`); strict TDD. Slices 1–3 merged via PRs #839, #867, #899.
+  This PR covers ONLY Slice 4 (TUI live swarm progress panel).
 
 ## Scope
 
-- In scope (Slice 3):
-  - Mirror types + `SwarmRunner` interface + `AgentSwarmToolName` const in
-    `internal/harness/tools` (import-cycle-safe, same pattern as
-    `SubagentManager`); adapter `NewToolSwarmRunner` in `internal/subagents`.
-  - New `internal/harness/tools/deferred/agent_swarm.go`: `TierDeferred`,
-    `ActionExecute`, `Mutating: true`; params `prompt_template`, `items`,
-    `resume_agent_ids` + profile/model overrides; returns the report via
-    `MarshalToolResult`.
-  - Description `internal/harness/tools/descriptions/agent_swarm.md`
-    (sole-call rule, 128 cap, 5→+1/700ms ramp, env cap, resume semantics).
-  - Registration in `internal/harness/tools_default.go` via new
-    `AgentSwarmRunner` option; wired in `cmd/harnessd/runtime_container.go`.
-  - Member exclusion: per-run `DeniedTools` plumbed `tools.SubagentRequest` →
-    `subagents.Request` → `harness.RunRequest` → runState; enforced in
-    `filteredToolsForRun` (never offered) and in the step-engine call gate
-    (call blocked). The swarm sets it on every member.
-  - Runner sole-call rule in `runner_step_engine.go`: a response containing
-    `agent_swarm` plus any other call executes the (first) swarm call and
-    rejects the extras with a corrective error naming the rule.
-- Out of scope: TUI panel (Slice 4), new server endpoints.
+- In scope (Slice 4):
+  - Track the current run's `agent_swarm` tool call from SSE events
+    (`tool.call.started` → items from arguments; `tool.call.completed` →
+    exact member report) in a `swarmTracker` on the TUI model.
+  - Live grouped panel in the viewport: summary line (launched/completed
+    counts + cap 128) and per-member pending/running/completed/failed rows
+    with the item label, refreshed in place on each poll.
+  - Poll loop: while a swarm is active, re-fetch `/v1/subagents` every 1s
+    (`swarmPollTickMsg`); stop on completion or when all members terminal.
+    `RemoteSubagent` gains `created_at` (already sent by the server) for
+    creation-window member matching; NO server changes.
+  - `formatSubagentsLines` groups swarm members in the `/subagents` listing
+    (swarm section first, then the regular entries); no-swarm output
+    unchanged.
+- Out of scope: server endpoint changes, multi-run swarm tracking,
+  historical swarm persistence.
 
 ## Documentation Contract
 
 - Feature status: `in implementation`
-- Public docs affected: `internal/harness/tools/descriptions/agent_swarm.md`
-  (tool contract, model-facing)
+- Public docs affected: none (TUI behavior only)
 - Spec docs to update before code: none
 - Implementation notes to add after code: engineering-log entry per slice.
 
 ## Test Plan (TDD)
 
 - New failing tests to add first:
-  - `internal/harness/tools/deferred/agent_swarm_test.go`: definition shape
-    (ActionExecute/Mutating/TierDeferred/required params), arg parsing and
-    validation errors, profile resolution + override mapping, resume mapping,
-    report marshaling, runner-error propagation, nil-runner error.
-  - `internal/subagents/swarm_tool_runner_test.go`: adapter maps
-    tools.SwarmRequest ↔ subagents types both directions.
-  - `internal/harness/runner_swarm_test.go`: sole-call rule (swarm+extra →
-    corrective error, swarm alone → ok); DeniedTools gate (call blocked,
-    definitions filtered even when activated); approval flow surfaces
-    agent_swarm as mutating ActionExecute under destructive policy.
-  - `internal/subagents/swarm_e2e_test.go`: fakeprovider full-stack session —
-    find_tool activation, one `agent_swarm` call, 4 member runs with expanded
-    prompts, one aggregated tool result, run completes.
+  - internal (`package tui`): `formatSwarmPanelLines` multi-status rendering
+    (summary + per-member rows + cap), creation-window matching (old
+    subagents excluded, unmatched items pending), exact members after report,
+    `/subagents` grouping in `formatSubagentsLines`, no-swarm regression,
+    report parsing on completion, poll tick start/stop.
+  - external (`package tui_test`): SSE flow — agent_swarm started renders
+    the live panel, poll updates per-member status, completion renders exact
+    statuses and stops updating.
 - Existing tests to update: none.
-- Regression tests required: existing harness/deferred/subagents suites stay
-  green.
+- Regression tests required: existing TUI suites stay green unmodified.
 
 ## Cross-Surface Impact Map
 
-- None — additive tool + in-process enforcement; no provider/model flow,
-  config, or server API changes (TUI panel is Slice 4).
+- None — TUI-only; no provider/model flow, config, or server API changes.
 
 ## Implementation Checklist
 
@@ -80,9 +67,12 @@
 
 ## Risks and Mitigations
 
-- Risk: import cycle between harness/deferred and subagents.
-- Mitigation: mirror types in `tools` + adapter in `subagents`, exactly the
-  existing `SubagentManager`/`InlineManager` pattern.
-- Risk: sole-call gate breaking parallel tool execution for normal calls.
-- Mitigation: gate only engages when a response contains `agent_swarm`;
-  all other responses flow unchanged; regression suite validates.
+- Risk: mid-swarm member↔item matching is heuristic (creation window +
+  schedule order); concurrent unrelated subagent creation could misattribute.
+- Mitigation: single-run tracking only (agent_swarm is sole-call and blocks
+  the parent run, so at most one swarm is active per run); the aggregated
+  report at completion replaces heuristics with exact member IDs.
+- Risk: live panel line offsets going stale as other viewport content moves.
+- Mitigation: panel renders only while the parent run is blocked inside the
+  tool call (no interleaved tool cards); replacement is clamped; block
+  freezes at completion.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -13,7 +13,7 @@
 - `814-tasks-panel.md` — Epic #814 unified /tasks background panel: slice 1 `GET /v1/tasks` union, slice 2 bash-job exposure + kill, slice 3 TUI `/tasks` overlay (slices 1–3 in implementation/merged).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
-- `808-agent-swarm.md` — Agent swarm epic #808: Slice 1 swarm orchestrator + Slice 2 resume (merged), Slice 3 agent_swarm deferred tool with sole-call rule (in implementation).
+- `808-agent-swarm.md` — Agent swarm epic #808: Slices 1–3 (orchestrator, resume, agent_swarm tool; merged), Slice 4 TUI live swarm progress panel (in implementation).
 - `809-mcp-oauth.md` — Epic #809: slices 1–3 (headers/typed errors, token store, OAuth flow) merged; slice 4 (`harnesscli mcp login/logout/status` + 401 re-auth guidance) in implementation.
 - `812-session-visualizer.md` — Session visualizer epic #812, slice 1: embedded `/viz` static shell served by harnessd behind Bearer auth + `runs:read` (in implementation).
 - `820-tui-steering.md` — Epic #820 (in implementation): per-slice plans for mid-turn TUI steering (slices 1–2 merged; slice 3 ctrl+g binding in review).


### PR DESCRIPTION
Parent epic: #808. Part of #803.

## Slice 4 of #808 (final slice)

The `/subagents` view groups swarm members and updates their status live while a swarm runs.

### What landed

- **`cmd/harnesscli/tui/swarm_panel.go`** — a `swarmTracker` follows the current run's `agent_swarm` call from SSE events: `tool.call.started` parses the item list from the arguments, `tool.call.completed` parses the aggregated report for exact member IDs/statuses.
- **Live panel** — summary line (launched/completed counts, cap 128) plus per-member pending/running/completed/failed rows with the item label, refreshed **in place** in the viewport via keyed line-range replacement (no duplicate blocks).
- **Poll loop** — while a swarm is active, `/v1/subagents` is re-fetched every 1s (`SwarmPollTickMsg`); poll responses are marked (`SubagentsLoadedMsg.SwarmPoll`) so they refresh the panel instead of appending a listing. The loop stops on completion or when every member is terminal. **No server changes** — `RemoteSubagent` only gained the already-sent `created_at` field used for creation-window member matching.
- **Matching** — before the report arrives, items pair with new subagents by creation window in schedule order (resume entries render as `resumed`); the aggregated report at completion replaces the heuristic with exact members. Sound for a single run because `agent_swarm` is sole-call and blocks the parent run.
- **Listing grouping** — `formatSubagentsLines(items, panel)` renders the swarm section first in `/subagents` output; no-swarm output is unchanged.

### Tests (TDD — failed on undefined symbols before implementation)

- Internal: multi-status panel rendering (summary + rows + cap), creation-window matching (old subagents excluded, unmatched items pending, out-of-order input sorted), resume entries, exact report members, grouped listing, no-swarm regression.
- External SSE flow: panel appears on `agent_swarm` start → poll updates member status in place (exactly one block) → completion freezes exact statuses → stale poll ignored → tick starts/stops → `/subagents` listing groups the swarm.

### Verification

- `go test ./cmd/harnesscli/... -count=1` — ok (29 packages)
- `go test ./cmd/harnesscli/... -count=1 -race` — ok
- `gofmt`, `go vet` on touched packages — clean
- `GOCACHE=/tmp/go-build ./scripts/test-regression.sh` — PASS: `coveragegate: PASS (total=84.3%, min=80.0%, zero-functions=0)`