### PR TITLE
feat(tui): task actions — view output and stop from the /tasks panel

### DIFF
--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -577,6 +577,124 @@ func loadTasksCmd(baseURL, apiKey string) tea.Cmd {
 	}
 }
 
+// fetchTaskOutputCmd fetches one task's captured output for the /tasks panel
+// detail view (epic #814 slice 4): bash_job via GET /v1/jobs/{id}/output,
+// subagent via GET /v1/subagents/{id}. Success yields TaskOutputLoadedMsg;
+// failures yield TaskActionResultMsg with Action="output".
+func fetchTaskOutputCmd(baseURL, apiKey string, task RemoteTask) tea.Cmd {
+	return func() tea.Msg {
+		fail := func(err error) tea.Msg {
+			return TaskActionResultMsg{TaskID: task.ID, Action: "output", Err: err.Error()}
+		}
+		var path string
+		switch task.Type {
+		case "bash_job":
+			path = "/v1/jobs/" + task.ID + "/output"
+		case "subagent":
+			path = "/v1/subagents/" + task.ID
+		default:
+			return fail(fmt.Errorf("no output available for %s tasks", task.Type))
+		}
+
+		url := strings.TrimRight(baseURL, "/") + path
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, url, nil, apiKey)
+		if err != nil {
+			return fail(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fail(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fail(fmt.Errorf("server returned %d", resp.StatusCode))
+		}
+
+		switch task.Type {
+		case "bash_job":
+			var payload struct {
+				Output   string `json:"output"`
+				Running  bool   `json:"running"`
+				ExitCode int    `json:"exit_code"`
+				TimedOut bool   `json:"timed_out"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+				return fail(err)
+			}
+			status := fmt.Sprintf("exit_code %d", payload.ExitCode)
+			if payload.Running {
+				status = "running"
+			} else if payload.TimedOut {
+				status = "timed_out"
+			}
+			out := strings.TrimSpace(payload.Output)
+			if out == "" {
+				out = "(no output)"
+			}
+			return TaskOutputLoadedMsg{
+				TaskID: task.ID,
+				Title:  task.Label,
+				Output: fmt.Sprintf("%s\n\n[%s]", out, status),
+			}
+		default: // subagent
+			var payload RemoteSubagent
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+				return fail(err)
+			}
+			out := strings.TrimSpace(payload.Output)
+			if out == "" {
+				out = "(no output yet)"
+			}
+			return TaskOutputLoadedMsg{
+				TaskID: task.ID,
+				Title:  task.Label,
+				Output: fmt.Sprintf("%s\n\n[status: %s]", out, payload.Status),
+			}
+		}
+	}
+}
+
+// cancelTaskCmd stops a task via its type-appropriate endpoint (epic #814
+// slice 4): bash_job → POST /v1/jobs/{id}/kill, subagent →
+// POST /v1/subagents/{id}/cancel, cron → DELETE /v1/cron/jobs/{id},
+// callback → POST /v1/callbacks/{id}/cancel. The result arrives as
+// TaskActionResultMsg with Action="stop".
+func cancelTaskCmd(baseURL, apiKey string, task RemoteTask) tea.Cmd {
+	return func() tea.Msg {
+		fail := func(err error) tea.Msg {
+			return TaskActionResultMsg{TaskID: task.ID, Action: "stop", Err: err.Error()}
+		}
+		var method, path string
+		switch task.Type {
+		case "bash_job":
+			method, path = http.MethodPost, "/v1/jobs/"+task.ID+"/kill"
+		case "subagent":
+			method, path = http.MethodPost, "/v1/subagents/"+task.ID+"/cancel"
+		case "cron":
+			method, path = http.MethodDelete, "/v1/cron/jobs/"+task.ID
+		case "callback":
+			method, path = http.MethodPost, "/v1/callbacks/"+task.ID+"/cancel"
+		default:
+			return fail(fmt.Errorf("cannot stop %s tasks", task.Type))
+		}
+
+		url := strings.TrimRight(baseURL, "/") + path
+		req, err := newHarnessRequest(context.Background(), method, url, nil, apiKey)
+		if err != nil {
+			return fail(err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return fail(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return fail(fmt.Errorf("server returned %d", resp.StatusCode))
+		}
+		return TaskActionResultMsg{TaskID: task.ID, Action: "stop"}
+	}
+}
+
 // loadHooksCmd fetches GET /v1/hooks for the /hooks command. The TUI renders
 // server truth only — it never reads hook files from disk.
 func loadHooksCmd(baseURL, apiKey string) tea.Cmd {

--- a/cmd/harnesscli/tui/api_tasks_test.go
+++ b/cmd/harnesscli/tui/api_tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -113,5 +114,153 @@ func TestLoadTasksCmdUnreachable(t *testing.T) {
 	msg := loadTasksCmd(ts.URL, "")()
 	if _, ok := msg.(TasksLoadFailedMsg); !ok {
 		t.Fatalf("expected TasksLoadFailedMsg, got %T: %+v", msg, msg)
+	}
+}
+
+// --- slice 4: task output fetch + stop actions ---
+
+// TestFetchTaskOutputCmdBashJob verifies the bash_job output path calls
+// GET /v1/jobs/{id}/output and maps the payload into TaskOutputLoadedMsg.
+func TestFetchTaskOutputCmdBashJob(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/jobs/jm1:job_1/output" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"shell_id": "job_1", "running": false, "exit_code": 0, "timed_out": false, "output": "hello-from-job",
+		})
+	}))
+	defer ts.Close()
+
+	task := RemoteTask{ID: "jm1:job_1", Type: "bash_job", Label: "echo hello-from-job"}
+	msg := fetchTaskOutputCmd(ts.URL, "", task)()
+	loaded, ok := msg.(TaskOutputLoadedMsg)
+	if !ok {
+		t.Fatalf("expected TaskOutputLoadedMsg, got %T: %+v", msg, msg)
+	}
+	if loaded.TaskID != "jm1:job_1" {
+		t.Errorf("TaskID = %q, want jm1:job_1", loaded.TaskID)
+	}
+	if !strings.Contains(loaded.Output, "hello-from-job") {
+		t.Errorf("Output = %q, want it to contain 'hello-from-job'", loaded.Output)
+	}
+}
+
+// TestFetchTaskOutputCmdSubagent verifies the subagent output path calls
+// GET /v1/subagents/{id} and uses the subagent's Output field.
+func TestFetchTaskOutputCmdSubagent(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/subagents/sub-1" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id": "sub-1", "run_id": "run-1", "status": "completed", "output": "subagent did the thing",
+		})
+	}))
+	defer ts.Close()
+
+	task := RemoteTask{ID: "sub-1", Type: "subagent", Label: "workspace-sub-1"}
+	msg := fetchTaskOutputCmd(ts.URL, "", task)()
+	loaded, ok := msg.(TaskOutputLoadedMsg)
+	if !ok {
+		t.Fatalf("expected TaskOutputLoadedMsg, got %T: %+v", msg, msg)
+	}
+	if !strings.Contains(loaded.Output, "subagent did the thing") {
+		t.Errorf("Output = %q, want subagent output", loaded.Output)
+	}
+}
+
+// TestFetchTaskOutputCmdError verifies fetch failures surface as
+// TaskActionResultMsg with the output action.
+func TestFetchTaskOutputCmdError(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	task := RemoteTask{ID: "jm1:job_9", Type: "bash_job", Label: "x"}
+	msg := fetchTaskOutputCmd(ts.URL, "", task)()
+	result, ok := msg.(TaskActionResultMsg)
+	if !ok {
+		t.Fatalf("expected TaskActionResultMsg, got %T: %+v", msg, msg)
+	}
+	if result.Action != "output" || result.Err == "" {
+		t.Errorf("result = %+v, want Action=output with non-empty Err", result)
+	}
+}
+
+// TestCancelTaskCmdDispatch verifies each task type maps to its
+// type-appropriate stop endpoint and method.
+func TestCancelTaskCmdDispatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		task       RemoteTask
+		wantMethod string
+		wantPath   string
+	}{
+		{"bash job kill", RemoteTask{ID: "jm1:job_1", Type: "bash_job"}, http.MethodPost, "/v1/jobs/jm1:job_1/kill"},
+		{"subagent cancel", RemoteTask{ID: "sub-1", Type: "subagent"}, http.MethodPost, "/v1/subagents/sub-1/cancel"},
+		{"cron delete", RemoteTask{ID: "job-1", Type: "cron"}, http.MethodDelete, "/v1/cron/jobs/job-1"},
+		{"callback cancel", RemoteTask{ID: "cb-1", Type: "callback"}, http.MethodPost, "/v1/callbacks/cb-1/cancel"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			called := false
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				if r.Method != tc.wantMethod || r.URL.Path != tc.wantPath {
+					t.Errorf("request = %s %s, want %s %s", r.Method, r.URL.Path, tc.wantMethod, tc.wantPath)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			}))
+			defer ts.Close()
+
+			msg := cancelTaskCmd(ts.URL, "", tc.task)()
+			result, ok := msg.(TaskActionResultMsg)
+			if !ok {
+				t.Fatalf("expected TaskActionResultMsg, got %T: %+v", msg, msg)
+			}
+			if !called {
+				t.Error("no request was made")
+			}
+			if result.Err != "" {
+				t.Errorf("result.Err = %q, want empty on success", result.Err)
+			}
+			if result.TaskID != tc.task.ID {
+				t.Errorf("result.TaskID = %q, want %q", result.TaskID, tc.task.ID)
+			}
+		})
+	}
+}
+
+// TestCancelTaskCmdServerError verifies non-2xx responses surface as errors.
+func TestCancelTaskCmdServerError(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	task := RemoteTask{ID: "job-x", Type: "cron"}
+	msg := cancelTaskCmd(ts.URL, "", task)()
+	result, ok := msg.(TaskActionResultMsg)
+	if !ok {
+		t.Fatalf("expected TaskActionResultMsg, got %T: %+v", msg, msg)
+	}
+	if result.Err == "" {
+		t.Error("result.Err should describe the failure")
 	}
 }

--- a/cmd/harnesscli/tui/components/taskspanel/model.go
+++ b/cmd/harnesscli/tui/components/taskspanel/model.go
@@ -4,6 +4,8 @@
 // helpdialog component's value semantics — every method returns a new Model.
 package taskspanel
 
+import "strings"
+
 // TaskEntry is one row in the panel: a single piece of background work as
 // reported by GET /v1/tasks.
 type TaskEntry struct {
@@ -15,6 +17,18 @@ type TaskEntry struct {
 	Actions    []string
 }
 
+// Mode identifies which screen the panel shows.
+type Mode int
+
+const (
+	// ModeList is the task list (default).
+	ModeList Mode = iota
+	// ModeConfirm is the destructive-action confirmation prompt (cron delete).
+	ModeConfirm
+	// ModeDetail is the scrollable output view for one task.
+	ModeDetail
+)
+
 // Model is the tasks panel state. All methods return a new Model (value
 // semantics — safe for concurrent use when each goroutine holds its own copy).
 type Model struct {
@@ -24,6 +38,14 @@ type Model struct {
 	err     string
 	cursor  int
 	scroll  int
+
+	mode         Mode
+	confirmTask  TaskEntry
+	hasConfirm   bool
+	detailTitle  string
+	detailLines  []string
+	detailScroll int
+	notice       string
 }
 
 // New creates an inactive, empty panel.
@@ -32,8 +54,8 @@ func New() Model {
 }
 
 // Open activates the overlay and enters the loading state, clearing any stale
-// tasks, error, and cursor/scroll position so reopening /tasks always starts
-// fresh at the top.
+// tasks, error, mode, notice, and cursor/scroll position so reopening /tasks
+// always starts fresh at the top of the list.
 func (m Model) Open() Model {
 	m.active = true
 	m.loading = true
@@ -41,6 +63,12 @@ func (m Model) Open() Model {
 	m.tasks = nil
 	m.cursor = 0
 	m.scroll = 0
+	m.mode = ModeList
+	m.hasConfirm = false
+	m.detailTitle = ""
+	m.detailLines = nil
+	m.detailScroll = 0
+	m.notice = ""
 	return m
 }
 
@@ -76,11 +104,12 @@ func (m Model) CursorIndex() int {
 }
 
 // SetTasks replaces the task list after a successful fetch, clearing the
-// loading and error states and clamping the cursor into the new list.
+// loading, error, and notice states and clamping the cursor into the new list.
 func (m Model) SetTasks(tasks []TaskEntry) Model {
 	m.tasks = append([]TaskEntry(nil), tasks...)
 	m.loading = false
 	m.err = ""
+	m.notice = ""
 	if m.cursor >= len(m.tasks) {
 		m.cursor = len(m.tasks) - 1
 	}
@@ -127,6 +156,105 @@ func (m Model) Selected() (TaskEntry, bool) {
 		return TaskEntry{}, false
 	}
 	return m.tasks[m.cursor], true
+}
+
+// Mode returns the current panel screen (list, confirm, or detail).
+func (m Model) Mode() Mode {
+	return m.mode
+}
+
+// InConfirm reports whether the destructive-action prompt is showing.
+func (m Model) InConfirm() bool {
+	return m.mode == ModeConfirm
+}
+
+// InDetail reports whether the output detail view is showing.
+func (m Model) InDetail() bool {
+	return m.mode == ModeDetail
+}
+
+// AskConfirm enters confirm mode for a destructive stop action on the given
+// task (deleting a cron schedule cannot be undone).
+func (m Model) AskConfirm(task TaskEntry) Model {
+	m.mode = ModeConfirm
+	m.confirmTask = task
+	m.hasConfirm = true
+	return m
+}
+
+// PendingConfirm returns the task awaiting destructive-action confirmation.
+func (m Model) PendingConfirm() (TaskEntry, bool) {
+	if !m.hasConfirm {
+		return TaskEntry{}, false
+	}
+	return m.confirmTask, true
+}
+
+// ResolveConfirm exits confirm mode back to the list, keeping the task list
+// and cursor untouched.
+func (m Model) ResolveConfirm() Model {
+	m.mode = ModeList
+	m.hasConfirm = false
+	return m
+}
+
+// ShowOutput enters detail mode displaying the given title and output text
+// for one task (epic #814 slice 4 view-output action).
+func (m Model) ShowOutput(title, output string) Model {
+	m.mode = ModeDetail
+	m.detailTitle = title
+	m.detailLines = strings.Split(output, "\n")
+	m.detailScroll = 0
+	return m
+}
+
+// CloseDetail exits detail mode back to the list.
+func (m Model) CloseDetail() Model {
+	m.mode = ModeList
+	return m
+}
+
+// ScrollDetail scrolls the detail view by n lines (positive down), clamped so
+// at least one line stays in view.
+func (m Model) ScrollDetail(n int) Model {
+	m.detailScroll += n
+	if m.detailScroll < 0 {
+		m.detailScroll = 0
+	}
+	if max := len(m.detailLines) - 1; m.detailScroll > max {
+		m.detailScroll = max
+	}
+	return m
+}
+
+// DetailScroll returns the current detail scroll offset.
+func (m Model) DetailScroll() int {
+	return m.detailScroll
+}
+
+// SetNotice sets (or clears, with "") a transient notice line rendered inside
+// the panel — used to surface action errors (epic #814 slice 4).
+func (m Model) SetNotice(msg string) Model {
+	m.notice = msg
+	return m
+}
+
+// Notice returns the current notice line, or "" when there is none.
+func (m Model) Notice() string {
+	return m.notice
+}
+
+// HandleEscape backs out of confirm or detail mode to the list. In list mode
+// it is a no-op — the outer model closes the overlay instead.
+func (m Model) HandleEscape() Model {
+	switch m.mode {
+	case ModeConfirm:
+		return m.ResolveConfirm()
+	case ModeDetail:
+		return m.CloseDetail()
+	default:
+		return m
+	}
 }
 
 // View renders the panel at the given terminal dimensions. Zero dimensions

--- a/cmd/harnesscli/tui/components/taskspanel/model_test.go
+++ b/cmd/harnesscli/tui/components/taskspanel/model_test.go
@@ -148,3 +148,135 @@ func TestSelected(t *testing.T) {
 		t.Errorf("Selected ID after MoveDown = %q, want sub-1", sel.ID)
 	}
 }
+
+// --- slice 4: confirm + detail modes, notice ---
+
+func TestAskConfirmAndResolve(t *testing.T) {
+	t.Parallel()
+
+	cronTask := taskspanel.TaskEntry{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync"}
+	m := taskspanel.New().Open().SetTasks([]taskspanel.TaskEntry{cronTask})
+
+	m = m.AskConfirm(cronTask)
+	if !m.InConfirm() {
+		t.Fatal("AskConfirm should enter confirm mode")
+	}
+	pending, ok := m.PendingConfirm()
+	if !ok {
+		t.Fatal("PendingConfirm should return the task")
+	}
+	if pending.ID != "job-1" {
+		t.Errorf("PendingConfirm ID = %q, want job-1", pending.ID)
+	}
+
+	m = m.ResolveConfirm()
+	if m.InConfirm() {
+		t.Error("ResolveConfirm should leave confirm mode")
+	}
+	if _, ok := m.PendingConfirm(); ok {
+		t.Error("PendingConfirm should be empty after ResolveConfirm")
+	}
+	// The task list survives the confirm round-trip.
+	if m.TaskCount() != 1 {
+		t.Errorf("TaskCount after ResolveConfirm = %d, want 1", m.TaskCount())
+	}
+}
+
+func TestShowOutputAndCloseDetail(t *testing.T) {
+	t.Parallel()
+
+	m := taskspanel.New().Open().SetTasks(sampleTasks())
+	m = m.ShowOutput("sleep 30", "line one\nline two")
+
+	if !m.InDetail() {
+		t.Fatal("ShowOutput should enter detail mode")
+	}
+	m = m.CloseDetail()
+	if m.InDetail() {
+		t.Error("CloseDetail should leave detail mode")
+	}
+	// List state is preserved.
+	if m.TaskCount() != len(sampleTasks()) {
+		t.Errorf("TaskCount after CloseDetail = %d, want %d", m.TaskCount(), len(sampleTasks()))
+	}
+	if m.CursorIndex() != 0 {
+		t.Errorf("cursor should be preserved across detail mode, got %d", m.CursorIndex())
+	}
+}
+
+func TestDetailScrollClamps(t *testing.T) {
+	t.Parallel()
+
+	lines := make([]string, 50)
+	for i := range lines {
+		lines[i] = "row"
+	}
+	output := ""
+	for i, l := range lines {
+		if i > 0 {
+			output += "\n"
+		}
+		output += l
+	}
+
+	m := taskspanel.New().Open().ShowOutput("big job", output)
+	m = m.ScrollDetail(10)
+	if got := m.DetailScroll(); got != 10 {
+		t.Errorf("DetailScroll after +10 = %d, want 10", got)
+	}
+	m = m.ScrollDetail(-100)
+	if got := m.DetailScroll(); got != 0 {
+		t.Errorf("DetailScroll should clamp at 0, got %d", got)
+	}
+}
+
+func TestNoticeSetAndClearedOnRefresh(t *testing.T) {
+	t.Parallel()
+
+	m := taskspanel.New().Open().SetTasks(sampleTasks())
+	m = m.SetNotice("Action failed: boom")
+	if m.Notice() != "Action failed: boom" {
+		t.Errorf("Notice() = %q, want 'Action failed: boom'", m.Notice())
+	}
+	m = m.SetTasks(sampleTasks())
+	if m.Notice() != "" {
+		t.Errorf("SetTasks should clear the notice, got %q", m.Notice())
+	}
+}
+
+func TestHandleEscapeBacksOut(t *testing.T) {
+	t.Parallel()
+
+	base := taskspanel.New().Open().SetTasks(sampleTasks())
+
+	inDetail := base.ShowOutput("x", "y")
+	if escaped := inDetail.HandleEscape(); escaped.InDetail() {
+		t.Error("HandleEscape should leave detail mode")
+	}
+
+	cronTask := taskspanel.TaskEntry{ID: "job-1", Type: "cron", Label: "c"}
+	inConfirm := base.AskConfirm(cronTask)
+	if escaped := inConfirm.HandleEscape(); escaped.InConfirm() {
+		t.Error("HandleEscape should leave confirm mode")
+	}
+
+	// List mode: HandleEscape is a no-op (the model closes the overlay).
+	if escaped := base.HandleEscape(); escaped.InDetail() || escaped.InConfirm() {
+		t.Error("HandleEscape in list mode should be a no-op")
+	}
+}
+
+func TestOpenResetsModes(t *testing.T) {
+	t.Parallel()
+
+	m := taskspanel.New().Open().SetTasks(sampleTasks()).
+		SetNotice("boom").
+		ShowOutput("x", "y")
+	m = m.Open()
+	if m.InDetail() || m.InConfirm() {
+		t.Error("Open should reset to list mode")
+	}
+	if m.Notice() != "" {
+		t.Error("Open should clear the notice")
+	}
+}

--- a/cmd/harnesscli/tui/components/taskspanel/view.go
+++ b/cmd/harnesscli/tui/components/taskspanel/view.go
@@ -72,17 +72,114 @@ func render(m Model, width, height int) string {
 		contentLines = 3
 	}
 
+	switch m.mode {
+	case ModeConfirm:
+		return renderConfirm(m, width, height, dialogWidth, contentLines)
+	case ModeDetail:
+		return renderDetail(m, width, height, dialogWidth, contentLines)
+	default:
+		return renderList(m, width, height, dialogWidth, contentLines)
+	}
+}
+
+// renderList renders the task list screen (default mode).
+func renderList(m Model, width, height, dialogWidth, contentLines int) string {
 	title := lipgloss.NewStyle().Width(dialogWidth).Align(lipgloss.Center).
 		Render(styleTitle.Render("Background Tasks"))
 	sep := styleSeparator.Render(strings.Repeat("─", dialogWidth))
 	header := styleHeader.Render("  " + rowCells("TYPE", "STATUS", "AGE", "COMMAND"))
 	content := renderContent(m, dialogWidth, contentLines)
 	footer := styleFooterHint.Width(dialogWidth).Align(lipgloss.Center).
-		Render("↑/↓ navigate  r refresh  esc close")
+		Render("↑/↓ navigate  o output  x stop  r refresh  esc close")
 
-	body := title + "\n" + sep + "\n" + header + "\n" + content + "\n" + footer
+	body := title + "\n" + sep + "\n" + header + "\n" + content
+	// Transient notice line (action errors) sits above the footer.
+	if m.notice != "" {
+		body += "\n" + styleErrorLine.Render("  "+truncate(m.notice, dialogWidth-2))
+	}
+	body += "\n" + footer
+
 	dialog := styleDialog.Width(dialogWidth).Render(body)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, dialog)
+}
 
+// renderConfirm renders the destructive-action confirmation prompt (deleting
+// a cron schedule cannot be undone).
+func renderConfirm(m Model, width, height, dialogWidth, contentLines int) string {
+	title := lipgloss.NewStyle().Width(dialogWidth).Align(lipgloss.Center).
+		Render(styleTitle.Render("Confirm Delete"))
+	sep := styleSeparator.Render(strings.Repeat("─", dialogWidth))
+
+	prompt := []string{
+		"",
+		styleRow.Render(fmt.Sprintf("  Delete cron job %q?", truncate(m.confirmTask.Label, dialogWidth-24))),
+		styleErrorLine.Render("  This cannot be undone."),
+	}
+	for len(prompt) < contentLines {
+		prompt = append(prompt, "")
+	}
+	footer := styleFooterHint.Width(dialogWidth).Align(lipgloss.Center).
+		Render("y confirm  n cancel")
+
+	body := title + "\n" + sep + "\n" + strings.Join(prompt, "\n") + "\n" + footer
+	dialog := styleDialog.Width(dialogWidth).Render(body)
+	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, dialog)
+}
+
+// renderDetail renders the scrollable output view for one task.
+func renderDetail(m Model, width, height, dialogWidth, contentLines int) string {
+	titleText := "Output: " + truncate(m.detailTitle, dialogWidth-10)
+	title := lipgloss.NewStyle().Width(dialogWidth).Align(lipgloss.Center).
+		Render(styleTitle.Render(titleText))
+	sep := styleSeparator.Render(strings.Repeat("─", dialogWidth))
+
+	// Window the detail lines around the scroll offset with ▲/▼ indicators,
+	// mirroring the list windowing.
+	scroll := m.detailScroll
+	if scroll < 0 {
+		scroll = 0
+	}
+	if scroll > len(m.detailLines) {
+		scroll = len(m.detailLines)
+	}
+	visLines := m.detailLines[scroll:]
+	hasAbove := scroll > 0
+	hasBelow := len(visLines) > contentLines
+
+	contentSlots := contentLines
+	if hasAbove {
+		contentSlots--
+	}
+	if hasBelow {
+		contentSlots--
+	}
+	if contentSlots < 1 {
+		contentSlots = 1
+	}
+
+	var displayLines []string
+	if hasAbove {
+		displayLines = append(displayLines,
+			styleOverflowIndicator.Render(fmt.Sprintf("  ▲ %d more above", scroll)))
+	}
+	sliceEnd := contentSlots
+	if sliceEnd > len(visLines) {
+		sliceEnd = len(visLines)
+	}
+	for _, line := range visLines[:sliceEnd] {
+		displayLines = append(displayLines, styleRow.Render("  "+truncate(line, dialogWidth-2)))
+	}
+	if hasBelow {
+		displayLines = append(displayLines,
+			styleOverflowIndicator.Render(fmt.Sprintf("  ▼ %d more below", len(visLines)-contentSlots)))
+	}
+	content := padLines(displayLines, contentLines)
+
+	footer := styleFooterHint.Width(dialogWidth).Align(lipgloss.Center).
+		Render("↑/↓ scroll  h/← back  esc close")
+
+	body := title + "\n" + sep + "\n" + content + "\n" + footer
+	dialog := styleDialog.Width(dialogWidth).Render(body)
 	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, dialog)
 }
 

--- a/cmd/harnesscli/tui/components/taskspanel/view_test.go
+++ b/cmd/harnesscli/tui/components/taskspanel/view_test.go
@@ -170,3 +170,77 @@ func TestViewZeroSizeDoesNotPanic(t *testing.T) {
 		t.Error("View(0,0) should render with default dimensions, got empty string")
 	}
 }
+
+// --- slice 4: confirm + detail rendering ---
+
+// TestViewConfirmPrompt verifies the destructive-action confirmation prompt
+// (cron delete) names the action and the task.
+func TestViewConfirmPrompt(t *testing.T) {
+	t.Parallel()
+
+	cronTask := taskspanel.TaskEntry{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync"}
+	m := taskspanel.New().Open().SetTasks([]taskspanel.TaskEntry{cronTask}).AskConfirm(cronTask)
+	view := m.View(100, 30)
+
+	for _, want := range []string{"Delete cron job", "nightly-sync", "cannot be undone", "y confirm", "n"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("confirm view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// TestViewDetailMode verifies output detail rendering with title, content,
+// and a back hint.
+func TestViewDetailMode(t *testing.T) {
+	t.Parallel()
+
+	m := taskspanel.New().Open().SetTasks(sampleTasks())
+	m = m.ShowOutput("sleep 30", "first line\nsecond line")
+	view := m.View(100, 30)
+
+	for _, want := range []string{"sleep 30", "first line", "second line", "back"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("detail view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// TestViewDetailScrollIndicators verifies long output scrolls with overflow
+// indicators.
+func TestViewDetailScrollIndicators(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	for i := 1; i <= 40; i++ {
+		if i > 1 {
+			b.WriteString("\n")
+		}
+		b.WriteString(fmt.Sprintf("output line %d", i))
+	}
+
+	m := taskspanel.New().Open().ShowOutput("big job", b.String())
+	view := m.View(80, 16)
+	if !strings.Contains(view, "more below") {
+		t.Errorf("long output should show 'more below':\n%s", view)
+	}
+
+	m = m.ScrollDetail(35)
+	view = m.View(80, 16)
+	if !strings.Contains(view, "more above") {
+		t.Errorf("scrolled output should show 'more above':\n%s", view)
+	}
+	if !strings.Contains(view, "output line 40") {
+		t.Errorf("last output line should be visible after scrolling to the end:\n%s", view)
+	}
+}
+
+// TestViewNoticeLine verifies action errors surface inside the panel.
+func TestViewNoticeLine(t *testing.T) {
+	t.Parallel()
+
+	m := taskspanel.New().Open().SetTasks(sampleTasks()).SetNotice("kill failed: boom")
+	view := m.View(100, 30)
+	if !strings.Contains(view, "kill failed: boom") {
+		t.Errorf("panel should render the notice line:\n%s", view)
+	}
+}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -176,6 +176,23 @@ type TasksLoadedMsg struct{ Tasks []RemoteTask }
 // TasksLoadFailedMsg reports a failed /v1/tasks fetch.
 type TasksLoadFailedMsg struct{ Err string }
 
+// TaskOutputLoadedMsg carries one task's captured output for the /tasks
+// panel detail view (epic #814 slice 4).
+type TaskOutputLoadedMsg struct {
+	TaskID string
+	Title  string
+	Output string
+}
+
+// TaskActionResultMsg reports the outcome of a /tasks panel action (output
+// fetch failure, or a stop/kill/delete request; epic #814 slice 4). Err is
+// empty on success.
+type TaskActionResultMsg struct {
+	TaskID string
+	Action string // "output" | "stop"
+	Err    string
+}
+
 // HooksLoadedMsg carries the GET /v1/hooks listing for the /hooks command.
 type HooksLoadedMsg struct {
 	Hooks   []hookEntry     `json:"hooks"`

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -2717,6 +2717,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 			}
 			if m.overlayActive {
+				// The tasks panel consumes Escape first while a sub-mode
+				// (confirm prompt or output detail) is showing: Esc backs out
+				// to the task list rather than closing the overlay (epic #814
+				// slice 4).
+				if m.activeOverlay == "tasks" && m.tasksPanel.Mode() != taskspanel.ModeList {
+					m.tasksPanel = m.tasksPanel.HandleEscape()
+					return m, tea.Batch(cmds...)
+				}
 				m.overlayActive = false
 				m.activeOverlay = ""
 				m.helpDialog = m.helpDialog.Close()
@@ -2927,6 +2935,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.modelConfigReasoningCursor = reasoningLevelIndex(m.selectedReasoningEffort)
 				return m, tea.Batch(cmds...)
 			}
+			// When the tasks overlay is active, Enter opens the selected row's
+			// output detail (same action as 'o'; epic #814 slice 4).
+			if m.overlayActive && m.activeOverlay == "tasks" {
+				cmds = m.openSelectedTaskOutput(cmds)
+				return m, tea.Batch(cmds...)
+			}
 			// When the dropdown is active, Enter accepts the selected suggestion
 			// instead of submitting the input as a message.
 			if m.slashComplete.IsActive() {
@@ -2995,17 +3009,60 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "tasks":
 			// Route keyboard input to the tasks panel when it is open (epic
-			// #814 slice 3): arrows/j/k move the selection, r re-fetches.
+			// #814). List mode (slice 3): arrows/j/k move the selection,
+			// r re-fetches. Slice 4 adds the sub-modes and row actions:
+			// confirm mode answers the cron-delete prompt; detail mode
+			// scrolls output; o/Enter views output; x/ctrl+k stops a task.
 			switch {
-			case msg.Type == tea.KeyDown || msg.String() == "j":
-				m.tasksPanel = m.tasksPanel.MoveDown(1)
-			case msg.Type == tea.KeyUp || msg.String() == "k":
-				m.tasksPanel = m.tasksPanel.MoveUp(1)
-			case msg.String() == "r":
-				m.tasksPanel = m.tasksPanel.Open()
-				cmds = append(cmds, loadTasksCmd(m.config.BaseURL, m.config.APIKey))
+			case m.tasksPanel.InConfirm():
+				switch msg.String() {
+				case "y", "Y":
+					task, ok := m.tasksPanel.PendingConfirm()
+					m.tasksPanel = m.tasksPanel.ResolveConfirm()
+					if ok {
+						cmds = append(cmds, cancelTaskCmd(m.config.BaseURL, m.config.APIKey, remoteTaskFromEntry(task)))
+					}
+				case "n", "N":
+					m.tasksPanel = m.tasksPanel.ResolveConfirm()
+				}
+				return m, tea.Batch(cmds...)
+			case m.tasksPanel.InDetail():
+				switch {
+				case msg.Type == tea.KeyDown || msg.String() == "j":
+					m.tasksPanel = m.tasksPanel.ScrollDetail(1)
+				case msg.Type == tea.KeyUp || msg.String() == "k":
+					m.tasksPanel = m.tasksPanel.ScrollDetail(-1)
+				case msg.String() == "h" || msg.Type == tea.KeyLeft:
+					m.tasksPanel = m.tasksPanel.CloseDetail()
+				}
+				return m, tea.Batch(cmds...)
+			default:
+				switch {
+				case msg.Type == tea.KeyDown || msg.String() == "j":
+					m.tasksPanel = m.tasksPanel.MoveDown(1)
+				case msg.Type == tea.KeyUp || msg.String() == "k":
+					m.tasksPanel = m.tasksPanel.MoveUp(1)
+				case msg.String() == "r":
+					m.tasksPanel = m.tasksPanel.Open()
+					cmds = append(cmds, loadTasksCmd(m.config.BaseURL, m.config.APIKey))
+				case msg.String() == "o" || msg.Type == tea.KeyEnter:
+					cmds = m.openSelectedTaskOutput(cmds)
+				case msg.String() == "x" || msg.Type == tea.KeyCtrlK:
+					if sel, ok := m.tasksPanel.Selected(); ok {
+						switch {
+						case !stoppableEntry(sel):
+							m.tasksPanel = m.tasksPanel.SetNotice("task has no stop action")
+						case sel.Type == "cron":
+							// Deleting a cron schedule is destructive —
+							// confirm before firing (epic #814 slice 4).
+							m.tasksPanel = m.tasksPanel.AskConfirm(sel)
+						default:
+							cmds = append(cmds, cancelTaskCmd(m.config.BaseURL, m.config.APIKey, remoteTaskFromEntry(sel)))
+						}
+					}
+				}
+				return m, tea.Batch(cmds...)
 			}
-			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "model" && m.modelConfigMode && m.modelConfigKeyInputMode:
 			// Character input in config panel key input mode.
 			switch {
@@ -3908,6 +3965,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case TasksLoadFailedMsg:
 		m.tasksPanel = m.tasksPanel.SetError(msg.Err)
 		cmds = append(cmds, m.setStatusMsg("Load tasks failed: "+msg.Err))
+
+	case TaskOutputLoadedMsg:
+		m.tasksPanel = m.tasksPanel.ShowOutput(msg.Title, msg.Output)
+
+	case TaskActionResultMsg:
+		if msg.Err != "" {
+			// Surface action errors in the panel itself (epic #814 slice 4).
+			m.tasksPanel = m.tasksPanel.SetNotice(msg.Action + " failed: " + msg.Err)
+			cmds = append(cmds, m.setStatusMsg("Task "+msg.Action+" failed: "+msg.Err))
+		} else if msg.Action == "stop" {
+			// Refresh the list after a stop so the row reflects the outcome.
+			cmds = append(cmds, m.setStatusMsg("Task stopped"), loadTasksCmd(m.config.BaseURL, m.config.APIKey))
+		}
 
 	case HooksLoadedMsg:
 		for _, line := range formatHooksLines(msg) {
@@ -5278,6 +5348,55 @@ func (m Model) HelpDialogScrollOffset() int { return m.helpDialog.ScrollOffset()
 // TasksPanelCursor returns the selected row index in the /tasks overlay
 // (for testing, epic #814).
 func (m Model) TasksPanelCursor() int { return m.tasksPanel.CursorIndex() }
+
+// remoteTaskFromEntry converts a taskspanel row back to the wire DTO the
+// /v1 api commands expect (epic #814 slice 4).
+func remoteTaskFromEntry(e taskspanel.TaskEntry) RemoteTask {
+	return RemoteTask{
+		ID:         e.ID,
+		Type:       e.Type,
+		Status:     e.Status,
+		Label:      e.Label,
+		AgeSeconds: e.AgeSeconds,
+		Actions:    e.Actions,
+	}
+}
+
+// openSelectedTaskOutput performs the view-output action for the selected
+// /tasks row ('o' or Enter; epic #814 slice 4): bash jobs and subagents fetch
+// live output; cron and callback rows (no output endpoint) show their own
+// fields as a static detail view.
+func (m *Model) openSelectedTaskOutput(cmds []tea.Cmd) []tea.Cmd {
+	sel, ok := m.tasksPanel.Selected()
+	if !ok {
+		return cmds
+	}
+	switch sel.Type {
+	case "bash_job", "subagent":
+		cmds = append(cmds, fetchTaskOutputCmd(m.config.BaseURL, m.config.APIKey, remoteTaskFromEntry(sel)))
+	default:
+		m.tasksPanel = m.tasksPanel.ShowOutput(sel.Label, staticTaskDetail(sel))
+	}
+	return cmds
+}
+
+// stoppableEntry reports whether a task row advertises a stop action
+// (cancel for running work, delete for cron jobs).
+func stoppableEntry(e taskspanel.TaskEntry) bool {
+	for _, a := range e.Actions {
+		if a == "cancel" || a == "delete" {
+			return true
+		}
+	}
+	return false
+}
+
+// staticTaskDetail renders the detail view for task types with no output
+// endpoint (cron, callback) from the row's own fields.
+func staticTaskDetail(e taskspanel.TaskEntry) string {
+	return fmt.Sprintf("id: %s\ntype: %s\nstatus: %s\nage: %s\nactions: %s",
+		e.ID, e.Type, e.Status, taskspanel.FormatAge(e.AgeSeconds), strings.Join(e.Actions, ", "))
+}
 
 // boxOverlay wraps overlay content in a RoundedBorder lipgloss box so that
 // /stats and /context get consistent chrome matching /help, /model etc.

--- a/cmd/harnesscli/tui/tasks_overlay_814_test.go
+++ b/cmd/harnesscli/tui/tasks_overlay_814_test.go
@@ -5,6 +5,9 @@ package tui_test
 // empty/loading/error states and cursor navigation. Row actions are slice 4.
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -201,4 +204,356 @@ func TestTasks_HelpListsCommand(t *testing.T) {
 		m = m2.(tui.Model)
 	}
 	t.Errorf("/help must list the /tasks command (after scrolling); got:\n%s", m.View())
+}
+
+// --- slice 4: view output + stop actions ---
+
+// initModelWithURL builds a model pointed at the given harnessd test server.
+func initModelWithURL(t *testing.T, w, h int, baseURL string) tui.Model {
+	t.Helper()
+	cfg := tui.DefaultTUIConfig()
+	cfg.BaseURL = baseURL
+	m := tui.New(cfg)
+	m2, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: h})
+	return m2.(tui.Model)
+}
+
+// execCmds runs a (possibly batched) tea.Cmd tree and collects the messages.
+func execCmds(t *testing.T, cmd tea.Cmd) []tea.Msg {
+	t.Helper()
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, execCmds(t, c)...)
+		}
+		return out
+	}
+	return []tea.Msg{msg}
+}
+
+// openTasksWithRows opens /tasks and loads the given rows.
+func openTasksWithRows(t *testing.T, m tui.Model, tasks []tui.RemoteTask) tui.Model {
+	t.Helper()
+	m = sendSlashCommand(m, "/tasks")
+	if !m.OverlayActive() || m.ActiveOverlay() != "tasks" {
+		t.Fatalf("precondition: tasks overlay must be open (active=%v kind=%q)", m.OverlayActive(), m.ActiveOverlay())
+	}
+	m2, _ := m.Update(tui.TasksLoadedMsg{Tasks: tasks})
+	return m2.(tui.Model)
+}
+
+// TestTasks_ViewOutputBashJob verifies 'o' on a bash job fetches its output
+// and shows the detail view; 'h' returns to the list.
+func TestTasks_ViewOutputBashJob(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/jobs/jm1:job_1/output" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"shell_id": "job_1", "running": true, "output": "partial output here"})
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "jm1:job_1", Type: "bash_job", Status: "running", Label: "sleep 30", AgeSeconds: 5, Actions: []string{"cancel"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = m2.(tui.Model)
+	msgs := execCmds(t, cmd)
+	if len(msgs) != 1 {
+		t.Fatalf("'o' should issue exactly one fetch cmd, got %d msgs: %v", len(msgs), msgs)
+	}
+	loaded, ok := msgs[0].(tui.TaskOutputLoadedMsg)
+	if !ok {
+		t.Fatalf("expected TaskOutputLoadedMsg, got %T", msgs[0])
+	}
+
+	m3, _ := m.Update(loaded)
+	m = m3.(tui.Model)
+	view := m.View()
+	if !strings.Contains(view, "partial output here") {
+		t.Errorf("detail view should show the job output:\n%s", view)
+	}
+
+	// 'h' returns to the list.
+	m4, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	m = m4.(tui.Model)
+	if view := m.View(); !strings.Contains(view, "COMMAND") {
+		t.Errorf("'h' should return to the task list:\n%s", view)
+	}
+}
+
+// TestTasks_ViewOutputCronStaticDetail verifies 'o' on a cron row shows the
+// task's own details without any fetch.
+func TestTasks_ViewOutputCronStaticDetail(t *testing.T) {
+	m := initModel(t, 100, 30)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync", AgeSeconds: 3780, Actions: []string{"pause", "delete"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = m2.(tui.Model)
+	if msgs := execCmds(t, cmd); len(msgs) != 0 {
+		t.Errorf("cron detail should not issue a fetch, got %v", msgs)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Output: nightly-sync") {
+		t.Errorf("cron 'o' should open the detail view titled 'Output: nightly-sync':\n%s", view)
+	}
+	if !strings.Contains(view, "cron") || !strings.Contains(view, "active") {
+		t.Errorf("cron detail should show the task's own info:\n%s", view)
+	}
+}
+
+// TestTasks_EnterAlsoOpensOutput verifies Enter is an alias for 'o'.
+func TestTasks_EnterAlsoOpensOutput(t *testing.T) {
+	m := initModel(t, 100, 30)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "cb-1", Type: "callback", Status: "pending", Label: "check deploy", AgeSeconds: 42, Actions: []string{"cancel"}},
+	})
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m2.(tui.Model)
+	if view := m.View(); !strings.Contains(view, "Output: check deploy") {
+		t.Errorf("Enter should open the detail view:\n%s", view)
+	}
+}
+
+// TestTasks_StopBashJobKillsAndRefreshes verifies 'x' on a running bash job
+// calls the kill endpoint and the completed action triggers a list refresh.
+func TestTasks_StopBashJobKillsAndRefreshes(t *testing.T) {
+	killCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/jobs/jm1:job_1/kill" && r.Method == http.MethodPost {
+			killCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "jm1:job_1", "killed": true})
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "jm1:job_1", Type: "bash_job", Status: "running", Label: "sleep 30", AgeSeconds: 5, Actions: []string{"cancel"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+	msgs := execCmds(t, cmd)
+	if !killCalled {
+		t.Fatal("'x' on a bash job must call POST /v1/jobs/{id}/kill")
+	}
+	// The action result feeds back into the model and triggers a refresh cmd.
+	var result tui.TaskActionResultMsg
+	for _, msg := range msgs {
+		if r, ok := msg.(tui.TaskActionResultMsg); ok {
+			result = r
+		}
+	}
+	m3, refreshCmd := m.Update(result)
+	m = m3.(tui.Model)
+	if result.Err != "" {
+		t.Fatalf("kill result.Err = %q, want empty", result.Err)
+	}
+	if refreshCmd == nil {
+		t.Error("successful stop should trigger a list refresh")
+	}
+}
+
+// TestTasks_StopCronRequiresConfirm verifies 'x' on a cron job shows the
+// confirmation prompt and only fires DELETE after 'y'.
+func TestTasks_StopCronRequiresConfirm(t *testing.T) {
+	deleteCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleteCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	cronRow := tui.RemoteTask{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync", AgeSeconds: 100, Actions: []string{"pause", "delete"}}
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{cronRow})
+
+	// 'x' shows the confirm prompt; nothing is deleted yet.
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+	if msgs := execCmds(t, cmd); len(msgs) != 0 {
+		t.Errorf("cron stop must wait for confirmation, got msgs %v", msgs)
+	}
+	if deleteCalled {
+		t.Fatal("DELETE fired before confirmation")
+	}
+	if view := m.View(); !strings.Contains(view, "Delete cron job") || !strings.Contains(view, "nightly-sync") {
+		t.Errorf("confirm prompt should name the cron job:\n%s", view)
+	}
+
+	// 'n' cancels — back to the list, still no DELETE.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = m3.(tui.Model)
+	if deleteCalled {
+		t.Fatal("DELETE fired after 'n'")
+	}
+	if view := m.View(); !strings.Contains(view, "COMMAND") {
+		t.Errorf("'n' should return to the list:\n%s", view)
+	}
+
+	// 'x' then 'y' fires the DELETE.
+	m4, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m4.(tui.Model)
+	m5, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	m = m5.(tui.Model)
+	execCmds(t, cmd)
+	if !deleteCalled {
+		t.Error("DELETE did not fire after 'y' confirmation")
+	}
+	if view := m.View(); !strings.Contains(view, "COMMAND") {
+		t.Errorf("after confirming, the panel should return to the list:\n%s", view)
+	}
+}
+
+// TestTasks_StopSubagentCancels verifies 'x' on a subagent cancels it
+// immediately (no confirmation).
+func TestTasks_StopSubagentCancels(t *testing.T) {
+	cancelCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/subagents/sub-1/cancel" && r.Method == http.MethodPost {
+			cancelCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"sub-1","status":"cancelling"}`))
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "sub-1", Type: "subagent", Status: "running", Label: "workspace-sub-1", AgeSeconds: 9, Actions: []string{"cancel"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+	execCmds(t, cmd)
+	if !cancelCalled {
+		t.Error("'x' on a subagent must call POST /v1/subagents/{id}/cancel")
+	}
+}
+
+// TestTasks_StopCallbackCancels verifies 'x' on a callback cancels it.
+func TestTasks_StopCallbackCancels(t *testing.T) {
+	cancelCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/callbacks/cb-1/cancel" && r.Method == http.MethodPost {
+			cancelCalled = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cb-1","status":"canceled"}`))
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "cb-1", Type: "callback", Status: "pending", Label: "check deploy", AgeSeconds: 42, Actions: []string{"cancel"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+	execCmds(t, cmd)
+	if !cancelCalled {
+		t.Error("'x' on a callback must call POST /v1/callbacks/{id}/cancel")
+	}
+}
+
+// TestTasks_ActionErrorSurfacesInPanel verifies a failed stop action renders
+// the error inside the panel (not just the status line).
+func TestTasks_ActionErrorSurfacesInPanel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "jm1:job_9", Type: "bash_job", Status: "running", Label: "sleep 30", AgeSeconds: 5, Actions: []string{"cancel"}},
+	})
+
+	m2, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+	for _, msg := range execCmds(t, cmd) {
+		m3, _ := m.Update(msg)
+		m = m3.(tui.Model)
+	}
+
+	if view := m.View(); !strings.Contains(view, "server returned 404") {
+		t.Errorf("panel should surface the action error:\n%s", view)
+	}
+	if !strings.Contains(m.StatusMsg(), "Task stop failed") {
+		t.Errorf("StatusMsg = %q, want it to contain 'Task stop failed'", m.StatusMsg())
+	}
+}
+
+// TestTasks_EscInDetailReturnsToList verifies Escape backs out of the detail
+// view to the list instead of closing the overlay.
+func TestTasks_EscInDetailReturnsToList(t *testing.T) {
+	m := initModel(t, 100, 30)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync", AgeSeconds: 100, Actions: []string{"delete"}},
+	})
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	m = m2.(tui.Model)
+	if view := m.View(); !strings.Contains(view, "nightly-sync") {
+		t.Fatalf("precondition: detail view must be open:\n%s", view)
+	}
+
+	m, _ = sendEscape(m)
+	if !m.OverlayActive() || m.ActiveOverlay() != "tasks" {
+		t.Fatal("Escape in detail mode should not close the tasks overlay")
+	}
+	if view := m.View(); !strings.Contains(view, "COMMAND") {
+		t.Errorf("Escape in detail mode should return to the list:\n%s", view)
+	}
+
+	// A second Escape closes the overlay.
+	m, _ = sendEscape(m)
+	if m.OverlayActive() {
+		t.Error("second Escape should close the tasks overlay")
+	}
+}
+
+// TestTasks_EscInConfirmCancels verifies Escape dismisses the cron delete
+// confirmation without firing.
+func TestTasks_EscInConfirmCancels(t *testing.T) {
+	deleteCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			deleteCalled = true
+		}
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	m := initModelWithURL(t, 100, 30, ts.URL)
+	m = openTasksWithRows(t, m, []tui.RemoteTask{
+		{ID: "job-1", Type: "cron", Status: "active", Label: "nightly-sync", AgeSeconds: 100, Actions: []string{"delete"}},
+	})
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	m = m2.(tui.Model)
+
+	m, _ = sendEscape(m)
+	if deleteCalled {
+		t.Error("Escape on the confirm prompt must not fire the DELETE")
+	}
+	if !m.OverlayActive() || m.ActiveOverlay() != "tasks" {
+		t.Error("Escape on the confirm prompt should return to the list, not close the overlay")
+	}
+	if view := m.View(); !strings.Contains(view, "COMMAND") {
+		t.Errorf("Escape on the confirm prompt should return to the list:\n%s", view)
+	}
 }

--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -504,6 +504,7 @@ func buildServerOptions(opts serverBootstrapOptions) server.ServerOptions {
 		RolloutDir:       opts.rolloutDir,
 		HooksSummary:     opts.hooksSummary,
 		CallbackLister:   opts.callbackMgr,
+		CallbackCanceler: opts.callbackMgr,
 		JobTracker:       opts.jobTracker,
 		ConfigReload:     configReloadFunc(opts.configReloader),
 	}

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -99,6 +99,13 @@
 - Validation: `go test ./cmd/harnesscli/... -count=1` green (29 packages);
   gofmt/vet clean on touched files.
 
+## 2026-07-21 (Unified /tasks Panel — Epic #814, Slice 4)
+
+- The `/tasks` overlay now supports row actions. `o`/Enter views output: bash jobs via the new `GET /v1/jobs/{id}/output` (backed by `JobTracker.Output`, runs:read, tenant-checked), subagents via the existing detail endpoint, and cron/callback rows via a static detail built from the row (no endpoint exists for those). `x`/Ctrl+K stops the selected task through the type-appropriate path: bash job kill (`/v1/jobs/{id}/kill`), subagent cancel, cron DELETE, and the new `POST /v1/callbacks/{id}/cancel` (new `CallbackCanceler` server option, wired from the daemon's `CallbackManager`; runs:write, tenant-checked).
+- Deleting a cron schedule is destructive, so `x` on a cron row opens a confirmation prompt (`taskspanel` confirm mode); DELETE only fires after `y`. Esc and `n` cancel the prompt.
+- The panel gained detail (scrollable output) and confirm sub-modes plus a transient notice line for action errors; Esc inside a sub-mode backs out to the list instead of closing the overlay (the global Esc chain now consults `tasksPanel.Mode()` first). Enter is handled in the global Enter block via a tasks guard delegating to the shared `openSelectedTaskOutput` helper. A successful stop triggers a list refresh.
+- Validation: failing-first tests across all layers — `job_tracker_test.go` Output, `http_tasks_test.go` (7 new endpoint tests), `taskspanel` mode/render tests (12 new), `api_tasks_test.go` (5 new incl. per-type dispatch table), `tasks_overlay_814_test.go` (10 new model tests covering every acceptance flow). `go test ./cmd/harnesscli/... -count=1` green; gofmt/vet clean.
+
 ## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
 
 - Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.

--- a/docs/plans/814-tasks-panel.md
+++ b/docs/plans/814-tasks-panel.md
@@ -10,7 +10,58 @@
 - `JobManager.List()` snapshot + tenant capture; daemon-level `harness.JobTracker` (`jm<N>:job_<n>` namespacing) registered via `DefaultRegistryOptions.JobTracker`.
 - `GET /v1/tasks` unions `bash_job` entries; `POST /v1/jobs/{id}/kill` terminates them (runs:write, tenant-scoped).
 
-## Slice 3 (this branch, epic/814-tasks-panel-s3): /tasks overlay listing unified background tasks
+## Slice 3 (merged, PR #893): /tasks overlay listing unified background tasks
+
+- `components/taskspanel` (value-semantics Model): TYPE/STATUS/AGE/COMMAND columns, cursor navigation with scroll-into-view windowing, empty/loading/error states.
+- `RemoteTask` + `loadTasksCmd`; `/tasks` registered in `cmd_parser.go` (auto-feeds `/help`, slash-complete, tab completion).
+
+## Slice 4 (this branch, epic/814-tasks-panel-s4): task actions — view output and stop from the /tasks panel
+
+### Context
+
+- Problem: the `/tasks` overlay (slice 3) is read-only; stopping work or reading output still requires agent cooperation or per-surface commands.
+- User impact: from a selected row the user can view recent output and stop/kill the task through the existing per-type mechanisms.
+- Constraints: slice 4 only — actions on the existing panel. Cron deletion requires a confirmation prompt. Strict TDD.
+
+### Scope
+
+- In scope:
+  - Server (TUI has no other path): `GET /v1/jobs/{id}/output` (bash job output via new `JobTracker.Output`, runs:read, tenant-checked) and `POST /v1/callbacks/{id}/cancel` (new `CallbackCanceler` option, runs:write, tenant-checked). Subagent cancel and cron delete endpoints already exist.
+  - `components/taskspanel`: confirm mode (`AskConfirm`/`PendingConfirm`/`ResolveConfirm` + prompt rendering), detail mode (`ShowOutput`/`CloseDetail`/scroll + rendering), transient notice line (`SetNotice`), `HandleEscape` backing out of sub-modes.
+  - TUI api: `fetchTaskOutputCmd` (bash_job → `/v1/jobs/{id}/output`, subagent → `/v1/subagents/{id}`), `cancelTaskCmd` (per-type dispatch: kill/cancel/DELETE/cancel), `TaskOutputLoadedMsg`/`TaskActionResultMsg`.
+  - `model.go`: mode-aware key routing (`o`/Enter output, `x`/Ctrl+K stop, cron delete confirms first, detail scroll/back, confirm y/n), Esc consumed by panel sub-modes before the overlay close, list refresh after a successful stop, action errors surfaced via the panel notice + status message.
+- Out of scope: streaming live output (SSE tail), periodic auto-refresh, per-type confirm prompts beyond cron delete, killing whole runs (only background tasks).
+
+### Test Plan (TDD)
+
+- Failing tests first:
+  - `internal/harness/job_tracker_test.go`: `Output` routes to the owning manager, unknown IDs → `ErrJobNotFound`.
+  - `internal/server/http_tasks_test.go`: job output endpoint (200 + payload, 404, 501, cross-tenant); callback cancel (200 + pending removed, 404, 501, cross-tenant).
+  - `components/taskspanel`: confirm prompt render + resolve, detail render/scroll/indicators, notice line, Esc handling, Open resets modes.
+  - `cmd/harnesscli/tui/api_tasks_test.go`: output fetch (bash_job, subagent, failure) and per-type cancel dispatch + server error.
+  - `cmd/harnesscli/tui/tasks_overlay_814_test.go`: `o` bash job → detail with fetched output; `o` cron → static detail without fetch; Enter alias; `x` bash job → kill + refresh; `x` cron → confirm prompt, no DELETE until `y`, `n`/Esc cancel; `x` subagent/callback → cancel endpoints; action error in panel; Esc in detail/confirm returns to list.
+- Existing tests to update: none expected.
+
+### Cross-Surface Impact Map
+
+- Not required (no provider/model flow surface). Config: None. Server API: two new routes (`/v1/jobs/{id}/output`, `/v1/callbacks/{id}/cancel`). TUI state: panel sub-modes (confirm/detail) + action messages. Regression tests: listed above.
+
+### Implementation Checklist
+
+- [x] Failing tests first (tracker, server, component, api, model).
+- [x] `JobTracker.Output` + `GET /v1/jobs/{id}/output`.
+- [x] `POST /v1/callbacks/{id}/cancel` + `CallbackCanceler` wiring.
+- [x] taskspanel confirm/detail/notice modes.
+- [x] TUI api commands + model wiring + Esc handling + refresh.
+- [x] gofmt/vet clean; `go test ./cmd/harnesscli/... -count=1` green (+ internal/server, internal/harness, cmd/harnessd).
+- [x] Docs (this plan, engineering log, indexes); commit, push, open PR (no merge).
+
+### Risks and Mitigations
+
+- Risk: Enter is captured by the global Enter-key block before overlay routing. Mitigation: explicit tasks guard in that block delegating to the shared `openSelectedTaskOutput` helper (covered by `TestTasks_EnterAlsoOpensOutput`).
+- Risk: Esc closes the whole overlay instead of backing out of a sub-mode. Mitigation: the Esc chain consults `tasksPanel.Mode()` first; regression tests cover both sub-modes.
+
+## Slice 3 detail (kept for reference)
 
 ### Context
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -10,7 +10,7 @@
 - `2026-07-20-kimi-subscription-auth-848-plan.md` — Epic #848 Kimi Code subscription auth, endpoint spike, token import, provider wiring, and CLI/TUI lifecycle (in implementation).
 - `2026-07-20-kimi-subscription-auth-848-impact-map.md` — Cross-surface impact map for Epic #848 Kimi subscription authentication.
 - `819-plan-mode.md` — Epic #819 slice 1: pin plan-mode exit semantics across approval modes (in implementation).
-- `814-tasks-panel.md` — Epic #814 unified /tasks background panel: slice 1 `GET /v1/tasks` union, slice 2 bash-job exposure + kill, slice 3 TUI `/tasks` overlay (slices 1–3 in implementation/merged).
+- `814-tasks-panel.md` — Epic #814 unified /tasks background panel: slice 1 `GET /v1/tasks` union, slice 2 bash-job exposure + kill, slice 3 TUI `/tasks` overlay, slice 4 panel actions (all four slices implemented).
 - `817-compact-cmd.md` — Epic #817 slice 1: preserve-instruction in `CompactRun` and the run compact endpoint (in implementation).
 - `815-config-reload.md` — Epic #815 Slice 1: hot-swappable vs restart-only config field classification with `ReloadDiff` (in implementation).
 - `808-agent-swarm.md` — Agent swarm epic #808: Slices 1–3 (orchestrator, resume, agent_swarm tool; merged), Slice 4 TUI live swarm progress panel (in implementation).

--- a/internal/harness/job_tracker.go
+++ b/internal/harness/job_tracker.go
@@ -129,6 +129,22 @@ func (t *JobTracker) Kill(taskID string) error {
 	return nil
 }
 
+// Output returns the captured output snapshot for the job identified by a
+// namespaced task ID, reusing the owning manager's Output (same payload as
+// the agent-facing job_output tool: output, running, exit_code, timed_out,
+// started_at). Unknown task IDs return ErrJobNotFound.
+func (t *JobTracker) Output(taskID string) (map[string]any, error) {
+	mgr, shellID, ok := t.resolve(taskID)
+	if !ok {
+		return nil, ErrJobNotFound
+	}
+	out, err := mgr.Output(shellID, false)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrJobNotFound, err)
+	}
+	return out, nil
+}
+
 // resolve splits a namespaced task ID and returns the owning manager.
 func (t *JobTracker) resolve(taskID string) (*htools.JobManager, string, bool) {
 	ref, shellID, found := strings.Cut(taskID, ":")

--- a/internal/harness/job_tracker_test.go
+++ b/internal/harness/job_tracker_test.go
@@ -245,3 +245,51 @@ func TestDefaultRegistryJobManagerRegistersWithTracker(t *testing.T) {
 		t.Fatalf("tracker has %d jobs after registry shutdown, want 0: %+v", len(got), got)
 	}
 }
+
+// TestJobTrackerOutput verifies Output routes to the owning manager and
+// returns the job's captured output (epic #814 slice 4: view output from the
+// /tasks panel).
+func TestJobTrackerOutput(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewJobTracker()
+	mgr := htools.NewJobManager(t.TempDir(), nil)
+	defer func() { _ = mgr.Shutdown(context.Background()) }()
+
+	ref := tracker.Register(mgr)
+	shellID := startTrackedJob(t, mgr, "echo hello-from-job")
+
+	// Wait for the job to finish so output is present.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := mgr.Output(shellID, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", shellID, err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("echo job did not finish in time")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	out, err := tracker.Output(ref + ":" + shellID)
+	if err != nil {
+		t.Fatalf("tracker.Output: %v", err)
+	}
+	text, _ := out["output"].(string)
+	if !strings.Contains(text, "hello-from-job") {
+		t.Errorf("tracker.Output output = %q, want it to contain 'hello-from-job'", text)
+	}
+	if running, _ := out["running"].(bool); running {
+		t.Error("finished job should report running=false")
+	}
+
+	for _, bad := range []string{"jm999:job_1", ref + ":job_999", "no-separator"} {
+		if _, err := tracker.Output(bad); !errors.Is(err, ErrJobNotFound) {
+			t.Errorf("Output(%q) error = %v, want ErrJobNotFound", bad, err)
+		}
+	}
+}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -91,6 +91,10 @@ type ServerOptions struct {
 	// conversations for GET /v1/tasks (epic #814). Optional; when nil the
 	// tasks union simply contains no callback entries.
 	CallbackLister CallbackLister
+	// CallbackCanceler cancels pending delayed callbacks for
+	// POST /v1/callbacks/{id}/cancel (epic #814 slice 4). Optional; when nil
+	// the cancel route returns 501.
+	CallbackCanceler CallbackCanceler
 	// JobTracker enumerates and kills background bash jobs across all tool
 	// registries for GET /v1/tasks and POST /v1/jobs/{id}/kill (epic #814
 	// slice 2). Optional; when nil, bash_job entries are absent and the kill
@@ -223,6 +227,7 @@ func NewWithOptions(opts ServerOptions) http.Handler {
 		mcpConnector:      opts.MCPConnector,
 		subagentManager:   opts.SubagentManager,
 		callbackLister:    opts.CallbackLister,
+		callbackCanceler:  opts.CallbackCanceler,
 		jobTracker:        opts.JobTracker,
 		checkpoints:       opts.Checkpoints,
 		runStore:          opts.Store,
@@ -315,7 +320,12 @@ func (s *Server) buildMux() http.Handler {
 
 	// POST /v1/jobs/{id}/kill — daemon-side kill path for background bash
 	// jobs (epic #814 slice 2). Requires runs:write; scope enforced inside.
+	// GET /v1/jobs/{id}/output — job output snapshot (epic #814 slice 4).
 	mux.Handle("/v1/jobs/", auth(http.HandlerFunc(s.handleJobByID)))
+
+	// POST /v1/callbacks/{id}/cancel — daemon-side cancel for pending delayed
+	// callbacks (epic #814 slice 4). Requires runs:write; enforced inside.
+	mux.Handle("/v1/callbacks/", auth(http.HandlerFunc(s.handleCallbackByID)))
 
 	// /v1/skills — GET requires runs:read; POST /verify requires runs:write.
 	mux.Handle("/v1/skills", auth(read(http.HandlerFunc(s.handleSkillsRoot))))
@@ -455,6 +465,10 @@ type Server struct {
 	// conversations for GET /v1/tasks (epic #814). When nil, callbacks are
 	// simply absent from the union.
 	callbackLister CallbackLister
+
+	// callbackCanceler cancels pending delayed callbacks for
+	// POST /v1/callbacks/{id}/cancel (epic #814 slice 4).
+	callbackCanceler CallbackCanceler
 
 	// jobTracker enumerates and kills background bash jobs daemon-wide for
 	// GET /v1/tasks and POST /v1/jobs/{id}/kill (epic #814 slice 2).

--- a/internal/server/http_tasks.go
+++ b/internal/server/http_tasks.go
@@ -38,6 +38,13 @@ type CallbackLister interface {
 	ListAll() []tools.CallbackInfo
 }
 
+// CallbackCanceler cancels a pending delayed callback by ID for
+// POST /v1/callbacks/{id}/cancel (epic #814 slice 4).
+// *tools.CallbackManager satisfies it via Cancel.
+type CallbackCanceler interface {
+	Cancel(id string) (tools.CallbackInfo, error)
+}
+
 // Task is the unified DTO returned by GET /v1/tasks. It captures one piece of
 // background work — a managed subagent, a cron job, or a pending delayed
 // callback — with the fields the /tasks panel needs to render a row.
@@ -207,11 +214,13 @@ func taskFromBashJob(tj harness.TrackedJob, now time.Time) Task {
 	}
 }
 
-// handleJobByID serves POST /v1/jobs/{id}/kill, the daemon-side kill path for
-// background bash jobs (epic #814 slice 2). The {id} is the namespaced task
-// ID from GET /v1/tasks ("<managerRef>:<shellID>"). Requires runs:write,
-// matching the mutating subagent/cron routes. Cross-tenant kills are 404
-// (not 403), matching subagent cancel semantics.
+// handleJobByID serves the per-job actions for background bash jobs:
+//   - POST /v1/jobs/{id}/kill   — daemon-side kill (epic #814 slice 2), runs:write
+//   - GET  /v1/jobs/{id}/output — captured output snapshot (epic #814 slice 4), runs:read
+//
+// The {id} is the namespaced task ID from GET /v1/tasks
+// ("<managerRef>:<shellID>"). Cross-tenant access is 404 (not 403), matching
+// subagent cancel semantics.
 func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
 	if s.jobTracker == nil {
 		writeError(w, http.StatusNotImplemented, "not_configured", "job tracker is not configured")
@@ -219,11 +228,24 @@ func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
 	}
 	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/jobs/"), "/")
 	parts := strings.Split(path, "/")
-	if len(parts) != 2 || parts[0] == "" || parts[1] != "kill" {
+	if len(parts) != 2 || parts[0] == "" {
 		writeError(w, http.StatusNotFound, "not_found", "job action not found")
 		return
 	}
 	id := parts[0]
+	switch parts[1] {
+	case "kill":
+		s.handleJobKill(w, r, id)
+	case "output":
+		s.handleJobOutput(w, r, id)
+	default:
+		writeError(w, http.StatusNotFound, "not_found", "job action not found")
+	}
+}
+
+// handleJobKill serves POST /v1/jobs/{id}/kill. Requires runs:write, matching
+// the mutating subagent/cron routes.
+func (s *Server) handleJobKill(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodPost {
 		writeMethodNotAllowed(w, http.MethodPost)
 		return
@@ -250,6 +272,85 @@ func (s *Server) handleJobByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"id": id, "killed": true})
+}
+
+// handleJobOutput serves GET /v1/jobs/{id}/output: the job's captured output
+// snapshot (same payload as the agent-facing job_output tool) for the /tasks
+// panel's view-output action (epic #814 slice 4). Requires runs:read.
+func (s *Server) handleJobOutput(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if !hasScope(r.Context(), store.ScopeRunsRead) {
+		writeScopeError(w, store.ScopeRunsRead)
+		return
+	}
+	// Tenant scoping mirrors handleJobKill.
+	if caller := TenantIDFromContext(r.Context()); caller != "" {
+		tj, ok := s.jobTracker.Get(id)
+		if !ok || tj.Info.TenantID != caller {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+			return
+		}
+	}
+	out, err := s.jobTracker.Output(id)
+	if err != nil {
+		if errors.Is(err, harness.ErrJobNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "output_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// handleCallbackByID serves POST /v1/callbacks/{id}/cancel, the daemon-side
+// cancel path for pending delayed callbacks (epic #814 slice 4). Requires
+// runs:write. Cross-tenant cancels are 404 (not 403), matching the other
+// task stop routes.
+func (s *Server) handleCallbackByID(w http.ResponseWriter, r *http.Request) {
+	if s.callbackCanceler == nil {
+		writeError(w, http.StatusNotImplemented, "not_configured", "callback manager is not configured")
+		return
+	}
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/v1/callbacks/"), "/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "cancel" {
+		writeError(w, http.StatusNotFound, "not_found", "callback action not found")
+		return
+	}
+	id := parts[0]
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if !hasScope(r.Context(), store.ScopeRunsWrite) {
+		writeScopeError(w, store.ScopeRunsWrite)
+		return
+	}
+	// Tenant scoping: when auth is enabled, the caller may only cancel their
+	// own tenant's callbacks. Pending callbacks are enumerated via the lister
+	// (the cancel path has no separate lookup).
+	if caller := TenantIDFromContext(r.Context()); caller != "" && s.callbackLister != nil {
+		owned := false
+		for _, info := range s.callbackLister.ListAll() {
+			if info.ID == id && info.TenantID == caller {
+				owned = true
+				break
+			}
+		}
+		if !owned {
+			writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("callback %q not found", id))
+			return
+		}
+	}
+	if _, err := s.callbackCanceler.Cancel(id); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"id": id, "status": "canceled"})
 }
 
 // taskAgeSeconds computes a non-negative age in whole seconds. Clock skew or

--- a/internal/server/http_tasks_test.go
+++ b/internal/server/http_tasks_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -629,5 +630,197 @@ func TestJobKillEndpoint_NotConfigured(t *testing.T) {
 	code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/jobs/jm1:job_1/kill", nil)
 	if code != http.StatusNotImplemented {
 		t.Fatalf("kill with unconfigured tracker: status %d, want 501", code)
+	}
+}
+
+// --- task output + callback cancel endpoints (epic #814 slice 4) ---
+
+// TestJobOutputEndpoint verifies GET /v1/jobs/{id}/output returns the job's
+// captured output (the view-output path for bash_job rows in /tasks).
+func TestJobOutputEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tracker, mgr := newTrackedJobManager(t)
+	shellID := startBashJob(t, mgr, context.Background(), "echo hello-from-job")
+
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		out, err := mgr.Output(shellID, false)
+		if err != nil {
+			t.Fatalf("Output(%s): %v", shellID, err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("echo job did not finish in time")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	var taskID string
+	for _, tj := range tracker.List() {
+		taskID = tj.TaskID
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, body := doSubagentRequest(t, ts, http.MethodGet, "", "/v1/jobs/"+taskID+"/output", nil)
+	if code != http.StatusOK {
+		t.Fatalf("GET /v1/jobs/%s/output: status %d, body %s; want 200", taskID, code, body)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode output response: %v", err)
+	}
+	text, _ := payload["output"].(string)
+	if !strings.Contains(text, "hello-from-job") {
+		t.Errorf("output payload = %q, want it to contain 'hello-from-job'", text)
+	}
+}
+
+// TestJobOutputEndpoint_NotFoundAndNotConfigured verifies 404 for unknown
+// jobs and 501 when no tracker is wired.
+func TestJobOutputEndpoint_NotFoundAndNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newTrackedJobManager(t)
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodGet, "", "/v1/jobs/jm999:job_1/output", nil)
+	if code != http.StatusNotFound {
+		t.Errorf("unknown job output: status %d, want 404", code)
+	}
+
+	bareHandler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t)})
+	bareTS := httptest.NewServer(bareHandler)
+	defer bareTS.Close()
+	code, _ = doSubagentRequest(t, bareTS, http.MethodGet, "", "/v1/jobs/jm1:job_1/output", nil)
+	if code != http.StatusNotImplemented {
+		t.Errorf("unconfigured tracker output: status %d, want 501", code)
+	}
+}
+
+// TestJobOutputEndpoint_CrossTenant verifies a caller cannot read another
+// tenant's job output.
+func TestJobOutputEndpoint_CrossTenant(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	_, keyA := newSubagentTenantAPIKey(t, "tenant-alpha", "key A")
+	tokenB, keyB := newSubagentTenantAPIKey(t, "tenant-bravo", "key B")
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	tracker, mgr := newTrackedJobManager(t)
+	startBashJob(t, mgr, tenantJobCtx("tenant-alpha"), "sleep 30")
+	var taskID string
+	for _, tj := range tracker.List() {
+		taskID = tj.TaskID
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms, JobTracker: tracker})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodGet, tokenB, "/v1/jobs/"+taskID+"/output", nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("cross-tenant output: status %d, want 404", code)
+	}
+}
+
+// TestCallbackCancelEndpoint verifies POST /v1/callbacks/{id}/cancel cancels a
+// pending delayed callback.
+func TestCallbackCancelEndpoint(t *testing.T) {
+	t.Parallel()
+
+	mgr := tools.NewCallbackManager(noopRunStarter{})
+	info, err := mgr.Set(tools.SetRequest{ConversationID: "conv-1", Delay: time.Hour, Prompt: "check deploy"})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), CallbackLister: mgr, CallbackCanceler: mgr})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, body := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/callbacks/"+info.ID+"/cancel", nil)
+	if code != http.StatusOK {
+		t.Fatalf("POST /v1/callbacks/%s/cancel: status %d, body %s; want 200", info.ID, code, body)
+	}
+	if got := len(mgr.ListAll()); got != 0 {
+		t.Fatalf("ListAll after cancel has %d pending callbacks, want 0", got)
+	}
+}
+
+// TestCallbackCancelEndpoint_NotFound verifies unknown IDs and already-fired
+// callbacks are reported.
+func TestCallbackCancelEndpoint_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mgr := tools.NewCallbackManager(noopRunStarter{})
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), CallbackLister: mgr, CallbackCanceler: mgr})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/callbacks/cb-missing/cancel", nil)
+	if code != http.StatusNotFound {
+		t.Errorf("unknown callback cancel: status %d, want 404", code)
+	}
+}
+
+// TestCallbackCancelEndpoint_NotConfigured verifies 501 without a canceler.
+func TestCallbackCancelEndpoint_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t)})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodPost, "", "/v1/callbacks/cb-1/cancel", nil)
+	if code != http.StatusNotImplemented {
+		t.Errorf("unconfigured callback cancel: status %d, want 501", code)
+	}
+}
+
+// TestCallbackCancelEndpoint_CrossTenant verifies a caller cannot cancel
+// another tenant's callback.
+func TestCallbackCancelEndpoint_CrossTenant(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	_, keyA := newSubagentTenantAPIKey(t, "tenant-alpha", "key A")
+	tokenB, keyB := newSubagentTenantAPIKey(t, "tenant-bravo", "key B")
+	if err := ms.CreateAPIKey(context.Background(), keyA); err != nil {
+		t.Fatalf("CreateAPIKey A: %v", err)
+	}
+	if err := ms.CreateAPIKey(context.Background(), keyB); err != nil {
+		t.Fatalf("CreateAPIKey B: %v", err)
+	}
+
+	mgr := tools.NewCallbackManager(noopRunStarter{})
+	info, err := mgr.Set(tools.SetRequest{ConversationID: "conv-1", Delay: time.Hour, Prompt: "check deploy", TenantID: "tenant-alpha"})
+	if err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	handler := NewWithOptions(ServerOptions{Runner: testRunnerForAgents(t), Store: ms, CallbackLister: mgr, CallbackCanceler: mgr})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	code, _ := doSubagentRequest(t, ts, http.MethodPost, tokenB, "/v1/callbacks/"+info.ID+"/cancel", nil)
+	if code != http.StatusNotFound {
+		t.Fatalf("cross-tenant callback cancel: status %d, want 404", code)
+	}
+	if got := len(mgr.ListAll()); got != 1 {
+		t.Fatalf("cross-tenant cancel removed the callback; %d pending, want 1", got)
 	}
 }


### PR DESCRIPTION
Parent epic: #814. Part of #803.

## Slice 4 (final) of epic #814 (unified /tasks background panel)

**View output** (`o`/Enter on a row):
- bash jobs: new `GET /v1/jobs/{id}/output` (new `JobTracker.Output`, runs:read, tenant-checked like the kill route)
- subagents: existing `GET /v1/subagents/{id}` detail endpoint
- cron/callback: static detail from the row itself (no endpoint exists)

**Stop** (`x`/Ctrl+K on a row), via the type-appropriate path:
- bash job → `POST /v1/jobs/{id}/kill` (slice 2)
- subagent → `POST /v1/subagents/{id}/cancel`
- cron → `DELETE /v1/cron/jobs/{id}` — **behind a confirmation prompt** (deleting a schedule is destructive; `y` fires, `n`/Esc cancels)
- callback → new `POST /v1/callbacks/{id}/cancel` (new `CallbackCanceler` server option wired from the daemon's `CallbackManager`; runs:write, tenant-checked)

**Panel mechanics:** scrollable detail mode (Esc/`h` back to list), confirm mode, transient notice line surfacing action errors in the panel, Esc consumed by sub-modes before the overlay close, list refresh after a successful stop.

## Tests (strict TDD — failing first)

- `internal/harness/job_tracker_test.go`: `Output` routing + `ErrJobNotFound`.
- `internal/server/http_tasks_test.go` (7 new): job output (200/payload, 404, 501, cross-tenant); callback cancel (200 + pending removed, 404, 501, cross-tenant).
- `components/taskspanel` (12 new): confirm prompt render/resolve, detail render/scroll/overflow indicators, notice line, Esc handling, Open resets modes.
- `cmd/harnesscli/tui/api_tasks_test.go` (5 new): output fetch (bash_job, subagent, failure) and per-type cancel dispatch table + server error.
- `cmd/harnesscli/tui/tasks_overlay_814_test.go` (10 new, covering every acceptance flow): `o` bash job → detail with fetched output + `h` back; `o` cron → static detail, zero fetches; Enter alias; `x` bash job → kill endpoint hit + refresh cmd; `x` cron → confirm shown, no DELETE until `y`, `n` and Esc cancel; `x` subagent/callback → cancel endpoints; action error rendered in panel + status line; Esc in detail/confirm returns to list, second Esc closes.

## Verification

- `go test ./cmd/harnesscli/... -count=1` — all 29 packages ok, zero failures
- `go test ./internal/server/ ./internal/harness/ ./cmd/harnessd/ -count=1` — all ok
- gofmt/go vet clean on all touched files

All four epic acceptance criteria are now covered: `/tasks` lists bash jobs, subagents, cron jobs, and callbacks with type/status/age/command; rows support view-output and stop through the per-type mechanisms (cron with confirmation); empty/loading/error states render distinctly; `GET /v1/tasks` serves non-TUI clients with consistent auth.