### PR TITLE
feat(server): event timeline view rendered from the run event stream

### DIFF
--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -175,6 +175,6 @@ Epic: #812 (parent #803).
 - [x] Extend node harness with timeline checks; watch red.
 - [x] Implement `app.js` timeline + `style.css`.
 - [x] `node --check`; harness green; gofmt/go vet clean.
-- [ ] `go test ./internal/server/... -count=1`.
+- [x] `go test ./internal/server/... -count=1`.
 - [x] Real-daemon e2e: run against a fake provider; curl SSE (history→live), confirm timeline assets served.
-- [ ] Commit, push `epic/812-session-visualizer-s4`, open PR against repo.
+- [x] Commit, push `epic/812-session-visualizer-s4`, open PR against repo. (PR #915; full regression suite result reported in PR body comments/notes.)

--- a/docs/plans/812-session-visualizer.md
+++ b/docs/plans/812-session-visualizer.md
@@ -138,4 +138,43 @@ Epic: #812 (parent #803).
 - [x] `node --check` the JS; gofmt/go vet clean.
 - [x] Run touched-package tests.
 - [x] Seeded-daemon e2e smoke (HARNESS_RUN_DB + seeded key/runs; curl list/detail; confirm new assets served) + DOM-stubbed render smoke (15/15).
-- [x] Commit, push `epic/812-session-visualizer-s3`, open PR against repo.
+- [x] Commit, push `epic/812-session-visualizer-s3`, open PR against repo. (Merged, PR #889.)
+
+---
+
+## Slice 4 (this branch): `feat(server): event timeline view rendered from the run event stream`
+
+### Context
+
+- Problem: run detail shows metadata + summary but not *what happened* during the run.
+- User impact: chronological, live-updating timeline of canonical events per run.
+- Constraints: no new endpoints; native `EventSource` cannot set headers → fetch-based SSE reader with the Bearer header; reconnect with `Last-Event-ID`; no duplicates on resume.
+- Contract facts verified in code:
+  - `GET /v1/runs/{id}/events` (`handleRunEvents`, http_runs.go:833): `runner.Subscribe` → replay history then live channel; frames `id: <runID>:<seq>` / `retry: 3000` / `event: <type>` / `data: <full harness.Event JSON {id,run_id,type,timestamp,payload}>`; `: ping` comment keepalives; server closes after the terminal event (`run.completed|failed|cancelled`, events.go:472); in-range `Last-Event-ID` skips seen seqs, unparseable/out-of-range falls back to full replay; runner in-memory only → 404 for post-restart historical runs (UI note, same as summary).
+  - Payloads: run.started `{prompt,tenant_id?}`; run.completed `{output,usage_totals,cost_totals}`; run.failed `{error,...}`; llm.turn.requested `{step}`; llm.turn.completed `{step,tool_calls,total_duration_ms,ttft_ms,provider}`; assistant.message `{content}`; assistant.message.delta `{step,content}`; tool.call.started `{call_id,tool,arguments}`; tool.call.completed `{call_id,tool,output,duration_ms}`; run.cost_limit_reached `{step,max_cost_usd,cumulative_cost_usd}`; usage/cost totals JSON: `prompt_tokens_total,completion_tokens_total,total_tokens / cost_usd_total,cost_status`.
+
+### Scope
+
+- In scope:
+  - `app.js`: `SSEClient` (fetch reader, frame parser, seq tracking, `Last-Event-ID` resume with backoff, dedupe by seq, abort on route change); timeline renderers — lifecycle markers (`run.*`), collapsible tool.call started/completed pairs (keyed by `call_id`), `llm.turn.*` rows, assistant bubbles (delta-append + final `assistant.message`), `run.cost_limit_reached` highlight, generic JSON fallback for unknown types; seq `#n` badges per row; auto-scroll with pause-on-scroll-up; replaces the slice-3 "timeline arrives later" note in the detail view.
+  - `style.css`: timeline styles.
+  - Go contract test: mid-flight connect → replayed history prefix in seq order, then live continuation, strictly increasing `runID:seq` ids, closes after terminal (the one gap: Last-Event-ID skip ×3, SSE framing, keepalive, and e2e from-start streaming are already covered — do not duplicate).
+- Out of scope: slices 5–6 (search, ops doc); store-backed replay for post-restart runs (server-side feature, not this epic); any endpoint change.
+
+### Test Plan (TDD)
+
+- Go: new httptest `TestRunEvents_HistoryThenLiveOrdering` (signaling provider: block in `Complete` until gate closes; connect after provider entry ⇒ first events are replayed history at seq 0..k, then live continuation to terminal, ids strictly increasing). Red step: fails to compile/pass before… — this is a characterization test of existing server behavior; expected to pass immediately, run first to pin the contract before the JS depends on it.
+- JS: extend the node DOM/fetch harness with a scripted SSE byte stream (history frames + live frames + a reconnect leg asserting the `Last-Event-ID` header and no duplicate rows) and timeline DOM assertions — run BEFORE implementing (red: missing timeline container/renderers), then implement to green.
+- Existing tests to update: none.
+- Regression: `go test ./internal/server/... -count=1`.
+
+### Implementation Checklist
+
+- [x] Verify event contract + payload shapes in code.
+- [x] Write Go contract test; run (pins existing behavior).
+- [x] Extend node harness with timeline checks; watch red.
+- [x] Implement `app.js` timeline + `style.css`.
+- [x] `node --check`; harness green; gofmt/go vet clean.
+- [ ] `go test ./internal/server/... -count=1`.
+- [x] Real-daemon e2e: run against a fake provider; curl SSE (history→live), confirm timeline assets served.
+- [ ] Commit, push `epic/812-session-visualizer-s4`, open PR against repo.

--- a/internal/server/http_viz_events_test.go
+++ b/internal/server/http_viz_events_test.go
@@ -1,0 +1,241 @@
+package server_test
+
+// http_viz_events_test.go — pins the GET /v1/runs/{id}/events contract that
+// the /viz session visualizer's timeline view depends on (epic #812, slice 4):
+//
+//   - A client connecting mid-flight first receives the run's stored history
+//     (replay), then live events as the run progresses.
+//   - Event ids are "<runID>:<seq>" with seq strictly increasing by 1 across
+//     the whole stream (replay and live phases concatenated), so the UI can
+//     render in order and reconnect with Last-Event-ID without duplicates.
+//   - The server closes the stream after the terminal event.
+//
+// Adjacent contracts are already covered elsewhere and intentionally not
+// duplicated: Last-Event-ID skip (TestLastEventIDSkipsSeenEvents,
+// TestRegression_C1_InRangeLastEventID_StillReplaysOnlyUnseenEvents),
+// adversarial Last-Event-ID (TestLastEventID_AdversarialValuesDoNotPanic),
+// SSE framing (TestWriteSSE_IncludesIDAndRetry), keepalive pings
+// (TestSSEKeepalivePingsInEventStream), and from-start streaming to a
+// terminal event (test/e2e TestE2E_HappyPathRunCompletes).
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+)
+
+// signalingProvider blocks inside Complete until released, and closes
+// called on entry so tests can synchronize on "the provider was invoked"
+// (which implies run.started and llm.turn.requested are already in the
+// run's event history).
+type signalingProvider struct {
+	called chan struct{}
+	done   chan struct{}
+	once   sync.Once
+}
+
+func (p *signalingProvider) Complete(ctx context.Context, _ harness.CompletionRequest) (harness.CompletionResult, error) {
+	p.once.Do(func() { close(p.called) })
+	select {
+	case <-ctx.Done():
+		return harness.CompletionResult{}, ctx.Err()
+	case <-p.done:
+		return harness.CompletionResult{Content: "signaling provider done"}, nil
+	}
+}
+
+// sseFrame is one parsed SSE frame from the events stream.
+type sseFrame struct {
+	id    string
+	event string
+	data  string
+}
+
+// readSSEFrame reads one frame (terminated by a blank line) from r,
+// skipping keepalive comment lines (": ping"). It returns the frame's id,
+// event, and data fields.
+func readSSEFrame(r *bufio.Reader) (sseFrame, error) {
+	var f sseFrame
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return sseFrame{}, err
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		switch {
+		case trimmed == "":
+			// Blank line ends the frame; a frame with no data was a comment.
+			if f.event == "" && f.data == "" {
+				continue
+			}
+			return f, nil
+		case strings.HasPrefix(trimmed, ":"):
+			// SSE comment (keepalive ping) — ignore.
+		case strings.HasPrefix(trimmed, "id: "):
+			f.id = strings.TrimPrefix(trimmed, "id: ")
+		case strings.HasPrefix(trimmed, "event: "):
+			f.event = strings.TrimPrefix(trimmed, "event: ")
+		case strings.HasPrefix(trimmed, "data: "):
+			if f.data != "" {
+				f.data += "\n"
+			}
+			f.data += strings.TrimPrefix(trimmed, "data: ")
+		}
+	}
+}
+
+func TestRunEvents_HistoryThenLiveOrdering(t *testing.T) {
+	t.Parallel()
+
+	sp := &signalingProvider{called: make(chan struct{}), done: make(chan struct{})}
+	runner := harness.NewRunner(
+		sp,
+		harness.NewRegistry(),
+		harness.RunnerConfig{DefaultModel: "gpt-4.1-mini", MaxSteps: 1},
+	)
+
+	handler := server.New(runner)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/v1/runs", "application/json", bytes.NewBufferString(`{"prompt":"timeline contract"}`))
+	if err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	defer res.Body.Close()
+	var created struct {
+		RunID string `json:"run_id"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+
+	// Wait until the provider is invoked: at that point run.started and
+	// llm.turn.requested are guaranteed to be in the run's history, so a
+	// client connecting now must receive them as replayed history.
+	select {
+	case <-sp.called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("provider was not invoked within 5s")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/v1/runs/"+created.RunID+"/events", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect to events stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+
+	// Phase 1: read the replayed history frames (before the run is released).
+	// Everything the run emitted up to the provider call must arrive first.
+	var frames []sseFrame
+	first, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read first frame (history): %v", err)
+	}
+	frames = append(frames, first)
+	second, err := readSSEFrame(reader)
+	if err != nil {
+		t.Fatalf("read second frame (history): %v", err)
+	}
+	frames = append(frames, second)
+
+	if frames[0].event != string(harness.EventRunStarted) {
+		t.Fatalf("first replayed frame = %q, want %q (history must replay from the beginning)", frames[0].event, harness.EventRunStarted)
+	}
+
+	// Phase 2: release the provider and read the live continuation to the
+	// terminal event.
+	close(sp.done)
+	for {
+		f, err := readSSEFrame(reader)
+		if err != nil {
+			t.Fatalf("read live frame: %v", err)
+		}
+		frames = append(frames, f)
+		if harness.IsTerminalEvent(harness.EventType(f.event)) {
+			break
+		}
+	}
+
+	// The whole stream (replay + live) must carry ids "<runID>:<seq>" with
+	// seq strictly increasing by 1 from 0 — the UI renders in this order and
+	// resumes with Last-Event-ID without duplicates.
+	for i, f := range frames {
+		runID, seq, err := harness.ParseEventID(f.id)
+		if err != nil {
+			t.Fatalf("frame %d: unparseable event id %q: %v", i, f.id, err)
+		}
+		if runID != created.RunID {
+			t.Fatalf("frame %d: id run %q, want %q", i, runID, created.RunID)
+		}
+		if seq != uint64(i) {
+			t.Fatalf("frame %d: seq = %d, want %d (ids must be strictly increasing without gaps)", i, seq, i)
+		}
+		// The data payload must be the full event JSON with a matching type.
+		var payload struct {
+			ID   string `json:"id"`
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(f.data), &payload); err != nil {
+			t.Fatalf("frame %d: data is not event JSON: %v", i, err)
+		}
+		if payload.Type != f.event {
+			t.Fatalf("frame %d: event line %q but data type %q", i, f.event, payload.Type)
+		}
+		if payload.ID != f.id {
+			t.Fatalf("frame %d: id line %q but data id %q", i, f.id, payload.ID)
+		}
+	}
+
+	last := frames[len(frames)-1]
+	if last.event != string(harness.EventRunCompleted) {
+		t.Fatalf("terminal frame = %q, want %q", last.event, harness.EventRunCompleted)
+	}
+
+	// The live phase must actually contain the events emitted after the
+	// provider was released (llm.turn.completed arrives after Complete
+	// returns), proving the stream continued past the replayed prefix.
+	var sawTurnCompleted bool
+	for _, f := range frames {
+		if f.event == string(harness.EventLLMTurnCompleted) {
+			sawTurnCompleted = true
+			break
+		}
+	}
+	if !sawTurnCompleted {
+		t.Fatal("stream missing llm.turn.completed after the provider was released (live continuation did not arrive)")
+	}
+
+	// The server must close the stream after the terminal event (the UI
+	// treats EOF as "run finished", not as a reconnect signal).
+	if _, err := readSSEFrame(reader); err != io.EOF && err == nil {
+		t.Fatal("expected stream to close after the terminal event")
+	} else if err != io.EOF {
+		// Any read error other than a clean EOF after the terminal event is
+		// acceptable only if it is the context deadline racing the close; fail
+		// otherwise to keep the contract strict.
+		if ctx.Err() == nil {
+			t.Fatalf("unexpected stream error after terminal event: %v", err)
+		}
+	}
+}

--- a/internal/server/viz/static/app.js
+++ b/internal/server/viz/static/app.js
@@ -1,4 +1,4 @@
-/* harnessd session visualizer — slices 1–3.
+/* harnessd session visualizer — slices 1–4.
  *
  * Token story: the API key arrives via the landing form or a ?token= query
  * param on first load, is kept in sessionStorage, and is sent only as an
@@ -6,11 +6,11 @@
  * The server never accepts tokens via query string; ?token= is consumed
  * client-side and immediately scrubbed from the address bar.
  *
- * Views (slice 3): hash routing between #/runs (runs list from GET /v1/runs,
+ * Views: hash routing between #/runs (runs list from GET /v1/runs,
  * client-side status/text filtering) and #/runs/{id} (run detail from
- * GET /v1/runs/{id} plus GET /v1/runs/{id}/summary when available). The
- * event timeline (slice 4) and search (slice 5) land later. Read-only: only
- * GET endpoints are ever called.
+ * GET /v1/runs/{id} plus GET /v1/runs/{id}/summary when available, plus the
+ * event timeline streamed from GET /v1/runs/{id}/events — slice 4). Search
+ * (slice 5) lands later. Read-only: only GET endpoints are ever called.
  */
 (function () {
   "use strict";
@@ -151,6 +151,7 @@
   // ---- routing ----
 
   function renderRoute() {
+    stopTimeline();
     var hash = window.location.hash || "#/runs";
     var match = hash.match(/^#\/runs\/([^/]+)$/);
     if (match) {
@@ -376,13 +377,410 @@
       html += '<p class="muted">' + escapeHTML(summaryNote || "Summary unavailable.") + "</p>";
     }
 
-    html += '<p class="muted">The event timeline arrives in a later slice.</p>';
+    html += "<h3>Event timeline</h3>" +
+      '<p class="muted" id="timeline-status">Connecting to the event stream…</p>' +
+      '<div id="timeline" class="timeline"></div>';
     viewEl.innerHTML = html;
+
+    activeTimeline = startTimeline(
+      runID,
+      document.getElementById("timeline"),
+      document.getElementById("timeline-status")
+    );
   }
 
   function detailRow(label, value) {
     return "<dt>" + escapeHTML(label) + "</dt><dd>" +
       escapeHTML(value == null || value === "" ? "—" : value) + "</dd>";
+  }
+
+  // ---- event timeline (slice 4) ----
+  //
+  // The timeline is fed by GET /v1/runs/{id}/events: the server replays the
+  // run's full history, then follows live, and closes after the terminal
+  // event. Native EventSource cannot set headers, so a fetch-based SSE
+  // reader sends the Bearer token; on a dropped stream it reconnects with
+  // Last-Event-ID (honoring the server's retry: hint) and dedupes by seq so
+  // an overlapped resume never renders a row twice.
+
+  var activeTimeline = null;
+
+  function stopTimeline() {
+    if (activeTimeline) {
+      activeTimeline.abort();
+      activeTimeline = null;
+    }
+  }
+
+  function startTimeline(runID, container, statusEl) {
+    var state = {
+      aborted: false,
+      controller: typeof AbortController !== "undefined" ? new AbortController() : null,
+      seen: {},
+      lastEventID: "",
+      retryMs: 3000, // server's retry: frame hint overrides this
+      toolCalls: {},
+      bubble: null,
+      bubbleSeqEl: null,
+      bubbleText: "",
+      paused: false,
+      terminal: false
+    };
+
+    container.addEventListener("scroll", function () {
+      var wasPaused = state.paused;
+      state.paused = container.scrollTop + container.clientHeight < container.scrollHeight - 40;
+      if (wasPaused && !state.paused) {
+        container.scrollTop = container.scrollHeight;
+      }
+    });
+
+    function setStatus(msg) {
+      statusEl.textContent = msg;
+    }
+
+    function mkEl(tag, className, html) {
+      var e = document.createElement(tag);
+      if (className) {
+        e.className = className;
+      }
+      if (html != null) {
+        e.innerHTML = html;
+      }
+      return e;
+    }
+
+    function seqOf(ev) {
+      var id = ev.id || "";
+      var idx = id.lastIndexOf(":");
+      if (idx < 0) {
+        return "";
+      }
+      return id.slice(idx + 1);
+    }
+
+    function rowWithBody(ev, extraClass) {
+      var r = mkEl("div", "tl-row " + extraClass);
+      r.appendChild(mkEl("span", "seq", "#" + escapeHTML(seqOf(ev))));
+      var body = mkEl("div", "tl-body");
+      r.appendChild(body);
+      return { row: r, body: body };
+    }
+
+    function appendRow(r) {
+      container.appendChild(r);
+      if (!state.paused) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+
+    function closeBubble() {
+      state.bubble = null;
+      state.bubbleSeqEl = null;
+      state.bubbleText = "";
+    }
+
+    function renderEvent(ev) {
+      var seq = seqOf(ev);
+      if (seq !== "") {
+        if (state.seen[seq]) {
+          return; // duplicate from an overlapped resume
+        }
+        state.seen[seq] = true;
+      }
+      if (ev.id) {
+        state.lastEventID = ev.id;
+      }
+      var p = ev.payload || {};
+      var rb;
+      switch (ev.type) {
+        case "run.started":
+          rb = rowWithBody(ev, "tl-lifecycle");
+          rb.body.innerHTML = "<strong>Run started</strong>" +
+            (p.prompt ? ' <span class="muted">— ' + escapeHTML(excerpt(String(p.prompt), 120)) + "</span>" : "");
+          appendRow(rb.row);
+          break;
+        case "run.queued":
+        case "run.waiting_for_user":
+        case "run.resumed": {
+          var label = {
+            "run.queued": "Run queued",
+            "run.waiting_for_user": "Waiting for user input…",
+            "run.resumed": "Run resumed"
+          }[ev.type];
+          rb = rowWithBody(ev, "tl-lifecycle");
+          rb.body.innerHTML = "<strong>" + label + "</strong>";
+          appendRow(rb.row);
+          break;
+        }
+        case "run.completed": {
+          var extras = "";
+          if (p.usage_totals && typeof p.usage_totals.total_tokens === "number") {
+            extras += " · " + escapeHTML(formatInt(p.usage_totals.total_tokens)) + " tokens";
+          }
+          if (p.cost_totals && typeof p.cost_totals.cost_usd_total === "number") {
+            extras += " · total cost " + escapeHTML(formatUSD(p.cost_totals.cost_usd_total));
+          }
+          rb = rowWithBody(ev, "tl-lifecycle tl-ok");
+          rb.body.innerHTML = "<strong>Run completed</strong>" + extras;
+          appendRow(rb.row);
+          state.terminal = true;
+          setStatus("Stream closed — run completed.");
+          break;
+        }
+        case "run.failed":
+        case "run.cancelled": {
+          var failed = ev.type === "run.failed";
+          rb = rowWithBody(ev, "tl-lifecycle tl-err");
+          rb.body.innerHTML = "<strong>" + (failed ? "Run failed" : "Run cancelled") + "</strong>" +
+            (failed && p.error ? ' <span class="muted">— ' + escapeHTML(String(p.error)) + "</span>" : "");
+          appendRow(rb.row);
+          state.terminal = true;
+          setStatus("Stream closed — run " + (failed ? "failed" : "cancelled") + ".");
+          break;
+        }
+        case "run.step.started":
+        case "run.step.completed": {
+          var stepLabel = ev.type === "run.step.started" ? "Step " + p.step + " started" : "Step " + p.step + " completed";
+          rb = rowWithBody(ev, "tl-quiet");
+          rb.body.innerHTML = '<span class="muted">' + escapeHTML(stepLabel) + "</span>";
+          appendRow(rb.row);
+          break;
+        }
+        case "llm.turn.requested":
+          rb = rowWithBody(ev, "tl-llm");
+          rb.body.innerHTML = "LLM turn " + escapeHTML(String(p.step != null ? p.step : "?")) + " requested";
+          appendRow(rb.row);
+          break;
+        case "llm.turn.completed": {
+          var parts = ["LLM turn " + escapeHTML(String(p.step != null ? p.step : "?")) + " completed"];
+          if (typeof p.tool_calls === "number") {
+            parts.push(escapeHTML(formatInt(p.tool_calls)) + " tool calls");
+          }
+          if (typeof p.total_duration_ms === "number") {
+            parts.push(escapeHTML(formatInt(p.total_duration_ms)) + "ms");
+          }
+          if (p.provider) {
+            parts.push("(" + escapeHTML(String(p.provider)) + ")");
+          }
+          rb = rowWithBody(ev, "tl-llm");
+          rb.body.innerHTML = parts.join(" · ");
+          appendRow(rb.row);
+          break;
+        }
+        case "assistant.message.delta":
+          if (!state.bubble) {
+            rb = rowWithBody(ev, "tl-assistant");
+            state.bubbleSeqEl = rb.row.children[0];
+            state.bubble = mkEl("div", "tl-bubble", "");
+            rb.body.appendChild(state.bubble);
+            state.bubbleText = "";
+            appendRow(rb.row);
+          }
+          state.bubbleText += p.content || "";
+          state.bubble.innerHTML = escapeHTML(state.bubbleText);
+          break;
+        case "assistant.message":
+          if (state.bubble) {
+            // Deltas fold into one row per message: the final content
+            // replaces the streamed preview and the final event's seq
+            // claims the row badge, keeping seq correlation accurate.
+            state.bubble.innerHTML = escapeHTML(String(p.content || ""));
+            if (state.bubbleSeqEl) {
+              state.bubbleSeqEl.innerHTML = "#" + escapeHTML(seq);
+            }
+            closeBubble();
+          } else {
+            rb = rowWithBody(ev, "tl-assistant");
+            rb.body.appendChild(mkEl("div", "tl-bubble", escapeHTML(String(p.content || ""))));
+            appendRow(rb.row);
+          }
+          break;
+        case "tool.call.started": {
+          closeBubble();
+          rb = rowWithBody(ev, "tl-tool");
+          var det = mkEl("details", "tool-call");
+          det.setAttribute("data-call-id", String(p.call_id || ""));
+          var summary = mkEl("summary", "", "🔧 " + escapeHTML(String(p.tool || "tool")));
+          det.appendChild(summary);
+          if (p.arguments) {
+            det.appendChild(mkEl("pre", "tl-json", escapeHTML(excerpt(String(p.arguments), 2000))));
+          }
+          rb.body.appendChild(det);
+          state.toolCalls[String(p.call_id)] = det;
+          appendRow(rb.row);
+          break;
+        }
+        case "tool.call.completed": {
+          var callID = String(p.call_id || "");
+          var target = state.toolCalls[callID] ||
+            container.querySelector('[data-call-id="' + callID + '"]');
+          var meta = "completed" + (typeof p.duration_ms === "number" ? " in " + escapeHTML(formatInt(p.duration_ms)) + "ms" : "");
+          if (target) {
+            if (p.output) {
+              target.appendChild(mkEl("pre", "tl-json", escapeHTML(excerpt(String(p.output), 2000))));
+            }
+            target.appendChild(mkEl("div", "tl-tool-meta muted", escapeHTML(meta)));
+            if (target.children.length > 0) {
+              target.children[0].innerHTML += " ✓";
+            }
+          } else {
+            rb = rowWithBody(ev, "tl-tool");
+            rb.body.innerHTML = "🔧 " + escapeHTML(String(p.tool || "tool")) + " " + escapeHTML(meta);
+            appendRow(rb.row);
+          }
+          if (!state.paused) {
+            container.scrollTop = container.scrollHeight;
+          }
+          break;
+        }
+        case "run.cost_limit_reached":
+          rb = rowWithBody(ev, "tl-warn");
+          rb.body.innerHTML = "<strong>Cost limit reached</strong> — cumulative " +
+            escapeHTML(formatUSD(p.cumulative_cost_usd)) + " of max " + escapeHTML(formatUSD(p.max_cost_usd));
+          appendRow(rb.row);
+          break;
+        case "assistant.thinking.delta":
+        case "tool.call.delta":
+        case "tool.output.delta":
+        case "usage.delta":
+          // Ephemeral streaming signals; the substance lands in the
+          // completed/final events.
+          return;
+        default: {
+          rb = rowWithBody(ev, "tl-generic");
+          rb.body.innerHTML = "<code>" + escapeHTML(String(ev.type)) + "</code>" +
+            '<pre class="tl-json">' + escapeHTML(JSON.stringify(p, null, 2)) + "</pre>";
+          appendRow(rb.row);
+          break;
+        }
+      }
+    }
+
+    function handleFrame(raw) {
+      var id = "";
+      var eventType = "";
+      var data = "";
+      raw.split(/\r?\n/).forEach(function (line) {
+        if (line.charAt(0) === ":") {
+          return; // SSE comment (keepalive ping)
+        }
+        if (line.indexOf("id: ") === 0) {
+          id = line.slice(4);
+        } else if (line.indexOf("event: ") === 0) {
+          eventType = line.slice(7);
+        } else if (line.indexOf("retry: ") === 0) {
+          var ms = parseInt(line.slice(7), 10);
+          if (!isNaN(ms) && ms >= 0) {
+            state.retryMs = ms;
+          }
+        } else if (line.indexOf("data: ") === 0) {
+          data = data ? data + "\n" + line.slice(6) : line.slice(6);
+        }
+      });
+      if (!data) {
+        return;
+      }
+      var ev;
+      try {
+        ev = JSON.parse(data);
+      } catch (e) {
+        return; // malformed frame — skip, keep streaming
+      }
+      ev.id = ev.id || id;
+      ev.type = ev.type || eventType;
+      renderEvent(ev);
+    }
+
+    function readStream(reader) {
+      var decoder = new TextDecoder();
+      var buffer = "";
+      function pump() {
+        return reader.read().then(function (result) {
+          if (result.done) {
+            return;
+          }
+          buffer += decoder.decode(result.value, { stream: true });
+          var parts = buffer.split(/\r?\n\r?\n/);
+          buffer = parts.pop();
+          parts.forEach(handleFrame);
+          return pump();
+        });
+      }
+      return pump();
+    }
+
+    function scheduleReconnect() {
+      if (state.aborted || state.terminal) {
+        return;
+      }
+      setStatus("Disconnected — reconnecting…");
+      setTimeout(function () {
+        if (!state.aborted && !state.terminal) {
+          connectStream();
+        }
+      }, state.retryMs);
+    }
+
+    function connectStream() {
+      if (state.aborted || state.terminal) {
+        return;
+      }
+      var headers = { Authorization: "Bearer " + currentToken() };
+      if (state.lastEventID) {
+        headers["Last-Event-ID"] = state.lastEventID;
+      }
+      var opts = { headers: headers };
+      if (state.controller) {
+        opts.signal = state.controller.signal;
+      }
+      fetch("/v1/runs/" + encodeURIComponent(runID) + "/events", opts)
+        .then(function (res) {
+          if (res.status === 401) {
+            sessionStorage.removeItem(TOKEN_KEY);
+            showTokenForm("Unauthorized — check the API key.");
+            return null;
+          }
+          if (res.status === 403) {
+            sessionStorage.removeItem(TOKEN_KEY);
+            showTokenForm("This key lacks the runs:read scope.");
+            return null;
+          }
+          if (res.status === 404) {
+            setStatus("Event stream unavailable — the daemon no longer holds this run in memory (historical run).");
+            return null;
+          }
+          if (!res.ok) {
+            throw new Error("events stream: HTTP " + res.status);
+          }
+          setStatus("Live — replaying history, then following new events.");
+          return readStream(res.body.getReader());
+        })
+        .then(function (done) {
+          if (done === null || state.aborted || state.terminal) {
+            return;
+          }
+          // Clean EOF before a terminal event: the server dropped us.
+          scheduleReconnect();
+        })
+        .catch(function (err) {
+          if (state.aborted || state.terminal || (err && err.name === "AbortError")) {
+            return;
+          }
+          scheduleReconnect();
+        });
+    }
+
+    connectStream();
+
+    return {
+      abort: function () {
+        state.aborted = true;
+        if (state.controller) {
+          state.controller.abort();
+        }
+      }
+    };
   }
 
   // ---- bootstrap ----

--- a/internal/server/viz/static/style.css
+++ b/internal/server/viz/static/style.css
@@ -276,3 +276,113 @@ pre.block.error {
   color: var(--accent);
   text-decoration: none;
 }
+
+/* ---- slice 4: event timeline ---- */
+
+.timeline {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  max-height: 440px;
+  overflow-y: auto;
+  padding: 10px 12px;
+}
+
+.tl-row {
+  display: flex;
+  gap: 10px;
+  padding: 3px 0;
+  align-items: baseline;
+}
+
+.tl-row .seq {
+  color: var(--muted);
+  flex: 0 0 42px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  text-align: right;
+}
+
+.tl-body {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.tl-lifecycle {
+  border-bottom: 1px solid var(--border);
+  padding: 6px 0;
+}
+
+.tl-ok .tl-body strong {
+  color: var(--ok);
+}
+
+.tl-err .tl-body strong {
+  color: var(--err);
+}
+
+.tl-quiet .tl-body {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.tl-llm .tl-body {
+  color: var(--text);
+}
+
+.tl-warn {
+  background: rgba(255, 196, 66, 0.08);
+  border: 1px solid #c9a227;
+  border-radius: 6px;
+  margin: 4px 0;
+  padding: 6px 8px;
+}
+
+.tl-warn .tl-body strong {
+  color: #e3b93c;
+}
+
+.tl-bubble {
+  background: var(--panel);
+  border-left: 2px solid var(--accent);
+  border-radius: 0 6px 6px 0;
+  margin: 2px 0;
+  padding: 8px 10px;
+  white-space: pre-wrap;
+}
+
+.tool-call {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin: 2px 0;
+  padding: 4px 8px;
+}
+
+.tool-call summary {
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.tl-json {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 4px;
+  font-size: 12px;
+  margin: 6px 0 2px;
+  max-height: 200px;
+  overflow: auto;
+  padding: 6px 8px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.tl-tool-meta {
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.tl-generic .tl-body {
+  color: var(--muted);
+}


### PR DESCRIPTION
Parent epic: #812. Part of #803.

## What

Slice 4 of #812: the run detail page in `/viz` gains a chronological, live-updating event timeline fed by `GET /v1/runs/{id}/events`.

**Client (`internal/server/viz/static/app.js` + `style.css`):**
- **Fetch-based SSE reader** — native `EventSource` cannot set headers, so the stream is read via `fetch` + `body.getReader()` with the Bearer token. Frames are parsed per the server format (`id: <runID>:<seq>`, `retry: 3000`, `event: <type>`, `data: <full event JSON>`; `: ping` comments skipped).
- **Resume without duplicates** — on a dropped stream the client reconnects with `Last-Event-ID` (honoring the server-sent `retry:` value) and dedupes by seq, so an overlapped resume never double-renders. Server closes after the terminal event → no reconnect; route change aborts the stream; 401/403 → token form; 404 (historical run — runner memory only) → "event stream unavailable" note.
- **Renderers** keyed off the `internal/harness/events.go` vocabulary: `run.*` lifecycle markers (token/cost totals on `run.completed`), collapsible `tool.call.started/completed` pairs keyed by `call_id`, `llm.turn.*` rows, assistant bubbles (deltas fold into one row per message; the final message claims the final event's seq badge), `run.cost_limit_reached` highlight, generic collapsible-JSON fallback for unknown types. Ephemeral `*.delta` signals (thinking/tool-call/tool-output/usage) are ignored — a real run emits thousands, and the completed/final events carry the substance. Every row carries a `#seq` badge to correlate with rollout JSONL. Auto-scroll follows new rows, pauses on scroll-up, resumes at bottom.

**Go contract test (`internal/server/http_viz_events_test.go`):** pins the endpoint contract the UI depends on — a mid-flight connect first receives replayed history from seq 0, then live continuation, with `<runID>:<seq>` ids strictly increasing by 1 across both phases, and the stream closes after the terminal event. Adjacent contracts were already covered and are deliberately not duplicated: Last-Event-ID skip (×2), adversarial Last-Event-ID, SSE framing, keepalive pings, from-start e2e streaming.

## Verification actually run

- `go test ./internal/server/ -run 'TestRunEvents_HistoryThenLiveOrdering' -count=3` → PASS
- `go test ./internal/server/... -count=1` → ok
- `go vet ./internal/server/ ./internal/server/viz/` → clean; `gofmt -l` on touched files → clean
- `node --check app.js` → OK
- **DOM/fetch-stubbed harness (29 checks)**: replay order, live continuation, resume headers `run:4`/`run:7`, dedupe across an overlapped resume, tool-call pairing (args+output+duration), cost-limit highlight, assistant bubble delta→final folding, generic fallback row, seq badges exactly once, auto-scroll pause (gated terminal frame does not yank scroll) and resume, events-404 note → **29/29 PASS**
- **Real-daemon e2e** (`HARNESS_PROVIDER=fake` + `HARNESS_FAKE_TURNS` + seeded `HARNESS_RUN_DB`, tmux): POSTed run streamed **4449 events** with ids strictly increasing `:0..:4448`, ending in `run.completed`; `tool.call.started` before `completed`; reconnect with `Last-Event-ID: :100` resumed at `:101`; `/viz/app.js` serves the timeline code under auth; no token → 401.

## Manual browser checklist (reviewers)

1. Start `harnessd`, run `harnesscli --prompt "…"` for a live run; open `/viz/?token=KEY` → click the running run.
2. Timeline replays history in seq order and appends live without reload; scroll up → appends stop yanking; scroll to bottom → following resumes.
3. Open a completed run → full timeline ends at the terminal marker with token/cost totals; reload → identical (no duplicates).
4. Throttle/kill the network mid-run → the timeline reconnects and resumes at the last seq with no duplicated rows.

## Out of scope (later slices)

Search view (5), operations doc (6). Store-backed replay for post-restart runs remains a separate server-side feature.