### PR TITLE
feat(acp): permission bridge via session/request_permission

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -21,6 +21,14 @@
   `TestRunnerImageBlockReachesOpenAIWire`) capture the real HTTP body of a
   `StartRun` with an attachment.
 
+## 2026-07-21 (ACP Server Mode — Epic #806, Slice 4)
+
+- Permission bridge: `tool.approval_required` SSE events now issue `session/request_permission` to the editor (options `allow-once`/`allow_once`, `reject-once`/`reject_once`; `toolCall` carries `toolCallId`, `title`, parsed `rawInput`). Selected allow -> `POST /v1/runs/{id}/approve`; reject / `cancelled` outcome / client JSON-RPC error -> `/deny` (fail closed).
+- Server grew editor-bound calls: `callClient` registers a pending call by id, and `dispatch` routes response-shaped messages (result/error, no method) to the waiter; unknown or already-completed ids stay logged-and-ignored.
+- Deadline discipline: the permission call runs on a `deadline_at`-bounded context; when it passes, the pending call is deregistered and nothing is POSTed (harnessd auto-denies at the deadline). Bridge goroutines ride a turn-scoped context and are awaited before the prompt response, so no bridge outlives its turn.
+- 501 no-broker: `ApproveRun`/`DenyRun` map harnessd's 501 to `ErrApprovalNotConfigured`, surfaced as an `agent_message_chunk` note instead of a hang until the deadline.
+- Validation: strict TDD (red: `undefined: permissionParams`, `srv.callClient`). Flows via scripted io.Pipe client + fake harnessd (new `/approve`/`/deny` routes with 501 mode): grant -> approve + `end_turn`; reject -> deny; `cancelled` -> deny; client error -> deny; deadline expiry -> no POST and a late answer ignored; 501 -> note, no hang.
+
 ## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
 
 - Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -121,7 +121,7 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - [x] Slice 4: callClient pending registry + response routing, ApproveRun/DenyRun + 501 sentinel, permission bridge with deadline + turn-scoped contexts.
 - [x] Slice 4: gofmt + go vet clean; `go test ./internal/acp/... -count=1` (+ `-race`, repeat) green; `cmd/harnesscli` green.
 - [x] Slice 4: update engineering log.
-- [ ] Slice 4: push branch `epic/806-acp-server-s4` and open PR (no merge).
+- [x] Slice 4: push branch `epic/806-acp-server-s4` and open PR (no merge) — PR #916.
 
 ## Risks and Mitigations
 

--- a/docs/plans/806-acp-server.md
+++ b/docs/plans/806-acp-server.md
@@ -68,6 +68,31 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - Scripted client performing `session/prompt` against the fake server observes `agent_message_chunk` notifications in order before the `session/prompt` result arrives.
 - `go test ./internal/acp/... -count=1` green (plus `-race`).
 
+## Slice 4 — permission bridge via session/request_permission (IN IMPLEMENTATION)
+
+### Scope (slice 4)
+
+- In scope:
+  - Client-bound calls: `Server.callClient(ctx, method, params)` — writes a JSON-RPC request to the editor, registers a pending call by id, and routes the client's response (result or error object) back to the waiter; `dispatch` now routes response-shaped messages to pending calls (unknown ids stay logged-and-ignored).
+  - `RunsClient.ApproveRun`/`DenyRun` (POST `/v1/runs/{id}/approve|deny`); `ErrApprovalNotConfigured` sentinel for the server's 501 no-broker response.
+  - `internal/acp/permission.go`: on `tool.approval_required` (payload `call_id`, `tool`, `arguments`, `deadline_at`), issue `session/request_permission` with options `allow-once`/`allow_once` and `reject-once`/`reject_once`; selected allow -> approve POST, selected reject / `cancelled` outcome / client error -> deny POST.
+  - Deadline discipline: the client call carries a `deadline_at`-bounded context; when it passes, the pending call is deregistered and nothing is POSTed (harnessd auto-denies at the deadline). Bridge goroutines are tied to a turn-scoped context so a finished turn can't leave stragglers.
+  - 501 no-broker: surface a `session/update` (`agent_message_chunk`) note instead of hanging until the deadline.
+- Out of scope: plan-approach option bridging (`ApproveWithOption`), `allow_always`/`reject_always` persistence, permission for mid-run user-input requests, docs/e2e (slice 5).
+
+### Test Plan (TDD, slice 4)
+
+- New failing tests:
+  - Units: permission-params shape (option ids/kinds, toolCall fields); outcome parsing table (selected allow/reject, cancelled, garbage).
+  - Server: `callClient` routes a client response to the waiter by id.
+  - Flows over scripted stdio + fake harnessd (new `/approve`/`/deny` routes with a 501 no-broker mode): grant -> approve POST + run completes; reject -> deny POST; `cancelled` outcome -> deny; client error -> deny; deadline expiry -> no POST, prompt still completes, late response ignored; 501 -> `session/update` note, no hang.
+- Existing tests: none modified; slices 1–3 tests must stay green.
+
+### Acceptance (slice 4)
+
+- Scripted run: fake server emits `tool.approval_required` and blocks until `/approve` arrives; the scripted client grants via `session/request_permission`; the run completes (`end_turn`).
+- `go test ./internal/acp/... -count=1` green (plus `-race`).
+
 ## Documentation Contract
 
 - Feature status: slice 1 `implemented` (PR #835); slice 2 `in implementation`.
@@ -91,7 +116,12 @@ Epic: #806 (parent #803). Branches: `epic/806-acp-server` (slice 1, merged), `ep
 - [x] Slice 3: translator + bounded coalescing queue + `WatchRun` + `writeNotification` + prompt wiring.
 - [x] Slice 3: gofmt + go vet clean; `go test ./internal/acp/ -count=1` (+ `-race`, `-count=3`) green; `cmd/harnesscli` green.
 - [x] Slice 3: update engineering log.
-- [ ] Slice 3: push branch `epic/806-acp-server-s3` and open PR (no merge).
+- [x] Slice 3: push branch `epic/806-acp-server-s3` and open PR (no merge) — PR #891.
+- [x] Slice 4: failing tests first (red: `undefined: permissionParams`, `srv.callClient`); id-unquote bug found by `TestCallClientRoutesResponses` hang and fixed with the test as regression.
+- [x] Slice 4: callClient pending registry + response routing, ApproveRun/DenyRun + 501 sentinel, permission bridge with deadline + turn-scoped contexts.
+- [x] Slice 4: gofmt + go vet clean; `go test ./internal/acp/... -count=1` (+ `-race`, repeat) green; `cmd/harnesscli` green.
+- [x] Slice 4: update engineering log.
+- [ ] Slice 4: push branch `epic/806-acp-server-s4` and open PR (no merge).
 
 ## Risks and Mitigations
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -26,7 +26,7 @@
 - `821-plugin-system.md` — Epic #821 slice 1: plugin home decision and `plugin.json` manifest v1 contract docs, plus legacy-dir startup warning (in implementation).
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
-- `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged), slice 2 (session/new + session/prompt over the runs API, merged), slice 3 (session/update notifications from the SSE stream, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
+- `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged), slice 2 (session/new + session/prompt over the runs API, merged), slice 3 (session/update notifications, merged), slice 4 (session/request_permission bridge, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
 - `805-undo-prompts.md` — Epic #805 plan: Slice 1 `ConversationStore.UndoPrompts` (merged, PR #838); Slice 2 `POST /v1/conversations/{id}/undo` route (merged, PR #868); Slice 3 TUI `/undo [n]` command (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.

--- a/internal/acp/client.go
+++ b/internal/acp/client.go
@@ -127,6 +127,42 @@ func (c *RunsClient) CancelRun(ctx context.Context, runID string) error {
 	return nil
 }
 
+// ErrApprovalNotConfigured is returned by ApproveRun/DenyRun when harnessd
+// answers 501 — it has no approval broker configured (see
+// internal/server/http.go), so the pending approval can never be decided
+// over HTTP and will instead time out at its deadline.
+var ErrApprovalNotConfigured = errors.New("acp: harnessd has no approval broker configured")
+
+// ApproveRun POSTs /v1/runs/{id}/approve, resuming the pending tool call.
+func (c *RunsClient) ApproveRun(ctx context.Context, runID string) error {
+	return c.postApprovalDecision(ctx, runID, "approve")
+}
+
+// DenyRun POSTs /v1/runs/{id}/deny, rejecting the pending tool call.
+func (c *RunsClient) DenyRun(ctx context.Context, runID string) error {
+	return c.postApprovalDecision(ctx, runID, "deny")
+}
+
+func (c *RunsClient) postApprovalDecision(ctx context.Context, runID, action string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/runs/"+runID+"/"+action, nil)
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", action, err)
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return fmt.Errorf("send %s request: %w", action, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
+	if resp.StatusCode == http.StatusNotImplemented {
+		return ErrApprovalNotConfigured
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("%s run %s: harnessd returned %s: %s", action, runID, resp.Status, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
 // terminalOutcome describes how a run ended, from the ACP adapter's view.
 type terminalOutcome struct {
 	eventType string // run.completed | run.failed | run.cancelled

--- a/internal/acp/fakeharness_test.go
+++ b/internal/acp/fakeharness_test.go
@@ -48,6 +48,8 @@ type fakeHarness struct {
 	runAuths    map[string]string // run id -> Authorization header on POST /v1/runs
 	cancels     []string          // run ids that received POST cancel
 	cancelAuths map[string]string
+	decisions   []string // "runID:approve" / "runID:deny" in arrival order
+	noBroker    bool     // when true, approve/deny answer 501 (no approval broker)
 	nextID      int
 }
 
@@ -123,6 +125,21 @@ func (fh *fakeHarness) handleRunByID(w http.ResponseWriter, r *http.Request) {
 		go run.finish("run.cancelled", `{}`)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"status":"cancelling"}`)
+	case "approve", "deny":
+		fh.mu.Lock()
+		noBroker := fh.noBroker
+		if !noBroker {
+			fh.decisions = append(fh.decisions, runID+":"+sub)
+		}
+		fh.mu.Unlock()
+		if noBroker {
+			// Mirror internal/server: approve/deny return 501 when no
+			// approval broker is configured.
+			http.Error(w, `{"error":{"code":"not_implemented","message":"approval broker is not configured"}}`, http.StatusNotImplemented)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":%q}`, sub+"d")
 	default:
 		http.NotFound(w, r)
 	}
@@ -196,4 +213,17 @@ func (fh *fakeHarness) cancelled(id string) bool {
 		}
 	}
 	return false
+}
+
+// decision returns "approve", "deny", or "" depending on what was POSTed for
+// the given run.
+func (fh *fakeHarness) decision(id string) string {
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	for _, d := range fh.decisions {
+		if strings.HasPrefix(d, id+":") {
+			return strings.TrimPrefix(d, id+":")
+		}
+	}
+	return ""
 }

--- a/internal/acp/jsonrpc.go
+++ b/internal/acp/jsonrpc.go
@@ -71,3 +71,12 @@ type notification struct {
 	Method  string `json:"method"`
 	Params  any    `json:"params,omitempty"`
 }
+
+// clientRequest is the wire shape of a JSON-RPC 2.0 request the server sends
+// to the editor (e.g. session/request_permission): an answer is expected.
+type clientRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      string `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}

--- a/internal/acp/permission.go
+++ b/internal/acp/permission.go
@@ -1,0 +1,117 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// tool.approval_required payload fields (internal/harness/events.go):
+// call_id, tool, arguments, deadline_at (RFC3339).
+
+// permissionParams builds the session/request_permission params for one
+// tool.approval_required event. Two options are offered per the epic: allow
+// this call once, or reject it.
+func permissionParams(sessionID, callID, tool, arguments string) map[string]any {
+	toolCall := map[string]any{
+		"toolCallId": callID,
+		"title":      tool,
+	}
+	if arguments != "" {
+		var raw any
+		if json.Unmarshal([]byte(arguments), &raw) == nil {
+			toolCall["rawInput"] = raw
+		}
+	}
+	return map[string]any{
+		"sessionId": sessionID,
+		"toolCall":  toolCall,
+		"options": []map[string]any{
+			{"optionId": "allow-once", "name": "Allow once", "kind": "allow_once"},
+			{"optionId": "reject-once", "name": "Reject", "kind": "reject_once"},
+		},
+	}
+}
+
+// parsePermissionOutcome reports whether the editor's response grants the
+// tool call. Only an explicit selection of allow-once grants; reject,
+// cancelled, unknown options, and malformed results all deny (fail closed).
+func parsePermissionOutcome(result json.RawMessage) bool {
+	var r struct {
+		Outcome struct {
+			Outcome  string `json:"outcome"`
+			OptionID string `json:"optionId"`
+		} `json:"outcome"`
+	}
+	if json.Unmarshal(result, &r) != nil {
+		return false
+	}
+	return r.Outcome.Outcome == "selected" && r.Outcome.OptionID == "allow-once"
+}
+
+// bridgeApproval runs one tool.approval_required event through the editor and
+// posts the decision back to harnessd. It returns nothing: failures are
+// logged to diag, and a run whose approval expires is denied server-side at
+// the deadline. Decisions (and the no-broker note) ride the turn's update
+// queue so they stay ordered with the rest of the stream.
+func (h *sessionHandlers) bridgeApproval(ctx context.Context, sessionID, runID string, ev runEvent, queue *updateQueue) {
+	callID := payloadString(ev.Data, "call_id")
+	tool := payloadString(ev.Data, "tool")
+	arguments := payloadString(ev.Data, "arguments")
+	deadlineStr := payloadString(ev.Data, "deadline_at")
+
+	callCtx := ctx
+	cancel := func() {}
+	if deadline, err := time.Parse(time.RFC3339, deadlineStr); err == nil {
+		callCtx, cancel = context.WithDeadline(ctx, deadline)
+	}
+	defer cancel()
+
+	result, rpcErr := h.srv.callClient(callCtx, "session/request_permission", permissionParams(sessionID, callID, tool, arguments))
+	if rpcErr != nil {
+		if callCtx.Err() != nil {
+			// Deadline passed or turn ended: harnessd auto-denies at the
+			// deadline; there is nothing to POST.
+			fmt.Fprintf(h.diag, "acp: approval for %s (%s) expired without an editor answer; harnessd will deny at the deadline\n", callID, tool)
+			return
+		}
+		// The editor answered with a JSON-RPC error: deny (fail closed).
+		fmt.Fprintf(h.diag, "acp: permission request for %s failed (%s); denying\n", callID, rpcErr.Message)
+		h.postDecision(ctx, runID, "deny", callID, queue)
+		return
+	}
+
+	if parsePermissionOutcome(result) {
+		h.postDecision(ctx, runID, "approve", callID, queue)
+	} else {
+		h.postDecision(ctx, runID, "deny", callID, queue)
+	}
+}
+
+// postDecision POSTs the approval decision, translating the 501 no-broker
+// case into a session/update note instead of a silent hang.
+func (h *sessionHandlers) postDecision(ctx context.Context, runID, action, callID string, queue *updateQueue) {
+	var err error
+	if action == "approve" {
+		err = h.client.ApproveRun(ctx, runID)
+	} else {
+		err = h.client.DenyRun(ctx, runID)
+	}
+	switch {
+	case err == nil:
+		fmt.Fprintf(h.diag, "acp: %sd %s for run %s\n", action, callID, runID)
+	case errors.Is(err, ErrApprovalNotConfigured):
+		fmt.Fprintf(h.diag, "acp: %s %s: harnessd has no approval broker configured\n", action, callID)
+		queue.push(map[string]any{
+			"sessionUpdate": "agent_message_chunk",
+			"content": map[string]any{
+				"type": "text",
+				"text": fmt.Sprintf("Tool call %s requires approval, but harnessd has no approval broker configured, so the decision cannot be delivered. The call will be denied when its approval deadline passes.", callID),
+			},
+		}, kindDelta)
+	default:
+		fmt.Fprintf(h.diag, "acp: %s %s: %v\n", action, callID, err)
+	}
+}

--- a/internal/acp/permission_test.go
+++ b/internal/acp/permission_test.go
@@ -1,0 +1,335 @@
+package acp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPermissionParamsShape(t *testing.T) {
+	params := permissionParams("sess_1", "call-1", "bash", `"ls -la"`)
+	if params["sessionId"] != "sess_1" {
+		t.Fatalf("sessionId = %v", params["sessionId"])
+	}
+	toolCall, _ := params["toolCall"].(map[string]any)
+	if toolCall["toolCallId"] != "call-1" || toolCall["title"] != "bash" {
+		t.Fatalf("toolCall = %v", toolCall)
+	}
+	options, _ := params["options"].([]map[string]any)
+	if len(options) != 2 {
+		t.Fatalf("options = %v, want exactly allow/reject", options)
+	}
+	allow, reject := options[0], options[1]
+	if allow["optionId"] != "allow-once" || allow["kind"] != "allow_once" {
+		t.Fatalf("allow option = %v", allow)
+	}
+	if reject["optionId"] != "reject-once" || reject["kind"] != "reject_once" {
+		t.Fatalf("reject option = %v", reject)
+	}
+}
+
+func TestParsePermissionOutcome(t *testing.T) {
+	cases := []struct {
+		name   string
+		result string
+		want   bool
+	}{
+		{"selected allow-once", `{"outcome":{"outcome":"selected","optionId":"allow-once"}}`, true},
+		{"selected reject-once", `{"outcome":{"outcome":"selected","optionId":"reject-once"}}`, false},
+		{"selected unknown option", `{"outcome":{"outcome":"selected","optionId":"allow-always-forever"}}`, false},
+		{"cancelled", `{"outcome":{"outcome":"cancelled"}}`, false},
+		{"empty result", `{}`, false},
+		{"garbage", `{"outcome":42}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parsePermissionOutcome(json.RawMessage(tc.result)); got != tc.want {
+				t.Fatalf("parsePermissionOutcome(%s) = %v, want %v", tc.result, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCallClientRoutesResponses proves the server can call the editor and get
+// the response routed back to the waiter by id.
+func TestCallClientRoutesResponses(t *testing.T) {
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	t.Cleanup(func() { inR.Close(); outR.Close(); outW.Close() })
+
+	srv := NewServer(inR, outW, io.Discard)
+	type callResult struct {
+		result json.RawMessage
+		rpcErr *rpcError
+	}
+	resultCh := make(chan callResult, 1)
+	srv.Handle("test/call-editor", func(ctx context.Context, params json.RawMessage) (any, *rpcError) {
+		result, rpcErr := srv.callClient(ctx, "session/request_permission", map[string]any{"sessionId": "s"})
+		resultCh <- callResult{result, rpcErr}
+		if rpcErr != nil {
+			return nil, rpcErr
+		}
+		return map[string]any{"echo": json.RawMessage(result)}, nil
+	})
+	c := newScriptedClient(t, srv, inW, outR)
+
+	reqID := c.send("test/call-editor", nil)
+	permID, method, _ := c.readRequest()
+	if method != "session/request_permission" {
+		t.Fatalf("editor-facing method = %q", method)
+	}
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "selected", "optionId": "allow-once"}})
+
+	select {
+	case cr := <-resultCh:
+		if cr.rpcErr != nil {
+			t.Fatalf("callClient returned error: %+v", cr.rpcErr)
+		}
+		if !strings.Contains(string(cr.result), "allow-once") {
+			t.Fatalf("callClient result = %s", cr.result)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("callClient never returned")
+	}
+
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", reqID) || resp.Error != nil {
+		t.Fatalf("handler response = %+v", resp)
+	}
+	c.close()
+}
+
+// approvalEvent is the harness payload for tool.approval_required.
+func approvalEvent(callID, tool, args, deadline string) string {
+	b, _ := json.Marshal(map[string]any{
+		"call_id": callID, "tool": tool, "arguments": args, "deadline_at": deadline,
+	})
+	return string(b)
+}
+
+// startPromptWithApproval drives a session to the point where harnessd asks
+// for tool approval, and returns the permission request the agent issued.
+func startPromptWithApproval(t *testing.T, c *scriptedClient, fh *fakeHarness, deadlineAt time.Time) (promptID int, permID json.RawMessage, permParams json.RawMessage) {
+	t.Helper()
+	initialize(t, c)
+	sid := sessionNew(t, c)
+	promptID = c.send("session/prompt", map[string]any{
+		"sessionId": sid,
+		"prompt":    []map[string]any{{"type": "text", "text": "do something risky"}},
+	})
+	waitFor(t, "run to be created", func() bool {
+		fh.mu.Lock()
+		defer fh.mu.Unlock()
+		return len(fh.runs) == 1
+	})
+	run := fh.run("")
+	go run.emit("tool.approval_required", approvalEvent("call-1", "bash", `"rm -rf /tmp/x"`, deadlineAt.UTC().Format(time.RFC3339)))
+
+	permID, method, params := c.readRequest()
+	if method != "session/request_permission" {
+		t.Fatalf("method = %q, want session/request_permission", method)
+	}
+	return promptID, permID, params
+}
+
+func TestSessionPromptApprovalGrantedRunsToCompletion(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+
+	deadline := time.Now().Add(5 * time.Minute)
+	promptID, permID, permParams := startPromptWithApproval(t, c, fh, deadline)
+
+	// The permission request must describe the tool call and offer allow/reject.
+	var params struct {
+		SessionID string `json:"sessionId"`
+		ToolCall  struct {
+			ToolCallID string `json:"toolCallId"`
+			Title      string `json:"title"`
+		} `json:"toolCall"`
+		Options []struct {
+			OptionID string `json:"optionId"`
+			Kind     string `json:"kind"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(permParams, &params); err != nil {
+		t.Fatalf("permission params: %v (%s)", err, permParams)
+	}
+	if params.ToolCall.ToolCallID != "call-1" || params.ToolCall.Title != "bash" {
+		t.Fatalf("toolCall = %+v", params.ToolCall)
+	}
+	if len(params.Options) != 2 || params.Options[0].OptionID != "allow-once" || params.Options[0].Kind != "allow_once" ||
+		params.Options[1].OptionID != "reject-once" || params.Options[1].Kind != "reject_once" {
+		t.Fatalf("options = %+v", params.Options)
+	}
+
+	// Grant permission: the agent must POST /approve, and the run then completes.
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "selected", "optionId": "allow-once"}})
+	runID := fh.run("").id
+	waitFor(t, "approve POST", func() bool { return fh.decision(runID) == "approve" })
+
+	run := fh.run(runID)
+	go func() {
+		run.emit("tool.call.completed", `{"call_id":"call-1","tool":"bash","output":"done","duration_ms":5}`)
+		run.finish("run.completed", `{"output":"all done"}`)
+	}()
+
+	// The tool_call_update notification precedes the prompt result.
+	msg := c.readAny()
+	if msg["method"] != "session/update" {
+		t.Fatalf("expected tool_call_update notification before the result, got %v", msg)
+	}
+	noteParams, _ := msg["params"].(map[string]any)
+	noteUpdate, _ := noteParams["update"].(map[string]any)
+	if noteUpdate["sessionUpdate"] != "tool_call_update" || noteUpdate["toolCallId"] != "call-1" || noteUpdate["status"] != "completed" {
+		t.Fatalf("update = %v, want tool_call_update completed for call-1", noteUpdate)
+	}
+
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %s, want %d", resp.ID, promptID)
+	}
+	var result struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v", err)
+	}
+	if result.StopReason != "end_turn" {
+		t.Fatalf("stopReason = %q, want end_turn", result.StopReason)
+	}
+}
+
+func TestSessionPromptPermissionRejectedDenies(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	_, permID, _ := startPromptWithApproval(t, c, fh, time.Now().Add(5*time.Minute))
+
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "selected", "optionId": "reject-once"}})
+	runID := fh.run("").id
+	waitFor(t, "deny POST", func() bool { return fh.decision(runID) == "deny" })
+
+	go fh.run(runID).finish("run.completed", `{"output":"denied path"}`)
+	resp := c.readResponse()
+	var result struct {
+		StopReason string `json:"stopReason"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("result shape: %v", err)
+	}
+	if result.StopReason != "end_turn" {
+		t.Fatalf("stopReason = %q, want end_turn", result.StopReason)
+	}
+}
+
+func TestSessionPromptPermissionOutcomeCancelledDenies(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	_, permID, _ := startPromptWithApproval(t, c, fh, time.Now().Add(5*time.Minute))
+
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "cancelled"}})
+	runID := fh.run("").id
+	waitFor(t, "deny POST after cancelled outcome", func() bool { return fh.decision(runID) == "deny" })
+
+	go fh.run(runID).finish("run.completed", `{"output":"over"}`)
+	resp := c.readResponse()
+	if resp.Error != nil {
+		t.Fatalf("prompt errored: %+v", resp.Error)
+	}
+}
+
+func TestSessionPromptPermissionClientErrorDenies(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+	_, permID, _ := startPromptWithApproval(t, c, fh, time.Now().Add(5*time.Minute))
+
+	c.respondError(permID, -32603, "editor exploded")
+	runID := fh.run("").id
+	waitFor(t, "deny POST after client error", func() bool { return fh.decision(runID) == "deny" })
+
+	go fh.run(runID).finish("run.completed", `{"output":"over"}`)
+	resp := c.readResponse()
+	if resp.Error != nil {
+		t.Fatalf("prompt errored: %+v", resp.Error)
+	}
+}
+
+// TestSessionPromptApprovalDeadlineExpires: when the approval deadline passes
+// without an editor answer, the pending permission call is cancelled — no
+// approve/deny is POSTed (harnessd auto-denies server-side) and a late
+// response is ignored.
+func TestSessionPromptApprovalDeadlineExpires(t *testing.T) {
+	fh := newFakeHarness(t)
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	promptID, permID, _ := startPromptWithApproval(t, c, fh, deadline)
+	runID := fh.run("").id
+
+	// Let the deadline pass; the bridge must not POST any decision.
+	time.Sleep(deadline.Sub(time.Now()) + 500*time.Millisecond)
+	if got := fh.decision(runID); got != "" {
+		t.Fatalf("decision %q POSTed after the deadline; want none", got)
+	}
+
+	// A late answer must be ignored (pending call deregistered) and the run
+	// can still finish.
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "selected", "optionId": "allow-once"}})
+	time.Sleep(200 * time.Millisecond)
+	if got := fh.decision(runID); got != "" {
+		t.Fatalf("late answer produced a %q POST; the pending call must have been cancelled", got)
+	}
+
+	go fh.run(runID).finish("run.completed", `{"output":"timed out"}`)
+	resp := c.readResponse()
+	if string(resp.ID) != fmt.Sprintf("%d", promptID) {
+		t.Fatalf("response id %s, want %d", resp.ID, promptID)
+	}
+	if resp.Error != nil {
+		t.Fatalf("prompt errored after approval timeout: %+v", resp.Error)
+	}
+}
+
+// TestSessionPromptApprovalNoBrokerSurfacesNote: when harnessd answers the
+// approve POST with 501 (no approval broker configured), the bridge surfaces
+// a session/update note instead of hanging until the deadline.
+func TestSessionPromptApprovalNoBrokerSurfacesNote(t *testing.T) {
+	fh := newFakeHarness(t)
+	fh.noBroker = true
+	c := newSessionServer(t, fh, "")
+	defer c.close()
+
+	// Long deadline: if the bridge hung for the deadline, the test would time out.
+	_, permID, _ := startPromptWithApproval(t, c, fh, time.Now().Add(5*time.Minute))
+	c.respond(permID, map[string]any{"outcome": map[string]any{"outcome": "selected", "optionId": "allow-once"}})
+
+	// Expect a session/update note explaining the missing broker.
+	msg := c.readAny()
+	if msg["method"] != "session/update" {
+		t.Fatalf("expected a session/update note after 501, got %v", msg)
+	}
+	params, _ := msg["params"].(map[string]any)
+	update, _ := params["update"].(map[string]any)
+	if update["sessionUpdate"] != "agent_message_chunk" {
+		t.Fatalf("update = %v, want agent_message_chunk note", update)
+	}
+	content, _ := update["content"].(map[string]any)
+	text, _ := content["text"].(string)
+	if !strings.Contains(text, "approval broker") {
+		t.Fatalf("note text = %q, want it to mention the approval broker", text)
+	}
+
+	go fh.run("").finish("run.completed", `{"output":"over"}`)
+	resp := c.readResponse()
+	if resp.Error != nil {
+		t.Fatalf("prompt errored: %+v", resp.Error)
+	}
+}

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -28,6 +28,16 @@ type Server struct {
 	diag     io.Writer
 	handlers map[string]Handler
 	wg       sync.WaitGroup // in-flight handler goroutines
+
+	pendingMu sync.Mutex
+	pending   map[string]chan clientResponse // in-flight editor-bound calls, by id
+	nextCall  int
+}
+
+// clientResponse is the editor's answer to a server-initiated request.
+type clientResponse struct {
+	result json.RawMessage
+	rpcErr *rpcError
 }
 
 // NewServer returns a Server reading requests from r, writing protocol
@@ -42,6 +52,7 @@ func NewServer(r io.Reader, w io.Writer, diag io.Writer) *Server {
 		conn:     NewConn(r, w),
 		diag:     diag,
 		handlers: make(map[string]Handler),
+		pending:  make(map[string]chan clientResponse),
 	}
 	s.Handle("initialize", handleInitialize)
 	return s
@@ -97,10 +108,35 @@ func (s *Server) dispatch(ctx context.Context, line []byte) error {
 	}
 
 	// A message carrying result/error but no method is a JSON-RPC response
-	// from the client (e.g. an answer to a future session/request_permission
-	// call). There is nothing to route it to yet; drop it quietly.
+	// from the client — an answer to a server-initiated call (e.g.
+	// session/request_permission). Route it to the pending waiter by id;
+	// responses for unknown or already-completed ids are dropped quietly.
 	if req.Method == "" && (bytes.Contains(line, []byte(`"result"`)) || bytes.Contains(line, []byte(`"error"`))) {
-		fmt.Fprintf(s.diag, "acp: ignoring client response with no pending request (id %s)\n", idForLog(req.ID))
+		var r struct {
+			Result json.RawMessage `json:"result"`
+			Error  *rpcError       `json:"error"`
+		}
+		_ = json.Unmarshal(line, &r)
+		idKey := ""
+		if req.ID != nil {
+			// The pending map is keyed by the bare id value; the wire form
+			// is JSON-encoded, so unquote it (falling back to raw bytes for
+			// non-string ids).
+			if err := json.Unmarshal(*req.ID, &idKey); err != nil {
+				idKey = string(*req.ID)
+			}
+		}
+		s.pendingMu.Lock()
+		ch, ok := s.pending[idKey]
+		if ok {
+			delete(s.pending, idKey)
+		}
+		s.pendingMu.Unlock()
+		if !ok {
+			fmt.Fprintf(s.diag, "acp: ignoring client response with no pending request (id %s)\n", idForLog(req.ID))
+			return nil
+		}
+		ch <- clientResponse{result: r.Result, rpcErr: r.Error}
 		return nil
 	}
 
@@ -174,4 +210,35 @@ func idForLog(id *json.RawMessage) string {
 		return "<absent>"
 	}
 	return string(*id)
+}
+
+// callClient sends a JSON-RPC request to the editor (e.g.
+// session/request_permission) and waits for its response. The wait ends when
+// the editor answers, ctx is cancelled (turn over or approval deadline
+// passed — the pending call is deregistered so a late answer is ignored), or
+// the write fails. A JSON-RPC error object from the editor is returned as
+// rpcErr.
+func (s *Server) callClient(ctx context.Context, method string, params any) (json.RawMessage, *rpcError) {
+	s.pendingMu.Lock()
+	s.nextCall++
+	id := fmt.Sprintf("acp-%d", s.nextCall)
+	ch := make(chan clientResponse, 1)
+	s.pending[id] = ch
+	s.pendingMu.Unlock()
+	defer func() {
+		s.pendingMu.Lock()
+		delete(s.pending, id)
+		s.pendingMu.Unlock()
+	}()
+
+	if err := s.conn.WriteJSON(clientRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}); err != nil {
+		return nil, &rpcError{Code: CodeInternalError, Message: "write client request: " + err.Error()}
+	}
+
+	select {
+	case resp := <-ch:
+		return resp.result, resp.rpcErr
+	case <-ctx.Done():
+		return nil, &rpcError{Code: CodeInternalError, Message: "client call cancelled: " + ctx.Err().Error()}
+	}
 }

--- a/internal/acp/session.go
+++ b/internal/acp/session.go
@@ -184,14 +184,31 @@ func (h *sessionHandlers) handleSessionPrompt(ctx context.Context, params json.R
 	// slow editor can force (deltas coalesce or drop; lifecycle updates win).
 	queue := newUpdateQueue(updateQueueCapacity)
 	writer := startUpdateWriter(queue, h.srv, req.SessionID, h.diag)
-	outcome, err := h.client.WatchRun(ctx, runID, func(ev runEvent) {
+
+	// tool.approval_required events spawn permission bridges that call the
+	// editor and post the decision back. They run on a turn-scoped context
+	// and are awaited before the turn's response so no bridge outlives it.
+	turnCtx, cancelTurn := context.WithCancel(ctx)
+	var bridges sync.WaitGroup
+	outcome, err := h.client.WatchRun(turnCtx, runID, func(ev runEvent) {
+		if ev.Type == "tool.approval_required" {
+			bridges.Add(1)
+			go func() {
+				defer bridges.Done()
+				h.bridgeApproval(turnCtx, req.SessionID, runID, ev, queue)
+			}()
+			return
+		}
 		if update, kind, ok := translateRunEvent(ev); ok {
 			queue.push(update, kind)
 		}
 	})
 	// The terminal event has been seen: no more updates will be produced.
-	// Drain the queue fully before responding — the spec requires all
+	// Unblock any bridges still waiting on the editor, wait for them to exit,
+	// then drain the queue fully before responding — the spec requires all
 	// session/update notifications to arrive before the session/prompt result.
+	cancelTurn()
+	bridges.Wait()
 	queue.close()
 	writer.wait()
 	if dropped := queue.droppedCount(); dropped > 0 {

--- a/internal/acp/session_test.go
+++ b/internal/acp/session_test.go
@@ -615,6 +615,42 @@ func (c *scriptedClient) readAny() map[string]any {
 	}
 }
 
+// readRequest reads one server-initiated request line (e.g.
+// session/request_permission) and returns its id (wire bytes, for echoing),
+// method, and raw params.
+func (c *scriptedClient) readRequest() (json.RawMessage, string, json.RawMessage) {
+	c.t.Helper()
+	msg := c.readAny()
+	if msg["method"] == nil {
+		c.t.Fatalf("expected a server-initiated request, got response: %v", msg)
+	}
+	rawID, _ := json.Marshal(msg["id"])
+	params, _ := json.Marshal(msg["params"])
+	method, _ := msg["method"].(string)
+	return json.RawMessage(rawID), method, params
+}
+
+// respond answers a server-initiated request with a result object.
+func (c *scriptedClient) respond(id json.RawMessage, result any) {
+	c.t.Helper()
+	b, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": id, "result": result})
+	if _, err := c.inW.Write(append(b, '\n')); err != nil {
+		c.t.Fatalf("write response: %v", err)
+	}
+}
+
+// respondError answers a server-initiated request with a JSON-RPC error.
+func (c *scriptedClient) respondError(id json.RawMessage, code int, message string) {
+	c.t.Helper()
+	b, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": id,
+		"error": map[string]any{"code": code, "message": message},
+	})
+	if _, err := c.inW.Write(append(b, '\n')); err != nil {
+		c.t.Fatalf("write error response: %v", err)
+	}
+}
+
 // TestSessionPromptStreamsUpdatesInOrder is the slice-3 acceptance test: a
 // scripted client performing session/prompt observes the exact ordered
 // session/update notification stream — agent_message_chunk deltas, a thought


### PR DESCRIPTION
Parent epic: #806. Part of #803.

## What
Slice 4 of epic #806 (ACP server mode for Zed/JetBrains): when a tool call needs approval, the editor presents ACP permission options and the decision resumes the run.

- **Editor-bound calls**: `Server.callClient(ctx, method, params)` writes a JSON-RPC request to the editor and registers a pending call by id; `dispatch` now routes response-shaped messages (result/error, no method) to the waiter — unknown or completed ids stay logged-and-ignored as before. (Regression-pinned: response ids must be JSON-unquoted before lookup.)
- **`internal/acp/permission.go`**: on `tool.approval_required` (`call_id`, `tool`, `arguments`, `deadline_at`) the turn issues `session/request_permission` with `allow-once`/`allow_once` + `reject-once`/`reject_once` options. Selected allow -> `POST /v1/runs/{id}/approve`; reject / `cancelled` outcome / client JSON-RPC error -> `/deny` (fail closed).
- **Deadline discipline**: the permission call runs on a `deadline_at`-bounded context; on expiry the pending call is deregistered and nothing is POSTed (harnessd auto-denies at the deadline). Bridge goroutines ride a turn-scoped context and are awaited before the prompt response — no bridge outlives its turn.
- **501 no-broker**: `RunsClient.ApproveRun`/`DenyRun` map harnessd's 501 to `ErrApprovalNotConfigured`, surfaced as an `agent_message_chunk` session/update note instead of a hang until the deadline.

Distinct from the SDK-based `internal/harnessacp` adapter (epic #746); untouched. Docs + subprocess e2e land in slice 5.

## Tests (strict TDD — failing tests first)
- Units: permission-params shape (option ids/kinds, toolCall fields); outcome parsing table (selected allow/reject/unknown, cancelled, garbage — fail closed).
- `callClient` response routing (id-unquote regression).
- Scripted io.Pipe flows against the fake harnessd (new `/approve`/`/deny` routes with a 501 mode): grant -> approve POST + `end_turn`; reject -> deny; `cancelled` -> deny; client error -> deny; deadline expiry -> no POST, prompt completes, late answer ignored; 501 -> note, no hang.

## Validation run
- `GOCACHE=/tmp/go-build go test ./internal/acp/... -count=1` — ok
- `GOCACHE=/tmp/go-build go test ./internal/acp/... -count=1 -race` — ok
- `GOCACHE=/tmp/go-build go test ./internal/acp/ -count=2 -run Permission|Approval` — ok
- `GOCACHE=/tmp/go-build go test ./cmd/harnesscli/ -count=1` — ok
- gofmt / go vet clean on touched files

Do not merge — slice 5 follows.