### PR TITLE
feat(tui): picker overlay for bare /undo

### DIFF
--- a/cmd/harnesscli/tui/api.go
+++ b/cmd/harnesscli/tui/api.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+	"go-agent-harness/cmd/harnesscli/tui/components/undopicker"
 )
 
 // newHarnessRequest builds an HTTP request targeting the harnessd server and,
@@ -939,6 +940,52 @@ func restoreRewindCmd(baseURL, conversationID, pointID, apiKey string) tea.Cmd {
 			out.Err = err.Error()
 		}
 		return out
+	}
+}
+
+// fetchUndoCandidatesCmd fetches the conversation history (with meta flags)
+// for the bare-/undo picker (epic #805 slice 4). On success it emits
+// UndoCandidatesLoadedMsg with the messages; on failure it sets Err.
+func fetchUndoCandidatesCmd(baseURL, conversationID, apiKey string) tea.Cmd {
+	return func() tea.Msg {
+		endpoint := strings.TrimRight(baseURL, "/") + "/v1/conversations/" + url.PathEscape(conversationID) + "/messages"
+		req, err := newHarnessRequest(context.Background(), http.MethodGet, endpoint, nil, apiKey)
+		if err != nil {
+			return UndoCandidatesLoadedMsg{Err: err.Error()}
+		}
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			return UndoCandidatesLoadedMsg{Err: err.Error()}
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return UndoCandidatesLoadedMsg{Err: "read response: " + err.Error()}
+		}
+		if resp.StatusCode != http.StatusOK {
+			return UndoCandidatesLoadedMsg{Err: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}
+		}
+		var payload struct {
+			Messages []struct {
+				Role             string `json:"role"`
+				Content          string `json:"content"`
+				IsMeta           bool   `json:"is_meta"`
+				IsCompactSummary bool   `json:"is_compact_summary"`
+			} `json:"messages"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return UndoCandidatesLoadedMsg{Err: "decode response: " + err.Error()}
+		}
+		messages := make([]undopicker.MessageView, len(payload.Messages))
+		for i, m := range payload.Messages {
+			messages[i] = undopicker.MessageView{
+				Role:             m.Role,
+				Content:          m.Content,
+				IsMeta:           m.IsMeta,
+				IsCompactSummary: m.IsCompactSummary,
+			}
+		}
+		return UndoCandidatesLoadedMsg{Messages: messages}
 	}
 }
 

--- a/cmd/harnesscli/tui/cmd_parser.go
+++ b/cmd/harnesscli/tui/cmd_parser.go
@@ -89,7 +89,7 @@ func builtinCommandEntries() []CommandEntry {
 		},
 		{
 			Name:        "undo",
-			Description: "Remove the last n prompts from the conversation (/undo [n])",
+			Description: "Remove recent prompts (/undo [n], or bare /undo to pick)",
 			Handler: func(cmd Command) CommandResult {
 				return CommandResult{Status: CmdOK}
 			},

--- a/cmd/harnesscli/tui/components/undopicker/messages.go
+++ b/cmd/harnesscli/tui/components/undopicker/messages.go
@@ -1,0 +1,7 @@
+package undopicker
+
+// UndoSelectedMsg is emitted when the user presses Enter on an enabled entry.
+// Entry.Count is the number of prompts the server must drop.
+type UndoSelectedMsg struct {
+	Entry UndoEntry
+}

--- a/cmd/harnesscli/tui/components/undopicker/model.go
+++ b/cmd/harnesscli/tui/components/undopicker/model.go
@@ -1,0 +1,218 @@
+// Package undopicker implements the overlay shown by bare /undo (epic #805
+// slice 4): the most recent user prompts, newest first, so the user can pick
+// the prompt to undo back to. Prompts at or below the most recent compaction
+// summary are shown disabled — undoing across a compaction is refused by the
+// store, so the picker never offers it.
+package undopicker
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+const (
+	// maxEntries caps how many prompts the picker lists (the K newest).
+	maxEntries = 10
+	// maxVisibleRows bounds the rendered window; longer lists scroll.
+	maxVisibleRows = 10
+)
+
+// MessageView is the subset of a conversation message the picker needs.
+type MessageView struct {
+	Role             string
+	Content          string
+	IsMeta           bool
+	IsCompactSummary bool
+}
+
+// UndoEntry is one selectable prompt in the picker.
+type UndoEntry struct {
+	Step     int    // index of the prompt in the fetched history (== store step)
+	Count    int    // prompts the server must drop to undo back here (1 = newest)
+	Preview  string // first line of the prompt, for display
+	Disabled bool   // at/below the compaction boundary — cannot be undone
+}
+
+// EntriesFromMessages converts fetched conversation history into picker
+// entries, newest first. Only non-meta user messages are prompts. Messages at
+// or below the most recent is_compact_summary row are marked Disabled, since
+// the server refuses to undo across a compaction boundary. Index in the slice
+// equals the store step (the store keeps steps contiguous from 0).
+func EntriesFromMessages(msgs []MessageView) []UndoEntry {
+	boundary := -1
+	for i, m := range msgs {
+		if m.IsCompactSummary {
+			boundary = i
+		}
+	}
+	var entries []UndoEntry
+	count := 0
+	for i := len(msgs) - 1; i >= 0 && len(entries) < maxEntries; i-- {
+		m := msgs[i]
+		if m.Role != "user" || m.IsMeta {
+			continue
+		}
+		count++
+		entries = append(entries, UndoEntry{
+			Step:     i,
+			Count:    count,
+			Preview:  firstLine(m.Content),
+			Disabled: i <= boundary,
+		})
+	}
+	return entries
+}
+
+// firstLine returns s up to the first newline, trimmed of trailing space.
+func firstLine(s string) string {
+	for i, r := range s {
+		if r == '\n' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// Model is the undo picker list state machine.
+// All methods return a new Model (value semantics), mirroring sessionpicker.
+type Model struct {
+	entries      []UndoEntry
+	selected     int
+	scrollOffset int
+	open         bool
+	Width        int
+	Height       int
+}
+
+// New creates a closed Model seeded with the given entries (newest first).
+// The initial selection is the first enabled entry.
+func New(entries []UndoEntry) Model {
+	cp := make([]UndoEntry, len(entries))
+	copy(cp, entries)
+	m := Model{entries: cp}
+	for i, e := range cp {
+		if !e.Disabled {
+			m.selected = i
+			break
+		}
+	}
+	return m
+}
+
+// Open opens the picker overlay.
+func (m Model) Open() Model {
+	m.open = true
+	return m
+}
+
+// Close closes the picker overlay.
+func (m Model) Close() Model {
+	m.open = false
+	return m
+}
+
+// IsOpen reports whether the picker is currently visible.
+func (m Model) IsOpen() bool {
+	return m.open
+}
+
+// Entries returns the picker entries (newest first).
+func (m Model) Entries() []UndoEntry {
+	cp := make([]UndoEntry, len(m.entries))
+	copy(cp, m.entries)
+	return cp
+}
+
+// Selected returns the currently selected entry.
+// Returns (zero, false) when the entries list is empty.
+func (m Model) Selected() (UndoEntry, bool) {
+	if len(m.entries) == 0 {
+		return UndoEntry{}, false
+	}
+	return m.entries[m.selected], true
+}
+
+// SelectUp moves the selection to the previous enabled entry, wrapping.
+func (m Model) SelectUp() Model {
+	return m.move(-1)
+}
+
+// SelectDown moves the selection to the next enabled entry, wrapping.
+func (m Model) SelectDown() Model {
+	return m.move(1)
+}
+
+// move advances the selection by delta, skipping disabled rows.
+func (m Model) move(delta int) Model {
+	n := len(m.entries)
+	if n == 0 {
+		return m
+	}
+	for i := 0; i < n; i++ {
+		m.selected = (m.selected + delta + n) % n
+		if !m.entries[m.selected].Disabled {
+			break
+		}
+	}
+	m.scrollOffset = adjustScroll(m.scrollOffset, m.selected, n, maxVisibleRows)
+	return m
+}
+
+// Update processes a tea.Msg and returns the updated Model plus any commands.
+// Key bindings:
+//   - Up / 'k' → SelectUp
+//   - Down / 'j' → SelectDown
+//   - Enter → emit UndoSelectedMsg for enabled entries only
+//   - Escape → Close
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.open {
+		return m, nil
+	}
+
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case key.Type == tea.KeyUp || (key.Type == tea.KeyRunes && string(key.Runes) == "k"):
+		return m.SelectUp(), nil
+
+	case key.Type == tea.KeyDown || (key.Type == tea.KeyRunes && string(key.Runes) == "j"):
+		return m.SelectDown(), nil
+
+	case key.Type == tea.KeyEnter:
+		entry, ok := m.Selected()
+		if !ok || entry.Disabled {
+			return m, nil
+		}
+		return m, func() tea.Msg {
+			return UndoSelectedMsg{Entry: entry}
+		}
+
+	case key.Type == tea.KeyEsc:
+		return m.Close(), nil
+	}
+
+	return m, nil
+}
+
+// adjustScroll ensures the selected index is visible within the scroll window.
+func adjustScroll(offset, selected, total, maxVisible int) int {
+	if total <= maxVisible {
+		return 0
+	}
+	if selected >= offset+maxVisible {
+		offset = selected - maxVisible + 1
+	}
+	if selected < offset {
+		offset = selected
+	}
+	maxOffset := total - maxVisible
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return offset
+}

--- a/cmd/harnesscli/tui/components/undopicker/model_test.go
+++ b/cmd/harnesscli/tui/components/undopicker/model_test.go
@@ -1,0 +1,263 @@
+package undopicker_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/undopicker"
+)
+
+// conversationFixture returns a message history with three real prompts,
+// interleaved meta noise, and a compaction summary, exercising every filter
+// rule of EntriesFromMessages:
+//
+//	0 user      "first question"
+//	1 assistant "first answer"
+//	2 system    compaction summary (is_compact_summary)
+//	3 user      "second question"
+//	4 user      meta note (is_meta — not a prompt)
+//	5 assistant "second answer"
+//	6 user      "third question"
+//	7 assistant "third answer"
+func conversationFixture() []undopicker.MessageView {
+	return []undopicker.MessageView{
+		{Role: "user", Content: "first question"},
+		{Role: "assistant", Content: "first answer"},
+		{Role: "system", Content: "summary of earlier context", IsCompactSummary: true},
+		{Role: "user", Content: "second question"},
+		{Role: "user", Content: "hidden note", IsMeta: true},
+		{Role: "assistant", Content: "second answer"},
+		{Role: "user", Content: "third question"},
+		{Role: "assistant", Content: "third answer"},
+	}
+}
+
+func pickerEntries() []undopicker.UndoEntry {
+	return []undopicker.UndoEntry{
+		{Step: 6, Count: 1, Preview: "third question"},
+		{Step: 3, Count: 2, Preview: "second question"},
+		{Step: 0, Count: 3, Preview: "first question", Disabled: true},
+	}
+}
+
+// ─── EntriesFromMessages ─────────────────────────────────────────────────────
+
+func TestEntriesFromMessages_NewestFirstWithCounts(t *testing.T) {
+	t.Parallel()
+
+	msgs := []undopicker.MessageView{
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+		{Role: "user", Content: "q3"},
+		{Role: "assistant", Content: "a3"},
+	}
+	entries := undopicker.EntriesFromMessages(msgs)
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3: %+v", len(entries), entries)
+	}
+	want := []struct {
+		step    int
+		count   int
+		preview string
+	}{
+		{4, 1, "q3"},
+		{2, 2, "q2"},
+		{0, 3, "q1"},
+	}
+	for i, w := range want {
+		e := entries[i]
+		if e.Step != w.step || e.Count != w.count || e.Preview != w.preview {
+			t.Errorf("entries[%d] = %+v, want step=%d count=%d preview=%q", i, e, w.step, w.count, w.preview)
+		}
+		if e.Disabled {
+			t.Errorf("entries[%d] unexpectedly disabled", i)
+		}
+	}
+}
+
+func TestEntriesFromMessages_SkipsMetaAndBoundary(t *testing.T) {
+	t.Parallel()
+
+	entries := undopicker.EntriesFromMessages(conversationFixture())
+	// Three real prompts: third (step 6, count 1), second (step 3, count 2),
+	// first (step 0, count 3 — at/below the compaction summary at step 2).
+	if len(entries) != 3 {
+		t.Fatalf("got %d entries, want 3 (meta user message must not count): %+v", len(entries), entries)
+	}
+	if entries[0].Count != 1 || entries[0].Preview != "third question" || entries[0].Disabled {
+		t.Errorf("entries[0] = %+v, want enabled count=1 third question", entries[0])
+	}
+	if entries[1].Count != 2 || entries[1].Preview != "second question" || entries[1].Disabled {
+		t.Errorf("entries[1] = %+v, want enabled count=2 second question", entries[1])
+	}
+	if entries[2].Count != 3 || entries[2].Preview != "first question" || !entries[2].Disabled {
+		t.Errorf("entries[2] = %+v, want DISABLED count=3 first question (below compaction)", entries[2])
+	}
+}
+
+func TestEntriesFromMessages_DisablesAtTheSummaryStep(t *testing.T) {
+	t.Parallel()
+
+	// A prompt exactly at the summary's step cannot happen (steps are unique),
+	// but multiple summaries are possible: the boundary is the MAX summary step.
+	msgs := []undopicker.MessageView{
+		{Role: "system", Content: "older summary", IsCompactSummary: true},
+		{Role: "user", Content: "q1"},
+		{Role: "assistant", Content: "a1"},
+		{Role: "system", Content: "newer summary", IsCompactSummary: true},
+		{Role: "user", Content: "q2"},
+		{Role: "assistant", Content: "a2"},
+	}
+	entries := undopicker.EntriesFromMessages(msgs)
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[0].Preview != "q2" || entries[0].Disabled {
+		t.Errorf("entries[0] = %+v, want enabled q2 (above newer summary)", entries[0])
+	}
+	if entries[1].Preview != "q1" || !entries[1].Disabled {
+		t.Errorf("entries[1] = %+v, want DISABLED q1 (below newer summary)", entries[1])
+	}
+}
+
+func TestEntriesFromMessages_Empty(t *testing.T) {
+	t.Parallel()
+
+	if entries := undopicker.EntriesFromMessages(nil); len(entries) != 0 {
+		t.Errorf("got %d entries for empty history, want 0", len(entries))
+	}
+}
+
+func TestEntriesFromMessages_CapsAtMaxEntries(t *testing.T) {
+	t.Parallel()
+
+	var msgs []undopicker.MessageView
+	for i := 0; i < 15; i++ {
+		msgs = append(msgs,
+			undopicker.MessageView{Role: "user", Content: "question"},
+			undopicker.MessageView{Role: "assistant", Content: "answer"},
+		)
+	}
+	entries := undopicker.EntriesFromMessages(msgs)
+	if len(entries) != 10 {
+		t.Fatalf("got %d entries, want the 10 newest", len(entries))
+	}
+	// Newest-first: counts run 1..10 (never 11+ — older prompts are unreachable).
+	for i, e := range entries {
+		if e.Count != i+1 {
+			t.Errorf("entries[%d].Count = %d, want %d", i, e.Count, i+1)
+		}
+	}
+}
+
+// ─── Model state ─────────────────────────────────────────────────────────────
+
+func TestModelStartsClosed(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries())
+	if m.IsOpen() {
+		t.Fatal("New() model should start closed")
+	}
+}
+
+func TestModelOpenClose(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	if !m.IsOpen() {
+		t.Fatal("Open() should set IsOpen")
+	}
+	m = m.Close()
+	if m.IsOpen() {
+		t.Fatal("Close() should clear IsOpen")
+	}
+}
+
+func TestModelNavigationSkipsDisabled(t *testing.T) {
+	t.Parallel()
+
+	// Entries: [enabled count=1, enabled count=2, DISABLED count=3].
+	m := undopicker.New(pickerEntries()).Open()
+
+	sel, ok := m.Selected()
+	if !ok || sel.Count != 1 {
+		t.Fatalf("initial selection = %+v, want count=1", sel)
+	}
+
+	// Down from count=2 must skip the disabled count=3 and wrap to count=1.
+	m = m.SelectDown()
+	if sel, _ := m.Selected(); sel.Count != 2 {
+		t.Fatalf("after down: selection = %+v, want count=2", sel)
+	}
+	m = m.SelectDown()
+	if sel, _ := m.Selected(); sel.Count != 1 {
+		t.Fatalf("down past disabled: selection = %+v, want wrap to count=1", sel)
+	}
+
+	// Up from count=1 must skip the disabled count=3 and wrap to count=2.
+	m = m.SelectUp()
+	if sel, _ := m.Selected(); sel.Count != 2 {
+		t.Fatalf("up past disabled: selection = %+v, want wrap to count=2", sel)
+	}
+}
+
+func TestModelEnterEmitsSelectedWithCount(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	m = m.SelectDown() // select count=2 ("second question")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter on an enabled row must emit a command")
+	}
+	msg, ok := cmd().(undopicker.UndoSelectedMsg)
+	if !ok {
+		t.Fatalf("expected UndoSelectedMsg, got %T", cmd())
+	}
+	if msg.Entry.Count != 2 || msg.Entry.Preview != "second question" {
+		t.Errorf("UndoSelectedMsg.Entry = %+v, want count=2 second question", msg.Entry)
+	}
+}
+
+func TestModelEnterOnAllDisabledEmitsNothing(t *testing.T) {
+	t.Parallel()
+
+	disabled := []undopicker.UndoEntry{
+		{Step: 0, Count: 1, Preview: "old question", Disabled: true},
+	}
+	m := undopicker.New(disabled).Open()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("Enter with only disabled rows must emit nothing, got %T", cmd())
+	}
+}
+
+func TestModelEscapeCloses(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.IsOpen() {
+		t.Fatal("Esc should close the picker")
+	}
+}
+
+func TestModelVimKeysNavigate(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if sel, _ := m.Selected(); sel.Count != 2 {
+		t.Fatalf("j: selection = %+v, want count=2", sel)
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if sel, _ := m.Selected(); sel.Count != 1 {
+		t.Fatalf("k: selection = %+v, want count=1", sel)
+	}
+}

--- a/cmd/harnesscli/tui/components/undopicker/view.go
+++ b/cmd/harnesscli/tui/components/undopicker/view.go
@@ -1,0 +1,105 @@
+package undopicker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	dimColor  = lipgloss.AdaptiveColor{Light: "#9B9B9B", Dark: "#5C5C5C"}
+	highlight = lipgloss.AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}
+
+	dimStyle       = lipgloss.NewStyle().Foreground(dimColor)
+	highlightStyle = lipgloss.NewStyle().Background(highlight).Foreground(lipgloss.Color("#FFFFFF"))
+	boldStyle      = lipgloss.NewStyle().Bold(true)
+)
+
+// View renders the undo picker as a rounded-border lipgloss box.
+// Returns "" when the model is not open. width=0 defaults to 80.
+func (m Model) View(width int) string {
+	if !m.open {
+		return ""
+	}
+	if width <= 0 {
+		width = 80
+	}
+
+	// Inner content width: rounded border uses 2 cols (border+space) on each side.
+	const padding = 4
+	innerWidth := width - padding
+	if innerWidth < 20 {
+		innerWidth = 20
+	}
+
+	var sb strings.Builder
+
+	sb.WriteString(boldStyle.Render("Undo to prompt"))
+	sb.WriteByte('\n')
+	sb.WriteByte('\n')
+
+	if len(m.entries) == 0 {
+		sb.WriteString(dimStyle.Render("  Nothing to undo yet"))
+		sb.WriteByte('\n')
+	} else {
+		total := len(m.entries)
+		visStart := m.scrollOffset
+		visEnd := visStart + maxVisibleRows
+		if visEnd > total {
+			visEnd = total
+		}
+
+		for i := visStart; i < visEnd; i++ {
+			e := m.entries[i]
+			isSelected := i == m.selected
+
+			rowContent := fmt.Sprintf("%d. %s", e.Count, e.Preview)
+			if e.Disabled {
+				rowContent += "  (compaction boundary — cannot undo)"
+			}
+			rowContent = truncateStr(rowContent, innerWidth)
+
+			switch {
+			case isSelected:
+				const marker = "> "
+				marked := marker + truncateStr(rowContent, innerWidth-len(marker))
+				padded := marked + strings.Repeat(" ", max(0, innerWidth-len([]rune(marked))))
+				sb.WriteString(highlightStyle.Render(padded))
+			case e.Disabled:
+				sb.WriteString(dimStyle.Render("  " + rowContent))
+			default:
+				sb.WriteString("  " + rowContent)
+			}
+			sb.WriteByte('\n')
+		}
+
+		if below := total - visEnd; below > 0 {
+			sb.WriteString(dimStyle.Render(fmt.Sprintf("  ... %d more", below)))
+			sb.WriteByte('\n')
+		}
+	}
+
+	sb.WriteByte('\n')
+	sb.WriteString(dimStyle.Render("  ↑/↓ navigate  enter undo to here  esc cancel"))
+	sb.WriteByte('\n')
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		Padding(0, 1).
+		Width(innerWidth)
+
+	return boxStyle.Render(sb.String())
+}
+
+// truncateStr clips s to at most maxLen runes.
+func truncateStr(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen])
+}

--- a/cmd/harnesscli/tui/components/undopicker/view_test.go
+++ b/cmd/harnesscli/tui/components/undopicker/view_test.go
@@ -1,0 +1,65 @@
+package undopicker_test
+
+import (
+	"strings"
+	"testing"
+
+	"go-agent-harness/cmd/harnesscli/tui/components/undopicker"
+)
+
+func TestViewClosedRendersEmpty(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries())
+	if got := m.View(80); got != "" {
+		t.Errorf("closed picker should render empty, got %q", got)
+	}
+}
+
+func TestViewShowsPreviewsNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	out := m.View(80)
+
+	third := strings.Index(out, "third question")
+	second := strings.Index(out, "second question")
+	first := strings.Index(out, "first question")
+	if third < 0 || second < 0 || first < 0 {
+		t.Fatalf("view is missing prompt previews:\n%s", out)
+	}
+	if !(third < second && second < first) {
+		t.Errorf("previews not in newest-first order: third@%d second@%d first@%d\n%s", third, second, first, out)
+	}
+}
+
+func TestViewDisabledRowShowsCompactionHint(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	out := m.View(80)
+
+	if !strings.Contains(out, "compaction") {
+		t.Errorf("view does not show the compaction hint for the disabled row:\n%s", out)
+	}
+}
+
+func TestViewFooterHint(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(pickerEntries()).Open()
+	out := m.View(80)
+	if !strings.Contains(out, "enter") || !strings.Contains(out, "esc") {
+		t.Errorf("view is missing the footer navigation hint:\n%s", out)
+	}
+}
+
+func TestViewEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	m := undopicker.New(nil).Open()
+	out := m.View(80)
+	if !strings.Contains(out, "Nothing") {
+		t.Errorf("empty picker should say there is nothing to undo:\n%s", out)
+	}
+}

--- a/cmd/harnesscli/tui/messages.go
+++ b/cmd/harnesscli/tui/messages.go
@@ -7,6 +7,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"go-agent-harness/cmd/harnesscli/tui/components/modelswitcher"
+	"go-agent-harness/cmd/harnesscli/tui/components/undopicker"
 )
 
 // ─── SSE Stream Messages ────────────────────────────────────────────────────
@@ -379,6 +380,20 @@ type UndoResultMsg struct {
 	Messages          []ConversationMessage
 	Err               string
 	Conflict          bool
+}
+
+// UndoCandidatesLoadedMsg carries the conversation history fetched so the bare
+// /undo picker can list recent prompts (epic #805 slice 4). Messages include
+// the meta flags needed to find the compaction boundary.
+type UndoCandidatesLoadedMsg struct {
+	Messages []undopicker.MessageView
+	Err      string
+}
+
+// UndoPickerSelectedMsg is emitted when the user confirms a prompt in the
+// /undo picker. Count is the number of prompts the server must drop.
+type UndoPickerSelectedMsg struct {
+	Count int
 }
 
 // ForkResultMsg carries the outcome of POST /v1/conversations/{id}/fork

--- a/cmd/harnesscli/tui/model.go
+++ b/cmd/harnesscli/tui/model.go
@@ -39,6 +39,7 @@ import (
 	"go-agent-harness/cmd/harnesscli/tui/components/thinkingbar"
 	"go-agent-harness/cmd/harnesscli/tui/components/tooluse"
 	"go-agent-harness/cmd/harnesscli/tui/components/transcriptexport"
+	"go-agent-harness/cmd/harnesscli/tui/components/undopicker"
 	"go-agent-harness/cmd/harnesscli/tui/components/viewport"
 	"go-agent-harness/internal/plugins"
 	"go-agent-harness/internal/provider/codex"
@@ -301,6 +302,9 @@ type Model struct {
 	// Session picker component and persistent session store.
 	sessionPicker sessionpicker.Model
 	sessionStore  *SessionStore
+
+	// undoPicker is the bare-/undo overlay listing recent prompts (epic #805).
+	undoPicker undopicker.Model
 
 	// permissionsPanel shows the client-local session permission rules.
 	permissionsPanel permissionspanel.Model
@@ -1645,9 +1649,22 @@ func executeClearCommand(m *Model, _ Command) ([]tea.Cmd, bool) {
 	return []tea.Cmd{m.setStatusMsg("Conversation cleared")}, false
 }
 
-// executeUndoCommand implements /undo [count] (Issue #805): it asks the server
-// to drop the last count user prompts (default 1) and everything after them,
-// then rebuilds the viewport from the refetched history (see UndoResultMsg).
+// wrapUndoPickerCmd translates the undo picker's UndoSelectedMsg into the
+// model-level UndoPickerSelectedMsg so the message-type switch handles it.
+// Other messages pass through unchanged.
+func wrapUndoPickerCmd(pickerCmd tea.Cmd) tea.Cmd {
+	return func() tea.Msg {
+		raw := pickerCmd()
+		if sel, ok := raw.(undopicker.UndoSelectedMsg); ok {
+			return UndoPickerSelectedMsg{Count: sel.Entry.Count}
+		}
+		return raw
+	}
+}
+
+// executeUndoCommand implements /undo [count] (Issue #805): with a numeric
+// argument it asks the server to drop the last count user prompts directly;
+// with no argument it opens the picker overlay of recent prompts (slice 4).
 // Malformed counts are command errors — no request is ever sent. The command
 // refuses while a run is active because the run's terminal persistence would
 // rewrite the store and silently clobber the undo.
@@ -1655,7 +1672,7 @@ func executeUndoCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	if len(cmd.Args) > 1 {
 		return []tea.Cmd{m.setStatusMsg("Usage: /undo [count]")}, false
 	}
-	count := 1
+	count := 0 // 0 means: open the picker
 	if len(cmd.Args) == 1 {
 		n, err := strconv.Atoi(cmd.Args[0])
 		if err != nil || n < 1 {
@@ -1668,6 +1685,13 @@ func executeUndoCommand(m *Model, cmd Command) ([]tea.Cmd, bool) {
 	}
 	if m.conversationID == "" {
 		return []tea.Cmd{m.setStatusMsg("Nothing to undo yet — send a prompt first")}, false
+	}
+	if count == 0 {
+		// Bare /undo: fetch the history and open the picker (slice 4).
+		return []tea.Cmd{
+			m.setStatusMsg("Loading prompts…"),
+			fetchUndoCandidatesCmd(m.config.BaseURL, m.conversationID, m.config.APIKey),
+		}, false
 	}
 	return []tea.Cmd{
 		m.setStatusMsg(fmt.Sprintf("Undoing %d prompt(s)…", count)),
@@ -2505,6 +2529,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeOverlay = ""
 				return m, tea.Batch(cmds...)
 			}
+			if m.activeOverlay == "undo" {
+				m.undoPicker = m.undoPicker.Close()
+				m.overlayActive = false
+				m.activeOverlay = ""
+				return m, tea.Batch(cmds...)
+			}
 			if m.activeOverlay == "search" {
 				m.overlayActive = false
 				m.activeOverlay = ""
@@ -2619,6 +2649,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.themePicker, tpCmd = m.themePicker.Update(msg)
 				if tpCmd != nil {
 					cmds = append(cmds, tpCmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
+			// When the undo overlay is active, Enter confirms the selected prompt
+			// (epic #805 slice 4). Overlay routing cases never see Enter — it is
+			// claimed by this Submit case first.
+			if m.overlayActive && m.activeOverlay == "undo" {
+				var upCmd tea.Cmd
+				m.undoPicker, upCmd = m.undoPicker.Update(msg)
+				if upCmd != nil {
+					cmds = append(cmds, wrapUndoPickerCmd(upCmd))
 				}
 				return m, tea.Batch(cmds...)
 			}
@@ -2956,6 +2997,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					}
 					return raw
 				})
+			}
+			return m, tea.Batch(cmds...)
+		case m.overlayActive && m.activeOverlay == "undo":
+			// Route navigation keys to the undo picker (epic #805 slice 4).
+			// Enter is claimed earlier by the Submit case.
+			var upCmd tea.Cmd
+			m.undoPicker, upCmd = m.undoPicker.Update(msg)
+			if upCmd != nil {
+				cmds = append(cmds, wrapUndoPickerCmd(upCmd))
 			}
 			return m, tea.Batch(cmds...)
 		case m.overlayActive && m.activeOverlay == "permissions":
@@ -4327,6 +4377,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.appendConversationMessages(msg.Messages)
 			cmds = append(cmds, m.setStatusMsg(fmt.Sprintf("Undid to before step %d (%d messages remain)", msg.RemovedFromStep, msg.RemainingMessages)))
 		}
+
+	case UndoCandidatesLoadedMsg:
+		// Bare /undo: open the picker with the fetched prompts (slice 4).
+		if msg.Err != "" {
+			cmds = append(cmds, m.setStatusMsg("Undo failed: "+msg.Err))
+			return m, tea.Batch(cmds...)
+		}
+		entries := undopicker.EntriesFromMessages(msg.Messages)
+		if len(entries) == 0 {
+			cmds = append(cmds, m.setStatusMsg("Nothing to undo yet — send a prompt first"))
+			return m, tea.Batch(cmds...)
+		}
+		m.undoPicker = undopicker.New(entries).Open()
+		m.undoPicker.Width = m.width
+		m.overlayActive = true
+		m.activeOverlay = "undo"
+
+	case UndoPickerSelectedMsg:
+		// Picker confirmed: close the overlay and run the undo for the
+		// selected prompt's count — the same path as /undo <count>.
+		m.undoPicker = m.undoPicker.Close()
+		m.overlayActive = false
+		m.activeOverlay = ""
+		cmds = append(cmds,
+			m.setStatusMsg(fmt.Sprintf("Undoing %d prompt(s)…", msg.Count)),
+			undoConversationCmd(m.config.BaseURL, m.conversationID, msg.Count, m.config.APIKey),
+		)
 	}
 
 	return m, tea.Batch(cmds...)
@@ -4437,6 +4514,12 @@ func (m Model) View() string {
 		case "sessions":
 			m.sessionPicker.Width = m.width
 			mainContent = m.sessionPicker.View(m.width)
+			if mainContent == "" {
+				mainContent = m.vp.View()
+			}
+		case "undo":
+			m.undoPicker.Width = m.width
+			mainContent = m.undoPicker.View(m.width)
 			if mainContent == "" {
 				mainContent = m.vp.View()
 			}

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-120x40.txt
@@ -34,4 +34,4 @@ Command Registry - 120x40
 /tasks — View background tasks (bash jobs, subagents, cron, callbacks)
 /theme — View and select a color theme
 /title — Set or show the current session title (/title clear to remove)
-/undo — Remove the last n prompts from the conversation (/undo [n])
+/undo — Remove recent prompts (/undo [n], or bare /undo to pick)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-200x50.txt
@@ -34,4 +34,4 @@ Command Registry - 200x50
 /tasks — View background tasks (bash jobs, subagents, cron, callbacks)
 /theme — View and select a color theme
 /title — Set or show the current session title (/title clear to remove)
-/undo — Remove the last n prompts from the conversation (/undo [n])
+/undo — Remove recent prompts (/undo [n], or bare /undo to pick)

--- a/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
+++ b/cmd/harnesscli/tui/testdata/snapshots/TUI-041-parser-80x24.txt
@@ -34,4 +34,4 @@ Command Registry - 80x24
 /tasks — View background tasks (bash jobs, subagents, cron, callbacks)
 /theme — View and select a color theme
 /title — Set or show the current session title (/title clear to remove)
-/undo — Remove the last n prompts from the conversation (/undo [n])
+/undo — Remove recent prompts (/undo [n], or bare /undo to pick)

--- a/cmd/harnesscli/tui/undo_command_test.go
+++ b/cmd/harnesscli/tui/undo_command_test.go
@@ -6,7 +6,58 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
+
+// collectCmdMsgs runs cmd (unwrapping tea.BatchMsg) and records the last
+// produced message for which keep returns true into *out. Sub-commands that
+// do not return promptly (e.g. status-expiry ticks) are skipped after a
+// short grace period so picker-flow tests stay fast.
+func collectCmdMsgs(cmd tea.Cmd, out *tea.Msg, keep func(tea.Msg) bool) {
+	if cmd == nil {
+		return
+	}
+	result := cmd()
+	if result == nil {
+		return
+	}
+	if batch, ok := result.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			collectSubCmdMsgs(sub, out, keep)
+		}
+		return
+	}
+	if keep(result) {
+		*out = result
+	}
+}
+
+func collectSubCmdMsgs(cmd tea.Cmd, out *tea.Msg, keep func(tea.Msg) bool) {
+	if cmd == nil {
+		return
+	}
+	ch := make(chan tea.Msg, 1)
+	go func() { ch <- cmd() }()
+	select {
+	case r := <-ch:
+		if r == nil {
+			return
+		}
+		if batch, ok := r.(tea.BatchMsg); ok {
+			for _, sub := range batch {
+				collectSubCmdMsgs(sub, out, keep)
+			}
+			return
+		}
+		if keep(r) {
+			*out = r
+		}
+	case <-time.After(500 * time.Millisecond):
+		// Delayed commands (status-expiry ticks) are irrelevant to these tests.
+	}
+}
 
 // ---------------------------------------------------------------------------
 // Epic #805 Slice 3: /undo command tests
@@ -147,15 +198,24 @@ func TestUndoConversationCmd_NetworkError(t *testing.T) {
 	}
 }
 
-// TestExecuteUndoCommand_DefaultCount verifies /undo with no args undoes one
-// prompt.
-func TestExecuteUndoCommand_DefaultCount(t *testing.T) {
+// TestExecuteUndoCommand_BareOpensPicker verifies that bare /undo (epic #805
+// slice 4) fetches the conversation history and opens the prompt picker
+// overlay instead of immediately undoing (the slice-3 numeric path is
+// unchanged; see TestExecuteUndoCommand_NumericArg).
+func TestExecuteUndoCommand_BareOpensPicker(t *testing.T) {
 	t.Parallel()
 
 	var got struct{ method, path, body string }
 	ts := undoTestServer(t, http.StatusOK,
-		`{"undone":true,"removed_from_step":0,"remaining_messages":1}`,
-		`{"messages":[]}`,
+		`{"undone":true,"removed_from_step":2,"remaining_messages":3}`,
+		`{"messages":[
+			{"role":"user","content":"first question"},
+			{"role":"assistant","content":"first answer"},
+			{"role":"user","content":"second question"},
+			{"role":"assistant","content":"second answer"},
+			{"role":"user","content":"third question"},
+			{"role":"assistant","content":"third answer"}
+		]}`,
 		&got)
 	defer ts.Close()
 
@@ -165,13 +225,204 @@ func TestExecuteUndoCommand_DefaultCount(t *testing.T) {
 	if quit {
 		t.Fatal("/undo must not quit")
 	}
-	cmd := lastCmd(t, cmds)
-	msg := cmd()
-	if !strings.Contains(got.body, `"count":1`) {
-		t.Errorf("default count body: %q", got.body)
+	msg := lastCmd(t, cmds)()
+
+	loaded, ok := msg.(UndoCandidatesLoadedMsg)
+	if !ok {
+		t.Fatalf("expected UndoCandidatesLoadedMsg, got %T", msg)
 	}
-	if _, ok := msg.(UndoResultMsg); !ok {
-		t.Fatalf("expected UndoResultMsg, got %T", msg)
+	if loaded.Err != "" {
+		t.Fatalf("unexpected fetch error: %s", loaded.Err)
+	}
+	// Bare /undo must not undo anything yet: no POST to /undo may have happened.
+	if got.method != "" {
+		t.Fatalf("bare /undo issued %s %s before a selection was made", got.method, got.path)
+	}
+
+	m2, _ := m.Update(loaded)
+	m = m2.(Model)
+	if !m.overlayActive || m.activeOverlay != "undo" {
+		t.Fatalf("picker overlay not open: overlayActive=%v activeOverlay=%q", m.overlayActive, m.activeOverlay)
+	}
+	if !m.undoPicker.IsOpen() {
+		t.Fatal("undoPicker is not open")
+	}
+	entries := m.undoPicker.Entries()
+	if len(entries) != 3 {
+		t.Fatalf("got %d picker entries, want 3: %+v", len(entries), entries)
+	}
+	if entries[0].Count != 1 || entries[0].Preview != "third question" {
+		t.Errorf("entries[0] = %+v, want count=1 'third question' (newest first)", entries[0])
+	}
+	if entries[2].Count != 3 || entries[2].Preview != "first question" {
+		t.Errorf("entries[2] = %+v, want count=3 'first question'", entries[2])
+	}
+}
+
+// TestUndoPickerFlow_ConfirmIssuesUndoRequest drives the full picker flow:
+// bare /undo → candidates loaded → picker opens → Down + Enter → the server
+// receives POST /undo with the selected entry's count (epic #805 slice 4
+// integration test).
+func TestUndoPickerFlow_ConfirmIssuesUndoRequest(t *testing.T) {
+	t.Parallel()
+
+	var got struct{ method, path, body string }
+	ts := undoTestServer(t, http.StatusOK,
+		`{"undone":true,"removed_from_step":2,"remaining_messages":3}`,
+		`{"messages":[
+			{"role":"user","content":"first question"},
+			{"role":"assistant","content":"first answer"},
+			{"role":"user","content":"second question"},
+			{"role":"assistant","content":"second answer"},
+			{"role":"user","content":"third question"},
+			{"role":"assistant","content":"third answer"}
+		]}`,
+		&got)
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	m.conversationID = "conv-undo"
+
+	// Open the picker.
+	cmds, _ := executeUndoCommand(&m, Command{Name: "undo"})
+	m2, _ := m.Update(lastCmd(t, cmds)())
+	m = m2.(Model)
+	if !m.undoPicker.IsOpen() {
+		t.Fatal("picker did not open")
+	}
+
+	// Move to the 2nd-newest prompt and confirm.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = m3.(Model)
+	m4, enterCmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = m4.(Model)
+	if enterCmd == nil {
+		t.Fatal("Enter on an enabled picker row must produce a command")
+	}
+	// Unwrap the (possibly batched) command to find the translated selection msg.
+	var selMsg tea.Msg
+	collectCmdMsgs(enterCmd, &selMsg, func(msg tea.Msg) bool {
+		_, ok := msg.(UndoPickerSelectedMsg)
+		return ok
+	})
+	if selMsg == nil {
+		t.Fatal("no UndoPickerSelectedMsg produced by Enter")
+	}
+
+	// The selection closes the overlay and dispatches the undo call.
+	m5, undoCmd := m.Update(selMsg)
+	m = m5.(Model)
+	if m.overlayActive || m.undoPicker.IsOpen() {
+		t.Errorf("overlay still open after selection: overlayActive=%v pickerOpen=%v", m.overlayActive, m.undoPicker.IsOpen())
+	}
+	if undoCmd == nil {
+		t.Fatal("selection did not dispatch the undo command")
+	}
+	collectCmdMsgs(undoCmd, &selMsg, func(msg tea.Msg) bool { return true })
+	if got.method != http.MethodPost || got.path != "/v1/conversations/conv-undo/undo" {
+		t.Fatalf("undo request: got %s %s, want POST /v1/conversations/conv-undo/undo", got.method, got.path)
+	}
+	if !strings.Contains(got.body, `"count":2`) {
+		t.Errorf("undo body: got %q, want count=2 (2nd-newest prompt)", got.body)
+	}
+}
+
+// TestUndoPickerFlow_EscapeCancelsWithoutHTTP verifies Esc closes the picker
+// without issuing any undo request.
+func TestUndoPickerFlow_EscapeCancelsWithoutHTTP(t *testing.T) {
+	t.Parallel()
+
+	var got struct{ method, path, body string }
+	ts := undoTestServer(t, http.StatusOK,
+		`{"undone":true}`,
+		`{"messages":[{"role":"user","content":"q1"},{"role":"assistant","content":"a1"}]}`,
+		&got)
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	m.conversationID = "conv-undo"
+	cmds, _ := executeUndoCommand(&m, Command{Name: "undo"})
+	m2, _ := m.Update(lastCmd(t, cmds)())
+	m = m2.(Model)
+	if !m.undoPicker.IsOpen() {
+		t.Fatal("picker did not open")
+	}
+
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = m3.(Model)
+	if m.overlayActive || m.undoPicker.IsOpen() {
+		t.Errorf("Esc did not close the picker: overlayActive=%v pickerOpen=%v", m.overlayActive, m.undoPicker.IsOpen())
+	}
+	if got.method != "" {
+		t.Errorf("Esc issued %s %s — no request may be sent on cancel", got.method, got.path)
+	}
+}
+
+// TestUndoPickerFlow_FetchError verifies a failed candidate fetch lands in the
+// status bar without opening the picker.
+func TestUndoPickerFlow_FetchError(t *testing.T) {
+	t.Parallel()
+
+	m := testRunControlModel("http://127.0.0.1:1") // unreachable
+	m.conversationID = "conv-undo"
+	cmds, _ := executeUndoCommand(&m, Command{Name: "undo"})
+	msg := lastCmd(t, cmds)()
+
+	loaded, ok := msg.(UndoCandidatesLoadedMsg)
+	if !ok {
+		t.Fatalf("expected UndoCandidatesLoadedMsg, got %T", msg)
+	}
+	if loaded.Err == "" {
+		t.Fatal("expected a fetch error for an unreachable server")
+	}
+	m2, _ := m.Update(loaded)
+	m = m2.(Model)
+	if m.overlayActive || m.undoPicker.IsOpen() {
+		t.Error("picker opened despite a failed fetch")
+	}
+	if !strings.Contains(m.statusMsg, "Undo failed") {
+		t.Errorf("expected an undo failure status, got %q", m.statusMsg)
+	}
+}
+
+// TestUndoPickerFlow_DisabledRowStaysUnselectable verifies that a prompt at or
+// below the compaction boundary is skipped by navigation and cannot be
+// confirmed, end to end at the model level.
+func TestUndoPickerFlow_DisabledRowStaysUnselectable(t *testing.T) {
+	t.Parallel()
+
+	var got struct{ method, path, body string }
+	ts := undoTestServer(t, http.StatusOK,
+		`{"undone":true}`,
+		`{"messages":[
+			{"role":"user","content":"old compacted question"},
+			{"role":"system","content":"summary","is_compact_summary":true},
+			{"role":"user","content":"new question"},
+			{"role":"assistant","content":"new answer"}
+		]}`,
+		&got)
+	defer ts.Close()
+
+	m := testRunControlModel(ts.URL)
+	m.conversationID = "conv-undo"
+	cmds, _ := executeUndoCommand(&m, Command{Name: "undo"})
+	m2, _ := m.Update(lastCmd(t, cmds)())
+	m = m2.(Model)
+
+	entries := m.undoPicker.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if !entries[1].Disabled || entries[1].Preview != "old compacted question" {
+		t.Errorf("entries[1] = %+v, want DISABLED 'old compacted question'", entries[1])
+	}
+
+	// Navigation can never land on the disabled row: Down from the only
+	// enabled row wraps back to itself.
+	m3, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = m3.(Model)
+	if sel, _ := m.undoPicker.Selected(); sel.Count != 1 || sel.Disabled {
+		t.Fatalf("selection landed on a disabled row: %+v", sel)
 	}
 }
 

--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -64,6 +64,14 @@
 - Validation: `go test ./cmd/harnesscli/... -count=1` (29 packages) and
   `-race` green; full regression suite (see PR body).
 
+## 2026-07-21 (`/undo` Picker Overlay — Epic #805, Slice 4)
+
+- Bare `/undo` now opens a prompt picker matching kimi-code behavior: new `undopicker` component (`cmd/harnesscli/tui/components/undopicker/`, modeled on `sessionpicker`) lists the last 10 non-meta user prompts newest-first with their relative position (`Count`, 1 = newest); Enter confirms, Esc cancels, navigation wraps and skips disabled rows.
+- Data path: `fetchUndoCandidatesCmd` GETs `{id}/messages` decoding `is_meta`/`is_compact_summary`; the pure `EntriesFromMessages` function filters prompts, assigns counts, and marks entries at/below the most recent compaction summary `Disabled` (the store refuses those undos — Slice 1 — so the picker never offers them; disabled rows render dimmed with a `(compaction boundary — cannot undo)` hint).
+- Selection flow: `UndoPickerSelectedMsg{Count}` closes the overlay and dispatches the Slice 3 `undoConversationCmd` — the numeric `/undo [n]` path is unchanged.
+- Key-routing note: overlay routing cases never see Enter (the `Submit` case claims it first) — profiles/theme handle Enter via explicit arms in the `Submit` case, and the undo picker follows that pattern (`wrapUndoPickerCmd` shared by the arm and the routing case). Discovered a pre-existing gap: the sessions overlay has no such arm, so Enter there is swallowed by the input area — filed as issue #917 (not fixed here; out of slice scope).
+- Validation: failing-first component tests (`model_test.go` — navigation/disabled/Enter/Esc/`EntriesFromMessages` rules; `view_test.go` — order/hints/empty) and model-level flow tests (`undo_command_test.go` — bare `/undo` opens the picker with no POST, Down+Enter issues `{"count":2}`, Esc cancels without HTTP, fetch error stays in the status bar, disabled row unselectable end to end); Slice 3's `TestExecuteUndoCommand_DefaultCount` rewritten as `TestExecuteUndoCommand_BareOpensPicker` (behavior change is deliberate per epic). tmux smoke vs `harnessd`: bare `/undo` shows the picker; Down+Enter on the 2nd-newest trims the viewport to prompt 1 + its answer; on a conversation with a mid-history summary the older prompt renders `(compaction boundary — cannot undo)` and navigation skips it; Esc closes cleanly.
+
 ## 2026-07-21 (ACP Server Mode — Epic #806, Slice 3)
 
 - Prompt turns now stream live output to the editor: `assistant.message.delta` -> `agent_message_chunk`, `assistant.thinking.delta` -> `agent_thought_chunk` (payload field `content`), `tool.call.started` -> `tool_call` (`status: in_progress`, `title` = tool name, `kind` via a tool-name table), `tool.call.completed` -> `tool_call_update` (`completed`, or `failed` when the payload carries `error`; output included as content). `toolCallId` is the harness `call_id`, stable across start/complete.

--- a/docs/plans/805-undo-prompts.md
+++ b/docs/plans/805-undo-prompts.md
@@ -1,68 +1,68 @@
 # Plan: 805-undo-prompts
 
 Parent epic: #805 (`/undo` — remove recent prompts from the active context). Parent tracker: #803.
-Slices 1 (`ConversationStore.UndoPrompts`, PR #838) and 2 (`POST /v1/conversations/{id}/undo`, PR #868) are **implemented and merged**. This plan now tracks **Slice 3**: `feat(tui): /undo [n] command with immediate viewport refresh`.
+Slices 1 (`ConversationStore.UndoPrompts`, PR #838), 2 (`POST /v1/conversations/{id}/undo`, PR #868), and 3 (`/undo [n]` TUI command, PR #898) are **implemented and merged**. This plan now tracks **Slice 4 (final)**: `feat(tui): picker overlay for bare /undo`.
 
 ## Context
 
-- Problem: a mis-typed or derailing prompt currently lives in go-code's context forever; the only escape is `/clear`, which destroys the whole session. kimi-code's `/undo [count]` trims the last N user prompts plus everything after them.
-- User impact: Slice 3 is the first user-facing surface — the TUI command that calls the Slice 2 endpoint and re-renders the trimmed conversation.
-- Constraints: strict TDD per `docs/runbooks/testing.md`; mirror the `/rewind` command + API-call patterns (`executeRewindCommand`, `restoreRewindCmd`, `rewind_api_test.go`); help dialog and slash completion pick the command up automatically from `builtinCommandEntries()` (`buildHelpDialog` consumes the registry).
+- Problem: a mis-typed or derailing prompt currently lives in go-code's context forever; the only escape is `/clear`, which destroys the whole session. kimi-code's `/undo [count]` trims the last N user prompts plus everything after them; bare `/undo` opens a picker of recent prompts.
+- User impact: Slice 4 matches kimi-code's bare-`/undo` behavior — pick the prompt to undo back to, instead of counting manually.
+- Constraints: strict TDD per `docs/runbooks/testing.md`; new overlay component mirrors `sessionpicker` (model/view/messages + `Update` key routing + Escape chain + View switch); selection dispatches the Slice 3 `undoConversationCmd`; compaction-boundary rows render disabled using the `is_compact_summary` flag from `GET {id}/messages`.
 
 ## Scope
 
 - In scope:
-  - `undoConversationCmd(baseURL, conversationID string, count int, apiKey string)` in `cmd/harnesscli/tui/api.go` following `restoreRewindCmd`: POST `{"count": n}`, on 200 also GET the trimmed history so the viewport can rebuild; `UndoResultMsg` in `messages.go` (`RemovedFromStep`, `RemainingMessages`, `Messages`, `Err`, `Conflict` for 409).
-  - `executeUndoCommand` in `model.go`: optional numeric arg (default 1); non-numeric/zero/negative/extra args are command errors (status message, no HTTP); refuse while `runActive` (an in-flight run's terminal persistence would clobber the undo); refuse with empty `conversationID`.
-  - `UndoResultMsg` handling in `Update`: success rebuilds viewport+transcript from the refetched history (extracted `resetTranscriptView` shared with `/clear`, extracted `appendConversationMessages` shared with `ConversationHistoryMsg`); 409 renders the compaction-boundary explanation inline in the viewport; other errors land in the status bar.
-  - Register `undo` in `builtinCommandEntries()` (`cmd_parser.go`); add `undoConversationCmd` to the `harnessAuthCases()` auth-header table; add `undo` to `TestTUI364_RegistryCompleteness`'s known-commands list.
-  - Tests in `cmd/harnesscli/tui/undo_command_test.go` (mirrors `rewind_api_test.go`).
-  - Bug fix riding along (issue #895, found by the slice's own smoke): `Runner.DropConversationCache` (`internal/harness/runner.go`) + call in `handleUndoConversation` (`internal/server/http_conversations.go`) so `GET {id}/messages` stops serving the stale in-memory mirror after undo; regression tests in `internal/harness/runner_prune_test.go` and `internal/server/http_undo_test.go`.
-- Out of scope: picker overlay for bare `/undo` (Slice 4), redo, store changes (merged), in-place prompt editing.
+  - New component `cmd/harnesscli/tui/components/undopicker/` (`model.go`, `view.go`, `messages.go`): newest-first list of the last K=10 non-meta user prompts (`UndoEntry{Step, Count, Preview, Disabled}`), Enter confirms, Esc cancels, navigation skips disabled rows.
+  - `EntriesFromMessages` pure function in the component: filters `role=user && !is_meta`, computes `Count` (1 = newest), and marks `Disabled` for steps at/below the most recent `is_compact_summary` message.
+  - `fetchUndoCandidatesCmd` (`api.go`): GET `{id}/messages` decoding `is_meta`/`is_compact_summary`; `UndoCandidatesLoadedMsg` / `UndoPickerSelectedMsg` (`messages.go`).
+  - `executeUndoCommand` change: bare `/undo` fetches candidates and opens the picker (numeric path from Slice 3 unchanged); `UndoPickerSelectedMsg` dispatches `undoConversationCmd` with the entry's `Count`.
+  - Model wiring: `undoPicker` field, `UndoCandidatesLoadedMsg` case (opens overlay, or status when nothing undoable), key routing case, Escape-chain arm, View-switch arm.
+  - Tests: component tests in `components/undopicker/model_test.go` + `view_test.go`; model-level flow tests in `cmd/harnesscli/tui/undo_command_test.go` (bare `/undo` → picker opens; Enter on the 2nd-newest entry → POST `{"count":2}`; disabled rows unselectable; Esc cancels without HTTP).
+  - Existing test update: `TestExecuteUndoCommand_DefaultCount` (Slice 3) — bare `/undo` no longer POSTs count=1; it opens the picker.
+- Out of scope: redo, server/store changes (merged), editing a prompt in place, slash-complete pagination changes.
 
 ## Documentation Contract
 
 - Feature status: `in implementation`
-- Public docs affected: TUI help dialog and slash completion (auto-populated from the registry — no static lists to edit).
+- Public docs affected: TUI help dialog description for `/undo` (registry entry text updated to mention the picker).
 - Spec docs to update before code: this plan.
-- Implementation notes to add after code: engineering-log entry (endpoint consumption + viewport semantics); plans INDEX description refresh.
+- Implementation notes to add after code: engineering-log entry; plans INDEX refresh.
 
 ## Test Plan (TDD)
 
-- New failing tests first (`cmd/harnesscli/tui/undo_command_test.go`, package `tui`):
-  - API level (httptest): success (method/path/body, decoded result + refetched messages); 409 → `Conflict=true` with the server's message; non-200 → `Err`; unreachable server → `Err`.
-  - Command level: `/undo` default count 1 and `/undo 3` reach the server with the right body; `/undo abc`, `/undo 0`, `/undo 1 2` → status error, zero HTTP calls; no conversation → status error, zero HTTP; run active → status error, zero HTTP.
-  - Model level: `UndoResultMsg` success removes the tail bubbles (`vp.View()` keeps prompt 1, drops prompt 2; transcript rebuilt; `is_meta` marker not rendered); `UndoResultMsg{Conflict}` shows the compaction explanation inline and leaves the view intact; `UndoResultMsg{Err}` leaves the view intact.
-  - Registry: `undo` resolves via `NewCommandRegistry().Lookup` and `ParseCommand("/undo")` dispatches `CmdOK`.
-- Existing tests to update: `TestTUI364_RegistryCompleteness` known-commands list (registry surface grew); `harnessAuthCases()` table (new authed call).
+- New failing tests first:
+  - `components/undopicker/model_test.go`: closed-by-default; open/close; up/down navigation wraps and skips disabled rows; Enter on an enabled row emits `UndoSelectedMsg` with the right `Count`; Enter on a disabled row emits nothing; Esc closes; `EntriesFromMessages` — meta skipping, count assignment, boundary disabling (at and below summary), empty input, K cap.
+  - `components/undopicker/view_test.go`: closed renders empty; rows show previews newest-first; disabled rows carry the compacted hint; footer hint present.
+  - `undo_command_test.go` (package `tui`): bare `/undo` GETs messages and opens the overlay with entries newest-first (no POST); Enter on the 2nd-newest entry issues POST `{"count":2}` (integration: picker → server call); Esc closes with no HTTP; fetch failure → status error.
+- Existing tests to update: `TestExecuteUndoCommand_DefaultCount` → rewritten as the bare-opens-picker test.
 - Regression tests required: `go test ./cmd/harnesscli/... -count=1`.
 
 ## Cross-Surface Impact Map
 
-- Not a provider/model flow change — no impact map required. Server API consumed is merged (Slice 2).
+- Not a provider/model flow change — no impact map required.
 
-## Implementation Checklist (Slice 3)
+## Implementation Checklist (Slice 4)
 
 - [x] Define acceptance criteria in tests (listed above).
 - [x] Document feature status and exact contract before code (this plan).
-- [x] Write failing tests first; verify red for the right reason (unknown command / nil message types).
-- [x] Implement minimal code changes (messages.go + api.go + model.go + cmd_parser.go + test allowlists).
-- [x] Run `go test ./cmd/harnesscli/tui/ -run Undo -count=1` green.
+- [x] Write failing tests first; verify red for the right reason (package undefined).
+- [x] Implement component + wiring.
+- [x] Run `go test ./cmd/harnesscli/tui/... -run Undo -count=1` green.
 - [x] Run full `go test ./cmd/harnesscli/... -count=1` green.
 - [x] gofmt + go vet clean.
 - [x] Engineering-log entry; plans INDEX refresh.
-- [x] Manual smoke: TUI against `harnessd`, 3 prompts, `/undo 2`, viewport shows only prompt 1 + responses (surfaced + fixed issue #895).
-- [ ] Commit, push `epic/805-undo-prompts-s3`, open PR (no merge).
+- [x] Manual smoke: bare `/undo` picker in tmux TUI — chose 2nd-newest, viewport trimmed to prompt 1 + answer; compacted prompt visibly disabled and skipped by navigation; Esc closes.
+- [ ] Commit, push `epic/805-undo-prompts-s4`, open PR (no merge).
 
 ## Risks and Mitigations
 
-- Risk: undo during an in-flight run is silently clobbered when the run's terminal persistence rewrites the store.
-  - Mitigation: `/undo` refuses while `m.runActive`; covered by a no-HTTP test.
-- Risk: refetched history renders the `is_meta` undo marker as a phantom bubble.
-  - Mitigation: the shared `appendConversationMessages` renders only `user`/`assistant` roles (same as resume); covered by the model-level test seeding a system-role marker.
-- Bug found (issue #895, fixed in this slice): `GET {id}/messages` prefers the runner's in-memory mirror, so the TUI refetch after a successful undo rebuilt the viewport with the removed messages. Fixed by `Runner.DropConversationCache` called from `handleUndoConversation`; regression tests in `internal/harness/runner_prune_test.go` and `internal/server/http_undo_test.go`.
+- Risk: message index vs store step divergence (picker counts from GET-messages order).
+  - Mitigation: the store keeps steps contiguous from 0 and `LoadMessages` orders by step, so array index == step; `Count` is computed the same way the store's `UndoPrompts` walks (non-meta user messages, newest-first), keeping client and server semantics aligned.
+- Risk: changing bare `/undo` from undo-1 (Slice 3) to picker breaks Slice 3 expectations.
+  - Mitigation: deliberate per epic ("Without a count, the TUI opens a picker"); the Slice 3 test is updated and the numeric path is untouched.
 
-## Slice 1–2 record (completed)
+## Slice 1–3 record (completed)
 
 - Slice 1 (PR #838): `ConversationStore.UndoPrompts` + SQLite implementation + sentinels + `is_meta` marker; `internal/harness/conversation_undo_test.go`.
-- Slice 2 (PR #868): `POST /v1/conversations/{id}/undo` (POST-only, `runs:write`, cross-tenant 404, `count`/`to_step` body, 400/404/409/501 mapping); `internal/server/http_undo_test.go`, `http_undo_tenant_test.go`; tmux curl smoke green.
+- Slice 2 (PR #868): `POST /v1/conversations/{id}/undo` (POST-only, `runs:write`, cross-tenant 404, `count`/`to_step` body, 400/404/409/501 mapping); tmux curl smoke green.
+- Slice 3 (PR #898): `/undo [n]` command + `undoConversationCmd` + viewport rebuild; fixed stale-mirror bug #895 via `Runner.DropConversationCache`; tmux TUI smoke green.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -27,7 +27,7 @@
 - `813-skill-args.md` — Epic #813 slice 1: quote-aware argument tokenizer (`SplitArgs`) for skill argument paths (in implementation).
 - `807-service-install.md` — Epic #807 slice 1: `harnesscli service install/uninstall` with launchd + systemd generators (in implementation).
 - `806-acp-server.md` — ACP server mode epic #806: slice 1 (stdio JSON-RPC framing + initialize, merged), slice 2 (session/new + session/prompt over the runs API, merged), slice 3 (session/update notifications, merged), slice 4 (session/request_permission bridge, in implementation) in the stdlib-only `internal/acp` package plus the `harness acp` subcommand.
-- `805-undo-prompts.md` — Epic #805 plan: Slice 1 `ConversationStore.UndoPrompts` (merged, PR #838); Slice 2 `POST /v1/conversations/{id}/undo` route (merged, PR #868); Slice 3 TUI `/undo [n]` command (in implementation).
+- `805-undo-prompts.md` — Epic #805 plan: Slice 1 `ConversationStore.UndoPrompts` (merged, PR #838); Slice 2 `POST /v1/conversations/{id}/undo` route (merged, PR #868); Slice 3 TUI `/undo [n]` command (merged, PR #898); Slice 4 bare-`/undo` picker overlay (in implementation).
 - `2026-07-19-acp-epic-746-plan.md` — ACP server mode epic #746 (in implementation).
 - `2026-07-20-live-model-discovery-849-plan.md` — provider-agnostic cached live model discovery for Epic #849.
 


### PR DESCRIPTION
Parent epic: #805. Part of #803.

## What

Final slice of the `/undo` epic: bare `/undo` opens a picker of recent prompts, per kimi-code behavior.

- New `undopicker` component (`cmd/harnesscli/tui/components/undopicker/`, modeled on `sessionpicker`): newest-first list of the last 10 non-meta user prompts with relative position (`Count`, 1 = newest). Enter confirms, Esc cancels, navigation wraps and **skips disabled rows**.
- `EntriesFromMessages` (pure): filters `role=user && !is_meta`, assigns counts, and marks prompts at/below the most recent `is_compact_summary` row **Disabled** — the store refuses those undos (Slice 1), so the picker never offers them; disabled rows render dimmed with a `(compaction boundary — cannot undo)` hint.
- Data path: `fetchUndoCandidatesCmd` GETs `{id}/messages` decoding meta flags → `UndoCandidatesLoadedMsg` opens the overlay → `UndoPickerSelectedMsg{Count}` closes it and dispatches the Slice 3 `undoConversationCmd`. The numeric `/undo [n]` path is unchanged.
- Key routing: Enter is handled via an explicit arm in the `Submit` case — overlay routing cases never see Enter (same pattern as profiles/theme). Escape chain and View switch wired; help text updated (`/undo [n], or bare /undo to pick`).
- Note: while studying the routing I found a pre-existing gap — **the `/sessions` picker has no Submit arm, so Enter there is swallowed**. Filed as issue #917 (not fixed here; out of slice scope).

## Tests (strict TDD — red verified before implementation)

- Component (`undopicker/model_test.go`, `view_test.go`): closed-by-default, open/close, navigation wraps + skips disabled, Enter emits with the right `Count`, Enter on all-disabled emits nothing, Esc closes, j/k keys, `EntriesFromMessages` (meta skipping, counts, at/below boundary, multi-summary max boundary, empty, K cap), view ordering/hints/empty state.
- Model flow (`undo_command_test.go`): bare `/undo` GETs messages and opens the picker with **zero POST**; Down+Enter issues `{"count":2}` (full integration); Esc closes without HTTP; fetch error stays in status bar; disabled row unselectable end to end. Slice 3's `TestExecuteUndoCommand_DefaultCount` rewritten as `TestExecuteUndoCommand_BareOpensPicker` (deliberate behavior change per epic).

## Verification (all actually run)

- `go test ./cmd/harnesscli/tui/ -run Undo -count=1` — PASS
- `go test ./cmd/harnesscli/... -count=1` — **exit 0, 30 packages ok, 0 FAIL** (twice: before and after help-text/snapshot changes)
- `go vet ./cmd/harnesscli/...` clean; touched files gofmt-clean
- tmux smoke vs rebuilt `harnessd` (fake provider + conversation DB): bare `/undo` renders the picker; Down highlights `2. second smoke prompt`; Enter trims the viewport to `first smoke prompt` + `answer one`. On a seeded conversation with a mid-history compaction summary, the older prompt renders `(compaction boundary — cannot undo)` and Down skips it; Esc closes the picker.

Engineering-log entry + plan update included. Plan: `docs/plans/805-undo-prompts.md`.