### PR TITLE
Render block-level markdown in assistant replies

### DIFF
--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -178,9 +178,22 @@ struct AssistantBubble: View {
                 ForEach(Array(MarkdownBlock.parse(message.text).enumerated()), id: \.offset) {
                     _, block in
                     switch block {
-                    case .text(let body):
+                    case .paragraph(let body):
                         Text(.init(body)).textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                    case .heading(let level, let text):
+                        Text(.init(text))
+                            .font(MarkdownBlock.headingFont(level)).fontWeight(.semibold)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    case .unorderedListItem(let text):
+                        MarkdownListRow(marker: "•", text: text)
+                    case .orderedListItem(let number, let text):
+                        MarkdownListRow(marker: "\(number).", text: text)
+                    case .quote(let text):
+                        MarkdownQuoteRow(text: text)
+                    case .rule:
+                        Divider()
                     case .code(let code, let language):
                         CodeBlock(code: code, language: language)
                     }
@@ -198,18 +211,55 @@ struct AssistantBubble: View {
     }
 }
 
-/// Fenced code needs monospace and a copy button; `Text(.init:)` renders
-/// markdown but collapses fenced blocks into inline styling.
-enum MarkdownBlock {
-    case text(String)
+/// `Text(.init:)` only renders *inline* markdown (bold, italic, links, inline
+/// code): it has no concept of block structure, so headings/lists/quotes came
+/// out as literal `#`/`-`/`>` characters with no line breaks between them.
+/// This splits a reply into block-level pieces so each one can pick its own
+/// view, while still handing inline markdown for the block's own text back to
+/// `Text(.init:)`.
+///
+/// Tables are out of scope — no attempt is made to detect `|` rows.
+/// Nested lists are out of scope too: every list item is flat regardless of
+/// leading indentation, to keep this parser (which reruns on every streamed
+/// token) cheap and simple.
+enum MarkdownBlock: Equatable {
+    case paragraph(String)
+    case heading(level: Int, text: String)
+    case unorderedListItem(String)
+    case orderedListItem(number: Int, text: String)
+    case quote(String)
+    case rule
     case code(String, String?)
+
+    static func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: return .title
+        case 2: return .title2
+        case 3: return .title3
+        case 4: return .headline
+        case 5: return .subheadline
+        default: return .footnote
+        }
+    }
 
     static func parse(_ markdown: String) -> [MarkdownBlock] {
         var blocks: [MarkdownBlock] = []
-        var buffer: [String] = []
+        var paragraph: [String] = []
         var code: [String] = []
         var language: String?
         var inFence = false
+
+        // A blank line or the start of any other block ends the paragraph
+        // that was accumulating; a bare run of plain lines does not.
+        func flushParagraph() {
+            guard !paragraph.isEmpty else { return }
+            // Two trailing spaces is CommonMark's hard line break. Joining
+            // with a bare "\n" reads fine here but `Text(.init:)` reflows a
+            // soft newline away, which is exactly the collapsing this exists
+            // to avoid.
+            blocks.append(.paragraph(paragraph.joined(separator: "  \n")))
+            paragraph = []
+        }
 
         for line in markdown.components(separatedBy: .newlines) {
             if line.hasPrefix("```") {
@@ -219,23 +269,112 @@ enum MarkdownBlock {
                     language = nil
                     inFence = false
                 } else {
-                    if !buffer.isEmpty {
-                        blocks.append(.text(buffer.joined(separator: "\n")))
-                        buffer = []
-                    }
+                    flushParagraph()
                     let tag = line.dropFirst(3).trimmingCharacters(in: .whitespaces)
                     language = tag.isEmpty ? nil : tag
                     inFence = true
                 }
                 continue
             }
-            if inFence { code.append(line) } else { buffer.append(line) }
+            if inFence {
+                code.append(line)
+                continue
+            }
+
+            if let block = heading(line) {
+                flushParagraph()
+                blocks.append(block)
+            } else if let block = unorderedItem(line) {
+                flushParagraph()
+                blocks.append(block)
+            } else if let block = orderedItem(line) {
+                flushParagraph()
+                blocks.append(block)
+            } else if let block = blockQuote(line) {
+                flushParagraph()
+                blocks.append(block)
+            } else if isRule(line) {
+                flushParagraph()
+                blocks.append(.rule)
+            } else if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                flushParagraph()
+            } else {
+                paragraph.append(line)
+            }
         }
 
         // An unterminated fence is normal mid-stream: show it as code anyway.
         if inFence, !code.isEmpty { blocks.append(.code(code.joined(separator: "\n"), language)) }
-        if !buffer.isEmpty { blocks.append(.text(buffer.joined(separator: "\n"))) }
+        flushParagraph()
         return blocks
+    }
+
+    private static func heading(_ line: String) -> MarkdownBlock? {
+        let level = line.prefix(while: { $0 == "#" }).count
+        guard (1...6).contains(level) else { return nil }
+        let rest = line.dropFirst(level)
+        guard rest.hasPrefix(" ") else { return nil }
+        return .heading(level: level, text: rest.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func unorderedItem(_ line: String) -> MarkdownBlock? {
+        guard let marker = line.first, "-*+".contains(marker) else { return nil }
+        let rest = line.dropFirst()
+        guard rest.hasPrefix(" ") else { return nil }
+        return .unorderedListItem(rest.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func orderedItem(_ line: String) -> MarkdownBlock? {
+        let digits = line.prefix(while: \.isNumber)
+        guard !digits.isEmpty, let number = Int(digits) else { return nil }
+        let rest = line.dropFirst(digits.count)
+        guard rest.hasPrefix(". ") else { return nil }
+        return .orderedListItem(
+            number: number, text: rest.dropFirst(2).trimmingCharacters(in: .whitespaces))
+    }
+
+    /// Named apart from the `quote` case itself: a same-named helper with a
+    /// matching single-`String` argument shape resolved ambiguously against
+    /// the case's own initializer and silently returned the wrong thing.
+    private static func blockQuote(_ line: String) -> MarkdownBlock? {
+        guard line.hasPrefix(">") else { return nil }
+        return .quote(line.dropFirst().trimmingCharacters(in: .whitespaces))
+    }
+
+    /// `---`, `***`, `___` (3+ of the same character, nothing else on the
+    /// line) is CommonMark's thematic break. Checked before the list-item
+    /// tests below would even matter: none of them accept a bare `-`/`*` run
+    /// with no following space, so there is no real ambiguity to resolve.
+    private static func isRule(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard let marker = trimmed.first, "-*_".contains(marker) else { return false }
+        return trimmed.count >= 3 && trimmed.allSatisfy { $0 == marker }
+    }
+}
+
+/// Hanging indent for list markers: the marker sits in its own fixed-width
+/// column so a wrapped second line lands under the text, not under the
+/// bullet/number.
+struct MarkdownListRow: View {
+    let marker: String
+    let text: String
+    var body: some View {
+        HStack(alignment: .top, spacing: 6) {
+            Text(marker).foregroundStyle(.secondary).frame(minWidth: 18, alignment: .trailing)
+            Text(.init(text)).textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct MarkdownQuoteRow: View {
+    let text: String
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle().fill(.tertiary).frame(width: 3)
+            Text(.init(text)).foregroundStyle(.secondary).textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/macapp/Tests/GoCodeUITests/MarkdownBlockTests.swift
+++ b/macapp/Tests/GoCodeUITests/MarkdownBlockTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+
+@testable import GoCodeUI
+
+@Suite("MarkdownBlock parsing")
+struct MarkdownBlockTests {
+
+    @Test("headings parse with their level, one per line")
+    func headings() {
+        let blocks = MarkdownBlock.parse("# Title\n## Subtitle\n###### Tiny")
+        #expect(
+            blocks == [
+                .heading(level: 1, text: "Title"),
+                .heading(level: 2, text: "Subtitle"),
+                .heading(level: 6, text: "Tiny"),
+            ])
+    }
+
+    @Test("a line of only hashes with no space is not a heading")
+    func notAHeadingWithoutSpace() {
+        let blocks = MarkdownBlock.parse("#nospace")
+        #expect(blocks == [.paragraph("#nospace")])
+    }
+
+    @Test("unordered list markers -, *, + all produce list items")
+    func unorderedList() {
+        let blocks = MarkdownBlock.parse("- first\n* second\n+ third")
+        #expect(
+            blocks == [
+                .unorderedListItem("first"),
+                .unorderedListItem("second"),
+                .unorderedListItem("third"),
+            ])
+    }
+
+    @Test("ordered list keeps the given numbers, not a recount")
+    func orderedList() {
+        let blocks = MarkdownBlock.parse("1. one\n2. two\n7. seven")
+        #expect(
+            blocks == [
+                .orderedListItem(number: 1, text: "one"),
+                .orderedListItem(number: 2, text: "two"),
+                .orderedListItem(number: 7, text: "seven"),
+            ])
+    }
+
+    @Test("block quotes strip the marker and leading space")
+    func blockQuote() {
+        let blocks = MarkdownBlock.parse("> a wise remark")
+        #expect(blocks == [.quote("a wise remark")])
+    }
+
+    @Test("thematic breaks in --- *** or ___ form become a rule")
+    func horizontalRule() {
+        #expect(MarkdownBlock.parse("---") == [.rule])
+        #expect(MarkdownBlock.parse("***") == [.rule])
+        #expect(MarkdownBlock.parse("___") == [.rule])
+    }
+
+    @Test("a heading immediately followed by a list keeps both blocks distinct")
+    func headingThenList() {
+        let blocks = MarkdownBlock.parse("## Steps\n- one\n- two")
+        #expect(
+            blocks == [
+                .heading(level: 2, text: "Steps"),
+                .unorderedListItem("one"),
+                .unorderedListItem("two"),
+            ])
+    }
+
+    @Test("a fenced code block interrupts a list and resumes after it")
+    func listInterruptedByFence() {
+        let blocks = MarkdownBlock.parse("- before\n```swift\nlet x = 1\n```\n- after")
+        #expect(
+            blocks == [
+                .unorderedListItem("before"),
+                .code("let x = 1", "swift"),
+                .unorderedListItem("after"),
+            ])
+    }
+
+    @Test("an unterminated fence mid-stream still renders as code")
+    func unterminatedFenceMidStream() {
+        let blocks = MarkdownBlock.parse("```swift\nlet x = 1")
+        #expect(blocks == [.code("let x = 1", "swift")])
+    }
+
+    @Test("a paragraph's internal line break is preserved, not collapsed")
+    func paragraphKeepsLineBreak() {
+        let blocks = MarkdownBlock.parse("first line\nsecond line")
+        // Two trailing spaces before the newline is CommonMark's explicit hard
+        // break, so Text(.init:) renders it as a real line break instead of
+        // reflowing the two source lines into one.
+        #expect(blocks == [.paragraph("first line  \nsecond line")])
+    }
+
+    @Test("a blank line ends a paragraph rather than merging into the next one")
+    func blankLineEndsParagraph() {
+        let blocks = MarkdownBlock.parse("first paragraph\n\nsecond paragraph")
+        #expect(
+            blocks == [
+                .paragraph("first paragraph"),
+                .paragraph("second paragraph"),
+            ])
+    }
+}
+
+@Suite("MarkdownBlock parsing — regression")
+struct MarkdownBlockRegressionTests {
+
+    /// A realistic streamed reply mixing every block type in one pass. If
+    /// block detection reverts to the old single-`.text`-blob behavior (or
+    /// any one branch stops being checked before the plain-paragraph
+    /// fallback), this collapses back into far fewer blocks than expected —
+    /// unlike the narrower per-type tests above, which would still each pass
+    /// individually against a parser that only handles one case at a time.
+    @Test(
+        "a full reply mixing heading, list, quote, rule, code and prose parses as distinct blocks")
+    func mixedDocument() {
+        let markdown = """
+            ## Plan
+
+            - step one
+            - step two
+
+            > a caveat worth reading
+
+            ---
+
+            ```swift
+            let x = 1
+            ```
+
+            Done.
+            """
+        let blocks = MarkdownBlock.parse(markdown)
+        #expect(
+            blocks == [
+                .heading(level: 2, text: "Plan"),
+                .unorderedListItem("step one"),
+                .unorderedListItem("step two"),
+                .quote("a caveat worth reading"),
+                .rule,
+                .code("let x = 1", "swift"),
+                .paragraph("Done."),
+            ])
+    }
+
+    /// `blockQuote(_:)` and the `.quote` case used to share the name `quote`,
+    /// and that ambiguity made every quote silently fall through to the
+    /// plain-paragraph branch instead of raising a compiler error — the kind
+    /// of regression a rename or refactor could reintroduce without an
+    /// obvious build failure. Asserting `.quote` shows up correctly inside a
+    /// larger document (not just in isolation) guards against that class of
+    /// silent-wrong-overload bug recurring.
+    @Test("a block quote surrounded by other blocks is not swallowed into a paragraph")
+    func quoteNotSwallowedByParagraph() {
+        let blocks = MarkdownBlock.parse("intro line\n> quoted line\noutro line")
+        #expect(
+            blocks == [
+                .paragraph("intro line"),
+                .quote("quoted line"),
+                .paragraph("outro line"),
+            ])
+    }
+}


### PR DESCRIPTION
## Problem

Assistant replies showed headings, lists, quotes and horizontal rules as literal characters, and line breaks inside a paragraph collapsed.

The parser only separated fenced code from everything else, and everything else went through `Text(.init:)` — a `LocalizedStringKey`, which renders *inline* markdown (bold, italic, links) but has no concept of block structure.

## Solution

`MarkdownBlock` now recognises headings (levels 1–6), ordered and unordered list items, block quotes and horizontal rules alongside the existing fenced code, each rendered with its own view — hanging-indent list rows, a left rule for quotes, a per-level heading font, `Divider()` for rules.

Paragraph lines are joined with a CommonMark hard break so `Text` stops reflowing them away.

## A bug found while implementing

A private helper `quote(_:) -> MarkdownBlock?` had the same name and argument shape as the enum's own `case quote(String)` initialiser. Swift's overload resolution silently picked the wrong one, so **every block quote fell through to a paragraph with no build error**. Renamed, with a regression test that exercises a quote inside a larger document so this class of bug cannot reappear quietly.

## Scope

Tables are out of scope and list nesting is flat. Both are documented where the parser would otherwise look unfinished.

## Testing

New parser-level test suite covering every block type plus the edge cases that matter while streaming: a heading immediately followed by a list, a list interrupted by a fenced block, an unterminated fence mid-stream, and a paragraph containing a line break. Built test-first — the suite was red before the implementation existed.

103 tests pass, `swift build` clean, `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9