### PR TITLE
fix: conversation-scoped SSE stream so callback/cron runs are visible

### DIFF
--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -287,6 +287,15 @@ type Runner struct {
 	// It is populated when a run completes and its conversation is saved to the
 	// in-memory conversations map. Used to validate caller-supplied conversation IDs.
 	conversationOwners map[string]conversationOwner
+	// convSubscribers maps conversation_id -> set of subscriber channels for the
+	// conversation-scoped SSE route (GET /v1/conversations/{id}/events, issue
+	// #950). Unlike run-scoped subscribers (runState.subscribers), these persist
+	// across every run started on the conversation -- including a run started
+	// by a delayed callback or cron job after the originating run has already
+	// ended, which run-scoped subscription cannot observe (there is no run to
+	// subscribe to yet when the client connects). Guarded by mu, same as runs
+	// and the other conversation-keyed maps.
+	convSubscribers map[string]map[chan Event]struct{}
 	// cancelFuncs maps runID → context.CancelFunc for cooperative cancellation.
 	// An entry is present while the run's execute() goroutine is active.
 	// CancelRun looks up and calls the function to interrupt provider and tool
@@ -410,6 +419,7 @@ func NewRunner(provider Provider, tools *Registry, config RunnerConfig) *Runner 
 		closedSubscribers:   make(map[chan Event]struct{}),
 		conversationTouched: make(map[string]time.Time),
 		conversationOwners:  make(map[string]conversationOwner),
+		convSubscribers:     make(map[string]map[chan Event]struct{}),
 		auditBuckets:        make(map[string]*auditBucket),
 		done:                make(chan struct{}),
 	}
@@ -1915,6 +1925,101 @@ func (r *Runner) Subscribe(runID string) ([]Event, <-chan Event, func(), error) 
 		}
 	}
 	return history, ch, cancel, nil
+}
+
+// SubscribeConversation subscribes to every event emitted by any run on the
+// given conversation, not just a single run -- including a run the caller
+// never itself started. This closes the observability gap documented in
+// callback_bridge.go: callback.fired (and any cron-started run) may execute
+// after the originating run has ended, when there is no run to Subscribe to
+// yet. A client that opened the conversation stream earlier still observes
+// it here, because delivery is keyed by conversation ID, not run ID.
+//
+// Returns ErrConversationNotFound-shaped error (via fmt.Errorf, matching
+// Subscribe's contract) for an unknown conversation, so the HTTP layer can
+// give it the same 404 semantics as its sibling conversation sub-resource
+// routes.
+//
+// ponytail: the replayed history only covers the conversation's current live
+// run, if one exists (mirroring the "most recently created non-terminated
+// run" resolution callback_bridge.go already uses for delivery). Events from
+// runs that completed before this call are not replayed. Add a
+// runStore-backed conversation event history if resuming across a full
+// reconnect gap spanning already-completed runs turns out to matter.
+func (r *Runner) SubscribeConversation(convID string) ([]Event, <-chan Event, func(), error) {
+	convID = strings.TrimSpace(convID)
+	if convID == "" {
+		return nil, nil, nil, fmt.Errorf("conversation id is required")
+	}
+	if !r.conversationExists(convID) {
+		return nil, nil, nil, fmt.Errorf("conversation %q not found", convID)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var history []Event
+	var liveRunID string
+	var liveCreatedAt time.Time
+	for id, state := range r.runs {
+		if state == nil || state.terminated || state.run.ConversationID != convID {
+			continue
+		}
+		if liveRunID == "" || state.run.CreatedAt.After(liveCreatedAt) {
+			liveRunID, liveCreatedAt = id, state.run.CreatedAt
+		}
+	}
+	if liveRunID != "" {
+		src := r.runs[liveRunID].events
+		history = make([]Event, len(src))
+		for i, ev := range src {
+			history[i] = ev
+			history[i].Payload = deepClonePayload(ev.Payload)
+		}
+	}
+
+	ch := make(chan Event, 64)
+	if r.convSubscribers[convID] == nil {
+		r.convSubscribers[convID] = make(map[chan Event]struct{})
+	}
+	r.convSubscribers[convID][ch] = struct{}{}
+
+	cancel := func() {
+		r.mu.Lock()
+		shouldClose := false
+		if subs, ok := r.convSubscribers[convID]; ok {
+			if _, exists := subs[ch]; exists {
+				delete(subs, ch)
+				shouldClose = true
+				if len(subs) == 0 {
+					delete(r.convSubscribers, convID)
+				}
+			}
+		}
+		r.mu.Unlock()
+		if shouldClose {
+			r.closeSubscriber(ch)
+		}
+	}
+	return history, ch, cancel, nil
+}
+
+// conversationExists reports whether convID corresponds to a conversation the
+// runner knows about: either a run (live or completed) recorded in memory, or
+// a conversation recorded in the persistent ConversationStore. It gives
+// SubscribeConversation the same 404-for-unknown-ID semantics as the other
+// conversation sub-resource routes (see ConversationMessages).
+func (r *Runner) conversationExists(convID string) bool {
+	r.mu.RLock()
+	for _, state := range r.runs {
+		if state != nil && state.run.ConversationID == convID {
+			r.mu.RUnlock()
+			return true
+		}
+	}
+	r.mu.RUnlock()
+	_, ok := r.ConversationMessages(convID)
+	return ok
 }
 
 func (r *Runner) closeSubscriber(ch chan Event) {

--- a/internal/harness/runner_event_journal.go
+++ b/internal/harness/runner_event_journal.go
@@ -109,6 +109,14 @@ func (j *eventJournal) prepareLocked(state *runState, runID string, eventType Ev
 	delivery.event = event
 	delivery.eventSeq = eventSeq
 
+	// Conversation-scoped subscribers (GET /v1/conversations/{id}/events,
+	// issue #950) observe every event from every run on this conversation, in
+	// addition to that run's own run-scoped subscribers. Each subscriber has
+	// its own channel (allocated by Subscribe / SubscribeConversation), so a
+	// caller subscribed to both never receives the same event twice on the
+	// same channel.
+	convSubs := j.runner.convSubscribers[state.run.ConversationID]
+
 	// For non-terminal events, preserve the original fanout behavior by
 	// publishing while the runner lock is still held so a concurrent cancel
 	// cannot close the channel between our check and send.
@@ -122,13 +130,30 @@ func (j *eventJournal) prepareLocked(state *runState, runID string, eventType Ev
 				// Drop if subscriber is too slow; event is still persisted in run history.
 			}
 		}
+		for ch := range convSubs {
+			evCopy := event
+			evCopy.Payload = deepClonePayload(storedPayload)
+			select {
+			case ch <- evCopy:
+			default:
+				// Drop if subscriber is too slow; event is still persisted in run history.
+			}
+		}
 	} else {
 		// Terminal events need a stronger ordering guarantee: append to the store
 		// before subscribers can observe the terminal event. We still snapshot the
 		// subscriber deliveries while the runner lock is held so the payload stays
 		// isolated and the subscriber set is consistent for this event.
-		delivery.subscribers = make([]subscriberDelivery, 0, len(state.subscribers))
+		delivery.subscribers = make([]subscriberDelivery, 0, len(state.subscribers)+len(convSubs))
 		for ch := range state.subscribers {
+			evCopy := event
+			evCopy.Payload = deepClonePayload(storedPayload)
+			delivery.subscribers = append(delivery.subscribers, subscriberDelivery{
+				ch:    ch,
+				event: evCopy,
+			})
+		}
+		for ch := range convSubs {
 			evCopy := event
 			evCopy.Payload = deepClonePayload(storedPayload)
 			delivery.subscribers = append(delivery.subscribers, subscriberDelivery{

--- a/internal/server/http_conversation_events_tenant_test.go
+++ b/internal/server/http_conversation_events_tenant_test.go
@@ -1,0 +1,122 @@
+package server_test
+
+// http_conversation_events_tenant_test.go — proves GET
+// /v1/conversations/{id}/events (issue #950) is gated the same way as its
+// sibling conversation sub-resource routes (messages, export, runs): it
+// requires runs:read scope, and it 404s (rather than leaking existence or
+// content) for a conversation owned by a different tenant.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+	"go-agent-harness/internal/server"
+	"go-agent-harness/internal/store"
+)
+
+// BT-004: the route requires runs:read scope, same as every sibling GET
+// conversation sub-resource route.
+func TestConversationEvents_RequiresRunsReadScope(t *testing.T) {
+	t.Parallel()
+
+	ms := store.NewMemoryStore()
+	const tenantID = "tenant-conv-events-scope"
+
+	noScopeToken, noScopeKey := generateFastAPIKey(t, tenantID, "no scopes", nil)
+	if err := ms.CreateAPIKey(context.Background(), noScopeKey); err != nil {
+		t.Fatalf("CreateAPIKey(no scope): %v", err)
+	}
+	readToken, readKey := generateFastAPIKey(t, tenantID, "read", []string{store.ScopeRunsRead})
+	if err := ms.CreateAPIKey(context.Background(), readKey); err != nil {
+		t.Fatalf("CreateAPIKey(read): %v", err)
+	}
+
+	prov := fakeprovider.New([]fakeprovider.Turn{{Hang: true}})
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     3,
+	})
+	handler := server.NewWithOptions(server.ServerOptions{Runner: runner, Store: ms})
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() { runner.Shutdown(context.Background()) })
+
+	run, err := runner.StartRun(harness.RunRequest{Prompt: "hello", TenantID: tenantID})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	t.Cleanup(prov.Release)
+
+	// No-scope caller must be rejected -- same as every sibling GET
+	// conversation sub-resource route -- before conversation existence or
+	// tenant ownership is even considered.
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel1()
+	req1, _ := http.NewRequestWithContext(ctx1, http.MethodGet, ts.URL+"/v1/conversations/"+run.ConversationID+"/events", nil)
+	req1.Header.Set("Authorization", "Bearer "+noScopeToken)
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatalf("GET events (no scope): %v", err)
+	}
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusForbidden {
+		body, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("no-scope GET events: status = %d, want %d; body=%s", resp1.StatusCode, http.StatusForbidden, body)
+	}
+	var denied struct {
+		Error    string `json:"error"`
+		Required string `json:"required"`
+	}
+	if err := json.NewDecoder(resp1.Body).Decode(&denied); err != nil {
+		t.Fatalf("decode forbidden body: %v", err)
+	}
+	if denied.Error != "insufficient_scope" || denied.Required != store.ScopeRunsRead {
+		t.Errorf("forbidden body = %+v, want error=insufficient_scope required=%s", denied, store.ScopeRunsRead)
+	}
+
+	// Positive control: the same route with runs:read succeeds. Without this,
+	// a blanket-403 implementation could pass the assertion above too.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	req2, _ := http.NewRequestWithContext(ctx2, http.MethodGet, ts.URL+"/v1/conversations/"+run.ConversationID+"/events", nil)
+	req2.Header.Set("Authorization", "Bearer "+readToken)
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("GET events (read scope): %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("read-scope GET events: status = %d, want %d; body=%s", resp2.StatusCode, http.StatusOK, body)
+	}
+}
+
+// BT-005: a conversation owned by tenant A must be invisible to tenant B on
+// this route, matching blockConversationCrossTenant's contract for sibling
+// GET conversation sub-resource routes (messages, export, runs).
+func TestConversationEvents_CrossTenantDenied(t *testing.T) {
+	t.Parallel()
+
+	f := newTwoTenantFixture(t)
+	runID := f.startRun(t, f.tokenA)
+	f.waitInFlight(t)
+	convID := f.convIDFromRun(t, runID)
+
+	// Owner (tenant A) can open the conversation stream.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenA, "/v1/conversations/"+convID+"/events"); code != http.StatusOK {
+		t.Errorf("owner GET conversation events: got %d, want 200; body %s", code, body)
+	}
+
+	// Tenant B must not be able to open (or even learn of the existence of)
+	// tenant A's conversation stream.
+	if code, body := f.doByID(t, http.MethodGet, f.tokenB, "/v1/conversations/"+convID+"/events"); code != http.StatusNotFound {
+		t.Errorf("tenant B GET conversation events: got %d, want 404; body %s", code, body)
+	}
+}

--- a/internal/server/http_conversation_events_test.go
+++ b/internal/server/http_conversation_events_test.go
@@ -1,0 +1,294 @@
+package server
+
+// http_conversation_events_test.go — proves GET /v1/conversations/{id}/events
+// (issue #950) streams events for ANY run on a conversation, not just a run
+// the connected client itself started. This is the fix for delayed
+// (set_delayed_callback) and cron-started runs whose output was previously
+// invisible: those runs execute on a conversation with no run-scoped SSE
+// listener attached (internal/harness/callback_bridge.go), so nothing was
+// ever streamed to the client. A conversation-scoped subscriber does not have
+// this gap: it is registered once and observes every run started afterwards.
+//
+// Design notes:
+//   - package server (in-package) to mirror http_callback_sse_test.go: needed
+//     so a future extension of these tests could reach unexported helpers.
+//   - Uses fakeprovider (content-only turns, no tool calls) so each run
+//     completes in exactly one Complete() call -- deterministic without Hang.
+//   - openConversationEventsStream's synchronization guarantee: the handler
+//     (handleConversationEvents) calls Runner.SubscribeConversation, which
+//     registers the subscriber channel BEFORE the response headers are
+//     written. Since http.Client.Do only returns once headers are received,
+//     any run started after Do() returns is guaranteed to be observed live,
+//     not just replayed from history.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"go-agent-harness/internal/fakeprovider"
+	"go-agent-harness/internal/harness"
+)
+
+// conversationSSEEvent is a minimally-typed view of an SSE-delivered
+// harness.Event frame for the assertions in this file.
+type conversationSSEEvent struct {
+	Type    string         `json:"type"`
+	RunID   string         `json:"run_id"`
+	Payload map[string]any `json:"payload"`
+}
+
+// newConversationEventsTestServer builds a Runner backed by a scripted
+// fakeprovider (one content-only turn per run) and an httptest server for it.
+func newConversationEventsTestServer(t *testing.T, turns []fakeprovider.Turn) (*harness.Runner, *httptest.Server) {
+	t.Helper()
+
+	prov := fakeprovider.New(turns)
+	runner := harness.NewRunner(prov, harness.NewRegistry(), harness.RunnerConfig{
+		DefaultModel: "test-model",
+		MaxSteps:     3,
+	})
+	t.Cleanup(func() { runner.Shutdown(context.Background()) })
+
+	ts := httptest.NewServer(New(runner))
+	t.Cleanup(ts.Close)
+
+	return runner, ts
+}
+
+// pollUntilRunTerminal polls GetRun until runID reaches a terminal status.
+func pollUntilRunTerminal(t *testing.T, runner *harness.Runner, runID string) harness.Run {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		run, ok := runner.GetRun(runID)
+		if !ok {
+			t.Fatalf("run %q not found", runID)
+		}
+		switch run.Status {
+		case harness.RunStatusCompleted, harness.RunStatusFailed, harness.RunStatusCancelled:
+			return run
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("run %q did not reach a terminal status in time", runID)
+	return harness.Run{}
+}
+
+// openConversationEventsStream issues GET /v1/conversations/{id}/events and
+// returns a channel of decoded SSE frames plus a cleanup func. By the time
+// this function returns, the runner has already registered the subscription
+// (see the package doc comment above) -- callers can rely on that ordering.
+func openConversationEventsStream(t *testing.T, baseURL, convID string) (<-chan conversationSSEEvent, func()) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/conversations/"+convID+"/events", nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("open conversation events stream: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("conversation events stream: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	out := make(chan conversationSSEEvent, 64)
+	go func() {
+		defer close(out)
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for scanner.Scan() {
+			data, ok := strings.CutPrefix(scanner.Text(), "data: ")
+			if !ok {
+				continue
+			}
+			var ev conversationSSEEvent
+			if err := json.Unmarshal([]byte(data), &ev); err != nil {
+				continue
+			}
+			out <- ev
+		}
+	}()
+
+	return out, func() { resp.Body.Close() }
+}
+
+// waitForRunStartedEvent reads events until it sees run.started for runID.
+func waitForRunStartedEvent(t *testing.T, events <-chan conversationSSEEvent, runID string) conversationSSEEvent {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("conversation events stream closed before run.started was observed")
+			}
+			if ev.Type == "run.started" && ev.RunID == runID {
+				return ev
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for run.started for run %q on the conversation stream", runID)
+		}
+	}
+}
+
+// BT-001: subscribing to a conversation's events receives events from a run
+// the subscriber did not start.
+func TestConversationEvents_ReceivesRunSubscriberDidNotStart(t *testing.T) {
+	t.Parallel()
+
+	runner, ts := newConversationEventsTestServer(t, []fakeprovider.Turn{
+		{Content: "run one output"},
+		{Content: "run two output"},
+	})
+
+	const convID = "conv-bt001"
+
+	run1, err := runner.StartRun(harness.RunRequest{Prompt: "first", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run1: %v", err)
+	}
+	pollUntilRunTerminal(t, runner, run1.ID)
+
+	events, closeStream := openConversationEventsStream(t, ts.URL, convID)
+	defer closeStream()
+
+	// run2 is started directly against the runner -- not through the HTTP
+	// client that opened the conversation stream. This stands in for a
+	// callback- or cron-started run: something other than the subscriber
+	// caused it to start.
+	run2, err := runner.StartRun(harness.RunRequest{Prompt: "second", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run2: %v", err)
+	}
+
+	got := waitForRunStartedEvent(t, events, run2.ID)
+	if conv, _ := got.Payload["conversation_id"].(string); conv != convID {
+		t.Errorf("run.started conversation_id = %q, want %q", conv, convID)
+	}
+}
+
+// BT-002: a second run on the same conversation also reaches the same
+// subscriber (proves the conversation stream is not a one-shot delivery).
+func TestConversationEvents_SecondRunAlsoReachesSameSubscriber(t *testing.T) {
+	t.Parallel()
+
+	runner, ts := newConversationEventsTestServer(t, []fakeprovider.Turn{
+		{Content: "run one output"},
+		{Content: "run two output"},
+		{Content: "run three output"},
+	})
+
+	const convID = "conv-bt002"
+
+	run1, err := runner.StartRun(harness.RunRequest{Prompt: "first", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run1: %v", err)
+	}
+	pollUntilRunTerminal(t, runner, run1.ID)
+
+	events, closeStream := openConversationEventsStream(t, ts.URL, convID)
+	defer closeStream()
+
+	run2, err := runner.StartRun(harness.RunRequest{Prompt: "second", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run2: %v", err)
+	}
+	waitForRunStartedEvent(t, events, run2.ID)
+	pollUntilRunTerminal(t, runner, run2.ID)
+
+	run3, err := runner.StartRun(harness.RunRequest{Prompt: "third", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run3: %v", err)
+	}
+	waitForRunStartedEvent(t, events, run3.ID)
+}
+
+// BT-003: the route 404s for an unknown conversation.
+func TestConversationEvents_UnknownConversation404(t *testing.T) {
+	t.Parallel()
+
+	_, ts := newConversationEventsTestServer(t, nil)
+
+	resp, err := http.Get(ts.URL + "/v1/conversations/does-not-exist/events")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	var body struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.Error.Code != "not_found" {
+		t.Errorf("error.code = %q, want %q", body.Error.Code, "not_found")
+	}
+}
+
+// Regression (issue #950): a delayed-callback-style run that starts and
+// completes entirely AFTER the originating run has already ended must still
+// have its full output (not just a started marker) observed by a subscriber
+// that opened the conversation stream in between -- proving the fix covers
+// the exact reported scenario, not just a "run started" ping.
+func TestConversationEvents_RegressionCallbackStyleRunAfterOriginatingRunEnded(t *testing.T) {
+	t.Parallel()
+
+	runner, ts := newConversationEventsTestServer(t, []fakeprovider.Turn{
+		{Content: "original run output"},
+		{Content: "delayed callback run output"},
+	})
+
+	const convID = "conv-regression-950"
+
+	run1, err := runner.StartRun(harness.RunRequest{Prompt: "start", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun run1: %v", err)
+	}
+	// The originating run has fully ended -- mirroring callback.fired firing
+	// well after the run that scheduled it (internal/harness/callback_bridge.go),
+	// long after that run's own /v1/runs/{id}/events stream has closed.
+	pollUntilRunTerminal(t, runner, run1.ID)
+
+	events, closeStream := openConversationEventsStream(t, ts.URL, convID)
+	defer closeStream()
+
+	callbackRun, err := runner.StartRun(harness.RunRequest{Prompt: "callback fired", ConversationID: convID})
+	if err != nil {
+		t.Fatalf("StartRun callback-style run: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("conversation stream closed before the callback-style run.completed was observed")
+			}
+			if ev.RunID == callbackRun.ID && ev.Type == string(harness.EventRunCompleted) {
+				output, _ := ev.Payload["output"].(string)
+				if output != "delayed callback run output" {
+					t.Errorf("callback-style run output = %q, want %q", output, "delayed callback run output")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the callback-style run.completed on the conversation stream")
+		}
+	}
+}

--- a/internal/server/http_conversation_events_test.go
+++ b/internal/server/http_conversation_events_test.go
@@ -292,3 +292,74 @@ func TestConversationEvents_RegressionCallbackStyleRunAfterOriginatingRunEnded(t
 		}
 	}
 }
+
+// Regression: fan-out must be keyed by conversation ID, not global. A
+// subscriber on conversation A must never observe a run started on a
+// different conversation B -- if Runner.convSubscribers were ever collapsed
+// into one shared set (or the emit-time lookup used the wrong key), this
+// would catch it immediately, whereas the BT-001/BT-002 tests above only ever
+// exercise a single conversation and could not.
+func TestConversationEvents_RegressionNoCrossConversationLeak(t *testing.T) {
+	t.Parallel()
+
+	runner, ts := newConversationEventsTestServer(t, []fakeprovider.Turn{
+		{Content: "conv A first run"},
+		{Content: "conv B first run"},
+		{Content: "conv B second run"},
+		{Content: "conv A second run"},
+	})
+
+	const (
+		convA = "conv-a-950-isolation"
+		convB = "conv-b-950-isolation"
+	)
+
+	// Establish both conversations (each needs at least one completed run to
+	// be "known" -- see Runner.conversationExists) before subscribing.
+	runA1, err := runner.StartRun(harness.RunRequest{Prompt: "a1", ConversationID: convA})
+	if err != nil {
+		t.Fatalf("StartRun runA1: %v", err)
+	}
+	pollUntilRunTerminal(t, runner, runA1.ID)
+
+	runB1, err := runner.StartRun(harness.RunRequest{Prompt: "b1", ConversationID: convB})
+	if err != nil {
+		t.Fatalf("StartRun runB1: %v", err)
+	}
+	pollUntilRunTerminal(t, runner, runB1.ID)
+
+	events, closeStream := openConversationEventsStream(t, ts.URL, convA)
+	defer closeStream()
+
+	// A run on the OTHER conversation must never reach convA's subscriber.
+	runB2, err := runner.StartRun(harness.RunRequest{Prompt: "b2", ConversationID: convB})
+	if err != nil {
+		t.Fatalf("StartRun runB2: %v", err)
+	}
+	pollUntilRunTerminal(t, runner, runB2.ID)
+
+	// Positive control: a run on convA must still reach the subscriber,
+	// proving the stream is live and correctly wired -- not merely silent.
+	runA2, err := runner.StartRun(harness.RunRequest{Prompt: "a2", ConversationID: convA})
+	if err != nil {
+		t.Fatalf("StartRun runA2: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case ev, ok := <-events:
+			if !ok {
+				t.Fatal("conversation A stream closed before runA2's run.started was observed")
+			}
+			if ev.RunID == runB2.ID {
+				t.Fatalf("conversation A subscriber observed event %q from conversation B's run %q -- cross-conversation leak", ev.Type, ev.RunID)
+			}
+			if ev.Type == "run.started" && ev.RunID == runA2.ID {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for runA2's run.started on the conversation A stream")
+		}
+	}
+}

--- a/internal/server/http_conversations.go
+++ b/internal/server/http_conversations.go
@@ -80,6 +80,30 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GET /v1/conversations/{id}/events — conversation-scoped SSE stream
+	// (runs:read) (issue #950). Streams events from ANY run on the
+	// conversation, including a run the connected client did not itself
+	// start (e.g. a delayed set_delayed_callback firing, or a cron-started
+	// run) -- the gap documented in internal/harness/callback_bridge.go,
+	// where a run-scoped subscriber has nothing to attach to once the
+	// originating run has already ended.
+	if len(parts) == 2 && parts[1] == "events" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		if !hasScope(r.Context(), store.ScopeRunsRead) {
+			writeScopeError(w, store.ScopeRunsRead)
+			return
+		}
+		convID := parts[0]
+		if s.blockConversationCrossTenant(w, r, convID) {
+			return
+		}
+		s.handleConversationEvents(w, r, convID)
+		return
+	}
+
 	// GET /v1/conversations/{id}/runs — list runs for a conversation (runs:read)
 	if len(parts) == 2 && parts[1] == "runs" {
 		if r.Method != http.MethodGet {
@@ -216,6 +240,87 @@ func (s *Server) handleConversations(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.NotFound(w, r)
+}
+
+// handleConversationEvents handles GET /v1/conversations/{id}/events
+// (issue #950). It mirrors handleRunEvents' SSE contract (Last-Event-ID
+// resumption, keepalive pings, same headers) but subscribes to the whole
+// conversation via Runner.SubscribeConversation instead of a single run, so
+// events from every run on the conversation are observed -- including a run
+// the connected client did not itself start.
+//
+// Unlike handleRunEvents, this stream does NOT close when it observes a
+// terminal run event (run.completed/failed/cancelled): a terminal event ends
+// one run, not the conversation, and a later run (e.g. a delayed callback
+// firing) must still reach this same connection. It only ends on client
+// disconnect or the subscription channel closing.
+func (s *Server) handleConversationEvents(w http.ResponseWriter, r *http.Request, convID string) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+
+	history, stream, cancel, err := s.runner.SubscribeConversation(convID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", fmt.Sprintf("conversation %q not found", convID))
+		return
+	}
+	defer cancel()
+
+	// Support Last-Event-ID reconnection: skip already-seen events. See
+	// handleRunEvents for the full rationale (bounds-checked slicing only;
+	// an out-of-range or unparseable Last-Event-ID falls back to a full
+	// replay rather than guessing or panicking). The replayed history here
+	// only ever comes from the conversation's current live run (if any), so
+	// the same seq-based skip logic applies unchanged.
+	if lastID := r.Header.Get("Last-Event-ID"); lastID != "" {
+		if _, seq, err := harness.ParseEventID(lastID); err == nil {
+			historyLen := uint64(len(history))
+			if seq < historyLen {
+				history = history[seq+1:]
+			}
+		}
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "stream_unsupported", "response writer does not support streaming")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	for _, event := range history {
+		if err := writeSSE(w, event); err != nil {
+			return
+		}
+		flusher.Flush()
+	}
+
+	ticker := time.NewTicker(sseKeepaliveInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case event, ok := <-stream:
+			if !ok {
+				return
+			}
+			if err := writeSSE(w, event); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ticker.C:
+			if err := writeSSEPing(w); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 func (s *Server) handleListRewindPoints(w http.ResponseWriter, r *http.Request, convID string) {


### PR DESCRIPTION
## Summary

Fixes #950. `set_delayed_callback` and cron-started runs execute after the
originating run has ended, when there is no run left to attach an SSE
listener to — `internal/harness/callback_bridge.go` documents this as a
no-op for SSE. The run still executes and costs tokens, but its output was
never seen.

- Adds `GET /v1/conversations/{id}/events`: subscribes at the conversation
  level (`Runner.SubscribeConversation`, keyed by `Runner.convSubscribers`)
  instead of a single run, so a client observes every run started on the
  conversation afterwards — including one it did not itself start.
- Reuses the existing event journal instead of a parallel system: every run
  event already goes through `runner_event_journal.go`'s `prepareLocked`; it
  now fans out to the run's own subscribers *and* the conversation's
  subscribers.
- The route mirrors the existing per-run SSE contract (`Last-Event-ID`
  resumption, keepalive pings, `runs:read` scope + cross-tenant 404 via
  `blockConversationCrossTenant`, same as sibling conversation sub-resource
  routes) but — unlike the per-run route — never closes on a run's terminal
  event, since a later run on the same conversation must still reach the
  same connection.

Out of scope (per the task): the macOS app client and
`CallbackManager`/bridge semantics are unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/server/... -count=1`
- [x] `go test ./internal/harness/... -count=1`
- [x] `go test ./... -count=1` (full suite green)
- [x] New tests: subscriber receives a run it did not start; a second run on
      the same conversation reaches the same subscriber; 404 for an unknown
      conversation; `runs:read` scope enforced; cross-tenant conversation
      denied; regression test for the exact issue #950 scenario (a
      callback-style run's full output observed after the originating run
      ended); regression test that conversation A never observes an event
      from a run on conversation B.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9