### PR TITLE
fix(macapp): diff memoisation, bounded file completion scan, export/rewind cleanup, shared card styling

### DIFF
--- a/macapp/Sources/GoCodeUI/ActivityView.swift
+++ b/macapp/Sources/GoCodeUI/ActivityView.swift
@@ -81,12 +81,11 @@ private struct TaskRow: View {
             Image(systemName: icon).foregroundStyle(.tint)
             VStack(alignment: .leading, spacing: 2) {
                 Text(task.label).font(.callout).lineLimit(1)
-                HStack(spacing: 6) {
+                MetadataRow {
                     Text(task.type)
                     Text(task.status)
                     if let age = task.ageSeconds { Text("\(age)s") }
                 }
-                .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
         }
@@ -110,14 +109,13 @@ private struct RunRow: View {
             Circle().fill(color).frame(width: 7, height: 7)
             VStack(alignment: .leading, spacing: 2) {
                 Text(run.prompt ?? run.id).font(.callout).lineLimit(1)
-                HStack(spacing: 6) {
+                MetadataRow {
                     if let status = run.status { Text(status) }
                     if let model = run.model { Text(model) }
                     if let date = run.createdAt {
                         Text(date.formatted(date: .omitted, time: .shortened))
                     }
                 }
-                .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
         }
@@ -143,7 +141,7 @@ private struct SectionBox<Content: View>: View {
             VStack(alignment: .leading, spacing: 7) { content }
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 10))
+                .cardStyle()
         }
     }
 }

--- a/macapp/Sources/GoCodeUI/CardStyle.swift
+++ b/macapp/Sources/GoCodeUI/CardStyle.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// Card background shared by every grouped content box (issue #951 finding 15:
+/// `SectionBox` and `CheckpointCard` hand-built this identically, `DiffView`
+/// built a near-identical variant at a different opacity/radius).
+struct CardStyle: ViewModifier {
+    var cornerRadius: CGFloat = 10
+    var opacity: Double = 0.3
+
+    func body(content: Content) -> some View {
+        content.background(.quaternary.opacity(opacity), in: .rect(cornerRadius: cornerRadius))
+    }
+}
+
+extension View {
+    func cardStyle(cornerRadius: CGFloat = 10, opacity: Double = 0.3) -> some View {
+        modifier(CardStyle(cornerRadius: cornerRadius, opacity: opacity))
+    }
+}
+
+/// Caption-weight, secondary-colored metadata row shared by list-row
+/// summaries (`TaskRow`, `RunRow`, `ConversationRow`, `CheckpointCard`), which
+/// each hand-built the same `HStack` + `.font(.caption).foregroundStyle(.secondary)`.
+struct MetadataRow<Content: View>: View {
+    var spacing: CGFloat = 6
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        HStack(spacing: spacing) { content }
+            .font(.caption).foregroundStyle(.secondary)
+    }
+}

--- a/macapp/Sources/GoCodeUI/DiffView.swift
+++ b/macapp/Sources/GoCodeUI/DiffView.swift
@@ -1,6 +1,17 @@
 import HarnessKit
 import SwiftUI
 
+/// Counts calls that compute a fresh `Diff` for a `DiffView` instance.
+///
+/// Test-only seam (issue #951 finding 4): `Diff` rebuilds the whole LCS table
+/// on every access, so this proves the view computes it exactly once per
+/// instance instead of once per property read. `ToolEdit` lives in HarnessKit,
+/// which this task may not touch, so the cache — and the counter — live here.
+@MainActor
+enum DiffComputationCounter {
+    static var count = 0
+}
+
 /// Renders a file edit as a unified diff.
 ///
 /// Rows are virtualised: a whole-file rewrite can be thousands of lines and the
@@ -9,7 +20,17 @@ struct DiffView: View {
     let edit: ToolEdit
     @State private var showsContext = true
 
-    private var diff: Diff { edit.diff }
+    /// Computed once, in `init`, rather than left as `edit.diff`: the body
+    /// reads `.additions`, `.deletions`, `.hasChanges` and `.lines`
+    /// separately, and each of those used to rerun the LCS walk — again on
+    /// every re-render, e.g. toggling "show unchanged lines".
+    @State var diff: Diff
+
+    init(edit: ToolEdit) {
+        self.edit = edit
+        DiffComputationCounter.count += 1
+        _diff = State(initialValue: edit.diff)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -35,7 +56,7 @@ struct DiffView: View {
                     }
                 }
             }
-            .background(.quaternary.opacity(0.25), in: .rect(cornerRadius: 8))
+            .cardStyle(cornerRadius: 8, opacity: 0.25)
         }
     }
 

--- a/macapp/Sources/GoCodeUI/FileCompletion.swift
+++ b/macapp/Sources/GoCodeUI/FileCompletion.swift
@@ -5,6 +5,24 @@ import Foundation
 /// Scans off the main thread and is cancellable, because a large repo has
 /// hundreds of thousands of files and the composer must stay responsive.
 public struct FileCompletion: Sendable {
+    /// Keeps at most `limit` matches during the walk, best score first, so a
+    /// huge repo never holds every match in memory before sorting.
+    private struct TopN {
+        let limit: Int
+        private(set) var results: [Match] = []
+
+        mutating func insert(_ match: Match) {
+            let index = results.firstIndex { Self.isBetter(match, $0) } ?? results.count
+            guard index < limit else { return }
+            results.insert(match, at: index)
+            if results.count > limit { results.removeLast() }
+        }
+
+        private static func isBetter(_ a: Match, _ b: Match) -> Bool {
+            a.score == b.score ? a.relativePath.count < b.relativePath.count : a.score > b.score
+        }
+    }
+
     public struct Match: Sendable, Hashable, Identifiable {
         public var id: String { relativePath }
         public let relativePath: String
@@ -23,18 +41,35 @@ public struct FileCompletion: Sendable {
     }
 
     /// Returns the best matches for `query`, most relevant first.
+    ///
+    /// `Task.detached` does not inherit the caller's cancellation, so the
+    /// detached task is cancelled explicitly from `onCancel` — otherwise the
+    /// `Task.isCancelled` checks in `scan` observe a task nobody ever cancels.
     public func matches(for query: String, limit: Int = 30) async -> [Match] {
         let needle = query.lowercased()
         let roots = self.roots
-        return await Task.detached(priority: .userInitiated) {
+        let scanTask = Task.detached(priority: .userInitiated) {
             Self.scan(roots: roots, needle: needle, limit: limit)
-        }.value
+        }
+        return await withTaskCancellationHandler {
+            await scanTask.value
+        } onCancel: {
+            scanTask.cancel()
+        }
     }
 
     /// Synchronous so `FileManager`'s enumerator can be iterated — its iterator
     /// is unavailable from an async context.
     private static func scan(roots: [URL], needle: String, limit: Int) -> [Match] {
-        var results: [Match] = []
+        var top = TopN(limit: limit)
+
+        // ponytail: this does not stop descending into a subtree once `top`
+        // is full — a sound version of that needs to know a subtree's best
+        // possible score in advance, and ties are broken by path length,
+        // which isn't knowable until a candidate is actually seen. Bounding
+        // memory to `limit` matches (instead of accumulating every match in
+        // the repo) is the fix that actually mattered; add subtree pruning
+        // only if profiling shows the walk itself, not the sort, is the cost.
         for suppliedRoot in roots {
             // macOS resolves /tmp and /var through symlinks, so the enumerator
             // yields /private/... paths while the supplied root does not.
@@ -66,19 +101,10 @@ public struct FileCompletion: Sendable {
                     ? String(url.path.dropFirst(root.path.count + 1))
                     : url.path
                 guard let score = score(relative.lowercased(), needle) else { continue }
-                results.append(Match(relativePath: relative, score: score))
+                top.insert(Match(relativePath: relative, score: score))
             }
         }
-        // Best score first, then shortest path — shallow files are usually the
-        // intended target.
-        return
-            results
-            .sorted {
-                $0.score == $1.score
-                    ? $0.relativePath.count < $1.relativePath.count : $0.score > $1.score
-            }
-            .prefix(limit)
-            .map { $0 }
+        return top.results
     }
 
     /// Canonical filesystem path, with every symlink resolved.

--- a/macapp/Sources/GoCodeUI/SessionsView.swift
+++ b/macapp/Sources/GoCodeUI/SessionsView.swift
@@ -6,6 +6,7 @@ struct SessionsView: View {
     @Bindable var project: ProjectSession
     @Binding var section: Section
     @State private var search = ""
+    @State private var exportError: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -54,6 +55,14 @@ struct SessionsView: View {
             }
         }
         .task { await project.refreshConversations() }
+        .alert(
+            "Export failed",
+            isPresented: .init(get: { exportError != nil }, set: { if !$0 { exportError = nil } })
+        ) {
+            Button("OK", role: .cancel) { exportError = nil }
+        } message: {
+            Text(exportError ?? "")
+        }
     }
 
     private var filtered: [ConversationInfo] {
@@ -66,11 +75,23 @@ struct SessionsView: View {
     private func export(_ conversation: ConversationInfo) {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "\(conversation.displayTitle).jsonl"
-        panel.allowedContentTypes = [UTType.json]
+        // The export is NDJSON, not JSON — declare a type that matches the
+        // ".jsonl" extension we actually write instead of claiming `.json`.
+        panel.allowedContentTypes = [
+            UTType(filenameExtension: "jsonl", conformingTo: .plainText) ?? .plainText
+        ]
         guard panel.runModal() == .OK, let url = panel.url else { return }
+        // Call the client directly with the id being exported — `openConversation`
+        // would replace whatever the user is currently looking at in chat just
+        // to prime state, for an export that never needed to touch it.
+        guard let client = project.harnessClient else { return }
         Task {
-            await project.openConversation(conversation)
-            await project.exportTranscript(to: url)
+            do {
+                let data = try await client.exportConversation(id: conversation.id)
+                try data.write(to: url)
+            } catch {
+                exportError = error.localizedDescription
+            }
         }
     }
 
@@ -89,7 +110,7 @@ private struct ConversationRow: View {
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(conversation.displayTitle).lineLimit(1)
-                HStack(spacing: 8) {
+                MetadataRow(spacing: 8) {
                     if let date = conversation.updatedAt ?? conversation.createdAt {
                         Text(date.formatted(date: .abbreviated, time: .shortened))
                     }
@@ -100,7 +121,6 @@ private struct ConversationRow: View {
                         Text("$\(String(format: "%.4f", cost))")
                     }
                 }
-                .font(.caption).foregroundStyle(.secondary)
             }
             Spacer()
         }
@@ -112,7 +132,14 @@ private struct ConversationRow: View {
 struct CheckpointsView: View {
     @Bindable var project: ProjectSession
     @State private var confirming: RewindPoint?
-    @State private var forceNext = false
+
+    // NOTE (issue #951 finding 9): a "Restore anyway" path for the server's
+    // `409 rewind_refused` (a file changed outside the harness) still has no
+    // UI. Wiring it properly needs `ProjectSession.rewind` to surface that
+    // refusal distinctly instead of collapsing every failure into
+    // `statusMessage` text — `ProjectSession.swift` is out of scope for this
+    // task, so the previously dead `forceNext` toggle (set to `false` on tap,
+    // never `true`) is removed rather than left half-wired.
 
     var body: some View {
         Group {
@@ -128,7 +155,6 @@ struct CheckpointsView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         ForEach(project.rewindPoints) { point in
                             CheckpointCard(point: point) {
-                                forceNext = false
                                 confirming = point
                             }
                         }
@@ -146,7 +172,7 @@ struct CheckpointsView: View {
             Button("Cancel", role: .cancel) { confirming = nil }
             Button("Restore", role: .destructive) {
                 if let point = confirming {
-                    Task { await project.rewind(to: point, force: forceNext) }
+                    Task { await project.rewind(to: point) }
                 }
                 confirming = nil
             }
@@ -170,8 +196,7 @@ private struct CheckpointCard: View {
                     Text(point.tool.map { "Before \($0)" } ?? "Checkpoint")
                         .font(.callout.weight(.medium))
                     if let date = point.createdAt {
-                        Text(date.formatted(date: .abbreviated, time: .standard))
-                            .font(.caption).foregroundStyle(.secondary)
+                        MetadataRow { Text(date.formatted(date: .abbreviated, time: .standard)) }
                     }
                 }
                 Spacer()
@@ -196,7 +221,7 @@ private struct CheckpointCard: View {
             }
         }
         .padding(12)
-        .background(.quaternary.opacity(0.3), in: .rect(cornerRadius: 10))
+        .cardStyle()
     }
 }
 

--- a/macapp/Tests/GoCodeUITests/DiffViewTests.swift
+++ b/macapp/Tests/GoCodeUITests/DiffViewTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import GoCodeUI
+@testable import HarnessKit
+
+@Suite("Diff memoisation")
+struct DiffViewTests {
+
+    /// Builds a `ToolEdit` via the same JSON path the app uses, so the fixture
+    /// exercises the real `ToolEdit.diff` computation, not a stand-in.
+    private func makeEdit(before: String, after: String) -> ToolEdit {
+        let object: [String: Any] = ["path": "a.txt", "old_text": before, "new_text": after]
+        let data = try! JSONSerialization.data(withJSONObject: object)
+        let arguments = String(data: data, encoding: .utf8)!
+        return ToolEdit(tool: "edit", arguments: arguments)!
+    }
+
+    /// Regression guard for issue #951 finding 4: `DiffView` used to read
+    /// `edit.diff` (a computed property that reruns the whole LCS walk) once
+    /// per access — `.additions`, `.deletions`, `.hasChanges` and `.lines` each
+    /// paid for it separately. The view must compute it exactly once and reuse
+    /// the stored value for every property it reads while rendering.
+    @Test("computes the diff once per view instance, not once per property read")
+    @MainActor
+    func computesDiffOnce() {
+        let before = (0..<200).map { "line \($0)" }.joined(separator: "\n")
+        let after = (0..<200).map { $0 == 100 ? "changed" : "line \($0)" }.joined(separator: "\n")
+        let edit = makeEdit(before: before, after: after)
+
+        DiffComputationCounter.count = 0
+        let view = DiffView(edit: edit)
+
+        // Simulate exactly the reads `DiffView.body` performs per render.
+        _ = view.diff.additions
+        _ = view.diff.deletions
+        _ = view.diff.hasChanges
+        _ = view.diff.lines
+
+        #expect(DiffComputationCounter.count == 1)
+    }
+}

--- a/macapp/Tests/GoCodeUITests/FileCompletionTests.swift
+++ b/macapp/Tests/GoCodeUITests/FileCompletionTests.swift
@@ -71,6 +71,71 @@ struct FileCompletionTests {
     }
 }
 
+@Suite("FileCompletion bounded scan")
+struct FileCompletionBoundedScanTests {
+
+    /// `count` files that all match "target" with an identical score (same
+    /// contiguous prefix, same basename bonuses) but strictly increasing path
+    /// length, so the expected top-`limit` is deterministic regardless of the
+    /// order the filesystem enumerator happens to visit them in.
+    private func makeTieBreakTree(count: Int) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "bounded-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for index in 0..<count {
+            let name = "target" + String(repeating: "x", count: index) + ".txt"
+            try "x".write(to: root.appending(path: name), atomically: true, encoding: .utf8)
+        }
+        return root
+    }
+
+    /// `count` files that all match "target", named so length stays bounded
+    /// (unlike `makeTieBreakTree`, which grows the name with the index).
+    private func makeLargeTree(count: Int) throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "bounded-large-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for index in 0..<count {
+            try "x".write(
+                to: root.appending(path: "target-\(index).txt"), atomically: true,
+                encoding: .utf8)
+        }
+        return root
+    }
+
+    /// Regression guard for issue #951 finding 5: the scan used to accumulate
+    /// every match in the repo before sorting and truncating. With more
+    /// matching candidates than `limit`, exactly `limit` results must come
+    /// back, and they must be the genuinely best-scoring ones — not just
+    /// whichever `limit` happened to be encountered first.
+    @Test("keeps only the best `limit` matches when candidates exceed it")
+    func boundedToLimit() async throws {
+        let completion = FileCompletion(roots: [try makeTieBreakTree(count: 20)])
+        let matches = await completion.matches(for: "target", limit: 5)
+        #expect(matches.count == 5)
+        #expect(
+            Set(matches.map(\.relativePath))
+                == Set([
+                    "target.txt", "targetx.txt", "targetxx.txt", "targetxxx.txt",
+                    "targetxxxx.txt",
+                ]))
+    }
+
+    /// Regression guard for issue #951 finding 5: the doc comment claims the
+    /// scan is cancellable, but `Task.detached` inside `matches` never
+    /// inherited the caller's cancellation, so the `Task.isCancelled` checks
+    /// in `scan` never tripped. Cancelling the caller must now stop the scan.
+    @Test("stops scanning when the caller's task is cancelled")
+    func cancellationPropagates() async throws {
+        let root = try makeLargeTree(count: 4000)
+        let completion = FileCompletion(roots: [root])
+        let task = Task { await completion.matches(for: "target", limit: 4000) }
+        task.cancel()
+        let result = await task.value
+        #expect(result.isEmpty)
+    }
+}
+
 @Suite("Composer mention parsing")
 struct MentionParsingTests {
 

--- a/macapp/Tests/GoCodeUITests/FileCompletionTests.swift
+++ b/macapp/Tests/GoCodeUITests/FileCompletionTests.swift
@@ -121,6 +121,17 @@ struct FileCompletionBoundedScanTests {
                 ]))
     }
 
+    /// Edge case the bounded top-N must not break: when candidates never
+    /// exceed `limit`, every one of them must still come back — the `index <
+    /// limit` guard in `TopN.insert` must not silently drop matches while the
+    /// set isn't even full yet.
+    @Test("returns every match when there are fewer than `limit`")
+    func returnsAllWhenUnderLimit() async throws {
+        let completion = FileCompletion(roots: [try makeTieBreakTree(count: 3)])
+        let matches = await completion.matches(for: "target", limit: 5)
+        #expect(matches.count == 3)
+    }
+
     /// Regression guard for issue #951 finding 5: the doc comment claims the
     /// scan is cancellable, but `Task.detached` inside `matches` never
     /// inherited the caller's cancellation, so the `Task.isCancelled` checks


### PR DESCRIPTION
## Summary

Fixes 4 findings from #951 (findings 4, 5, 7, 9, 15), scoped to `DiffView.swift`, `Diff`-adjacent code in `GoCodeUI`, `FileCompletion.swift`, `SessionsView.swift`, `ActivityView.swift`, plus a new `CardStyle.swift`.

- **Finding 4** — `DiffView` used to read `edit.diff` (a computed property that reruns the LCS walk) once per property access (`.additions`/`.deletions`/`.hasChanges`/`.lines`), and again on every re-render. `ToolEdit.diff` lives in `HarnessKit`, which is out of scope for this task, so the diff is memoised in the view instead: `@State var diff` set once in `init`.
- **Finding 5** — `FileCompletion.matches` claimed cancellation it didn't have (`Task.detached` doesn't inherit the caller's cancellation). Now uses `withTaskCancellationHandler` to cancel the detached task when the caller is cancelled. The scan also keeps a bounded top-N (capped at `limit`) during the walk instead of accumulating every match before sorting and truncating.
- **Finding 7** — `SessionsView.export` used to call `project.openConversation(conversation)` first, replacing the user's open chat, purely to prime state for `exportTranscript(to:)` (which only reads the currently-open conversation). Now calls `project.harnessClient?.exportConversation(id:)` directly and writes the bytes itself. Also fixed the save panel's declared type (was `UTType.json` for an NDJSON `.jsonl` payload).
- **Finding 9** — `CheckpointsView.forceNext` was dead state (set `false` on tap, never `true`), so a `409 rewind_refused` had no UI path. Wiring a "Restore anyway" path properly needs `ProjectSession.rewind` to surface that refusal distinctly instead of collapsing every failure into `statusMessage` text — `ProjectSession.swift` is owned by another in-flight change and out of scope here, so the dead toggle is deleted rather than left half-wired. A `NOTE` in `CheckpointsView` documents what's still needed.
- **Finding 15** — extracted `.cardStyle()` and `MetadataRow` (new `CardStyle.swift`) to replace the duplicated card background and caption/secondary metadata-row patterns in `SectionBox`, `CheckpointCard`, `DiffView`, `TaskRow`, `RunRow`, `ConversationRow`.

## Approach notes (asked for in the task)

- **Finding 4**: chose the `@State`-in-view memoisation option, not a stored property on `ToolEdit.init`, because `ToolEdit`/`Diff` live in `HarnessKit`, which this task's file ownership excludes.
- **Finding 9**: judged the "proper" fix (surface `409 rewind_refused` distinctly with a "Restore anyway" action) too large given `ProjectSession.swift` is out of scope — deleted the dead `forceNext` toggle instead and left a `NOTE` documenting the still-needed work, per the task's explicit fallback instruction.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 107/107 passing
- [x] `swift format lint --strict --recursive Sources Tests` — clean
- [x] New tests: `DiffViewTests.computesDiffOnce` (counter-based proof the LCS diff computes once per view instance), `FileCompletionBoundedScanTests.boundedToLimit` / `.returnsAllWhenUnderLimit` / `.cancellationPropagates`

Closes part of #951 (findings 4, 5, 7, 9, 15 of 15 — the rest are out of scope for this branch).