### PR TITLE
fix(macapp): correctness findings 3, 6, 11, 12, 13, 14 from #951

### DIFF
--- a/macapp/Sources/GoCodeUI/ProjectSession.swift
+++ b/macapp/Sources/GoCodeUI/ProjectSession.swift
@@ -5,17 +5,69 @@ import Observation
 /// Locates the `harnessd` binary to supervise.
 public enum HarnessBinary {
     /// Resolution order: explicit override, then `PATH`, then a repo-local
-    /// build — which is what a developer running from source has.
+    /// build — what a developer running from source has. A `PATH` entry
+    /// with no `prompts/catalog.yaml` resolvable above it cannot actually
+    /// boot (harnessd exits at startup with no prompt engine); a bootable
+    /// candidate is preferred over one that isn't, wherever it was found
+    /// (#951 finding 11 — this is exactly the failure a PATH-installed
+    /// harnessd caused in practice).
     public static func locate(fileManager: FileManager = .default) -> URL? {
         if let override = ProcessInfo.processInfo.environment["HARNESS_BINARY"] {
             let url = URL(fileURLWithPath: override)
             if fileManager.isExecutableFile(atPath: url.path) { return url }
         }
-        for directory in ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":") ?? [] {
-            let candidate = URL(fileURLWithPath: String(directory)).appending(path: "harnessd")
-            if fileManager.isExecutableFile(atPath: candidate.path) { return candidate }
+
+        let candidates =
+            pathCandidates(fileManager: fileManager)
+            + repoLocalCandidates(
+                startingPoints: [
+                    URL(fileURLWithPath: fileManager.currentDirectoryPath), Bundle.main.bundleURL,
+                ], fileManager: fileManager)
+        return candidates.first(where: { canBoot($0, fileManager: fileManager) })
+            ?? candidates.first
+    }
+
+    private static func pathCandidates(fileManager: FileManager) -> [URL] {
+        (ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":") ?? [])
+            .map { URL(fileURLWithPath: String($0)).appending(path: "harnessd") }
+            .filter { fileManager.isExecutableFile(atPath: $0.path) }
+    }
+
+    /// Walks up from each starting point for `.harnessd-bin/harnessd` — what
+    /// `scripts/live-test.sh` builds — or a bare `harnessd`.
+    static func repoLocalCandidates(startingPoints: [URL], fileManager: FileManager) -> [URL] {
+        var found: [URL] = []
+        for start in startingPoints {
+            var directory = start
+            for _ in 0..<8 {
+                let inBinDir = directory.appending(path: ".harnessd-bin").appending(
+                    path: "harnessd")
+                let bare = directory.appending(path: "harnessd")
+                for candidate in [inBinDir, bare]
+                where fileManager.isExecutableFile(atPath: candidate.path) {
+                    found.append(candidate)
+                }
+                let parent = directory.deletingLastPathComponent()
+                if parent.path == directory.path { break }
+                directory = parent
+            }
         }
-        return nil
+        return found
+    }
+
+    /// A binary with no `prompts/catalog.yaml` above it exits immediately at
+    /// startup — harnessd resolves its prompt engine relative to its
+    /// installation directory (mirrors `HarnessSupervisor.findInstallationRoot`).
+    static func canBoot(_ binary: URL, fileManager: FileManager) -> Bool {
+        var directory = binary.deletingLastPathComponent()
+        for _ in 0..<8 {
+            let catalog = directory.appending(path: "prompts").appending(path: "catalog.yaml")
+            if fileManager.fileExists(atPath: catalog.path) { return true }
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path { break }
+            directory = parent
+        }
+        return false
     }
 }
 
@@ -135,21 +187,33 @@ public final class ProjectSession {
 
     // MARK: - Data
 
+    /// `try?` here used to discard every failure, so a transport error looked
+    /// identical to "nothing to show" — the daemon being briefly unreachable
+    /// read the same as an empty catalog. Failures now surface via
+    /// `statusMessage`; a failed refresh leaves the previous data in place
+    /// rather than blanking a working catalog over one bad request (#951
+    /// finding 3).
     public func refreshCatalog() async {
         guard let client else { return }
-        async let models = try? await client.models()
-        async let providers = try? await client.providers()
-        async let profiles = try? await client.profiles()
-        self.models = await models ?? []
-        self.providers = await providers ?? []
-        self.profiles = await profiles ?? []
+        async let models = try await client.models()
+        async let providers = try await client.providers()
+        async let profiles = try await client.profiles()
+        do { self.models = try await models } catch { statusMessage = error.localizedDescription }
+        do { self.providers = try await providers } catch {
+            statusMessage = error.localizedDescription
+        }
+        do { self.profiles = try await profiles } catch {
+            statusMessage = error.localizedDescription
+        }
     }
 
     public func refreshConversations() async {
         guard let client else { return }
-        // Conversation persistence is optional server-side; an unconfigured
-        // store is a normal state, not an error worth showing.
-        conversations = (try? await client.conversations(limit: 100)) ?? []
+        do {
+            conversations = try await client.conversations(limit: 100)
+        } catch {
+            statusMessage = error.localizedDescription
+        }
     }
 
     public func refreshRewindPoints() async {
@@ -157,15 +221,36 @@ public final class ProjectSession {
             rewindPoints = []
             return
         }
-        rewindPoints = (try? await client.rewindPoints(conversationID: conversationID)) ?? []
+        do {
+            rewindPoints = try await client.rewindPoints(conversationID: conversationID)
+        } catch {
+            statusMessage = error.localizedDescription
+        }
     }
 
     public func refreshActivity() async {
         guard let client else { return }
-        tasks = (try? await client.tasks()) ?? []
-        runs = try? await client.runs()
+        do {
+            tasks = try await client.tasks()
+        } catch {
+            statusMessage = error.localizedDescription
+        }
+        do {
+            // `client.runs()` already turns the deliberate "no run store
+            // configured" 501 into `nil`; anything thrown here is a genuine
+            // transport/server failure and must not be folded into that same
+            // nil, or a network blip reads as "no run store configured" — a
+            // lie about the daemon's configuration (#951 finding 3).
+            runs = try await client.runs()
+        } catch {
+            statusMessage = error.localizedDescription
+        }
         if let runID = run?.currentRunID {
-            todos = (try? await client.todos(runID: runID)) ?? []
+            do {
+                todos = try await client.todos(runID: runID)
+            } catch {
+                statusMessage = error.localizedDescription
+            }
         }
     }
 
@@ -187,8 +272,16 @@ public final class ProjectSession {
         run?.profile = selectedProfile
         run?.submit()
         Task {
-            // Give the run a moment to register before listing.
-            try? await Task.sleep(for: .seconds(1))
+            // `run.submit()` starts its own unstructured task that only sets
+            // `conversationID` once harnessd has actually minted one — a
+            // fixed sleep before refreshing was a guess at how long that
+            // takes and flaked under load. Poll the observable state instead,
+            // bounded so a run that never registers (e.g. it fails
+            // immediately) cannot hang this refresh forever.
+            for _ in 0..<20 {
+                if run?.conversationID != nil { break }
+                try? await Task.sleep(for: .milliseconds(100))
+            }
             await refreshConversations()
         }
     }

--- a/macapp/Sources/HarnessKit/ClientAskUser.swift
+++ b/macapp/Sources/HarnessKit/ClientAskUser.swift
@@ -10,11 +10,20 @@ public struct AskUserQuestion: Sendable, Decodable, Hashable, Identifiable {
         public let description: String?
     }
 
-    public var id: String { question }
     public let question: String
     public let header: String?
     public let options: [Option]?
     public let multiSelect: Bool?
+    /// This question's position in its prompt's `questions` array, stamped by
+    /// `AskUserPrompt.init(from:)` right after decoding. The wire payload has
+    /// no id field for a question, and `question` text alone collides when
+    /// the agent asks the same thing twice — `id` used to just be `question`,
+    /// so duplicates glitched `ForEach` diffing (#951 finding 6).
+    var index: Int = 0
+
+    enum CodingKeys: String, CodingKey { case question, header, options, multiSelect }
+
+    public var id: String { "\(index):\(question)" }
 
     public var allowsMultipleAnswers: Bool { multiSelect ?? false }
     /// With no options the answer is free text.
@@ -33,6 +42,23 @@ public struct AskUserPrompt: Sendable, Decodable, Hashable {
         case callID = "call_id"
         case tool, questions
         case deadlineAt = "deadline_at"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        runID = try container.decode(String.self, forKey: .runID)
+        callID = try container.decode(String.self, forKey: .callID)
+        tool = try container.decodeIfPresent(String.self, forKey: .tool)
+        deadlineAt = try container.decodeIfPresent(Date.self, forKey: .deadlineAt)
+        // Stamp array position here — the only place a question's index into
+        // its own prompt is available — so `AskUserQuestion.id` stays unique
+        // even when two questions share identical wording.
+        questions = try container.decode([AskUserQuestion].self, forKey: .questions)
+            .enumerated().map { index, question in
+                var question = question
+                question.index = index
+                return question
+            }
     }
 }
 

--- a/macapp/Sources/HarnessKit/ClientModelSettings.swift
+++ b/macapp/Sources/HarnessKit/ClientModelSettings.swift
@@ -13,7 +13,10 @@ public struct ModelSettingsProvider: Sendable, Decodable, Identifiable, Hashable
     public let keyRef: String?
     public let modelCount: Int
     public let exposedCount: Int
-    public let fetchedAt: String?
+    /// Decoded RFC3339 like every other timestamp in this codebase — it was
+    /// `String?` here alone, leaving formatting to whichever view read it
+    /// (#951 finding 13).
+    public let fetchedAt: Date?
     public let fetchError: String?
     public let models: [ModelSettingsEntry]?
 

--- a/macapp/Sources/HarnessKit/ClientTasks.swift
+++ b/macapp/Sources/HarnessKit/ClientTasks.swift
@@ -24,12 +24,19 @@ public struct TodoItem: Sendable, Decodable, Identifiable, Hashable {
     public let id: String?
     public let text: String
     public let status: String
+    /// This item's position in the decoded array, stamped by `todos(runID:)`
+    /// right after decoding. Used only as a fallback identity: `stableID`
+    /// used to be `id ?? text`, so two todos with identical text and no
+    /// server id collided into one `ForEach` identity (#951 finding 6).
+    var index: Int = 0
+
+    enum CodingKeys: String, CodingKey { case id, text, status }
 
     public var isDone: Bool { status == "completed" || status == "done" }
 }
 
 extension TodoItem {
-    public var stableID: String { id ?? text }
+    public var stableID: String { id ?? "\(index):\(text)" }
 }
 
 /// A run as listed by the dashboard.
@@ -58,7 +65,13 @@ extension HarnessClient {
     public func todos(runID: String) async throws -> [TodoItem] {
         struct Response: Decodable { let todos: [TodoItem]? }
         let response: Response = try await get("/v1/runs/\(runID)/todos")
-        return response.todos ?? []
+        // Stamp array position for `stableID`'s no-server-id fallback — see
+        // `TodoItem.index`.
+        return (response.todos ?? []).enumerated().map { index, item in
+            var item = item
+            item.index = index
+            return item
+        }
     }
 
     /// Lists runs for the dashboard.

--- a/macapp/Sources/HarnessKit/HarnessClient.swift
+++ b/macapp/Sources/HarnessKit/HarnessClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// A structured error returned by harnessd, or a transport-level failure.
 public struct HarnessError: Error, Sendable, Hashable {
@@ -171,11 +172,22 @@ public final class HarnessClient: Sendable {
                         let frames = parser.consume(buffer)
                         buffer.removeAll(keepingCapacity: true)
                         for frame in frames {
-                            guard let event = try? HarnessEvent(frame: frame) else { continue }
-                            continuation.yield(event)
-                            if event.type.isTerminal {
-                                continuation.finish()
-                                return
+                            do {
+                                let event = try HarnessEvent(frame: frame)
+                                continuation.yield(event)
+                                if event.type.isTerminal {
+                                    continuation.finish()
+                                    return
+                                }
+                            } catch {
+                                // A malformed frame used to vanish with no
+                                // trace — the exact thing you need surfaced
+                                // when debugging a stream (#951 finding 14).
+                                // One bad frame does not justify tearing down
+                                // the whole run stream, so log and keep going.
+                                Self.eventDecodeLogger.error(
+                                    "dropping malformed SSE frame \(frame.id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                                )
                             }
                         }
                     }
@@ -191,6 +203,12 @@ public final class HarnessClient: Sendable {
     }
 
     // MARK: - Transport
+
+    /// A frame that fails to decode is a bug worth seeing (finding 14): stream
+    /// parsing itself must never throw for it, so this is the only place that
+    /// can report it.
+    static let eventDecodeLogger = Logger(
+        subsystem: "dev.gocode.harnesskit", category: "event-stream")
 
     /// Convenience for the many plain GET endpoints.
     /// harnessd stamps timestamps as RFC3339, with fractional seconds on some

--- a/macapp/Sources/HarnessKit/JSONValue.swift
+++ b/macapp/Sources/HarnessKit/JSONValue.swift
@@ -25,7 +25,9 @@ extension JSONValue {
     public var intValue: Int? {
         switch self {
         case .int(let i): return i
-        case .double(let d): return Int(exactly: d.rounded())
+        // `.rounded()` before `Int(exactly:)` fabricated integers — 2.5 read
+        // as 3. Only a double with no fractional part is really an int.
+        case .double(let d): return Int(exactly: d)
         default: return nil
         }
     }

--- a/macapp/Tests/GoCodeUITests/HarnessBinaryTests.swift
+++ b/macapp/Tests/GoCodeUITests/HarnessBinaryTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import GoCodeUI
+
+/// A `FileManager` that reports a fixed current directory and treats one
+/// extra path as executable. Both the real cwd and `PATH` are process-global,
+/// so faking them through the `fileManager` seam this function already takes
+/// keeps the test hermetic instead of mutating global state other tests
+/// might read concurrently.
+private final class FakeLocateFileManager: FileManager, @unchecked Sendable {
+    let fixedCurrentDirectory: String
+    let extraExecutablePath: String
+
+    init(fixedCurrentDirectory: String, extraExecutablePath: String) {
+        self.fixedCurrentDirectory = fixedCurrentDirectory
+        self.extraExecutablePath = extraExecutablePath
+    }
+
+    override var currentDirectoryPath: String { fixedCurrentDirectory }
+
+    override func isExecutableFile(atPath path: String) -> Bool {
+        path == extraExecutablePath || super.isExecutableFile(atPath: path)
+    }
+}
+
+/// `HarnessBinary.locate`'s doc comment always promised "explicit override,
+/// then PATH, then a repo-local build", but no repo-local fallback existed.
+/// This is not theoretical: a PATH-installed `harnessd` has no `prompts/`
+/// directory above it, so the daemon boots and immediately exits — the app
+/// launched a server that was already dead (#951 finding 11).
+@Suite("HarnessBinary.locate")
+struct HarnessBinaryTests {
+
+    @Test(
+        "prefers a bootable repo-local build over a PATH entry that cannot boot",
+        .enabled(if: ProcessInfo.processInfo.environment["HARNESS_BINARY"] == nil)
+    )
+    func prefersBootableRepoLocalBuild() throws {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "gocode-locate-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: root) }
+
+        // A repo-local build under `.harnessd-bin/` — what `live-test.sh`
+        // produces — with `prompts/catalog.yaml` resolvable above it.
+        let binDir = root.appending(path: ".harnessd-bin")
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let repoLocalBinary = binDir.appending(path: "harnessd")
+        try Data().write(to: repoLocalBinary)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: repoLocalBinary.path)
+        let promptsDir = root.appending(path: "prompts")
+        try fm.createDirectory(at: promptsDir, withIntermediateDirectories: true)
+        try Data().write(to: promptsDir.appending(path: "catalog.yaml"))
+
+        // A PATH entry that the fake FileManager reports as executable, but
+        // with no prompts/ directory anywhere above it — it cannot boot.
+        let firstPathDir = try #require(
+            ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":").first
+                .map(String.init))
+        let unbootablePathCandidate = firstPathDir + "/harnessd"
+
+        let fakeFileManager = FakeLocateFileManager(
+            fixedCurrentDirectory: root.path, extraExecutablePath: unbootablePathCandidate)
+
+        let located = HarnessBinary.locate(fileManager: fakeFileManager)
+        #expect(located?.path == repoLocalBinary.path)
+    }
+
+    /// Regression angle: when nothing anywhere is bootable, `locate()` must
+    /// still fall back to the first candidate it found (old PATH-only
+    /// behaviour) rather than giving up and returning nil — a real harnessd
+    /// that pins its own prompts directory via `HARNESS_PROMPTS_DIR` boots
+    /// fine even without a nearby `prompts/catalog.yaml`.
+    @Test(
+        "falls back to the PATH candidate when no candidate is bootable",
+        .enabled(if: ProcessInfo.processInfo.environment["HARNESS_BINARY"] == nil)
+    )
+    func fallsBackToPathCandidateWhenNoneBoot() throws {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "gocode-locate-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let firstPathDir = try #require(
+            ProcessInfo.processInfo.environment["PATH"]?.split(separator: ":").first
+                .map(String.init))
+        let pathCandidate = firstPathDir + "/harnessd"
+
+        let fakeFileManager = FakeLocateFileManager(
+            fixedCurrentDirectory: root.path, extraExecutablePath: pathCandidate)
+
+        let located = HarnessBinary.locate(fileManager: fakeFileManager)
+        #expect(located?.path == pathCandidate)
+    }
+}

--- a/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
+++ b/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
@@ -118,4 +118,44 @@ struct ProjectSessionActivityTests {
         #expect(project.statusMessage != nil)
         #expect(project.runs?.count == 1)
     }
+
+    /// Regression angle distinct from the `runs`-specific test above: the
+    /// fix applies to every `refresh*` method, not just `refreshActivity`.
+    /// `refreshCatalog` must also surface a failure via `statusMessage`
+    /// instead of swallowing it, and must not blank out a catalog that
+    /// already loaded successfully.
+    @Test("refreshCatalog surfaces a failure without discarding an already-loaded catalog")
+    func refreshCatalogSurfacesFailureWithoutDiscardingData() async throws {
+        let project = makeProject()
+        let modelsStatus = Box(200)
+        ActivityStubProtocol.set { request in
+            switch request.url?.path {
+            case "/v1/models":
+                switch modelsStatus.current {
+                case 200:
+                    return .init(
+                        status: 200,
+                        body: Data(
+                            #"{"models":[{"id":"gpt-5","provider":"openai"}]}"#.utf8))
+                default:
+                    return .init(
+                        status: 500, body: Data(#"{"error":{"code":"boom","message":"boom"}}"#.utf8)
+                    )
+                }
+            default:
+                return .init(status: 200, body: Data("{}".utf8))
+            }
+        }
+
+        await project.start()
+
+        await project.refreshCatalog()
+        #expect(project.models.count == 1)
+        #expect(project.statusMessage == nil)
+
+        modelsStatus.current = 500
+        await project.refreshCatalog()
+        #expect(project.statusMessage != nil)
+        #expect(project.models.count == 1, "a failed refresh must not blank the working catalog")
+    }
 }

--- a/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
+++ b/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import HarnessKit
+import Testing
+
+@testable import GoCodeUI
+
+/// Minimal HTTP stub for exercising `ProjectSession` without a live harnessd.
+///
+/// `ProjectSession.connect(to:)` always builds its `HarnessClient` with the
+/// default `URLSession.shared` (there is no injection seam — see #951 finding
+/// 2, out of scope here), so the stub has to register globally rather than
+/// through a per-session configuration. Scoped to one fixed loopback port so
+/// it never intercepts another suite's traffic.
+private final class ActivityStubProtocol: URLProtocol, @unchecked Sendable {
+    struct Response: Sendable {
+        var status: Int = 200
+        var body: Data = Data()
+    }
+
+    static let port = 18912
+    nonisolated(unsafe) private static var handler: (@Sendable (URLRequest) -> Response)?
+    private static let lock = NSLock()
+
+    static func set(_ handler: @escaping @Sendable (URLRequest) -> Response) {
+        lock.withLock { self.handler = handler }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.port == port
+    }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = Self.lock.withLock { Self.handler }?(request) ?? Response()
+        let http = HTTPURLResponse(
+            url: request.url!, statusCode: response.status,
+            httpVersion: "HTTP/1.1", headerFields: ["Content-Type": "application/json"])!
+        client?.urlProtocol(self, didReceive: http, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: response.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
+/// `refreshActivity` used `runs = try? await client.runs()`, which conflates
+/// a transport failure with `client.runs()`'s deliberate `nil` for a 501 "no
+/// run store configured" response — so a network blip displayed the same
+/// message as a daemon that was never configured to persist runs at all
+/// (#951 finding 3).
+@Suite("ProjectSession activity refresh", .serialized)
+@MainActor
+struct ProjectSessionActivityTests {
+
+    private static let baseURL = URL(string: "http://127.0.0.1:\(ActivityStubProtocol.port)")!
+
+    private func makeProject() -> ProjectSession {
+        URLProtocol.registerClass(ActivityStubProtocol.self)
+        return ProjectSession(
+            workspace: URL(fileURLWithPath: NSTemporaryDirectory()),
+            externalBaseURL: Self.baseURL)
+    }
+
+    /// Boxes the mutable status code so the stub's `@Sendable` handler
+    /// closure can read a value the test changes between calls.
+    private final class Box: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value: Int
+        init(_ value: Int) { self.value = value }
+        var current: Int {
+            get { lock.withLock { value } }
+            set { lock.withLock { value = newValue } }
+        }
+    }
+
+    @Test("a genuine 501 stays nil with no error, but a real failure surfaces via statusMessage")
+    func distinguishesTransportErrorFromNoStoreSignal() async throws {
+        let project = makeProject()
+        let runsStatus = Box(501)
+        ActivityStubProtocol.set { request in
+            switch request.url?.path {
+            case "/v1/runs":
+                switch runsStatus.current {
+                case 200:
+                    return .init(status: 200, body: Data(#"{"runs":[{"id":"run_1"}]}"#.utf8))
+                case 501:
+                    return .init(
+                        status: 501,
+                        body: Data(#"{"error":{"code":"not_configured","message":"no store"}}"#.utf8))
+                default:
+                    return .init(
+                        status: 500, body: Data(#"{"error":{"code":"boom","message":"boom"}}"#.utf8))
+                }
+            default:
+                // Every other endpoint the connect-time background refreshes
+                // hit — keep them boring so only /v1/runs drives the test.
+                return .init(status: 200, body: Data("{}".utf8))
+            }
+        }
+
+        await project.start()
+
+        // Daemon genuinely has no run store: normal state, no error.
+        await project.refreshActivity()
+        #expect(project.runs == nil)
+        #expect(project.statusMessage == nil)
+
+        // A real dataset now exists.
+        runsStatus.current = 200
+        await project.refreshActivity()
+        #expect(project.runs?.count == 1)
+
+        // Now a genuine server error — must surface, and must not silently
+        // read as "no run store configured" by wiping the last-known data.
+        runsStatus.current = 500
+        await project.refreshActivity()
+        #expect(project.statusMessage != nil)
+        #expect(project.runs?.count == 1)
+    }
+}

--- a/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
+++ b/macapp/Tests/GoCodeUITests/ProjectSessionActivityTests.swift
@@ -85,10 +85,12 @@ struct ProjectSessionActivityTests {
                 case 501:
                     return .init(
                         status: 501,
-                        body: Data(#"{"error":{"code":"not_configured","message":"no store"}}"#.utf8))
+                        body: Data(
+                            #"{"error":{"code":"not_configured","message":"no store"}}"#.utf8))
                 default:
                     return .init(
-                        status: 500, body: Data(#"{"error":{"code":"boom","message":"boom"}}"#.utf8))
+                        status: 500, body: Data(#"{"error":{"code":"boom","message":"boom"}}"#.utf8)
+                    )
                 }
             default:
                 // Every other endpoint the connect-time background refreshes

--- a/macapp/Tests/HarnessKitTests/ClientModelSettingsTests.swift
+++ b/macapp/Tests/HarnessKitTests/ClientModelSettingsTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Testing
+
+@testable import HarnessKit
+
+/// Regression coverage for finding 13: `fetchedAt` used to be `String?` while
+/// every other timestamp in this codebase decodes RFC3339 through the shared
+/// decoder. If `fetchedAt` ever regressed back to a plain string (or the
+/// custom date strategy stopped applying to it), this test fails.
+@Suite("ModelSettingsProvider")
+struct ClientModelSettingsTests {
+
+    private func provider(json: String) throws -> ModelSettingsProvider {
+        try HarnessClient.decoder.decode(ModelSettingsProvider.self, from: Data(json.utf8))
+    }
+
+    @Test("fetchedAt decodes an RFC3339 timestamp into a real Date")
+    func fetchedAtDecodesToDate() throws {
+        let decoded = try provider(
+            json: """
+                {"name":"openai","base_url":"https://api.openai.com","protocol":"openai",
+                 "auth_kind":"api_key","builtin":true,"has_credential":true,"key_ref":null,
+                 "model_count":3,"exposed_count":1,"fetched_at":"2026-07-27T12:00:00Z",
+                 "fetch_error":null,"models":null}
+                """)
+        let fetchedAt = try #require(decoded.fetchedAt)
+        #expect(abs(fetchedAt.timeIntervalSince1970 - 1_785_153_600) < 1)
+    }
+
+    @Test("fetchedAt stays nil when the provider has never fetched")
+    func fetchedAtNilWhenAbsent() throws {
+        let decoded = try provider(
+            json: """
+                {"name":"openai","base_url":"https://api.openai.com","protocol":"openai",
+                 "auth_kind":"api_key","builtin":true,"has_credential":true,"key_ref":null,
+                 "model_count":0,"exposed_count":0,"fetched_at":null,
+                 "fetch_error":null,"models":null}
+                """)
+        #expect(decoded.fetchedAt == nil)
+    }
+}

--- a/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
+++ b/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
@@ -333,7 +333,9 @@ struct HarnessClientSuite {
                 .init(
                     status: 200,
                     chunks: [
-                        Data(#"{"todos":[{"id":"todo_1","text":"write tests","status":"pending"}]}"#.utf8)
+                        Data(
+                            #"{"todos":[{"id":"todo_1","text":"write tests","status":"pending"}]}"#
+                                .utf8)
                     ])
             }
             let todos = try await makeClient().todos(runID: "run_1")

--- a/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
+++ b/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
@@ -300,4 +300,45 @@ struct HarnessClientSuite {
             #expect(request.url?.path == "/v1/runs/run_1/events")
         }
     }
+
+    @Suite("todos")
+    struct HarnessClientTodoTests {
+
+        /// The server can omit `id` entirely; `stableID` used to fall back to
+        /// raw text, so two todos with the same text collided into one
+        /// `ForEach` identity. `todos(runID:)` is where the fix stamps each
+        /// item's array position (#951 finding 6).
+        @Test("todos(runID:) gives duplicate-text, id-less items distinct stableIDs")
+        func todosWithDuplicateTextDontCollide() async throws {
+            StubURLProtocol.set { _ in
+                .init(
+                    status: 200,
+                    chunks: [
+                        Data(
+                            #"{"todos":[{"text":"write tests","status":"pending"},{"text":"write tests","status":"pending"}]}"#
+                                .utf8)
+                    ])
+            }
+            let todos = try await makeClient().todos(runID: "run_1")
+            #expect(todos.count == 2)
+            #expect(Set(todos.map(\.stableID)).count == 2)
+        }
+
+        /// Regression angle: when the server does send an id, it must still
+        /// win over the position stamp — the fix only fills a gap, it must not
+        /// override real identity.
+        @Test("todos(runID:) still prefers a server-provided id")
+        func todosPreferServerID() async throws {
+            StubURLProtocol.set { _ in
+                .init(
+                    status: 200,
+                    chunks: [
+                        Data(#"{"todos":[{"id":"todo_1","text":"write tests","status":"pending"}]}"#.utf8)
+                    ])
+            }
+            let todos = try await makeClient().todos(runID: "run_1")
+            #expect(todos.first?.stableID == "todo_1")
+        }
+    }
+
 }

--- a/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
+++ b/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
@@ -299,6 +299,43 @@ struct HarnessClientSuite {
             #expect(request.value(forHTTPHeaderField: "Last-Event-ID") == "run_1:7")
             #expect(request.url?.path == "/v1/runs/run_1/events")
         }
+
+        /// Regression for finding 14: a malformed frame used to be silently
+        /// dropped via `try?`, and if it had been terminal-looking it could
+        /// never have surfaced *why* the stream produced fewer events than
+        /// expected. The fix logs and continues, so the well-formed frames on
+        /// either side of a bad one must still both arrive.
+        @Test("skips a malformed frame but still delivers the events around it")
+        func skipsMalformedFrameAndContinues() async throws {
+            let frames = """
+                id: run_1:0
+                event: run.started
+                data: {"id":"run_1:0","run_id":"run_1","type":"run.started","payload":{}}
+
+                id: run_1:1
+                event: assistant.message
+                data: { this is not valid json
+
+                id: run_1:2
+                event: run.completed
+                data: {"id":"run_1:2","run_id":"run_1","type":"run.completed","payload":{}}
+
+
+                """
+            StubURLProtocol.set { _ in
+                .init(
+                    status: 200,
+                    headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(frames.utf8)])
+            }
+
+            var received: [HarnessEventType] = []
+            for try await event in makeClient().events(runID: "run_1") {
+                received.append(event.type)
+            }
+
+            #expect(received == [.runStarted, .runCompleted])
+        }
     }
 
     @Suite("todos")
@@ -340,6 +377,31 @@ struct HarnessClientSuite {
             }
             let todos = try await makeClient().todos(runID: "run_1")
             #expect(todos.first?.stableID == "todo_1")
+        }
+
+        /// Regression angle distinct from the two above: a realistic mixed
+        /// batch — some items with a real id, some without, and duplicate
+        /// text among the id-less ones — must still come out fully unique.
+        @Test("todos(runID:) keeps every stableID unique in a mixed batch")
+        func todosMixedBatchStaysUnique() async throws {
+            StubURLProtocol.set { _ in
+                .init(
+                    status: 200,
+                    chunks: [
+                        Data(
+                            #"""
+                            {"todos":[
+                                {"id":"todo_1","text":"write tests","status":"done"},
+                                {"text":"write docs","status":"pending"},
+                                {"text":"write docs","status":"pending"}
+                            ]}
+                            """#
+                            .utf8)
+                    ])
+            }
+            let todos = try await makeClient().todos(runID: "run_1")
+            #expect(todos.count == 3)
+            #expect(Set(todos.map(\.stableID)).count == 3)
         }
     }
 

--- a/macapp/Tests/HarnessKitTests/IdentityCollisionTests.swift
+++ b/macapp/Tests/HarnessKitTests/IdentityCollisionTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import HarnessKit
+
+/// `AskUserQuestion.id` used to be the question text itself, so two questions
+/// with identical wording in one prompt collided and glitched `ForEach`
+/// diffing. The companion fix for `TodoItem.stableID` is covered where it is
+/// actually exercised, in `HarnessClientTests` (`todos(runID:)` is what stamps
+/// the array position the fix relies on). See #951 finding 6.
+@Suite("Identifiable id collisions")
+struct IdentityCollisionTests {
+
+    @Test("AskUserQuestion.id differs for duplicate question text in one prompt")
+    func askUserQuestionIDsDontCollide() throws {
+        let json = """
+            {"run_id":"run_1","call_id":"call_1","questions":[
+                {"question":"Continue?"},
+                {"question":"Continue?"},
+                {"question":"Continue?"}
+            ]}
+            """
+        let prompt = try HarnessClient.decoder.decode(AskUserPrompt.self, from: Data(json.utf8))
+        #expect(Set(prompt.questions.map(\.id)).count == 3)
+    }
+}

--- a/macapp/Tests/HarnessKitTests/JSONValueTests.swift
+++ b/macapp/Tests/HarnessKitTests/JSONValueTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@testable import HarnessKit
+
+/// `JSONValue.intValue` used to round doubles, silently turning `2.5` into
+/// `3` — a fabricated integer harnessd never sent. `Int(exactly:)` is the fix:
+/// only a double with no fractional part converts (#951 finding 12).
+@Suite("JSONValue")
+struct JSONValueTests {
+
+    @Test("intValue keeps an exact integral double")
+    func intValueKeepsIntegralDouble() {
+        #expect(JSONValue.double(4.0).intValue == 4)
+    }
+
+    @Test("intValue rejects a fractional double instead of rounding it")
+    func intValueRejectsFractionalDouble() {
+        #expect(JSONValue.double(2.5).intValue == nil)
+    }
+
+    /// Regression angle distinct from the two above: a double so large it
+    /// cannot fit in `Int` must also fail closed, the same way a fractional
+    /// value does — proving the fix is "only exact values convert", not just
+    /// "reject halves".
+    @Test("intValue rejects a double outside Int's range")
+    func intValueRejectsOutOfRangeDouble() {
+        #expect(JSONValue.double(1e30).intValue == nil)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes six correctness findings from the adversarial review in #951, scoped to `macapp/Sources/GoCodeUI/ProjectSession.swift` and five `HarnessKit` files.

- **Finding 12** — `JSONValue.intValue` used `Int(exactly: d.rounded())`, silently turning `2.5` into `3`. Now `Int(exactly: d)`; only an exact integral double converts.
- **Finding 6** — `AskUserQuestion.id` was the question text; `TodoItem.stableID` fell back to raw text. Both now stamp array position at construction (`AskUserPrompt.init(from:)`, `HarnessClient.todos(runID:)`) so duplicate text no longer collides in `ForEach`. A real server id still wins when present.
- **Finding 11** — `HarnessBinary.locate`'s doc comment promised a repo-local fallback after `PATH` that never existed — the exact cause of a real outage (a PATH-installed harnessd with no `prompts/` directory nearby boots and immediately exits). `locate()` now walks up from the cwd and the app bundle for `.harnessd-bin/harnessd` or a bare `harnessd`, and prefers a candidate with `prompts/catalog.yaml` resolvable above it over one that can't actually boot.
- **Finding 3** — every `ProjectSession.refresh*` method stopped swallowing errors via `try?`; failures now surface through `statusMessage` without discarding already-loaded data. `refreshActivity` specifically keeps `client.runs()`'s deliberate 501-derived `nil` distinct from a genuine transport error (previously a network blip displayed "no run store configured"). `submit()` replaces its 1-second sleep race with a bounded poll (100ms × 20) on `RunSession.conversationID`.
- **Finding 14** (partial) — the run-stream loop no longer drops a malformed SSE frame via `try?`; it logs via a shared `os.Logger` and keeps reading. The per-frame `JSONDecoder` allocation is in `HarnessEvent.swift`, outside this task's file scope — not fixed here.
- **Finding 13** — `ModelSettingsProvider.fetchedAt` is now `Date?` (decoded RFC3339 via the existing shared decoder) instead of `String?`. `ModelSettingsView.swift` (not owned by this change) still compiles against the new type via `Date`'s default description but needs a one-line `.formatted()` follow-up for a nicely formatted display.

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 117 tests in 28 suites pass, including 6 new behavioral tests (red→green) and 6 regression tests
- [x] `swift format lint --strict --recursive Sources Tests` clean
- [x] TDD audit trail: `test(red)` → `fix` → `test(regression)` commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9