### PR TITLE
macapp: elevated composer card, collapsible inspector, labeled rail

### DIFF
--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -61,7 +61,10 @@ public struct AppShell: View {
                 }
             }
         }
-        .frame(minWidth: 960, minHeight: 600)
+        // Widened for the labeled rail (was 50pt icon-only, now 220pt) plus
+        // room for the inspector pane to open without squeezing the
+        // transcript below its own minWidth.
+        .frame(minWidth: 1040, minHeight: 600)
         // The root surface. Every other token in `Theme` is defined relative
         // to this value, so it has to be painted explicitly rather than left
         // as the system window background — that's the one substitution
@@ -172,45 +175,101 @@ private struct ProjectView: View {
     }
 }
 
+/// Labeled, sectioned nav — was a 50pt icon-only strip with no labels and no
+/// grouping (baseline gap #5). Sessions + Checkpoints are grouped under a
+/// "History" heading per the design plan's A2, since both browse past state
+/// rather than switching between live-run modes the way Chat/Activity do.
 private struct IconRail: View {
     @Binding var section: Section
     let project: ProjectSession
     let onClose: () -> Void
 
     var body: some View {
-        VStack(spacing: 4) {
-            ForEach(Section.allCases) { item in
-                Button {
-                    section = item
-                } label: {
-                    Image(systemName: item.icon)
-                        .font(.system(size: 16))
-                        .frame(width: 38, height: 34)
-                        .background(
-                            section == item ? Theme.accent.opacity(0.16) : .clear,
-                            in: .rect(cornerRadius: 8)
-                        )
-                        .foregroundStyle(section == item ? Theme.accent : Theme.foregroundTertiary)
-                }
-                .buttonStyle(.plain)
-                .help(item.title)
-            }
+        VStack(alignment: .leading, spacing: 2) {
+            RailRow(section: $section, item: .chat)
+            RailRow(section: $section, item: .activity)
+
+            RailSectionHeader("History")
+            RailRow(section: $section, item: .sessions)
+            RailRow(section: $section, item: .checkpoints)
+
             Spacer()
+
+            RailRow(section: $section, item: .settings)
+
             Button(action: onClose) {
-                Image(systemName: "xmark.circle")
-                    .font(.system(size: 15))
-                    .frame(width: 38, height: 34)
-                    .foregroundStyle(Theme.foregroundTertiary)
+                HStack(spacing: 10) {
+                    Image(systemName: "xmark.circle").font(.system(size: 15)).frame(width: 18)
+                    Text("Close").font(.callout)
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 10).padding(.vertical, 8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .foregroundStyle(Theme.foregroundTertiary)
+                .contentShape(.rect)
             }
             .buttonStyle(.plain)
             .help("Close project and stop its server")
+            .accessibilityLabel("Close project and stop its server")
         }
-        .padding(.vertical, 10)
-        .frame(width: 50)
+        .padding(.vertical, 10).padding(.horizontal, 8)
+        .frame(width: 220)
         // The rail sits beside content, not on it — one step above the root
         // background rather than the same translucent `.quaternary` fill
         // every surface in the app used to share.
         .background(Theme.surface)
+    }
+}
+
+/// One nav row: icon + text label, so the accessibility name is the label
+/// text rather than the SF Symbol identifier (baseline gap #5) and a sighted
+/// user gets a name too, not just a glyph.
+private struct RailRow: View {
+    @Binding var section: Section
+    let item: Section
+
+    var body: some View {
+        Button {
+            section = item
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 15))
+                    .frame(width: 18)
+                    // The label text alone names this row; without this the
+                    // icon contributes its own SF Symbol identifier to the
+                    // combined accessibility description.
+                    .accessibilityHidden(true)
+                Text(item.title).font(.callout)
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10).padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                section == item ? Theme.accent.opacity(0.16) : .clear,
+                in: .rect(cornerRadius: 8)
+            )
+            .foregroundStyle(section == item ? Theme.accent : Theme.foregroundTertiary)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .help(item.title)
+        .accessibilityLabel(item.title)
+    }
+}
+
+private struct RailSectionHeader: View {
+    let title: String
+    init(_ title: String) { self.title = title }
+
+    var body: some View {
+        Text(title.uppercased())
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(Theme.foregroundTertiary)
+            .padding(.horizontal, 10).padding(.top, 10).padding(.bottom, 2)
+            // A heading, not a control — VoiceOver should announce it once
+            // as a group label, not treat it as another focusable row.
+            .accessibilityAddTraits(.isHeader)
     }
 }
 

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -6,9 +6,13 @@ struct ChatView: View {
     @Bindable var project: ProjectSession
     @Bindable var run: RunSession
     @State private var selected: ToolActivity?
+    // Baseline gap #3: a permanent HSplitView pane held 44% of the window's
+    // area to show one tool call's JSON. Default it closed and let it open on
+    // demand instead, matching Codex's floating, give-the-space-back panel.
+    @State private var showInspector = false
 
     var body: some View {
-        HSplitView {
+        HStack(spacing: 0) {
             VStack(spacing: 0) {
                 TranscriptView(items: run.transcript.items, selected: $selected)
                 Divider()
@@ -25,8 +29,31 @@ struct ChatView: View {
             }
             .frame(minWidth: 400, idealWidth: 520)
 
-            InspectorPane(activity: selected)
-                .frame(minWidth: 380)
+            if showInspector {
+                Divider()
+                // Fixed rather than a resizable split: sized toward Codex's
+                // ~360pt card instead of stretching to consume half the
+                // window the way the old always-open HSplitView pane did.
+                InspectorPane(activity: selected)
+                    .frame(width: 380)
+            }
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showInspector.toggle()
+                } label: {
+                    Image(systemName: showInspector ? "sidebar.trailing" : "sidebar.right")
+                }
+                .help(showInspector ? "Hide tool inspector" : "Show tool inspector")
+                .accessibilityLabel(showInspector ? "Hide tool inspector" : "Show tool inspector")
+            }
+        }
+        // Clicking a tool call is the reason the inspector exists; open it
+        // automatically on selection rather than leaving the click looking
+        // like it did nothing because the pane defaults to closed.
+        .onChange(of: selected) { _, activity in
+            if activity != nil { showInspector = true }
         }
     }
 }
@@ -536,7 +563,10 @@ struct StatusBar: View {
                 Button("Stop") { run.cancel() }.controlSize(.small)
             }
         }
-        .padding(.horizontal, 14).padding(.vertical, 7)
+        // 16pt matches the transcript column's own inset (runner-up gap: the
+        // status/approval/plan strips and the transcript disagreed on their
+        // left edge — 14 vs 16 — for no reason).
+        .padding(.horizontal, 16).padding(.vertical, 7)
         .background(Theme.surface)
     }
 
@@ -621,7 +651,8 @@ struct ApprovalBar: View {
                 .background(Theme.surfaceElevated, in: .rect(cornerRadius: 6))
             }
         }
-        .padding(.horizontal, 14).padding(.vertical, 9)
+        // Same 16pt left inset as the transcript column and the status bar.
+        .padding(.horizontal, 16).padding(.vertical, 9)
         .background(Color.orange.opacity(0.12))
     }
 }
@@ -681,7 +712,8 @@ struct AskUserView: View {
                     .disabled(answers.count < prompt.questions.count)
             }
         }
-        .padding(14)
+        // Same 16pt left inset as the transcript column and the status bar.
+        .padding(.horizontal, 16).padding(.vertical, 14)
         .background(Theme.accent.opacity(0.08))
     }
 }
@@ -696,43 +728,57 @@ struct Composer: View {
     @State private var mentionTask: Task<Void, Never>?
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 8) {
             if !mentions.isEmpty {
                 MentionPopup(matches: mentions) { match in
                     run.draft = MentionQuery.replacing(run.draft, with: match.relativePath)
                     mentions = []
                 }
             }
-            HStack(alignment: .bottom, spacing: 8) {
+
+            // One elevated card holds every composer control (baseline gap
+            // #2): the field, send button, model picker and plan toggle used
+            // to read as three unrelated regions — the field, a right-hand
+            // gutter for send, and a separate borderless strip below.
+            VStack(alignment: .leading, spacing: 10) {
                 TextField(placeholder, text: $run.draft, axis: .vertical)
                     .textFieldStyle(.plain)
                     .lineLimit(1...10)
                     .focused($focused)
                     .onSubmit(send)
                     .onChange(of: run.draft) { _, text in updateMentions(for: text) }
-                    .padding(.horizontal, 12).padding(.vertical, 9)
-                    .background(Theme.surfaceElevated, in: .rect(cornerRadius: 10))
 
-                Button(action: send) {
-                    Image(systemName: run.canSteer ? "arrow.turn.up.right" : "arrow.up.circle.fill")
+                HStack(spacing: 10) {
+                    ModelChip(project: project)
+                    Toggle("Plan mode", isOn: $project.planMode)
+                        .toggleStyle(.checkbox).font(.caption)
+                        .help("Restrict the agent to writing a plan file until you approve it")
+                    Spacer()
+                    Button("New") { project.newConversation() }
+                        .buttonStyle(.plain).font(.caption).foregroundStyle(
+                            Theme.foregroundTertiary)
+
+                    Button(action: send) {
+                        Image(
+                            systemName: run.canSteer
+                                ? "arrow.turn.up.right" : "arrow.up.circle.fill"
+                        )
                         .font(.title2)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(run.draft.trimmed.isEmpty)
+                    .help(run.canSteer ? "Steer the running task" : "Send")
+                    .accessibilityLabel(run.canSteer ? "Steer the running task" : "Send message")
                 }
-                .buttonStyle(.plain)
-                .disabled(run.draft.trimmed.isEmpty)
-                .help(run.canSteer ? "Steer the running task" : "Send")
             }
-
-            HStack(spacing: 10) {
-                ModelChip(project: project)
-                Toggle("Plan mode", isOn: $project.planMode)
-                    .toggleStyle(.checkbox).font(.caption)
-                    .help("Restrict the agent to writing a plan file until you approve it")
-                Spacer()
-                Button("New") { project.newConversation() }
-                    .buttonStyle(.plain).font(.caption).foregroundStyle(Theme.foregroundTertiary)
-            }
+            .padding(.horizontal, 16).padding(.vertical, 12)
+            .background(Theme.surfaceElevated, in: .rect(cornerRadius: 14))
         }
-        .padding(12)
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+        // A real bottom inset (was 0 — the old control strip ran flush to the
+        // window edge) so the card reads as inset chrome, not a footer.
+        .padding(.bottom, 18)
         .onAppear { focused = true }
     }
 
@@ -992,7 +1038,8 @@ struct PlanApprovalView: View {
                     .disabled(!plan.options.isEmpty && selected == nil)
             }
         }
-        .padding(14)
+        // Same 16pt left inset as the transcript column and the status bar.
+        .padding(.horizontal, 16).padding(.vertical, 14)
         .background(Theme.accent.opacity(0.08))
     }
 }


### PR DESCRIPTION
## Summary

Fixes gaps #2, #3, #5 and the left-edge runner-up from `.ux/design-baseline.md` (a measured GoCode vs. Codex comparison). Scope: layout, structure, accessibility only — no color values changed, per the concurrent palette work happening on `feat/design-tokens-palette` in `DesignSystem/Theme.swift`, `AppShell.swift`'s color tokens, etc.

- **Composer (gap #2)** — `ChatView.swift`: the text field, send button, model picker, and plan-mode toggle now live in one elevated card with an 18pt bottom inset, replacing a bare field + a separate right-hand send gutter + a borderless control strip flush to the window edge.
- **Inspector (gap #3)** — `ChatView.swift`: the tool-call inspector is now collapsible via a toolbar toggle and defaults to closed, instead of a permanent `HSplitView` pane. It reopens automatically when a tool row is selected, and is sized to a fixed 380pt instead of stretching to roughly half the window.
- **Rail (gap #5)** — `AppShell.swift`: the 50pt icon-only rail is now a 220pt labeled rail — every row has a text label, an explicit `accessibilityLabel`, and `.help()` (including Close), fixing SF-Symbol-identifiers-as-accessibility-labels. Sessions + Checkpoints are grouped under a "History" heading per the design plan's A2.
- **Left-edge runner-up** — `ChatView.swift`: the status bar, approval bar, ask-user prompt, and plan banner now share the transcript column's 16pt left inset (was 14pt/12pt in various places).
- Bumped `AppShell`'s window `minWidth` 960 → 1040 so the wider rail plus an open inspector still fit without squeezing the transcript below its own minWidth.

## Measured (nativeui driver, own workspace, baseline's 1167×987 window size)

- Composer card: 898×68pt, bottom inset 19pt (was 520×34pt field + separate 36pt strip, 0pt bottom inset). Codex measures 883×118pt inset 19pt — bottom inset now matches exactly.
- Inspector: 0% of window area by default (was permanently 44.1%). Manually opened, it measures 380×935 = 30.8% of this window's area.
- Rail: 220pt wide (was 50pt), 37pt row pitch (matches Codex's measured 37pt nav pitch), every row has a human-readable label instead of an SF Symbol identifier.
- Status bar text and the composer card's left edge land at the same x (297 at this window width) after the shared-inset fix.

## Not done (flagged, not silently skipped)

Full pixel alignment of the tool-chip-box and assistant-body-text left edges (67pt/88pt in the baseline) — both are offset further right by their own leading icon + spacing. Matching Codex's single edge there means removing the icon prefix from `ToolRow` (closer to design-plan A3's "chip-style activity rows" restyle), which is a visual redesign of that row rather than an inset fix, so it's left for that track.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 121/121 pass
- [x] `swift format lint --strict --recursive Sources Tests` — clean
- [x] Manually verified with the `nativeui` accessibility driver: rail labels/grouping, composer card geometry, inspector default-collapsed + toggle + auto-open-on-select, at both the dev window size and the baseline's 1167×987 size

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9