### PR TITLE
macapp: headless ToolWalk — walk all 61 tools through the app's own client

### DIFF
--- a/macapp/Package.swift
+++ b/macapp/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
         .library(name: "HarnessKit", targets: ["HarnessKit"]),
         .library(name: "GoCodeUI", targets: ["GoCodeUI"]),
         .executable(name: "GoCode", targets: ["GoCodeApp"]),
+        .executable(name: "ToolWalk", targets: ["ToolWalk"]),
     ],
     targets: [
         // Transport + domain model for the harnessd HTTP/SSE contract.
@@ -15,11 +16,16 @@ let package = Package(
         .target(name: "HarnessKit"),
         .target(name: "GoCodeUI", dependencies: ["HarnessKit"]),
         .executableTarget(name: "GoCodeApp", dependencies: ["GoCodeUI"]),
+        // Drives ProjectSession/RunSession headlessly (no window needed) to
+        // walk every registered tool through the app's own client and
+        // transcript code — see scripts/ui-walk-tools.txt.
+        .executableTarget(name: "ToolWalk", dependencies: ["HarnessKit", "GoCodeUI"]),
         .testTarget(
             name: "HarnessKitTests",
             dependencies: ["HarnessKit"],
             resources: [.copy("Fixtures")]
         ),
         .testTarget(name: "GoCodeUITests", dependencies: ["GoCodeUI"]),
+        .testTarget(name: "ToolWalkTests", dependencies: ["ToolWalk"]),
     ]
 )

--- a/macapp/Sources/ToolWalk/Runner.swift
+++ b/macapp/Sources/ToolWalk/Runner.swift
@@ -1,0 +1,114 @@
+import Foundation
+import GoCodeUI
+import HarnessKit
+
+struct RunnerConfig: Sendable {
+    var timeoutPerTool: Duration
+    var pollInterval: Duration
+
+    static let `default` = RunnerConfig(
+        timeoutPerTool: .seconds(240), pollInterval: .milliseconds(200))
+}
+
+/// Drives every `ToolSpec` through the app's own `ProjectSession`/`RunSession`
+/// — the same `submit()` the composer's Send button calls — one fresh
+/// conversation per tool, and judges each on its transcript.
+@MainActor
+enum Runner {
+    static func walk(
+        project: ProjectSession, specs: [ToolSpec], config: RunnerConfig = .default
+    ) async -> [ToolResult] {
+        var results: [ToolResult] = []
+        for (index, spec) in specs.enumerated() {
+            print("[toolwalk] [\(index + 1)/\(specs.count)] \(spec.name) ...", terminator: "")
+
+            // A fresh conversation per tool: TierDeferred tools are activated
+            // by find_tool per-run, and every prompt in ui-walk-tools.txt
+            // already assumes it starts from nothing activated. It also keeps
+            // one tool's failure (or a huge nested agent transcript) from
+            // polluting the context every later tool runs in.
+            project.newConversation()
+            guard let run = project.run else {
+                let result = ToolResult(
+                    name: spec.name, verdict: "fail", reply: "no active RunSession on project")
+                results.append(result)
+                print(" FAIL (no run session)")
+                continue
+            }
+
+            run.draft = spec.prompt
+            project.submit()
+
+            let finished = await waitForTerminal(run: run, config: config)
+            if !finished {
+                run.cancel()
+                // Give the cooperative cancel a moment to land before moving
+                // on, or the next tool's newConversation() races its teardown.
+                try? await Task.sleep(for: .seconds(1))
+            }
+
+            let result = judge(tool: spec.name, observed: observe(run, timedOut: !finished))
+            results.append(result)
+            print(" \(result.verdict.uppercased())")
+        }
+        return results
+    }
+
+    /// Polls until the run reaches a terminal state, answering any pending
+    /// question or approval exactly as the composer's own controls would.
+    /// Without this, AskUserQuestion (and any tool a permission rule gates)
+    /// would simply hang every walk until the timeout.
+    private static func waitForTerminal(run: RunSession, config: RunnerConfig) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: config.timeoutPerTool)
+        while ContinuousClock.now < deadline {
+            if let prompt = run.pendingQuestions {
+                var answers: [String: String] = [:]
+                for question in prompt.questions {
+                    answers[question.id] = question.options?.first?.label ?? "yes"
+                }
+                run.answer(answers)
+            }
+            if run.transcript.pendingApproval != nil {
+                run.approve()
+            }
+            if let plan = run.transcript.pendingPlan {
+                run.approve(option: plan.options.first?.id)
+            }
+            if !run.isBusy { return true }
+            try? await Task.sleep(for: config.pollInterval)
+        }
+        return false
+    }
+
+    /// Reduces a real transcript to the primitives `judge` reasons over.
+    static func observe(_ run: RunSession, timedOut: Bool) -> ObservedRun {
+        var completed: [String] = []
+        var blocked: [String] = []
+        var failed: [String] = []
+        var replies: [String] = []
+
+        for item in run.transcript.items {
+            switch item.kind {
+            case .toolActivity(let activity):
+                switch activity.status {
+                case .completed: completed.append(activity.tool)
+                case .blocked: blocked.append(activity.tool)
+                case .failed: failed.append(activity.tool)
+                case .running: break
+                }
+            case .assistantMessage(let message):
+                if !message.text.isEmpty { replies.append(message.text) }
+            default:
+                break
+            }
+        }
+
+        return ObservedRun(
+            toolCompleted: completed, toolBlocked: blocked, toolFailed: failed,
+            finalReply: replies.last ?? "",
+            runFailed: run.transcript.runState == .failed,
+            runCancelled: run.transcript.runState == .cancelled,
+            connectionError: run.connectionError,
+            timedOut: timedOut)
+    }
+}

--- a/macapp/Sources/ToolWalk/ToolSpec.swift
+++ b/macapp/Sources/ToolWalk/ToolSpec.swift
@@ -12,8 +12,25 @@ enum ToolSpecError: Error, Equatable {
     case malformedLine(String)
 }
 
-// STUB — deliberately wrong, to prove the tests above fail for the right
-// reason before the real parser is written.
+/// Parses `tool|prompt` lines. Only the first "|" delimits: a prompt itself
+/// may contain "|" (several in the real file do, e.g. quoted shell pipes),
+/// so splitting on every "|" would truncate those prompts.
 func parseToolSpecs(_ contents: String) throws -> [ToolSpec] {
-    []
+    var specs: [ToolSpec] = []
+    for rawLine in contents.split(separator: "\n", omittingEmptySubsequences: false) {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+        guard !line.isEmpty else { continue }
+
+        guard let separator = line.firstIndex(of: "|") else {
+            throw ToolSpecError.malformedLine(line)
+        }
+        let name = String(line[line.startIndex..<separator]).trimmingCharacters(in: .whitespaces)
+        let prompt = String(line[line.index(after: separator)...]).trimmingCharacters(
+            in: .whitespaces)
+        guard !name.isEmpty, !prompt.isEmpty else {
+            throw ToolSpecError.malformedLine(line)
+        }
+        specs.append(ToolSpec(name: name, prompt: prompt))
+    }
+    return specs
 }

--- a/macapp/Sources/ToolWalk/ToolSpec.swift
+++ b/macapp/Sources/ToolWalk/ToolSpec.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// One line of `scripts/ui-walk-tools.txt`: the registered tool name and the
+/// exact prompt to submit for it. Kept as a plain value type so parsing is
+/// testable with no daemon involved.
+struct ToolSpec: Equatable, Sendable {
+    let name: String
+    let prompt: String
+}
+
+enum ToolSpecError: Error, Equatable {
+    case malformedLine(String)
+}
+
+// STUB — deliberately wrong, to prove the tests above fail for the right
+// reason before the real parser is written.
+func parseToolSpecs(_ contents: String) throws -> [ToolSpec] {
+    []
+}

--- a/macapp/Sources/ToolWalk/ToolWalkMain.swift
+++ b/macapp/Sources/ToolWalk/ToolWalkMain.swift
@@ -1,12 +1,94 @@
 import Foundation
+import GoCodeUI
+import HarnessKit
 
-// Entry point placeholder for the red commit: the real orchestration (seed a
-// workspace, spawn harnessd via ProjectSession, walk every tool, judge the
-// transcript) lands in the green commit. Named apart from `main.swift` so the
-// module stays `@testable import`-able from ToolWalkTests.
+enum ToolWalkError: Error {
+    case repoRootNotFound
+}
+
+/// Headlessly walks every registered tool through the app's own client and
+/// transcript code: `ProjectSession`/`RunSession`/`HarnessClient` from
+/// `GoCodeUI`/`HarnessKit`, the same objects the composer's Send button
+/// drives. No `URLRequest` of its own — see scripts/ui-walk-tools.txt for the
+/// per-tool prompts and CLAUDE.md context for why this exists (the target
+/// machine's screen is locked, so an accessibility-driven walk cannot run).
 @main
+@MainActor
 struct ToolWalkMain {
     static func main() async throws {
-        fatalError("ToolWalk is not implemented yet")
+        let environment = ProcessInfo.processInfo.environment
+        let repoRoot = try resolveRepoRoot()
+        let toolsFile = repoRoot.appending(path: "scripts").appending(path: "ui-walk-tools.txt")
+        let specs = try parseToolSpecs(String(contentsOf: toolsFile, encoding: .utf8))
+        print("[toolwalk] \(specs.count) tools to walk, from \(toolsFile.path)")
+
+        let workspace =
+            environment["TOOLWALK_WORKSPACE"].map(URL.init(fileURLWithPath:))
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "toolwalk-\(UUID().uuidString)")
+        try seedWorkspace(at: workspace)
+        print("[toolwalk] workspace: \(workspace.path)")
+
+        guard HarnessBinary.locate() != nil else {
+            print("[toolwalk] FATAL: could not locate a harnessd binary. Set HARNESS_BINARY.")
+            exit(1)
+        }
+
+        let project = ProjectSession(workspace: workspace)
+        await project.start()
+        guard project.phase == .ready else {
+            print("[toolwalk] FATAL: harnessd did not start: \(project.phase)")
+            exit(1)
+        }
+        project.selectedModel = environment["TOOLWALK_MODEL"] ?? "gpt-oss-120b"
+
+        let timeoutSeconds = environment["TOOLWALK_TIMEOUT_SECONDS"].flatMap { Int($0) } ?? 240
+        let config = RunnerConfig(
+            timeoutPerTool: .seconds(timeoutSeconds), pollInterval: .milliseconds(200))
+
+        let results = await Runner.walk(project: project, specs: specs, config: config)
+        await project.shutdown()
+
+        let resultsPath = environment["TOOLWALK_RESULTS_PATH"] ?? "/tmp/toolwalk-results.json"
+        try writeResults(results, to: URL(fileURLWithPath: resultsPath))
+        print("[toolwalk] results written to \(resultsPath)")
+
+        printSummary(results)
+        exit(results.allSatisfy { $0.verdict == "pass" } ? 0 : 1)
     }
+}
+
+/// Finds the repo root by walking up for `scripts/ui-walk-tools.txt`, mirroring
+/// how `HarnessSupervisor` walks up for `prompts/catalog.yaml` — so the binary
+/// works when invoked from anywhere inside the checkout, not only its root.
+private func resolveRepoRoot(fileManager: FileManager = .default) throws -> URL {
+    var directory = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+    for _ in 0..<8 {
+        let candidate = directory.appending(path: "scripts").appending(path: "ui-walk-tools.txt")
+        if fileManager.fileExists(atPath: candidate.path) { return directory }
+        let parent = directory.deletingLastPathComponent()
+        if parent.path == directory.path { break }
+        directory = parent
+    }
+    throw ToolWalkError.repoRootNotFound
+}
+
+private func writeResults(_ results: [ToolResult], to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    try encoder.encode(results).write(to: url)
+}
+
+private func printSummary(_ results: [ToolResult]) {
+    let nameWidth = results.map { $0.name.count }.max() ?? 0
+    print("\n[toolwalk] RESULTS")
+    print(String(repeating: "-", count: 72))
+    for result in results {
+        let mark = result.verdict == "pass" ? "PASS" : "FAIL"
+        let paddedName = result.name.padding(toLength: nameWidth, withPad: " ", startingAt: 0)
+        print("\(mark)  \(paddedName)  \(result.reply.prefix(80))")
+    }
+    print(String(repeating: "-", count: 72))
+    let passCount = results.filter { $0.verdict == "pass" }.count
+    print("[toolwalk] \(passCount)/\(results.count) tools passed")
 }

--- a/macapp/Sources/ToolWalk/ToolWalkMain.swift
+++ b/macapp/Sources/ToolWalk/ToolWalkMain.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+// Entry point placeholder for the red commit: the real orchestration (seed a
+// workspace, spawn harnessd via ProjectSession, walk every tool, judge the
+// transcript) lands in the green commit. Named apart from `main.swift` so the
+// module stays `@testable import`-able from ToolWalkTests.
+@main
+struct ToolWalkMain {
+    static func main() async throws {
+        fatalError("ToolWalk is not implemented yet")
+    }
+}

--- a/macapp/Sources/ToolWalk/Verdict.swift
+++ b/macapp/Sources/ToolWalk/Verdict.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// What the transcript showed for one tool's run, reduced to the primitives
+/// `judge` needs. Deliberately independent of `HarnessKit.Transcript` (whose
+/// item initializers are not public outside that module) so this — the part
+/// that decides pass/fail — is constructible and testable with plain values.
+struct ObservedRun: Sendable {
+    var toolCompleted: [String]
+    var toolBlocked: [String]
+    var toolFailed: [String]
+    var finalReply: String
+    var runFailed: Bool
+    var runCancelled: Bool
+    var connectionError: String?
+    var timedOut: Bool
+}
+
+/// One tool's verdict, written into `/tmp/toolwalk-results.json`.
+struct ToolResult: Codable, Sendable {
+    let name: String
+    let verdict: String
+    let reply: String
+}
+
+// STUB — deliberately wrong (always "pass"), to prove the tests above fail
+// for the right reason before the real judging rule is written.
+func judge(tool: String, observed: ObservedRun) -> ToolResult {
+    ToolResult(name: tool, verdict: "pass", reply: observed.finalReply)
+}

--- a/macapp/Sources/ToolWalk/Verdict.swift
+++ b/macapp/Sources/ToolWalk/Verdict.swift
@@ -22,8 +22,65 @@ struct ToolResult: Codable, Sendable {
     let reply: String
 }
 
-// STUB — deliberately wrong (always "pass"), to prove the tests above fail
-// for the right reason before the real judging rule is written.
+/// Phrases a model uses to describe *not* calling a tool. A tool call can
+/// show up as "completed" in the transcript and the model can still, in the
+/// same turn, tell the user it could not do the thing — that is a failure,
+/// not evidence the tool worked.
+private let deflectionPhrases = [
+    "i cannot call", "i can't call", "i do not have access to", "i don't have access to",
+    "unable to call", "no such tool", "not available to me", "i am not able to call",
+    "i'm not able to call", "cannot invoke", "can't invoke",
+    "i don't have the ability to call", "i do not have the ability to call",
+    "as an ai, i cannot", "i wasn't able to call", "i was not able to call",
+]
+
+/// Judges one tool's transcript. A tool passes only when its own
+/// `ToolActivity` reached `.completed` *and* the final assistant reply is a
+/// non-empty message that does not itself disclaim the call — a 200 status
+/// or a confident-sounding reply is not, by itself, evidence the tool ran.
 func judge(tool: String, observed: ObservedRun) -> ToolResult {
-    ToolResult(name: tool, verdict: "pass", reply: observed.finalReply)
+    if observed.timedOut {
+        return ToolResult(
+            name: tool, verdict: "fail",
+            reply: "timed out waiting for the run to reach a terminal state "
+                + "(reply so far: \(observed.finalReply))")
+    }
+    if let error = observed.connectionError, !error.isEmpty {
+        return ToolResult(name: tool, verdict: "fail", reply: "transport error: \(error)")
+    }
+    if observed.runCancelled {
+        return ToolResult(
+            name: tool, verdict: "fail", reply: "run was cancelled before completing")
+    }
+    if observed.toolFailed.contains(tool) {
+        return ToolResult(
+            name: tool, verdict: "fail",
+            reply: "tool call reported failure; reply: \(observed.finalReply)")
+    }
+    if observed.toolBlocked.contains(tool) {
+        return ToolResult(
+            name: tool, verdict: "fail",
+            reply: "tool call is still blocked awaiting approval")
+    }
+    guard observed.toolCompleted.contains(tool) else {
+        let suffix =
+            observed.finalReply.isEmpty ? "" : "; assistant said: \(observed.finalReply)"
+        return ToolResult(
+            name: tool, verdict: "fail", reply: "the tool '\(tool)' was never invoked\(suffix)")
+    }
+
+    let reply = observed.finalReply.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !reply.isEmpty else {
+        return ToolResult(
+            name: tool, verdict: "fail",
+            reply: "tool call completed but the assistant gave no reply")
+    }
+    let lowered = reply.lowercased()
+    if let phrase = deflectionPhrases.first(where: { lowered.contains($0) }) {
+        return ToolResult(
+            name: tool, verdict: "fail",
+            reply: "assistant reply disclaims the tool call (matched \"\(phrase)\"): \(reply)")
+    }
+
+    return ToolResult(name: tool, verdict: "pass", reply: reply)
 }

--- a/macapp/Sources/ToolWalk/Workspace.swift
+++ b/macapp/Sources/ToolWalk/Workspace.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum WorkspaceError: Error {
+    case commandFailed(command: String, status: Int32, stderr: String)
+}
+
+/// Seeds a throwaway workspace with real git history and a `go.mod` so the
+/// git/file tools being walked have something to act on — an empty directory
+/// makes prompts like "grep for 'module' in go.mod" or "the most recent
+/// commit touching go.mod" nonsensical.
+///
+/// Two commits, not one: `git_diff_range`'s prompt asks for `HEAD~1..HEAD`,
+/// which is not a valid range with only one commit. The first commit's
+/// message itself is the fixture for `git_log_search`, whose prompt searches
+/// commits for "seed".
+func seedWorkspace(at directory: URL) throws {
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+    let goMod = "module toolwalk\n\ngo 1.21\n"
+    try goMod.write(to: directory.appending(path: "go.mod"), atomically: true, encoding: .utf8)
+
+    try runGit(["init", "--quiet"], in: directory)
+    try runGit(["config", "user.email", "toolwalk@example.com"], in: directory)
+    try runGit(["config", "user.name", "ToolWalk"], in: directory)
+    try runGit(["add", "go.mod"], in: directory)
+    try runGit(["commit", "--quiet", "-m", "seed: initial commit"], in: directory)
+
+    let readme = "# ToolWalk scratch workspace\n"
+    try readme.write(
+        to: directory.appending(path: "README.md"), atomically: true, encoding: .utf8)
+    try runGit(["add", "README.md"], in: directory)
+    try runGit(["commit", "--quiet", "-m", "docs: add readme"], in: directory)
+}
+
+@discardableResult
+private func runGit(_ arguments: [String], in directory: URL) throws -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git"] + arguments
+    process.currentDirectoryURL = directory
+
+    let stdout = Pipe()
+    let stderr = Pipe()
+    process.standardOutput = stdout
+    process.standardError = stderr
+
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+        let errorText = String(
+            decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        throw WorkspaceError.commandFailed(
+            command: "git " + arguments.joined(separator: " "),
+            status: process.terminationStatus, stderr: errorText)
+    }
+    return String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+}

--- a/macapp/Tests/ToolWalkTests/RegressionTests.swift
+++ b/macapp/Tests/ToolWalkTests/RegressionTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import ToolWalk
+
+/// Two angles the behavioral tests in ToolSpecTests/VerdictTests don't cover:
+/// the on-disk JSON contract the task promises, and the ordering guarantee
+/// Runner.walk silently depends on.
+@Suite("ToolWalk regressions")
+struct RegressionTests {
+
+    /// `/tmp/toolwalk-results.json` is the deliverable: "per tool: name,
+    /// verdict, reply". If `ToolResult`'s coding keys are ever renamed or its
+    /// Codable conformance loses `verdict`/`reply` (e.g. a refactor adds a
+    /// `detail` field instead of reusing `reply`), the results file silently
+    /// stops matching what was promised and any downstream reader breaks.
+    @Test("ToolResult encodes to JSON with exactly name, verdict, reply")
+    func toolResultJSONContract() throws {
+        let result = ToolResult(name: "bash", verdict: "pass", reply: "UIWALK_BASH_OK")
+        let data = try JSONEncoder().encode(result)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == ["name", "verdict", "reply"])
+        #expect(object["name"] as? String == "bash")
+        #expect(object["verdict"] as? String == "pass")
+        #expect(object["reply"] as? String == "UIWALK_BASH_OK")
+    }
+
+    /// Several tools in ui-walk-tools.txt depend on an earlier tool's
+    /// server-side state: cron_create (line 13) must run before cron_get/
+    /// cron_list/cron_pause/cron_resume/cron_delete reference its "uiwalk"
+    /// job, and create_skill/create_workflow must precede verify_skill/
+    /// run_workflow. Runner.walk executes specs in array order with no
+    /// reordering step, so parsing must preserve file order exactly — a
+    /// parser that sorted or grouped entries (e.g. by name) would silently
+    /// break every one of those dependent tools.
+    @Test("parseToolSpecs preserves the file's line order")
+    func preservesFileOrder() throws {
+        let specs = try parseToolSpecs(
+            """
+            cron_create|create the uiwalk job
+            cron_get|get the uiwalk job
+            cron_delete|delete the uiwalk job
+            """)
+        #expect(specs.map(\.name) == ["cron_create", "cron_get", "cron_delete"])
+    }
+}

--- a/macapp/Tests/ToolWalkTests/ToolSpecTests.swift
+++ b/macapp/Tests/ToolWalkTests/ToolSpecTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import ToolWalk
+
+/// `scripts/ui-walk-tools.txt` is `tool|prompt` per line; these tests pin the
+/// parsing rules the live walk depends on before any daemon is involved.
+@Suite("ToolSpec parsing")
+struct ToolSpecTests {
+
+    @Test("splits each line on the first pipe into name and prompt")
+    func splitsNameAndPrompt() throws {
+        let specs = try parseToolSpecs(
+            """
+            bash|Use the bash tool to run: echo OK and report the exact output.
+            grep|Use the grep tool to grep for 'module' in go.mod|extra pipe stays in the prompt
+            """)
+
+        #expect(specs.count == 2)
+        #expect(specs[0].name == "bash")
+        #expect(specs[0].prompt == "Use the bash tool to run: echo OK and report the exact output.")
+        // Only the first "|" is a delimiter — a prompt containing "|" must not
+        // be truncated.
+        #expect(
+            specs[1].prompt
+                == "Use the grep tool to grep for 'module' in go.mod|extra pipe stays in the prompt"
+        )
+    }
+
+    @Test("trims surrounding whitespace from both fields")
+    func trimsWhitespace() throws {
+        let specs = try parseToolSpecs("  ls  |  list the directory  ")
+        #expect(specs.count == 1)
+        #expect(specs[0].name == "ls")
+        #expect(specs[0].prompt == "list the directory")
+    }
+
+    @Test("skips blank lines without producing a spec")
+    func skipsBlankLines() throws {
+        let specs = try parseToolSpecs("bash|do a thing\n\n\nread|read a thing\n")
+        #expect(specs.count == 2)
+    }
+
+    @Test("rejects a line with no separator")
+    func rejectsMissingSeparator() {
+        #expect(throws: ToolSpecError.self) {
+            try parseToolSpecs("bash without a pipe")
+        }
+    }
+
+    @Test("rejects a line with an empty tool name")
+    func rejectsEmptyName() {
+        #expect(throws: ToolSpecError.self) {
+            try parseToolSpecs("|a prompt with no tool name")
+        }
+    }
+
+    @Test("rejects a line with an empty prompt")
+    func rejectsEmptyPrompt() {
+        #expect(throws: ToolSpecError.self) {
+            try parseToolSpecs("bash|   ")
+        }
+    }
+
+    /// Regression: the real file this walk depends on must keep parsing to
+    /// exactly 61 uniquely-named tools. If a future edit breaks the format —
+    /// a missing pipe, a duplicated tool line — this fails loudly instead of
+    /// the walk silently dropping or double-running a tool.
+    @Test("the real ui-walk-tools.txt parses to 61 unique tool specs")
+    func realToolsFileParsesCompletely() throws {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // ToolWalkTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // macapp
+            .deletingLastPathComponent()  // repo root
+            .appending(path: "scripts").appending(path: "ui-walk-tools.txt")
+        let contents = try String(contentsOf: url, encoding: .utf8)
+
+        let specs = try parseToolSpecs(contents)
+        #expect(specs.count == 61)
+        #expect(Set(specs.map(\.name)).count == 61, "every tool name must be unique")
+    }
+}

--- a/macapp/Tests/ToolWalkTests/VerdictTests.swift
+++ b/macapp/Tests/ToolWalkTests/VerdictTests.swift
@@ -1,0 +1,106 @@
+import Testing
+
+@testable import ToolWalk
+
+/// `judge` is the whole point of the walk: it decides whether a tool's
+/// transcript is evidence the tool actually ran, independent of the live
+/// daemon or model. These tests build `ObservedRun` values by hand — the
+/// same shape `Runner.observe(_:timedOut:)` produces from a real
+/// `RunSession.transcript` — so the judging rule is provable without a
+/// network call.
+@Suite("judge")
+struct VerdictTests {
+
+    private func observed(
+        completed: [String] = [], blocked: [String] = [], failed: [String] = [],
+        reply: String = "", runFailed: Bool = false, runCancelled: Bool = false,
+        connectionError: String? = nil, timedOut: Bool = false
+    ) -> ObservedRun {
+        ObservedRun(
+            toolCompleted: completed, toolBlocked: blocked, toolFailed: failed,
+            finalReply: reply, runFailed: runFailed, runCancelled: runCancelled,
+            connectionError: connectionError, timedOut: timedOut)
+    }
+
+    @Test("passes when the tool completed and the assistant reports on it")
+    func passesOnCompletedToolWithReply() {
+        let result = judge(
+            tool: "bash",
+            observed: observed(completed: ["bash"], reply: "The command printed UIWALK_BASH_OK."))
+        #expect(result.verdict == "pass")
+        #expect(result.reply == "The command printed UIWALK_BASH_OK.")
+    }
+
+    /// The central regression case: a run that returned 200 and produced a
+    /// plausible-sounding reply, but never actually invoked the tool under
+    /// test (e.g. the model narrated success instead of calling it). If
+    /// `judge` is ever changed to pass on reply text alone, this fails.
+    @Test("fails when the reply sounds like success but the tool never ran")
+    func failsWhenToolNeverInvokedDespiteConfidentReply() {
+        let result = judge(
+            tool: "deploy",
+            observed: observed(
+                completed: [], reply: "Deployment completed successfully with no errors."))
+        #expect(result.verdict == "fail")
+        #expect(result.reply.contains("never invoked"))
+    }
+
+    @Test("fails when the assistant explicitly disclaims calling the tool")
+    func failsOnDeflection() {
+        let result = judge(
+            tool: "download",
+            observed: observed(
+                completed: ["download"],
+                reply: "I don't have access to a download tool, so I can't do that."))
+        #expect(result.verdict == "fail")
+    }
+
+    @Test("fails when the tool call itself reported failure")
+    func failsOnToolFailure() {
+        let result = judge(
+            tool: "apply_patch",
+            observed: observed(failed: ["apply_patch"], reply: "The patch could not be applied."))
+        #expect(result.verdict == "fail")
+    }
+
+    @Test("fails when the tool call is still blocked awaiting approval")
+    func failsOnBlockedApproval() {
+        let result = judge(
+            tool: "bash",
+            observed: observed(blocked: ["bash"], reply: "Waiting for approval."))
+        #expect(result.verdict == "fail")
+    }
+
+    @Test("fails on an empty reply even if the tool completed")
+    func failsOnEmptyReply() {
+        let result = judge(tool: "ls", observed: observed(completed: ["ls"], reply: ""))
+        #expect(result.verdict == "fail")
+    }
+
+    @Test("fails when the run timed out")
+    func failsOnTimeout() {
+        let result = judge(
+            tool: "agent",
+            observed: observed(completed: ["agent"], reply: "still working", timedOut: true))
+        #expect(result.verdict == "fail")
+        #expect(result.reply.contains("timed out"))
+    }
+
+    @Test("fails on a transport error regardless of any reply")
+    func failsOnConnectionError() {
+        let result = judge(
+            tool: "write",
+            observed: observed(
+                completed: ["write"], reply: "wrote the file", connectionError: "connection reset")
+        )
+        #expect(result.verdict == "fail")
+    }
+
+    @Test("fails when the run was cancelled before finishing")
+    func failsOnCancellation() {
+        let result = judge(
+            tool: "grep",
+            observed: observed(completed: ["grep"], reply: "found it", runCancelled: true))
+        #expect(result.verdict == "fail")
+    }
+}


### PR DESCRIPTION
## Summary

Adds `macapp/Sources/ToolWalk`, a Swift executable target that walks all 61 registered harness tools through the native app's **own code path** — `ProjectSession`/`RunSession`/`HarnessClient` from `GoCodeUI`/`HarnessKit`, the same objects the composer's Send button drives. No `URLRequest` of its own. Built because the target machine's screen is locked, so an accessibility-driven walk (the existing `scripts/ui-walk-*.sh`) cannot get a window.

For each `tool|prompt` line in `scripts/ui-walk-tools.txt` (unmodified), it:
1. Starts a fresh conversation on a `ProjectSession` backed by a real, supervised `harnessd` (via `HarnessSupervisor`, exactly as the app does).
2. Submits the prompt through `RunSession.submit()`.
3. Auto-answers `AskUserQuestion` and auto-approves any pending tool/plan approval, the same calls the composer's own controls make — otherwise the walk hangs on the first gated tool.
4. Reads the transcript model back and judges pass/fail on it: a tool only passes when its `ToolActivity` reached `.completed` **and** the final assistant reply is non-empty and doesn't itself disclaim the call. A 200 status or a confident-sounding reply is not, by itself, evidence.
5. Writes `/tmp/toolwalk-results.json` (`name`, `verdict`, `reply` per tool) and prints a summary table.

TDD audit trail (`git log --oneline`): `test(red)` → `feat` (green) → `test(regression)`, three separate commits.

## Result of running it

**46 / 61 passed** against a real `harnessd` on Cerebras `gpt-oss-120b`. Full table in `/tmp/toolwalk-results.json` on the run host. Failures, by cause (all with the transcript reply the walker recorded):

**Genuine app/tool gap found by exercising the real code path:**
- `create_workflow` / `run_workflow` — both fail because `HARNESS_SOURCE_ROOT` is unset in the child `harnessd`'s environment. `HarnessSupervisor` does not set it, and neither does the real macOS app today — so this reproduces in the shipped app, not just in this synthetic workspace. Worth a follow-up.

**Judge correctly caught a hallucinated tool call (this is the walker doing its job):**
- `git_diff_range` and `cron_pause` — the assistant's reply *describes* calling the tool and even fabricates plausible-looking JSON output, but no matching completed `ToolActivity` exists in the transcript. The judge fails these on purpose; passing them would be exactly the "trust a 200 and a confident reply" mistake this walk exists to avoid.

**Fixture-ordering artifact (scripts/ui-walk-tools.txt, left intact per instructions):**
- `cron_get` / `cron_resume` — line 14 (`cron_delete`) removes the `uiwalk` job immediately after line 13 creates it, before lines 15–18 (`cron_get`, `cron_pause`, `cron_resume`) run against it. Not a ToolWalk or tool bug — a property of the given prompt order.

**Structurally cannot succeed from a top-level run:**
- `notify_parent` / `task_complete` — both correctly error ("no recorded parent" / "only available to subagents") because ToolWalk always submits root-level runs. The tools are proven to respond correctly for that case; they can't "pass" a walk that never spawns a subagent context.

**Fixture wording references something that doesn't exist:**
- `get_profile_manifest` — asks for profile `'default'`, but this harness's profiles are named `full`/`bash-runner`/`file-writer`/`github`/`researcher`/`reviewer` — no `default`. The tool ran and correctly reported "not found."

**Expected given the throwaway workspace:**
- `deploy` — real invocation, real error (`no platform config found`) — the synthetic workspace isn't a deployable project.

**Model reasoning/tool-discovery confusion (non-deterministic, not obviously a code bug):**
- `AskUserQuestion`, `job_kill` — model searched via `find_tool` and concluded it couldn't find/activate the tool, then gave up without calling it.
- `message_subagent` — started one subagent, then tried to message a different (non-existent) subagent id of its own invention.

**Unclear, no assistant reply recorded:**
- `validate_profile`, `working_memory` — transcript shows no completed activity and no reply text; cause not further diagnosed here.

## What this does and does not prove

Proves: the app's real `HarnessClient`, run lifecycle (start/stream/terminal-state), transcript reduction, and pending-question/approval plumbing work end to end against a live provider, for every one of the 61 registered tools.

Does **not** prove: anything about SwiftUI view rendering, layout, or hit-testing — no window was ever created, matching the constraint that the screen is locked. This is a code-path walk, not a substitute for clicking the real UI.

## Test plan
- [x] `swift build --package-path macapp --product ToolWalk`
- [x] `swift test` — 146/146 tests pass (18 new in `ToolWalkTests`, no regressions elsewhere)
- [x] `swift format lint --strict --recursive Sources Tests`
- [x] Ran the walker against a real `harnessd` + Cerebras `gpt-oss-120b`: 46/61 tools passed, full transcript-backed results in `/tmp/toolwalk-results.json`

Claude-Session: https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>