### PR TITLE
Pass the harness module root so workflows work from the app

### DIFF
--- a/macapp/Sources/HarnessKit/HarnessSupervisor.swift
+++ b/macapp/Sources/HarnessKit/HarnessSupervisor.swift
@@ -204,6 +204,13 @@ public actor HarnessSupervisor {
         if fileManager.fileExists(atPath: pricing.path) {
             environment["HARNESS_PRICING_CATALOG_PATH"] = pricing.path
         }
+        // Workflow authoring compiles Go against the harness module, so it needs
+        // the module root. Without it create_workflow and run_workflow fail
+        // outright — not degraded, unavailable — for every app-launched daemon,
+        // because nothing else in the app's environment supplies it.
+        if fileManager.fileExists(atPath: root.appending(path: "go.mod").path) {
+            environment["HARNESS_SOURCE_ROOT"] = root.path
+        }
         return environment
     }
 

--- a/macapp/Tests/HarnessKitTests/SupervisorEnvironmentTests.swift
+++ b/macapp/Tests/HarnessKitTests/SupervisorEnvironmentTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import HarnessKit
+
+/// Workflow authoring compiles Go against the harness module. Without the module
+/// root the tools do not degrade, they fail outright — and nothing else in the
+/// app's environment supplies it, so a missing value here means every
+/// app-launched daemon cannot create or run a workflow at all.
+@Suite("Supervisor installation environment")
+struct SupervisorEnvironmentTests {
+    private func makeInstallation() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "supervisor-env-\(UUID().uuidString)")
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: root.appending(path: "prompts"), withIntermediateDirectories: true)
+        try "".write(
+            to: root.appending(path: "prompts").appending(path: "catalog.yaml"),
+            atomically: true, encoding: .utf8)
+        try "module go-agent-harness\n".write(
+            to: root.appending(path: "go.mod"),
+            atomically: true, encoding: .utf8)
+        try fm.createDirectory(at: root.appending(path: "bin"), withIntermediateDirectories: true)
+        return root
+    }
+
+    @Test("the module root is passed to the daemon")
+    func passesSourceRoot() throws {
+        let root = try makeInstallation()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let binary = root.appending(path: "bin").appending(path: "harnessd")
+        let env = HarnessSupervisor.installationEnvironment(for: binary)
+        #expect(env["HARNESS_SOURCE_ROOT"] == root.path)
+    }
+
+    @Test("an installation without the module is not claimed to have one")
+    func omitsSourceRootWhenAbsent() throws {
+        let root = try makeInstallation()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.removeItem(at: root.appending(path: "go.mod"))
+        let binary = root.appending(path: "bin").appending(path: "harnessd")
+        let env = HarnessSupervisor.installationEnvironment(for: binary)
+        #expect(env["HARNESS_SOURCE_ROOT"] == nil)
+    }
+}


### PR DESCRIPTION
Fixes the first confirmed defect in #961.

## Problem

`create_workflow` and `run_workflow` fail for every app-launched daemon:

> the `create_workflow` tool reported an error because the harness environment variable `HARNESS_SOURCE_ROOT` was not set

Workflow authoring compiles Go against the harness module and needs that root (`internal/workflow/source.go:441,796`). `HarnessSupervisor` passes `HARNESS_PROMPTS_DIR`, `HARNESS_MODEL_CATALOG_PATH` and `HARNESS_PRICING_CATALOG_PATH` — but never this one. Workflows aren't degraded from the app, they're unavailable.

## How it was found

By walking all 61 tools through the **app's own** `HarnessClient`, run lifecycle and transcript model, rather than over raw HTTP. It does not reproduce in the HTTP sweep because that runs with the repo as the workspace, where the value happens to resolve — which is exactly why driving the app's path is worth doing separately.

## Fix

Set it, but only when the installation root actually contains the module, so an installation without one isn't claimed to have it.

Two regression tests: the root is passed when present, and absent when it isn't. 130 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9