### PR TITLE
macapp: follow the conversation, not just the run it started (#950)

### DIFF
--- a/macapp/Sources/GoCodeUI/ProjectSession.swift
+++ b/macapp/Sources/GoCodeUI/ProjectSession.swift
@@ -165,6 +165,7 @@ public final class ProjectSession {
     /// opening projects does not leave a trail of orphaned servers.
     public func shutdown() async {
         run?.cancel()
+        run?.stopConversationStream()
         await supervisor?.stop()
         supervisor = nil
         client = nil

--- a/macapp/Sources/GoCodeUI/RunSession.swift
+++ b/macapp/Sources/GoCodeUI/RunSession.swift
@@ -30,6 +30,26 @@ public final class RunSession {
     /// Escalates a second interrupt from cooperative cancel to a hard stop.
     private var cancelRequested = false
 
+    /// Keeps the conversation-wide stream (issue #950) open for as long as a
+    /// conversation is selected, independent of whether this app instance
+    /// started the run producing events -- a delayed callback or cron run can
+    /// fire after the run that scheduled it already ended, with no run left
+    /// to `events(runID:)` subscribe to.
+    private var conversationStreamTask: Task<Void, Never>?
+    /// The conversation `conversationStreamTask` is currently open for, so
+    /// re-setting `conversationID` to the same value (e.g. `rebind` called
+    /// twice) does not tear down and reopen the stream needlessly.
+    private var streamingConversationID: String?
+    /// Event ids already applied to the transcript. The per-run stream
+    /// started by `submit()` and the conversation-wide stream both observe
+    /// the same events for a run this app started, so without this a reply
+    /// would render twice. `HarnessEvent.id` (`<run id>:<sequence>`) is
+    /// unique across every run, so a plain set is enough to dedupe.
+    // ponytail: unbounded for the session's lifetime -- fine at chat-transcript
+    // scale; revisit with an LRU/bounded cap if a conversation runs long
+    // enough for this to matter.
+    private var seenEventIDs: Set<String> = []
+
     public init(client: HarnessClient) {
         self.client = client
     }
@@ -72,10 +92,13 @@ public final class RunSession {
                 let started = try await client.startRun(request)
                 currentRunID = started.runID
                 if self.conversationID == nil { self.conversationID = started.runID }
+                // Keyed by conversation, not by this run: on a conversation's
+                // later runs `conversationID` is already the first run's id,
+                // so this must not retarget the stream to `started.runID`.
+                if let conversationID { trackConversationStream(conversationID) }
 
                 for try await event in client.events(runID: started.runID) {
-                    transcript.apply(event)
-                    await handleSideEffects(of: event, runID: started.runID)
+                    await apply(event, runID: started.runID)
                 }
             } catch let error as HarnessError {
                 connectionError = error.message
@@ -145,10 +168,16 @@ public final class RunSession {
         self.conversationID = conversationID
         currentRunID = nil
         connectionError = nil
+        trackConversationStream(conversationID)
     }
 
+    /// Stops following this session's conversation. Called on a fresh
+    /// conversation, and by `ProjectSession.shutdown()` so a torn-down
+    /// harnessd does not leave the reconnect loop spinning against a process
+    /// that will never answer again.
     public func reset() {
         streamTask?.cancel()
+        stopConversationStream()
         transcript.reset()
         conversationID = nil
         currentRunID = nil
@@ -158,11 +187,70 @@ public final class RunSession {
 
     public func rebind(conversationID: String) {
         self.conversationID = conversationID
+        trackConversationStream(conversationID)
     }
 
     public func recallPreviousPrompt() {
         guard let last = promptHistory.last else { return }
         draft = last
+    }
+
+    // MARK: - Conversation-wide event stream (issue #950)
+
+    /// Opens the conversation-wide stream for `conversationID` unless it is
+    /// already open for that same conversation.
+    private func trackConversationStream(_ conversationID: String) {
+        guard streamingConversationID != conversationID else { return }
+        stopConversationStream()
+        streamingConversationID = conversationID
+        conversationStreamTask = Task { [client] in
+            await self.streamConversation(client: client, conversationID: conversationID)
+        }
+    }
+
+    public func stopConversationStream() {
+        conversationStreamTask?.cancel()
+        conversationStreamTask = nil
+        streamingConversationID = nil
+    }
+
+    /// Keeps re-opening `client.conversationEvents` for as long as this task
+    /// is not cancelled. The server-side stream only ends on client
+    /// disconnect or genuine transport failure -- never on a terminal run
+    /// event -- so any exit from the inner loop here is a dropped connection,
+    /// not "the conversation is done"; reconnecting with the last seen event
+    /// id is what makes a flaky connection recoverable instead of a silent
+    /// dead subscription (the exact bug this stream exists to fix).
+    private func streamConversation(client: HarnessClient, conversationID: String) async {
+        var lastEventID: String?
+        while !Task.isCancelled {
+            do {
+                for try await event in client.conversationEvents(
+                    conversationID: conversationID, lastEventID: lastEventID)
+                {
+                    lastEventID = event.id
+                    await apply(event, runID: event.runID)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                // Transport error -- fall through to the reconnect delay below.
+            }
+            if Task.isCancelled { return }
+            // ponytail: fixed short delay, no exponential backoff/jitter --
+            // add one if this ever hammers a genuinely-down server.
+            try? await Task.sleep(for: .milliseconds(500))
+        }
+    }
+
+    /// Applies `event` to the transcript at most once. Both the per-run
+    /// stream started by `submit()` and the conversation-wide stream deliver
+    /// the same events for a run this app started, and rendering both copies
+    /// would double every message (issue #950 requirement 4).
+    private func apply(_ event: HarnessEvent, runID: String) async {
+        guard seenEventIDs.insert(event.id).inserted else { return }
+        transcript.apply(event)
+        await handleSideEffects(of: event, runID: runID)
     }
 
     // MARK: - Side effects

--- a/macapp/Sources/GoCodeUI/RunSession.swift
+++ b/macapp/Sources/GoCodeUI/RunSession.swift
@@ -74,11 +74,21 @@ public final class RunSession {
         promptHistory.append(prompt)
         transcript.appendUserPrompt(prompt)
 
-        streamTask = Task { [client, model, planMode, conversationID, extraDirs, profile] in
+        // `startingConversationID` is deliberately renamed away from the
+        // property it's captured from: a capture named `conversationID`
+        // would shadow `self.conversationID` for the rest of this closure,
+        // so the `if let conversationID { trackConversationStream(...) }`
+        // check below would silently see the stale pre-run value (nil, for
+        // a brand-new conversation) forever instead of the id this run just
+        // minted -- exactly the bug that left the conversation stream never
+        // started for the run that most needs it.
+        streamTask = Task {
+            [client, model, planMode, startingConversationID = conversationID, extraDirs, profile]
+            in
             do {
                 var request = HarnessClient.StartRunRequest(prompt: prompt)
                 request.model = model
-                request.conversationID = conversationID
+                request.conversationID = startingConversationID
                 if planMode { request.planMode = true }
                 if !extraDirs.isEmpty { request.extraDirs = extraDirs }
                 request.profile = profile
@@ -93,9 +103,11 @@ public final class RunSession {
                 currentRunID = started.runID
                 if self.conversationID == nil { self.conversationID = started.runID }
                 // Keyed by conversation, not by this run: on a conversation's
-                // later runs `conversationID` is already the first run's id,
-                // so this must not retarget the stream to `started.runID`.
-                if let conversationID { trackConversationStream(conversationID) }
+                // later runs `self.conversationID` is already the first run's
+                // id, so this must not retarget the stream to `started.runID`.
+                if let conversationID = self.conversationID {
+                    trackConversationStream(conversationID)
+                }
 
                 for try await event in client.events(runID: started.runID) {
                     await apply(event, runID: started.runID)

--- a/macapp/Sources/HarnessKit/HarnessClient.swift
+++ b/macapp/Sources/HarnessKit/HarnessClient.swift
@@ -150,14 +150,48 @@ public final class HarnessClient: Sendable {
             request.setValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
         }
         authorize(&request)
+        // A terminal event ends this one run, and there is nothing further to
+        // wait for on this connection.
+        return streamEvents(request: request, closeOnTerminal: true)
+    }
 
+    /// Streams every event on a conversation across however many runs execute
+    /// on it -- including a run this client never itself started, such as a
+    /// delayed callback or cron job firing after the run that scheduled it
+    /// already ended (issue #950). Mirrors `events(runID:)`'s SSE contract
+    /// (Last-Event-ID resumption, same frame parsing) but, matching the
+    /// server's `handleConversationEvents`, never finishes on a terminal
+    /// event: `run.completed`/`failed`/`cancelled` ends one run on the
+    /// conversation, not the conversation itself. The caller owns
+    /// reconnecting if the connection drops -- this stream only ends on a
+    /// genuine transport error or cancellation.
+    public func conversationEvents(
+        conversationID: String, lastEventID: String? = nil
+    ) -> AsyncThrowingStream<HarnessEvent, Error> {
+        var request = URLRequest(
+            url: baseURL.appending(path: "/v1/conversations/\(conversationID)/events"))
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        if let lastEventID {
+            request.setValue(lastEventID, forHTTPHeaderField: "Last-Event-ID")
+        }
+        authorize(&request)
+        return streamEvents(request: request, closeOnTerminal: false)
+    }
+
+    /// Shared SSE transport for both event streams above: opens the
+    /// connection, reassembles frames byte-by-byte (a network read can split
+    /// mid-frame), and decodes each into a `HarnessEvent`. `closeOnTerminal`
+    /// is the only behavioral difference between a single run's stream and
+    /// the whole-conversation stream.
+    private func streamEvents(
+        request: URLRequest, closeOnTerminal: Bool
+    ) -> AsyncThrowingStream<HarnessEvent, Error> {
         let session = self.session
-        let streamRequest = request
         return AsyncThrowingStream {
             (continuation: AsyncThrowingStream<HarnessEvent, Error>.Continuation) in
             let task = Task { @Sendable in
                 do {
-                    let (bytes, response) = try await session.bytes(for: streamRequest)
+                    let (bytes, response) = try await session.bytes(for: request)
                     try Self.checkStatus(response, body: Data())
 
                     var parser = SSEParser()
@@ -175,7 +209,7 @@ public final class HarnessClient: Sendable {
                             do {
                                 let event = try HarnessEvent(frame: frame)
                                 continuation.yield(event)
-                                if event.type.isTerminal {
+                                if closeOnTerminal && event.type.isTerminal {
                                     continuation.finish()
                                     return
                                 }

--- a/macapp/Tests/GoCodeUITests/RunSessionConversationStreamTests.swift
+++ b/macapp/Tests/GoCodeUITests/RunSessionConversationStreamTests.swift
@@ -130,4 +130,115 @@ struct RunSessionConversationStreamTests {
 
         session.reset()
     }
+
+    /// Regression for requirement 4: without the dedup in `apply(_:runID:)`,
+    /// a run this app *did* start renders twice, because submit()'s per-run
+    /// stream and the conversation-wide stream both observe the same events
+    /// for it. Reverting the `seenEventIDs` guard added in the green commit
+    /// makes this fail by producing two assistant-message items instead of
+    /// one.
+    @Test("does not double-render a self-started run's events across both streams")
+    func dedupesEventsSeenOnBothStreams() async throws {
+        ConversationStreamStub.reset()
+        let frames = """
+            id: run_1:0
+            event: run.started
+            data: {"id":"run_1:0","run_id":"run_1","type":"run.started","payload":{}}
+
+            id: run_1:1
+            event: assistant.message
+            data: {"id":"run_1:1","run_id":"run_1","type":"assistant.message","payload":{"content":"hello there"}}
+
+            id: run_1:2
+            event: run.completed
+            data: {"id":"run_1:2","run_id":"run_1","type":"run.completed","payload":{}}
+
+
+            """
+        ConversationStreamStub.queue(
+            "/v1/runs",
+            [.init(status: 202, chunks: [Data(#"{"run_id":"run_1","status":"queued"}"#.utf8)])])
+        ConversationStreamStub.queue(
+            "/v1/runs/run_1/events",
+            [
+                .init(
+                    status: 200, headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(frames.utf8)])
+            ])
+        ConversationStreamStub.queue(
+            "/v1/conversations/run_1/events",
+            [
+                .init(
+                    status: 200, headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(frames.utf8)])
+            ])
+
+        let session = makeSession()
+        session.draft = "hi"
+        session.submit()
+
+        try await wait { session.transcript.runState == .completed }
+        // Both streams deliver identical frames concurrently; give the
+        // conversation-wide one a moment to also arrive before asserting
+        // nothing doubled.
+        try await Task.sleep(for: .milliseconds(200))
+
+        let assistantMessages = session.transcript.items.filter {
+            if case .assistantMessage = $0.kind { return true }
+            return false
+        }
+        #expect(
+            assistantMessages.count == 1,
+            "the same event arrived on the per-run stream and the conversation stream and was rendered twice"
+        )
+
+        session.reset()
+    }
+
+    /// Regression for requirement 5: a conversation stream that silently dies
+    /// is the same bug the whole feature exists to fix. If the reconnect loop
+    /// in `streamConversation` were removed, only "first" would ever arrive
+    /// and the request recorded for `/v1/conversations/conv_2/events` would
+    /// stay at one with no `Last-Event-ID` on any follow-up.
+    @Test("reconnects the conversation stream with Last-Event-ID after a drop")
+    func reconnectsAfterConnectionDrop() async throws {
+        ConversationStreamStub.reset()
+        let firstFrames = """
+            id: run_cb:0
+            event: assistant.message
+            data: {"id":"run_cb:0","run_id":"run_cb","type":"assistant.message","payload":{"content":"first"}}
+
+
+            """
+        let secondFrames = """
+            id: run_cb:1
+            event: assistant.message
+            data: {"id":"run_cb:1","run_id":"run_cb","type":"assistant.message","payload":{"content":"second"}}
+
+
+            """
+        ConversationStreamStub.queue(
+            "/v1/conversations/conv_2/events",
+            [
+                .init(
+                    status: 200, headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(firstFrames.utf8)]),
+                .init(
+                    status: 200, headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(secondFrames.utf8)]),
+            ])
+
+        let session = makeSession()
+        session.load(messages: [], conversationID: "conv_2")
+
+        try await wait { hasAssistantText(session, "second") }
+
+        let requests = ConversationStreamStub.requests.filter {
+            $0.url?.path == "/v1/conversations/conv_2/events"
+        }
+        #expect(requests.count >= 2, "expected a reconnect after the first response ended")
+        #expect(requests[1].value(forHTTPHeaderField: "Last-Event-ID") == "run_cb:0")
+
+        session.reset()
+    }
 }

--- a/macapp/Tests/GoCodeUITests/RunSessionConversationStreamTests.swift
+++ b/macapp/Tests/GoCodeUITests/RunSessionConversationStreamTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import HarnessKit
+import Testing
+
+@testable import GoCodeUI
+
+/// Minimal HTTP+SSE stub scoped to this file's tests.
+///
+/// Mirrors `HarnessKitTests.StubURLProtocol` (different test target, not
+/// exported, so it can't be reused directly). Responses are queued per path:
+/// each request to that path pops the next scripted response, repeating the
+/// last one once the queue drains, so a test can script a dropped connection
+/// followed by a reconnect without hand-rolling per-call state everywhere.
+private final class ConversationStreamStub: URLProtocol, @unchecked Sendable {
+    struct Response: Sendable {
+        var status: Int = 200
+        var headers: [String: String] = ["Content-Type": "application/json"]
+        var chunks: [Data] = []
+    }
+
+    nonisolated(unsafe) private static var handlers: [String: [Response]] = [:]
+    nonisolated(unsafe) private static var recorded: [URLRequest] = []
+    private static let lock = NSLock()
+
+    static func queue(_ path: String, _ responses: [Response]) {
+        lock.withLock { handlers[path] = responses }
+    }
+
+    static func reset() {
+        lock.withLock {
+            handlers = [:]
+            recorded = []
+        }
+    }
+
+    static var requests: [URLRequest] { lock.withLock { recorded } }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let request = self.request
+        let response: Response = Self.lock.withLock {
+            Self.recorded.append(request)
+            guard let path = request.url?.path, var queue = Self.handlers[path], !queue.isEmpty
+            else { return Response() }
+            let next = queue.removeFirst()
+            Self.handlers[path] = queue.isEmpty ? [next] : queue
+            return next
+        }
+        let http = HTTPURLResponse(
+            url: request.url!, statusCode: response.status,
+            httpVersion: "HTTP/1.1", headerFields: response.headers)!
+        client?.urlProtocol(self, didReceive: http, cacheStoragePolicy: .notAllowed)
+        for chunk in response.chunks {
+            client?.urlProtocol(self, didLoad: chunk)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Exercises the fix for issue #950: harnessd exposes a conversation-wide SSE
+/// stream (`GET /v1/conversations/{id}/events`) so a delayed callback or cron
+/// run that fires after the run that scheduled it already ended still reaches
+/// the app. These tests drive `RunSession` directly against the stub above,
+/// the same layer `RunSessionLiveTests` exercises against a real harnessd.
+@Suite("RunSession conversation-wide event stream", .serialized)
+@MainActor
+struct RunSessionConversationStreamTests {
+
+    private func makeSession() -> RunSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ConversationStreamStub.self]
+        let client = HarnessClient(
+            baseURL: URL(string: "http://127.0.0.1:8899")!,
+            session: URLSession(configuration: config))
+        return RunSession(client: client)
+    }
+
+    private func wait(
+        timeout: Duration = .seconds(5), for condition: () -> Bool
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if condition() { return }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        Issue.record("timed out waiting for condition")
+    }
+
+    private func hasAssistantText(_ session: RunSession, _ text: String) -> Bool {
+        session.transcript.items.contains {
+            if case .assistantMessage(let message) = $0.kind { return message.text == text }
+            return false
+        }
+    }
+
+    /// BT-002: a run this app instance never called `startRun`/`submit()` for
+    /// -- exactly the shape of a fired delayed callback -- must still render
+    /// in the transcript, because opening a conversation subscribes to every
+    /// run on it, not just the ones this client started.
+    @Test("renders output from a run this app never started")
+    func rendersUnstartedRunEvents() async throws {
+        ConversationStreamStub.reset()
+        let frames = """
+            id: run_cb:0
+            event: assistant.message
+            data: {"id":"run_cb:0","run_id":"run_cb","type":"assistant.message","payload":{"content":"CALLBACK_SURFACED_IN_UI"}}
+
+            id: run_cb:1
+            event: run.completed
+            data: {"id":"run_cb:1","run_id":"run_cb","type":"run.completed","payload":{}}
+
+
+            """
+        ConversationStreamStub.queue(
+            "/v1/conversations/conv_1/events",
+            [
+                .init(
+                    status: 200, headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(frames.utf8)])
+            ])
+
+        let session = makeSession()
+        session.load(messages: [], conversationID: "conv_1")
+
+        try await wait { hasAssistantText(session, "CALLBACK_SURFACED_IN_UI") }
+
+        session.reset()
+    }
+}

--- a/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
+++ b/macapp/Tests/HarnessKitTests/HarnessClientTests.swift
@@ -338,6 +338,68 @@ struct HarnessClientSuite {
         }
     }
 
+    @Suite("conversation event stream")
+    struct HarnessClientConversationStreamTests {
+
+        /// Issue #950: a delayed callback (or cron run) can fire on a
+        /// conversation after the run that scheduled it already reached a
+        /// terminal event. Unlike `events(runID:)`, the conversation stream
+        /// must keep delivering events from later runs past an earlier run's
+        /// `run.completed` -- that terminal event ends one run, not the
+        /// conversation.
+        @Test("delivers events across multiple runs and does not stop at a terminal event")
+        func deliversEventsAcrossRuns() async throws {
+            let frames = """
+                id: run_1:0
+                event: run.started
+                data: {"id":"run_1:0","run_id":"run_1","type":"run.started","payload":{}}
+
+                id: run_1:1
+                event: run.completed
+                data: {"id":"run_1:1","run_id":"run_1","type":"run.completed","payload":{}}
+
+                id: run_2:0
+                event: assistant.message
+                data: {"id":"run_2:0","run_id":"run_2","type":"assistant.message","payload":{"content":"callback fired"}}
+
+
+                """
+            StubURLProtocol.set { _ in
+                .init(
+                    status: 200,
+                    headers: ["Content-Type": "text/event-stream"],
+                    chunks: [Data(frames.utf8)])
+            }
+
+            var received: [HarnessEventType] = []
+            for try await event in makeClient().conversationEvents(conversationID: "conv_1") {
+                received.append(event.type)
+            }
+
+            // If the client closed on `run.completed` like `events(runID:)`
+            // does, `run_2`'s assistant message would never arrive.
+            #expect(received == [.runStarted, .runCompleted, .assistantMessage])
+
+            let request = try #require(StubURLProtocol.requests.first)
+            #expect(request.url?.path == "/v1/conversations/conv_1/events")
+        }
+
+        @Test("resumes the conversation stream from the last seen event id")
+        func resumesFromLastEventID() async throws {
+            StubURLProtocol.set { _ in
+                .init(status: 200, headers: ["Content-Type": "text/event-stream"], chunks: [])
+            }
+
+            for try await _ in makeClient().conversationEvents(
+                conversationID: "conv_1", lastEventID: "run_1:7")
+            {}
+
+            let request = try #require(StubURLProtocol.requests.first)
+            #expect(request.value(forHTTPHeaderField: "Last-Event-ID") == "run_1:7")
+            #expect(request.url?.path == "/v1/conversations/conv_1/events")
+        }
+    }
+
     @Suite("todos")
     struct HarnessClientTodoTests {
 


### PR DESCRIPTION
## Summary

- Client: `HarnessClient.conversationEvents(conversationID:lastEventID:)` streams `GET /v1/conversations/{id}/events`, reusing the existing SSE frame parser. Unlike `events(runID:)` it never closes on a terminal run event, matching the server's `handleConversationEvents` contract (a terminal event ends one run, not the conversation).
- App: `RunSession` opens this stream whenever a conversation becomes known (first run of a new conversation via `submit()`, or an explicit `load()`/`rebind()`), reconnects with `Last-Event-ID` if the connection drops, and dedupes on `HarnessEvent.id` so a run this app itself started (observed on both the per-run stream and the conversation stream) never renders twice. `ProjectSession.shutdown()` now also stops the conversation stream.
- Fixed a real bug found while writing the dedup regression test: `submit()`'s `Task` capture list shadowed `self.conversationID`, so the conversation stream was never actually opened for a brand-new conversation -- exactly the scenario in #950 (submit a prompt, schedule a delayed callback on that same conversation).

## Test plan
- [x] `swift build`, `swift test` (153 tests, 37 suites, all passing), `swift format lint --strict --recursive Sources Tests` (clean)
- [x] TDD audit trail: `test(red)` -> `feat` -> `test(regression)` commits, each with captured before/after test output
- [x] Live end-to-end: built `harnessd` + the app from this worktree, opened a fresh workspace, asked the agent to schedule a `set_delayed_callback` (30s, prompt "Say exactly CALLBACK_SURFACED_IN_UI"), waited past the delay, and diffed transcript snapshots via the accessibility driver. New content appeared that was not in the baseline -- the fired callback run's own reply (`CALLBACK_SURFACED_IN_UI`, its own new usage total, its own "Task status: DONE") -- distinct from the earlier scheduling-confirmation message that quotes the same string.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9