### PR TITLE
Cron: run harness jobs instead of silently failing them

### DIFF
--- a/cmd/harnessd/bootstrap_helpers.go
+++ b/cmd/harnessd/bootstrap_helpers.go
@@ -380,7 +380,7 @@ type cronBootstrap struct {
 	scheduler *cron.Scheduler
 }
 
-func buildCronBootstrap(workspace, cronURL string, logger func(string, ...any)) (cronBootstrap, error) {
+func buildCronBootstrap(workspace, cronURL string, logger func(string, ...any), harnessStarter cron.RunStarter) (cronBootstrap, error) {
 	if logger == nil {
 		logger = func(string, ...any) {}
 	}
@@ -400,7 +400,13 @@ func buildCronBootstrap(workspace, cronURL string, logger func(string, ...any)) 
 		return cronBootstrap{}, fmt.Errorf("migrate cron store: %w", err)
 	}
 	clock := cron.RealClock{}
-	scheduler := cron.NewScheduler(store, &cron.ShellExecutor{}, clock, cron.SchedulerConfig{MaxConcurrent: 5})
+	// Route by declared execution type. Handing every job to the shell
+	// executor meant a harness job could never succeed, however well formed.
+	executor := &cron.DispatchExecutor{
+		Shell:   &cron.ShellExecutor{},
+		Harness: &cron.HarnessExecutor{Starter: harnessStarter},
+	}
+	scheduler := cron.NewScheduler(store, executor, clock, cron.SchedulerConfig{MaxConcurrent: 5})
 	if err := scheduler.Start(context.Background()); err != nil {
 		store.Close()
 		return cronBootstrap{}, fmt.Errorf("start cron scheduler: %w", err)

--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -594,7 +594,8 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	var cronStore cron.Store
 	var cronScheduler *cron.Scheduler
 
-	cronBootstrap, err := buildCronBootstrap(workspace, cronURL, log.Printf)
+	cronStarter := &cronRunStarter{}
+	cronBootstrap, err := buildCronBootstrap(workspace, cronURL, log.Printf, cronStarter)
 	if err != nil {
 		return err
 	}
@@ -941,6 +942,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		todos:                todoManager,
 		triggers:             triggerRuntime,
 		callbackStarter:      callbackStarter,
+		cronStarter:          cronStarter,
 		callbackBridge:       callbackBridge,
 		callbackMgr:          callbackMgr,
 		jobTracker:           jobTracker,
@@ -1866,4 +1868,32 @@ func (a *embeddedCronAdapter) ListExecutions(ctx context.Context, jobID string, 
 
 func (a *embeddedCronAdapter) Health(_ context.Context) error {
 	return nil
+}
+
+// cronRunStarter bridges the cron scheduler to the harness Runner.
+//
+// The scheduler is built before the Runner exists, so the pointer is bound
+// later under a mutex — the same ordering the delayed-callback starter solves.
+// Without this the scheduler only ever had a shell executor, so a job declared
+// as harness work was accepted, stored, scheduled, and could never succeed.
+type cronRunStarter struct {
+	mu     sync.Mutex
+	runner *harness.Runner
+}
+
+func (a *cronRunStarter) StartRun(prompt, conversationID string) (string, error) {
+	a.mu.Lock()
+	r := a.runner
+	a.mu.Unlock()
+	if r == nil {
+		return "", fmt.Errorf("runner not yet initialized")
+	}
+	run, err := r.StartRun(harness.RunRequest{
+		Prompt:         prompt,
+		ConversationID: conversationID,
+	})
+	if err != nil {
+		return "", err
+	}
+	return run.ID, nil
 }

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -97,6 +97,7 @@ type httpRuntimeOptions struct {
 	todos                deferred.TodoManager
 	triggers             triggerRuntime
 	callbackStarter      *callbackRunStarter
+	cronStarter          *cronRunStarter
 	callbackBridge       *harness.CallbackEventBridge
 	callbackMgr          *htools.CallbackManager
 	jobTracker           *harness.JobTracker
@@ -276,6 +277,12 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 		opts.callbackStarter.mu.Lock()
 		opts.callbackStarter.runner = runner
 		opts.callbackStarter.mu.Unlock()
+	}
+
+	if opts.cronStarter != nil {
+		opts.cronStarter.mu.Lock()
+		opts.cronStarter.runner = runner
+		opts.cronStarter.mu.Unlock()
 	}
 
 	if opts.callbackBridge != nil {

--- a/internal/cron/executor_dispatch.go
+++ b/internal/cron/executor_dispatch.go
@@ -1,0 +1,96 @@
+package cron
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// RunStarter starts a harness run and returns its id.
+//
+// Cron takes this rather than a *harness.Runner so this package stays free of
+// a dependency on the harness, and so the daemon can bind the real runner
+// after the scheduler is already constructed.
+type RunStarter interface {
+	StartRun(prompt, conversationID string) (runID string, err error)
+}
+
+// harnessConfig is the JSON structure for harness execution config.
+//
+// The prompt lives here rather than on Job: the HTTP create route stores only
+// execution_config, and a top-level "prompt" in the request body is silently
+// discarded — which is how a harness job ends up with empty config and fails
+// to parse.
+type harnessConfig struct {
+	Prompt string `json:"prompt,omitempty"`
+	// ConversationID pins the run to an existing conversation so its output
+	// lands in a transcript someone is watching. Empty starts a fresh one.
+	ConversationID string `json:"conversation_id,omitempty"`
+}
+
+// HarnessExecutor runs a job as a harness agent run.
+type HarnessExecutor struct {
+	Starter RunStarter
+}
+
+// Execute starts a run for the job and returns its id.
+//
+// It returns as soon as the run is accepted rather than waiting for it to
+// finish: a cron job's timeout bounds how long *scheduling* may take, and an
+// agent run can legitimately outlive it. The run's own lifecycle is observable
+// through the normal run and conversation streams.
+func (e *HarnessExecutor) Execute(ctx context.Context, job Job) (string, error) {
+	if e == nil || e.Starter == nil {
+		return "", fmt.Errorf("harness execution is not configured on this daemon")
+	}
+
+	cfg := harnessConfig{}
+	if trimmed := strings.TrimSpace(job.ExecConfig); trimmed != "" {
+		if err := json.Unmarshal([]byte(trimmed), &cfg); err != nil {
+			return "", fmt.Errorf("parse execution config: %w", err)
+		}
+	}
+	prompt := cfg.Prompt
+	if strings.TrimSpace(prompt) == "" {
+		return "", fmt.Errorf("harness job %q has no prompt to run", job.Name)
+	}
+
+	runID, err := e.Starter.StartRun(prompt, cfg.ConversationID)
+	if err != nil {
+		return "", fmt.Errorf("start run: %w", err)
+	}
+	return "started run " + runID, nil
+}
+
+// DispatchExecutor routes a job to the executor for its execution type.
+//
+// Without this the shell executor received every job, including ones declared
+// as harness work — so a harness job was accepted by the API, stored,
+// scheduled, and stamped with last_run_at on every fire, while never being
+// able to succeed. The type was validated at the edge and unimplemented at the
+// centre.
+type DispatchExecutor struct {
+	Shell   Executor
+	Harness Executor
+}
+
+func (d *DispatchExecutor) Execute(ctx context.Context, job Job) (string, error) {
+	switch job.ExecType {
+	case ExecTypeHarness:
+		if d.Harness == nil {
+			return "", fmt.Errorf("execution type %q is not available on this daemon", job.ExecType)
+		}
+		return d.Harness.Execute(ctx, job)
+	case ExecTypeShell, "":
+		if d.Shell == nil {
+			return "", fmt.Errorf("execution type %q is not available on this daemon", job.ExecType)
+		}
+		return d.Shell.Execute(ctx, job)
+	default:
+		// Reaching here means the API accepted a type this dispatcher does
+		// not know about — the exact class of gap this type exists to close,
+		// so it is reported rather than silently treated as a shell command.
+		return "", fmt.Errorf("unknown execution type %q", job.ExecType)
+	}
+}


### PR DESCRIPTION
Fixes #965.

## The defect

The API accepts `execution_type: "harness"`, stores the job, schedules it, and stamps `last_run_at` on every fire — but `ShellExecutor` was the only executor and was wired in unconditionally:

```go
scheduler := cron.NewScheduler(store, &cron.ShellExecutor{}, clock, ...)
```

So a harness job was handed to the shell executor, failed to parse its config as `{"command":...}`, and **could never succeed**.

## Why it stayed invisible

Three things compound: the error lives only in the `cron_executions` SQLite table with no HTTP route to read it; `last_run_at` advances whether or not execution succeeded; and the scheduler adds multi-minute jitter (2m19s and 3m26s on my test jobs), so a job that never worked looks like one still pending.

I initially reported this as "cron does no work at all" — that was wrong, and the correction is in #965. Shell jobs work fine with correct JSON config.

## Fix

`DispatchExecutor` routes by declared type. `HarnessExecutor` starts a real run, returning once accepted rather than waiting — a job's timeout bounds scheduling, and an agent run can legitimately outlive it. An unknown execution type is now reported rather than silently treated as a shell command.

## Verified live

```
status = success
output = started run run_fbb96bbf-c8d6-47f0-8999-e86d7626652e
```

Where the same job previously recorded `parse execution config: unexpected end of JSON input`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9