### PR TITLE
Design system: spacing, type, radius and icon scales

### DIFF
--- a/macapp/Sources/GoCodeUI/ActivityView.swift
+++ b/macapp/Sources/GoCodeUI/ActivityView.swift
@@ -8,11 +8,11 @@ struct ActivityView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: Spacing.section) {
                 if !project.todos.isEmpty {
                     SectionBox(title: "Plan") {
                         ForEach(project.todos, id: \.stableID) { todo in
-                            HStack(spacing: 8) {
+                            HStack(spacing: Spacing.standard) {
                                 Image(
                                     systemName: todo.isDone
                                         ? "checkmark.circle.fill" : "circle"
@@ -24,7 +24,7 @@ struct ActivityView: View {
                                         todo.isDone ? Theme.foregroundTertiary : Theme.foreground)
                                 Spacer()
                             }
-                            .font(.callout)
+                            .font(Typography.body)
                         }
                     }
                 }
@@ -32,7 +32,7 @@ struct ActivityView: View {
                 SectionBox(title: "Background work") {
                     if project.tasks.isEmpty {
                         Text("Nothing running.")
-                            .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                            .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
                     } else {
                         ForEach(project.tasks) { task in
                             TaskRow(task: task)
@@ -44,7 +44,7 @@ struct ActivityView: View {
                     if let runs = project.runs {
                         if runs.isEmpty {
                             Text("No runs recorded yet.")
-                                .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                                .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
                         } else {
                             ForEach(runs) { run in
                                 RunRow(run: run)
@@ -55,11 +55,11 @@ struct ActivityView: View {
                         Text(
                             "This server has no run store configured, so past runs are not listed."
                         )
-                        .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
                     }
                 }
             }
-            .padding(16)
+            .padding(Spacing.large)
         }
         .task { await project.refreshActivity() }
         // Polling stops when the view is not shown, rather than running a fixed
@@ -78,10 +78,10 @@ private struct TaskRow: View {
     let task: TaskInfo
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: Spacing.standard) {
             Image(systemName: icon).foregroundStyle(.tint)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(task.label).font(.callout).lineLimit(1)
+            VStack(alignment: .leading, spacing: Spacing.tight) {
+                Text(task.label).font(Typography.body).lineLimit(1)
                 MetadataRow {
                     Text(task.type)
                     Text(task.status)
@@ -106,10 +106,10 @@ private struct RunRow: View {
     let run: RunSummaryInfo
 
     var body: some View {
-        HStack(spacing: 8) {
-            Circle().fill(color).frame(width: 7, height: 7)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(run.prompt ?? run.id).font(.callout).lineLimit(1)
+        HStack(spacing: Spacing.standard) {
+            Circle().fill(color).frame(width: IconSize.status, height: IconSize.status)
+            VStack(alignment: .leading, spacing: Spacing.tight) {
+                Text(run.prompt ?? run.id).font(Typography.body).lineLimit(1)
                 MetadataRow {
                     if let status = run.status { Text(status) }
                     if let model = run.model { Text(model) }
@@ -137,10 +137,11 @@ private struct SectionBox<Content: View>: View {
     @ViewBuilder let content: Content
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title).font(.caption.weight(.semibold)).foregroundStyle(Theme.foregroundQuaternary)
-            VStack(alignment: .leading, spacing: 7) { content }
-                .padding(12)
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            Text(title).font(Typography.caption.weight(.semibold)).foregroundStyle(
+                Theme.foregroundQuaternary)
+            VStack(alignment: .leading, spacing: Spacing.small) { content }
+                .padding(Spacing.inset)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .cardStyle()
         }

--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -64,7 +64,7 @@ public struct AppShell: View {
         // Widened for the labeled rail (was 50pt icon-only, now 220pt) plus
         // room for the inspector pane to open without squeezing the
         // transcript below its own minWidth.
-        .frame(minWidth: 1040, minHeight: 600)
+        .frame(minWidth: Layout.appMinimumWidth, minHeight: Layout.appMinimumHeight)
         // The root surface. Every other token in `Theme` is defined relative
         // to this value, so it has to be painted explicitly rather than left
         // as the system window background — that's the one substitution
@@ -78,14 +78,14 @@ private struct ProjectPicker: View {
     let onOpen: (URL) -> Void
 
     var body: some View {
-        VStack(spacing: 18) {
+        VStack(spacing: Spacing.section) {
             Image(systemName: "chevron.left.forwardslash.chevron.right")
-                .font(.system(size: 44, weight: .light))
+                .font(.system(size: IconSize.launch, weight: .light))
                 .foregroundStyle(.tint)
-            VStack(spacing: 6) {
-                Text("Open a project").font(.title2.weight(.semibold))
+            VStack(spacing: Spacing.small) {
+                Text("Open a project").font(Typography.title.weight(.semibold))
                 Text("Each project runs its own harness server.")
-                    .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                    .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
             }
             Button("Choose Folder…", action: choose)
                 .buttonStyle(.borderedProminent)
@@ -113,7 +113,7 @@ private struct ProjectView: View {
     let onClose: () -> Void
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: Spacing.none) {
             IconRail(section: $section, project: project, onClose: onClose)
             Divider()
             content
@@ -131,8 +131,8 @@ private struct ProjectView: View {
     }
 
     private var header: some View {
-        HStack(spacing: 6) {
-            Text(project.name).font(.headline)
+        HStack(spacing: Spacing.small) {
+            Text(project.name).font(Typography.heading)
             phaseBadge
         }
     }
@@ -185,7 +185,7 @@ private struct IconRail: View {
     let onClose: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: Spacing.tight) {
             RailRow(section: $section, item: .chat)
             RailRow(section: $section, item: .activity)
 
@@ -198,12 +198,13 @@ private struct IconRail: View {
             RailRow(section: $section, item: .settings)
 
             Button(action: onClose) {
-                HStack(spacing: 10) {
-                    Image(systemName: "xmark.circle").font(.system(size: 15)).frame(width: 18)
-                    Text("Close").font(.callout)
-                    Spacer(minLength: 0)
+                HStack(spacing: Spacing.comfortable) {
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: IconSize.standard)).frame(width: IconSize.row)
+                    Text("Close").font(Typography.body)
+                    Spacer(minLength: Spacing.none)
                 }
-                .padding(.horizontal, 10).padding(.vertical, 8)
+                .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .foregroundStyle(Theme.foregroundTertiary)
                 .contentShape(.rect)
@@ -212,8 +213,8 @@ private struct IconRail: View {
             .help("Close project and stop its server")
             .accessibilityLabel("Close project and stop its server")
         }
-        .padding(.vertical, 10).padding(.horizontal, 8)
-        .frame(width: 220)
+        .padding(.vertical, Spacing.comfortable).padding(.horizontal, Spacing.standard)
+        .frame(width: Layout.railWidth)
         // The rail sits beside content, not on it — one step above the root
         // background rather than the same translucent `.quaternary` fill
         // every surface in the app used to share.
@@ -232,22 +233,22 @@ private struct RailRow: View {
         Button {
             section = item
         } label: {
-            HStack(spacing: 10) {
+            HStack(spacing: Spacing.comfortable) {
                 Image(systemName: item.icon)
-                    .font(.system(size: 15))
-                    .frame(width: 18)
+                    .font(.system(size: IconSize.standard))
+                    .frame(width: IconSize.row)
                     // The label text alone names this row; without this the
                     // icon contributes its own SF Symbol identifier to the
                     // combined accessibility description.
                     .accessibilityHidden(true)
-                Text(item.title).font(.callout)
-                Spacer(minLength: 0)
+                Text(item.title).font(Typography.body)
+                Spacer(minLength: Spacing.none)
             }
-            .padding(.horizontal, 10).padding(.vertical, 8)
+            .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                section == item ? Theme.accent.opacity(0.16) : .clear,
-                in: .rect(cornerRadius: 8)
+                section == item ? Theme.accent.opacity(StateOpacity.selected) : .clear,
+                in: .rect(cornerRadius: CornerRadius.control)
             )
             .foregroundStyle(section == item ? Theme.accent : Theme.foregroundTertiary)
             .contentShape(.rect)
@@ -264,9 +265,10 @@ private struct RailSectionHeader: View {
 
     var body: some View {
         Text(title.uppercased())
-            .font(.caption2.weight(.semibold))
+            .font(Typography.detail.weight(.semibold))
             .foregroundStyle(Theme.foregroundTertiary)
-            .padding(.horizontal, 10).padding(.top, 10).padding(.bottom, 2)
+            .padding(.horizontal, Spacing.comfortable).padding(.top, Spacing.comfortable)
+            .padding(.bottom, Spacing.tight)
             // A heading, not a control — VoiceOver should announce it once
             // as a group label, not treat it as another focusable row.
             .accessibilityAddTraits(.isHeader)
@@ -276,10 +278,10 @@ private struct RailSectionHeader: View {
 private struct StartingView: View {
     let workspace: URL
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: Spacing.comfortable) {
             ProgressView()
             Text("Starting the harness for \(workspace.lastPathComponent)…")
-                .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
@@ -296,18 +298,18 @@ private struct StartupFailureView: View {
             Label(
                 "The harness server could not start", systemImage: "exclamationmark.triangle.fill"
             )
-            .font(.headline).foregroundStyle(.orange)
+            .font(Typography.heading).foregroundStyle(.orange)
             ScrollView {
                 Text(message)
-                    .font(.callout.monospaced()).textSelection(.enabled)
+                    .font(Typography.code).textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxHeight: 260)
-            .padding(10)
-            .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+            .padding(Spacing.comfortable)
+            .compactElevatedSurface()
             Button("Try Again", action: retry).buttonStyle(.borderedProminent)
         }
-        .padding(28)
+        .padding(Spacing.page)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }

--- a/macapp/Sources/GoCodeUI/CardStyle.swift
+++ b/macapp/Sources/GoCodeUI/CardStyle.swift
@@ -12,7 +12,7 @@ import SwiftUI
 /// is an opaque, explicit level instead, so `opacity` no longer has anything
 /// to parameterize.
 struct CardStyle: ViewModifier {
-    var cornerRadius: CGFloat = 10
+    var cornerRadius: CGFloat = CornerRadius.card
 
     func body(content: Content) -> some View {
         content.background(Theme.surfaceElevated, in: .rect(cornerRadius: cornerRadius))
@@ -20,8 +20,14 @@ struct CardStyle: ViewModifier {
 }
 
 extension View {
-    func cardStyle(cornerRadius: CGFloat = 10) -> some View {
+    func cardStyle(cornerRadius: CGFloat = CornerRadius.card) -> some View {
         modifier(CardStyle(cornerRadius: cornerRadius))
+    }
+
+    /// Compact elevated panels recur in code, disclosure, and popup surfaces.
+    /// They intentionally stay distinct from the roomier default card.
+    func compactElevatedSurface() -> some View {
+        background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.control))
     }
 }
 
@@ -29,11 +35,11 @@ extension View {
 /// (`TaskRow`, `RunRow`, `ConversationRow`, `CheckpointCard`), which each
 /// hand-built the same `HStack` + `.font(.caption).foregroundStyle(.secondary)`.
 struct MetadataRow<Content: View>: View {
-    var spacing: CGFloat = 6
+    var spacing: CGFloat = Spacing.small
     @ViewBuilder var content: Content
 
     var body: some View {
         HStack(spacing: spacing) { content }
-            .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+            .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
     }
 }

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -12,8 +12,8 @@ struct ChatView: View {
     @State private var showInspector = false
 
     var body: some View {
-        HStack(spacing: 0) {
-            VStack(spacing: 0) {
+        HStack(spacing: Spacing.none) {
+            VStack(spacing: Spacing.none) {
                 TranscriptView(items: run.transcript.items, selected: $selected)
                 Divider()
                 if let plan = run.transcript.pendingPlan {
@@ -27,7 +27,7 @@ struct ChatView: View {
                 }
                 Composer(project: project, run: run)
             }
-            .frame(minWidth: 400, idealWidth: 520)
+            .frame(minWidth: Layout.chatMinimumWidth, idealWidth: Layout.chatIdealWidth)
 
             if showInspector {
                 Divider()
@@ -35,7 +35,7 @@ struct ChatView: View {
                 // ~360pt card instead of stretching to consume half the
                 // window the way the old always-open HSplitView pane did.
                 InspectorPane(activity: selected)
-                    .frame(width: 380)
+                    .frame(width: Layout.inspectorWidth)
             }
         }
         .toolbar {
@@ -76,7 +76,7 @@ struct TranscriptView: View {
                     }
                     Color.clear.frame(height: 1).id(bottomAnchor)
                 }
-                .padding(16)
+                .padding(Spacing.large)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
             .onChange(of: items.last?.id) { _, _ in scrollIfPinned(proxy) }
@@ -133,7 +133,7 @@ struct CompactionRow: View {
     var body: some View {
         DisclosureGroup(isExpanded: $expanded) {
             Text(summary)
-                .font(.callout).textSelection(.enabled)
+                .font(Typography.body).textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.top, 5)
         } label: {
@@ -143,10 +143,10 @@ struct CompactionRow: View {
                     : "History compacted",
                 systemImage: "arrow.down.right.and.arrow.up.left")
         }
-        .font(.caption)
+        .font(Typography.caption)
         .foregroundStyle(Theme.foregroundTertiary)
-        .padding(10)
-        .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+        .padding(Spacing.comfortable)
+        .compactElevatedSurface()
     }
 }
 
@@ -168,7 +168,7 @@ struct CopyMessageButton: View {
             }
         } label: {
             Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                .font(.caption)
+                .font(Typography.caption)
                 .foregroundStyle(
                     copied ? AnyShapeStyle(.tint) : AnyShapeStyle(Theme.foregroundQuaternary)
                 )
@@ -188,8 +188,10 @@ struct UserBubble: View {
                 Spacer(minLength: 48)
                 Text(text)
                     .textSelection(.enabled)
-                    .padding(.horizontal, 12).padding(.vertical, 8)
-                    .background(Theme.accent.opacity(0.15), in: .rect(cornerRadius: 10))
+                    .padding(.horizontal, Spacing.inset).padding(.vertical, Spacing.standard)
+                    .background(
+                        Theme.accent.opacity(StateOpacity.userBubble),
+                        in: .rect(cornerRadius: CornerRadius.card))
             }
             CopyMessageButton(text: text)
         }
@@ -200,10 +202,10 @@ struct UserBubble: View {
 struct AssistantBubble: View {
     let message: AssistantMessage
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: Spacing.standard) {
             Image(systemName: "sparkle")
-                .foregroundStyle(.tint).font(.caption).padding(.top, 3)
-            VStack(alignment: .leading, spacing: 8) {
+                .foregroundStyle(.tint).font(Typography.caption).padding(.top, 3)
+            VStack(alignment: .leading, spacing: Spacing.standard) {
                 ForEach(Array(MarkdownBlock.parse(message.text).enumerated()), id: \.offset) {
                     _, block in
                     switch block {
@@ -388,7 +390,7 @@ struct MarkdownListRow: View {
     let marker: String
     let text: String
     var body: some View {
-        HStack(alignment: .top, spacing: 6) {
+        HStack(alignment: .top, spacing: Spacing.small) {
             Text(marker).foregroundStyle(Theme.foregroundTertiary).frame(
                 minWidth: 18, alignment: .trailing)
             Text(.init(text)).textSelection(.enabled)
@@ -400,8 +402,8 @@ struct MarkdownListRow: View {
 struct MarkdownQuoteRow: View {
     let text: String
     var body: some View {
-        HStack(spacing: 8) {
-            Rectangle().fill(Theme.foregroundQuaternary).frame(width: 3)
+        HStack(spacing: Spacing.standard) {
+            Rectangle().fill(Theme.foregroundQuaternary).frame(width: IconSize.rule)
             Text(.init(text)).foregroundStyle(Theme.foregroundTertiary).textSelection(.enabled)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -414,27 +416,29 @@ struct CodeBlock: View {
     @State private var copied = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: Spacing.none) {
             HStack {
-                Text(language ?? "code").font(.caption2).foregroundStyle(Theme.foregroundTertiary)
+                Text(language ?? "code").font(Typography.detail).foregroundStyle(
+                    Theme.foregroundTertiary)
                 Spacer()
                 Button(copied ? "Copied" : "Copy") {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(code, forType: .string)
                     copied = true
                 }
-                .buttonStyle(.plain).font(.caption2).foregroundStyle(Theme.foregroundTertiary)
+                .buttonStyle(.plain).font(Typography.detail).foregroundStyle(
+                    Theme.foregroundTertiary)
             }
-            .padding(.horizontal, 10).padding(.vertical, 5)
+            .padding(.horizontal, Spacing.comfortable).padding(.vertical, 5)
 
             ScrollView(.horizontal) {
                 Text(code)
-                    .font(.callout.monospaced()).textSelection(.enabled)
-                    .padding(.horizontal, 10).padding(.bottom, 9)
+                    .font(Typography.code).textSelection(.enabled)
+                    .padding(.horizontal, Spacing.comfortable).padding(.bottom, 9)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+        .compactElevatedSurface()
     }
 }
 
@@ -444,11 +448,11 @@ struct ThinkingRow: View {
     var body: some View {
         DisclosureGroup("Thinking", isExpanded: $expanded) {
             Text(text)
-                .font(.callout.monospaced()).foregroundStyle(Theme.foregroundTertiary)
+                .font(Typography.code).foregroundStyle(Theme.foregroundTertiary)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+        .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
     }
 }
 
@@ -459,21 +463,22 @@ struct ToolRow: View {
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(spacing: 8) {
-                statusIcon.frame(width: 15)
-                Text(activity.tool).font(.callout.weight(.medium))
+            HStack(spacing: Spacing.standard) {
+                statusIcon.frame(width: IconSize.standard)
+                Text(activity.tool).font(Typography.body.weight(.medium))
                 Text(ToolSummary.describe(activity))
-                    .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                    .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
                     .lineLimit(1).truncationMode(.middle)
                 Spacer()
                 if let ms = activity.durationMS, ms > 0 {
-                    Text("\(ms)ms").font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+                    Text("\(ms)ms").font(Typography.caption).foregroundStyle(
+                        Theme.foregroundQuaternary)
                 }
             }
-            .padding(.horizontal, 10).padding(.vertical, 7)
+            .padding(.horizontal, Spacing.comfortable).padding(.vertical, 7)
             .background(
-                isSelected ? Theme.accent.opacity(0.12) : Theme.surface,
-                in: .rect(cornerRadius: 8))
+                isSelected ? Theme.accent.opacity(StateOpacity.emphasis) : Theme.surface,
+                in: .rect(cornerRadius: CornerRadius.control))
         }
         .buttonStyle(.plain)
     }
@@ -508,9 +513,9 @@ enum ToolSummary {
 struct ErrorRow: View {
     let message: String
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: Spacing.standard) {
             Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.red)
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Spacing.compact) {
                 Text(message).textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 // An error is the message most likely to be pasted elsewhere.
@@ -518,8 +523,9 @@ struct ErrorRow: View {
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
-        .padding(10)
-        .background(Color.red.opacity(0.1), in: .rect(cornerRadius: 8))
+        .padding(Spacing.comfortable)
+        .background(
+            Color.red.opacity(StateOpacity.feedback), in: .rect(cornerRadius: CornerRadius.control))
     }
 }
 
@@ -529,13 +535,15 @@ struct ErrorRow: View {
 struct NoticeRow: View {
     let message: String
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .top, spacing: Spacing.standard) {
             Image(systemName: "info.circle.fill").foregroundStyle(.orange)
-            Text(message).font(.callout).textSelection(.enabled)
+            Text(message).font(Typography.body).textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(10)
-        .background(Color.orange.opacity(0.1), in: .rect(cornerRadius: 8))
+        .padding(Spacing.comfortable)
+        .background(
+            Color.orange.opacity(StateOpacity.feedback),
+            in: .rect(cornerRadius: CornerRadius.control))
     }
 }
 
@@ -546,12 +554,14 @@ struct StatusBar: View {
     @Bindable var run: RunSession
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Spacing.comfortable) {
             if run.isBusy { ProgressView().controlSize(.small).scaleEffect(0.7) }
-            Text(label).font(.callout).foregroundStyle(Theme.foregroundSecondary)
+            Text(label).font(Typography.body).foregroundStyle(Theme.foregroundSecondary)
             if let message = project.statusMessage {
-                Text("· \(message)").font(.caption).foregroundStyle(Theme.foregroundQuaternary)
-                    .lineLimit(1)
+                Text("· \(message)").font(Typography.caption).foregroundStyle(
+                    Theme.foregroundQuaternary
+                )
+                .lineLimit(1)
             }
             Spacer()
             UsageLabel(usage: run.transcript.usage)
@@ -566,7 +576,7 @@ struct StatusBar: View {
         // 16pt matches the transcript column's own inset (runner-up gap: the
         // status/approval/plan strips and the transcript disagreed on their
         // left edge — 14 vs 16 — for no reason).
-        .padding(.horizontal, 16).padding(.vertical, 7)
+        .padding(.horizontal, Spacing.large).padding(.vertical, 7)
         .background(Theme.surface)
     }
 
@@ -617,7 +627,7 @@ struct UsageLabel: View {
                     ? "\(usage.totalTokens) tok · $\(String(format: "%.4f", usage.costUSD))"
                     : "\(usage.totalTokens) tok · cost n/a"
             )
-            .font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+            .font(Typography.caption).foregroundStyle(Theme.foregroundQuaternary)
         }
     }
 }
@@ -630,30 +640,31 @@ struct ApprovalBar: View {
     @State private var showArguments = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            HStack(spacing: Spacing.standard) {
                 Image(systemName: "hand.raised.fill").foregroundStyle(.orange)
                 Text("Allow **\(approval.tool)** to run?")
                 Spacer()
                 Button(showArguments ? "Hide" : "Details") { showArguments.toggle() }
-                    .buttonStyle(.plain).font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                    .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
+                        Theme.foregroundTertiary)
                 Button("Deny") { run.deny() }
                 Button("Allow") { run.approve() }.buttonStyle(.borderedProminent)
             }
             if showArguments {
                 ScrollView {
                     Text(approval.arguments)
-                        .font(.caption.monospaced()).textSelection(.enabled)
+                        .font(Typography.codeCaption).textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxHeight: 120)
-                .padding(8)
-                .background(Theme.surfaceElevated, in: .rect(cornerRadius: 6))
+                .padding(Spacing.standard)
+                .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.code))
             }
         }
         // Same 16pt left inset as the transcript column and the status bar.
-        .padding(.horizontal, 16).padding(.vertical, 9)
-        .background(Color.orange.opacity(0.12))
+        .padding(.horizontal, Spacing.large).padding(.vertical, 9)
+        .background(Color.orange.opacity(StateOpacity.emphasis))
     }
 }
 
@@ -663,13 +674,13 @@ struct AskUserView: View {
     @State private var answers: [String: String] = [:]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: Spacing.inset) {
             Label("The agent needs your input", systemImage: "questionmark.bubble")
-                .font(.callout.weight(.medium))
+                .font(Typography.body.weight(.medium))
 
             ForEach(prompt.questions) { question in
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(question.question).font(.callout)
+                VStack(alignment: .leading, spacing: Spacing.small) {
+                    Text(question.question).font(Typography.body)
                     if question.isFreeform {
                         TextField(
                             "Your answer",
@@ -688,7 +699,7 @@ struct AskUserView: View {
                                     VStack(alignment: .leading) {
                                         Text(option.label)
                                         if let detail = option.description, !detail.isEmpty {
-                                            Text(detail).font(.caption)
+                                            Text(detail).font(Typography.caption)
                                                 .foregroundStyle(Theme.foregroundTertiary)
                                         }
                                     }
@@ -704,7 +715,7 @@ struct AskUserView: View {
             HStack {
                 if let deadline = prompt.deadlineAt {
                     Text("Answer by \(deadline.formatted(date: .omitted, time: .shortened))")
-                        .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
                 }
                 Spacer()
                 Button("Send") { onAnswer(answers) }
@@ -713,8 +724,8 @@ struct AskUserView: View {
             }
         }
         // Same 16pt left inset as the transcript column and the status bar.
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .background(Theme.accent.opacity(0.08))
+        .padding(.horizontal, Spacing.large).padding(.vertical, 14)
+        .background(Theme.accent.opacity(StateOpacity.subtle))
     }
 }
 
@@ -728,7 +739,7 @@ struct Composer: View {
     @State private var mentionTask: Task<Void, Never>?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.standard) {
             if !mentions.isEmpty {
                 MentionPopup(matches: mentions) { match in
                     run.draft = MentionQuery.replacing(run.draft, with: match.relativePath)
@@ -740,7 +751,7 @@ struct Composer: View {
             // #2): the field, send button, model picker and plan toggle used
             // to read as three unrelated regions — the field, a right-hand
             // gutter for send, and a separate borderless strip below.
-            VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: Spacing.comfortable) {
                 TextField(placeholder, text: $run.draft, axis: .vertical)
                     .textFieldStyle(.plain)
                     .lineLimit(1...10)
@@ -748,14 +759,14 @@ struct Composer: View {
                     .onSubmit(send)
                     .onChange(of: run.draft) { _, text in updateMentions(for: text) }
 
-                HStack(spacing: 10) {
+                HStack(spacing: Spacing.comfortable) {
                     ModelChip(project: project)
                     Toggle("Plan mode", isOn: $project.planMode)
-                        .toggleStyle(.checkbox).font(.caption)
+                        .toggleStyle(.checkbox).font(Typography.caption)
                         .help("Restrict the agent to writing a plan file until you approve it")
                     Spacer()
                     Button("New") { project.newConversation() }
-                        .buttonStyle(.plain).font(.caption).foregroundStyle(
+                        .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
                             Theme.foregroundTertiary)
 
                     Button(action: send) {
@@ -763,7 +774,7 @@ struct Composer: View {
                             systemName: run.canSteer
                                 ? "arrow.turn.up.right" : "arrow.up.circle.fill"
                         )
-                        .font(.title2)
+                        .font(Typography.display)
                     }
                     .buttonStyle(.plain)
                     .disabled(run.draft.trimmed.isEmpty)
@@ -771,14 +782,14 @@ struct Composer: View {
                     .accessibilityLabel(run.canSteer ? "Steer the running task" : "Send message")
                 }
             }
-            .padding(.horizontal, 16).padding(.vertical, 12)
-            .background(Theme.surfaceElevated, in: .rect(cornerRadius: 14))
+            .padding(.horizontal, Spacing.large).padding(.vertical, Spacing.inset)
+            .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.composer))
         }
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
+        .padding(.horizontal, Spacing.large)
+        .padding(.top, Spacing.standard)
         // A real bottom inset (was 0 — the old control strip ran flush to the
         // window edge) so the card reads as inset chrome, not a footer.
-        .padding(.bottom, 18)
+        .padding(.bottom, Spacing.section)
         .onAppear { focused = true }
     }
 
@@ -838,11 +849,11 @@ struct ModelChip: View {
             // One disabled line names the count and the reason.
             if !hiddenSummary.isEmpty {
                 Divider()
-                Text(hiddenSummary).font(.caption)
+                Text(hiddenSummary).font(Typography.caption)
             }
         } label: {
             Label(project.selectedModel ?? "Server default", systemImage: "cpu")
-                .font(.caption)
+                .font(Typography.caption)
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
@@ -898,12 +909,12 @@ struct InspectorPane: View {
         Group {
             if let activity {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: Spacing.inset) {
                         HStack {
-                            Text(activity.tool).font(.headline)
+                            Text(activity.tool).font(Typography.heading)
                             Spacer()
                             Text(String(describing: activity.status))
-                                .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                                .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
                         }
                         // An edit carries its before/after text, so it can be
                         // shown as a diff instead of raw JSON arguments.
@@ -916,15 +927,16 @@ struct InspectorPane: View {
                             LabelledCode(title: "Output", body: activity.output)
                         }
                     }
-                    .padding(16)
+                    .padding(Spacing.large)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             } else {
-                VStack(spacing: 8) {
+                VStack(spacing: Spacing.standard) {
                     Image(systemName: "sidebar.right")
-                        .font(.system(size: 30)).foregroundStyle(Theme.foregroundQuaternary)
+                        .font(.system(size: IconSize.emptyState)).foregroundStyle(
+                            Theme.foregroundQuaternary)
                     Text("Select a tool call to inspect it")
-                        .font(.callout).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
@@ -944,14 +956,15 @@ struct LabelledCode: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text(title).font(.caption.weight(.semibold)).foregroundStyle(Theme.foregroundQuaternary)
+            Text(title).font(Typography.caption.weight(.semibold)).foregroundStyle(
+                Theme.foregroundQuaternary)
             ScrollView(.horizontal) {
                 Text(content)
-                    .font(.callout.monospaced()).textSelection(.enabled)
+                    .font(Typography.code).textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .padding(10)
-            .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+            .padding(Spacing.comfortable)
+            .compactElevatedSurface()
         }
     }
 }
@@ -962,26 +975,26 @@ struct MentionPopup: View {
     let onPick: (FileCompletion.Match) -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: Spacing.none) {
             ForEach(matches) { match in
                 Button {
                     onPick(match)
                 } label: {
-                    HStack(spacing: 6) {
-                        Image(systemName: "doc").font(.caption2).foregroundStyle(
+                    HStack(spacing: Spacing.small) {
+                        Image(systemName: "doc").font(Typography.detail).foregroundStyle(
                             Theme.foregroundTertiary)
                         Text(match.relativePath)
-                            .font(.caption.monospaced())
+                            .font(Typography.codeCaption)
                             .lineLimit(1).truncationMode(.head)
                         Spacer()
                     }
-                    .padding(.horizontal, 10).padding(.vertical, 5)
+                    .padding(.horizontal, Spacing.comfortable).padding(.vertical, 5)
                     .contentShape(.rect)
                 }
                 .buttonStyle(.plain)
             }
         }
-        .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+        .compactElevatedSurface()
     }
 }
 
@@ -992,9 +1005,9 @@ struct PlanApprovalView: View {
     @State private var selected: String?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: Spacing.comfortable) {
             Label("Ready to leave plan mode", systemImage: "list.bullet.clipboard")
-                .font(.callout.weight(.medium))
+                .font(Typography.body.weight(.medium))
 
             ScrollView {
                 Text(.init(plan.plan))
@@ -1002,11 +1015,12 @@ struct PlanApprovalView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .frame(maxHeight: 220)
-            .padding(10)
-            .background(Theme.surfaceElevated, in: .rect(cornerRadius: 8))
+            .padding(Spacing.comfortable)
+            .compactElevatedSurface()
 
             if !plan.options.isEmpty {
-                Text("Approach").font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+                Text("Approach").font(Typography.caption).foregroundStyle(
+                    Theme.foregroundQuaternary)
                 ForEach(plan.options) { option in
                     Button {
                         selected = option.id
@@ -1015,10 +1029,10 @@ struct PlanApprovalView: View {
                             Image(
                                 systemName: selected == option.id
                                     ? "largecircle.fill.circle" : "circle")
-                            VStack(alignment: .leading, spacing: 1) {
+                            VStack(alignment: .leading, spacing: Spacing.hairline) {
                                 Text(option.label)
                                 if let detail = option.description, !detail.isEmpty {
-                                    Text(detail).font(.caption).foregroundStyle(
+                                    Text(detail).font(Typography.caption).foregroundStyle(
                                         Theme.foregroundTertiary)
                                 }
                             }
@@ -1039,7 +1053,7 @@ struct PlanApprovalView: View {
             }
         }
         // Same 16pt left inset as the transcript column and the status bar.
-        .padding(.horizontal, 16).padding(.vertical, 14)
-        .background(Theme.accent.opacity(0.08))
+        .padding(.horizontal, Spacing.large).padding(.vertical, 14)
+        .background(Theme.accent.opacity(StateOpacity.subtle))
     }
 }

--- a/macapp/Sources/GoCodeUI/DesignSystem/IconSize.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/IconSize.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Icon measurements are roles because a status dot, row glyph, and empty
+/// state communicate at different distances. They retain existing metrics.
+enum IconSize {
+    static let rule: CGFloat = 3
+    static let status: CGFloat = 7
+    static let detail: CGFloat = 14
+    static let standard: CGFloat = 15
+    static let row: CGFloat = 18
+    static let emptyState: CGFloat = 30
+    static let launch: CGFloat = 44
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Fixed dimensions describe product constraints, not spacing. Naming them
+/// prevents unrelated panes and fields from becoming accidental substitutes.
+enum Layout {
+    static let appMinimumWidth: CGFloat = 1_040
+    static let appMinimumHeight: CGFloat = 600
+    static let railWidth: CGFloat = 220
+    static let inspectorWidth: CGFloat = 380
+    static let chatMinimumWidth: CGFloat = 400
+    static let chatIdealWidth: CGFloat = 520
+    static let providerMinimumWidth: CGFloat = 240
+    static let providerIdealWidth: CGFloat = 280
+    static let modelMinimumWidth: CGFloat = 380
+    static let costFieldWidth: CGFloat = 54
+    static let diffGutterWidth: CGFloat = 38
+    static let emptyStateTextWidth: CGFloat = 320
+    static let providerSheetWidth: CGFloat = 460
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/Shape.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Shape.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// Corner roles describe the container's job, rather than making callers
+/// decide a radius independently. Values intentionally match the current UI.
+enum CornerRadius {
+    static let tag: CGFloat = 4
+    static let code: CGFloat = 6
+    static let control: CGFloat = 8
+    static let card: CGFloat = 10
+    static let composer: CGFloat = 14
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Shared layout rhythm. These are the distances that recur between controls,
+/// rows, and containers; keeping them here lets a later visual pass tune the
+/// rhythm without having to rediscover every use.
+enum Spacing {
+    static let none: CGFloat = 0
+    static let hairline: CGFloat = 1
+    static let tight: CGFloat = 2
+    static let compact: CGFloat = 4
+    static let small: CGFloat = 6
+    static let standard: CGFloat = 8
+    static let comfortable: CGFloat = 10
+    static let inset: CGFloat = 12
+    static let large: CGFloat = 16
+    static let section: CGFloat = 18
+    static let page: CGFloat = 28
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/StateOpacity.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/StateOpacity.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+/// State fills share a restrained transparency ramp. Names retain each current
+/// visual level while keeping state strength from becoming a scattered number.
+enum StateOpacity {
+    static let subtle: Double = 0.08
+    static let feedback: Double = 0.10
+    static let emphasis: Double = 0.12
+    static let userBubble: Double = 0.15
+    static let selected: Double = 0.16
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Semantic type roles preserve today's Dynamic Type-aware metrics while
+/// separating content purpose from the system style that happens to implement
+/// it. The roles leave room for the later 16pt primary-text / deeper Codex-like
+/// hierarchy pass without silently changing this pass's appearance.
+enum Typography {
+    static let display = Font.title2
+    static let title = Font.title2
+    static let heading = Font.headline
+    static let body = Font.callout
+    static let caption = Font.caption
+    static let detail = Font.caption2
+    static let code = Font.callout.monospaced()
+    static let codeCaption = Font.caption.monospaced()
+    static let codeDetail = Font.caption2.monospaced()
+    static let numericCaption = Font.caption.monospacedDigit()
+}

--- a/macapp/Sources/GoCodeUI/DiffView.swift
+++ b/macapp/Sources/GoCodeUI/DiffView.swift
@@ -33,30 +33,30 @@ struct DiffView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            HStack(spacing: Spacing.standard) {
                 Image(systemName: "doc.text").foregroundStyle(Theme.foregroundTertiary)
-                Text(edit.path).font(.callout.monospaced())
+                Text(edit.path).font(Typography.code)
                     .lineLimit(1).truncationMode(.head)
                 Spacer()
                 Text("+\(diff.additions)").foregroundStyle(.green)
                 Text("−\(diff.deletions)").foregroundStyle(.red)
             }
-            .font(.caption)
+            .font(Typography.caption)
 
             if diff.hasChanges {
                 Toggle("Show unchanged lines", isOn: $showsContext)
-                    .toggleStyle(.checkbox).font(.caption)
+                    .toggleStyle(.checkbox).font(Typography.caption)
             }
 
             ScrollView([.horizontal, .vertical]) {
-                LazyVStack(alignment: .leading, spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: Spacing.none) {
                     ForEach(visibleLines) { line in
                         DiffRow(line: line)
                     }
                 }
             }
-            .cardStyle(cornerRadius: 8)
+            .cardStyle(cornerRadius: CornerRadius.control)
         }
     }
 
@@ -69,27 +69,27 @@ private struct DiffRow: View {
     let line: Diff.Line
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: Spacing.none) {
             gutter(line.oldNumber)
             gutter(line.newNumber)
             Text(marker)
-                .font(.caption.monospaced())
+                .font(Typography.codeCaption)
                 .foregroundStyle(markerColor)
-                .frame(width: 14)
+                .frame(width: IconSize.detail)
             Text(line.text.isEmpty ? " " : line.text)
-                .font(.caption.monospaced())
+                .font(Typography.codeCaption)
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(.vertical, 1)
+        .padding(.vertical, Spacing.hairline)
         .background(background)
     }
 
     private func gutter(_ number: Int?) -> some View {
         Text(number.map(String.init) ?? "")
-            .font(.caption2.monospaced())
+            .font(Typography.codeDetail)
             .foregroundStyle(Theme.foregroundQuaternary)
-            .frame(width: 38, alignment: .trailing)
+            .frame(width: Layout.diffGutterWidth, alignment: .trailing)
             .padding(.trailing, 5)
     }
 
@@ -111,8 +111,8 @@ private struct DiffRow: View {
 
     private var background: Color {
         switch line.kind {
-        case .added: return .green.opacity(0.12)
-        case .removed: return .red.opacity(0.12)
+        case .added: return .green.opacity(StateOpacity.emphasis)
+        case .removed: return .red.opacity(StateOpacity.emphasis)
         case .context: return .clear
         }
     }

--- a/macapp/Sources/GoCodeUI/ModelSettingsView.swift
+++ b/macapp/Sources/GoCodeUI/ModelSettingsView.swift
@@ -133,8 +133,9 @@ struct ModelSettingsView: View {
 
     var body: some View {
         HSplitView {
-            providerList.frame(minWidth: 240, idealWidth: 280)
-            modelList.frame(minWidth: 380)
+            providerList.frame(
+                minWidth: Layout.providerMinimumWidth, idealWidth: Layout.providerIdealWidth)
+            modelList.frame(minWidth: Layout.modelMinimumWidth)
         }
         .task { await model.load() }
         .sheet(isPresented: $addingProvider) {
@@ -142,23 +143,23 @@ struct ModelSettingsView: View {
         }
         .safeAreaInset(edge: .bottom) {
             if let status = model.status {
-                HStack(spacing: 8) {
-                    Text(status).font(.caption).textSelection(.enabled)
+                HStack(spacing: Spacing.standard) {
+                    Text(status).font(Typography.caption).textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Button("Dismiss") { model.status = nil }
-                        .buttonStyle(.plain).font(.caption).foregroundStyle(
+                        .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
                             Theme.foregroundTertiary)
                 }
-                .padding(.horizontal, 14).padding(.vertical, 8)
+                .padding(.horizontal, 14).padding(.vertical, Spacing.standard)
                 .background(Theme.surface)
             }
         }
     }
 
     private var providerList: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Spacing.none) {
             HStack {
-                Text("Providers").font(.callout.weight(.medium))
+                Text("Providers").font(Typography.body.weight(.medium))
                 Spacer()
                 Button {
                     addingProvider = true
@@ -169,27 +170,30 @@ struct ModelSettingsView: View {
                 .buttonStyle(.plain)
                 .help("Add any OpenAI-compatible endpoint")
             }
-            .padding(.horizontal, 12).padding(.vertical, 9)
+            .padding(.horizontal, Spacing.inset).padding(.vertical, 9)
             Divider()
 
             List(model.providers, selection: $model.selectedProvider) { provider in
                 VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text(provider.name).font(.callout.weight(.medium))
+                    HStack(spacing: Spacing.small) {
+                        Text(provider.name).font(Typography.body.weight(.medium))
                         if !provider.builtin {
-                            Text("custom").font(.caption2)
-                                .padding(.horizontal, 5).padding(.vertical, 1)
-                                .background(Theme.surfaceHighest, in: .rect(cornerRadius: 4))
+                            Text("custom").font(Typography.detail)
+                                .padding(.horizontal, 5).padding(
+                                    .vertical, Spacing.hairline
+                                )
+                                .background(
+                                    Theme.surfaceHighest, in: .rect(cornerRadius: CornerRadius.tag))
                         }
                         Spacer()
                         Text("\(provider.exposedCount)/\(provider.modelCount)")
-                            .font(.caption.monospacedDigit()).foregroundStyle(
+                            .font(Typography.numericCaption).foregroundStyle(
                                 Theme.foregroundTertiary
                             )
                             .help("models exposed of models fetched")
                     }
                     Text(provider.baseURL)
-                        .font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundQuaternary)
                         .lineLimit(1).truncationMode(.middle)
                     if let error = provider.fetchError, !error.isEmpty {
                         // Say when it happened. A stored error survives until
@@ -199,11 +203,11 @@ struct ModelSettingsView: View {
                             provider.fetchedAt.map { "\(error)  (last tried \($0))" } ?? error,
                             systemImage: "exclamationmark.triangle.fill"
                         )
-                        .font(.caption2).foregroundStyle(.orange)
+                        .font(Typography.detail).foregroundStyle(.orange)
                         .lineLimit(3)
                     }
                 }
-                .padding(.vertical, 2)
+                .padding(.vertical, Spacing.tight)
                 .tag(provider.name)
             }
         }
@@ -212,7 +216,7 @@ struct ModelSettingsView: View {
     @ViewBuilder
     private var modelList: some View {
         if let provider = model.current {
-            VStack(spacing: 0) {
+            VStack(spacing: Spacing.none) {
                 header(for: provider)
                 Divider()
                 if provider.modelCount == 0 {
@@ -240,8 +244,8 @@ struct ModelSettingsView: View {
 
     private func header(for provider: ModelSettingsProvider) -> some View {
         VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 8) {
-                Text(provider.name).font(.headline)
+            HStack(spacing: Spacing.standard) {
+                Text(provider.name).font(Typography.heading)
                 Spacer()
                 if model.busy { ProgressView().controlSize(.small) }
                 Button("Fetch Models") { Task { await model.fetch(provider.name) } }
@@ -252,11 +256,13 @@ struct ModelSettingsView: View {
                     }
                 }
             }
-            HStack(spacing: 10) {
+            HStack(spacing: Spacing.comfortable) {
                 if let at = provider.fetchedAt {
-                    Text("Fetched \(at)").font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                    Text("Fetched \(at)").font(Typography.caption).foregroundStyle(
+                        Theme.foregroundTertiary)
                 } else {
-                    Text("Never fetched").font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                    Text("Never fetched").font(Typography.caption).foregroundStyle(
+                        Theme.foregroundTertiary)
                 }
                 // Where the credential lives, never the credential.
                 //
@@ -266,20 +272,22 @@ struct ModelSettingsView: View {
                 // is unset, and showing the reference alone reported a working
                 // key for a provider the server had just refused to fetch for.
                 if provider.needsNoCredential {
-                    Text("no credential needed").font(.caption).foregroundStyle(
+                    Text("no credential needed").font(Typography.caption).foregroundStyle(
                         Theme.foregroundQuaternary)
                 } else if !provider.hasCredential {
                     Label("no working credential", systemImage: "exclamationmark.triangle")
-                        .font(.caption).foregroundStyle(.orange)
+                        .font(Typography.caption).foregroundStyle(.orange)
                         .help(
                             provider.usesSubscription
                                 ? "Sign in with this provider's CLI on the machine running the daemon, then Fetch Models"
                                 : "Add a key for this provider in Settings › Providers")
                 } else if let ref = provider.keyRef, !ref.isEmpty {
                     Label(ref, systemImage: ref.hasPrefix("keychain:") ? "key.fill" : "doc.text")
-                        .font(.caption).foregroundStyle(Theme.foregroundQuaternary).lineLimit(1)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundQuaternary)
+                        .lineLimit(1)
                 } else if provider.usesSubscription {
-                    Text("vendor login").font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+                    Text("vendor login").font(Typography.caption).foregroundStyle(
+                        Theme.foregroundQuaternary)
                 }
             }
 
@@ -289,7 +297,7 @@ struct ModelSettingsView: View {
             // the selected row, so a key typed for one provider could be saved
             // against another.
 
-            HStack(spacing: 8) {
+            HStack(spacing: Spacing.standard) {
                 TextField("Filter models", text: $model.search)
                     .textFieldStyle(.roundedBorder)
                 Button("Expose All") {
@@ -301,12 +309,12 @@ struct ModelSettingsView: View {
                 }
             }
         }
-        .padding(12)
+        .padding(Spacing.inset)
     }
 
     private func modelRows(for provider: ModelSettingsProvider) -> some View {
         List(model.visibleModels) { entry in
-            HStack(spacing: 10) {
+            HStack(spacing: Spacing.comfortable) {
                 Toggle(
                     "",
                     isOn: Binding(
@@ -318,23 +326,24 @@ struct ModelSettingsView: View {
                 .labelsHidden()
                 .help("Show this model in the picker")
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Spacing.tight) {
                     Text(entry.displayName ?? entry.modelID)
-                        .font(.callout).lineLimit(1)
-                    HStack(spacing: 8) {
+                        .font(Typography.body).lineLimit(1)
+                    HStack(spacing: Spacing.standard) {
                         if entry.displayName != nil {
-                            Text(entry.modelID).font(.caption.monospaced())
+                            Text(entry.modelID).font(Typography.codeCaption)
                                 .foregroundStyle(Theme.foregroundQuaternary).lineLimit(1)
                         }
                         if let ctx = entry.contextSummary {
-                            Text(ctx).font(.caption).foregroundStyle(Theme.foregroundQuaternary)
+                            Text(ctx).font(Typography.caption).foregroundStyle(
+                                Theme.foregroundQuaternary)
                         }
                     }
                 }
                 Spacer()
                 CostCell(provider: provider.name, entry: entry, model: model)
             }
-            .padding(.vertical, 2)
+            .padding(.vertical, Spacing.tight)
         }
     }
 }
@@ -356,29 +365,29 @@ private struct CostCell: View {
     var body: some View {
         Group {
             if editing {
-                HStack(spacing: 4) {
-                    TextField("in", text: $inputDraft).frame(width: 54)
-                    TextField("out", text: $outputDraft).frame(width: 54)
+                HStack(spacing: Spacing.compact) {
+                    TextField("in", text: $inputDraft).frame(width: Layout.costFieldWidth)
+                    TextField("out", text: $outputDraft).frame(width: Layout.costFieldWidth)
                     Button("Save") { save() }.controlSize(.small)
                     Button("Cancel") { editing = false }
-                        .buttonStyle(.plain).font(.caption).foregroundStyle(
+                        .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
                             Theme.foregroundTertiary)
                 }
                 .textFieldStyle(.roundedBorder)
-                .font(.caption)
+                .font(Typography.caption)
             } else {
                 Button {
                     inputDraft = entry.inputCost.map { String($0) } ?? ""
                     outputDraft = entry.outputCost.map { String($0) } ?? ""
                     editing = true
                 } label: {
-                    HStack(spacing: 4) {
+                    HStack(spacing: Spacing.compact) {
                         Text(entry.priceSummary)
-                            .font(.caption)
+                            .font(Typography.caption)
                             .foregroundStyle(
                                 entry.inputCost == nil ? .orange : Theme.foregroundTertiary)
                         if entry.costSource == "user" {
-                            Image(systemName: "pencil").font(.caption2).foregroundStyle(
+                            Image(systemName: "pencil").font(Typography.detail).foregroundStyle(
                                 Theme.foregroundQuaternary
                             )
                             .help("Price you entered")
@@ -414,8 +423,8 @@ private struct AddProviderSheet: View {
     @State private var saving = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Add Provider").font(.headline)
+        VStack(alignment: .leading, spacing: Spacing.inset) {
+            Text("Add Provider").font(Typography.heading)
 
             Form {
                 TextField("Name", text: $name)
@@ -436,7 +445,7 @@ private struct AddProviderSheet: View {
                 if authKind == "api_key" {
                     SecureField("API key", text: $apiKey)
                     Text("Stored in your macOS Keychain. It is never written to the settings file.")
-                        .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
                 }
             }
             .formStyle(.grouped)
@@ -449,8 +458,8 @@ private struct AddProviderSheet: View {
                     .disabled(name.trimmed.isEmpty || baseURL.trimmed.isEmpty || saving)
             }
         }
-        .padding(16)
-        .frame(width: 460)
+        .padding(Spacing.large)
+        .frame(width: Layout.providerSheetWidth)
     }
 
     private func add() {

--- a/macapp/Sources/GoCodeUI/SessionsView.swift
+++ b/macapp/Sources/GoCodeUI/SessionsView.swift
@@ -9,7 +9,7 @@ struct SessionsView: View {
     @State private var exportError: String?
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Spacing.none) {
             HStack {
                 Image(systemName: "magnifyingglass").foregroundStyle(Theme.foregroundTertiary)
                 TextField("Search conversations", text: $search).textFieldStyle(.plain)
@@ -18,7 +18,7 @@ struct SessionsView: View {
                     section = .chat
                 }
             }
-            .padding(12)
+            .padding(Spacing.inset)
             Divider()
 
             if project.conversations.isEmpty {
@@ -104,13 +104,13 @@ private struct ConversationRow: View {
     let conversation: ConversationInfo
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: Spacing.comfortable) {
             if conversation.pinned == true {
-                Image(systemName: "pin.fill").font(.caption).foregroundStyle(.orange)
+                Image(systemName: "pin.fill").font(Typography.caption).foregroundStyle(.orange)
             }
             VStack(alignment: .leading, spacing: 3) {
                 Text(conversation.displayTitle).lineLimit(1)
-                MetadataRow(spacing: 8) {
+                MetadataRow(spacing: Spacing.standard) {
                     if let date = conversation.updatedAt ?? conversation.createdAt {
                         Text(date.formatted(date: .abbreviated, time: .shortened))
                     }
@@ -124,7 +124,7 @@ private struct ConversationRow: View {
             }
             Spacer()
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Spacing.compact)
     }
 }
 
@@ -152,14 +152,14 @@ struct CheckpointsView: View {
                 )
             } else {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: Spacing.comfortable) {
                         ForEach(project.rewindPoints) { point in
                             CheckpointCard(point: point) {
                                 confirming = point
                             }
                         }
                     }
-                    .padding(16)
+                    .padding(Spacing.large)
                 }
             }
         }
@@ -189,12 +189,12 @@ private struct CheckpointCard: View {
     let onRestore: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Spacing.standard) {
             HStack {
                 Image(systemName: "clock.arrow.circlepath").foregroundStyle(.tint)
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Spacing.tight) {
                     Text(point.tool.map { "Before \($0)" } ?? "Checkpoint")
-                        .font(.callout.weight(.medium))
+                        .font(Typography.body.weight(.medium))
                     if let date = point.createdAt {
                         MetadataRow { Text(date.formatted(date: .abbreviated, time: .standard)) }
                     }
@@ -207,13 +207,13 @@ private struct CheckpointCard: View {
                 // Say exactly which files a restore would overwrite.
                 VStack(alignment: .leading, spacing: 3) {
                     ForEach(files, id: \.path) { file in
-                        HStack(spacing: 6) {
+                        HStack(spacing: Spacing.small) {
                             Image(systemName: file.skipped == true ? "minus.circle" : "doc")
-                                .font(.caption2).foregroundStyle(Theme.foregroundTertiary)
-                            Text(file.path).font(.caption.monospaced()).lineLimit(1)
+                                .font(Typography.detail).foregroundStyle(Theme.foregroundTertiary)
+                            Text(file.path).font(Typography.codeCaption).lineLimit(1)
                                 .truncationMode(.middle)
                             if let reason = file.skipReason, !reason.isEmpty {
-                                Text("· \(reason)").font(.caption2).foregroundStyle(
+                                Text("· \(reason)").font(Typography.detail).foregroundStyle(
                                     Theme.foregroundQuaternary)
                             }
                         }
@@ -221,7 +221,7 @@ private struct CheckpointCard: View {
                 }
             }
         }
-        .padding(12)
+        .padding(Spacing.inset)
         .cardStyle()
     }
 }
@@ -232,13 +232,13 @@ struct EmptyState: View {
     let detail: String
 
     var body: some View {
-        VStack(spacing: 8) {
-            Image(systemName: icon).font(.system(size: 30)).foregroundStyle(
+        VStack(spacing: Spacing.standard) {
+            Image(systemName: icon).font(.system(size: IconSize.emptyState)).foregroundStyle(
                 Theme.foregroundQuaternary)
-            Text(title).font(.callout.weight(.medium))
+            Text(title).font(Typography.body.weight(.medium))
             Text(detail)
-                .font(.caption).foregroundStyle(Theme.foregroundTertiary)
-                .multilineTextAlignment(.center).frame(maxWidth: 320)
+                .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
+                .multilineTextAlignment(.center).frame(maxWidth: Layout.emptyStateTextWidth)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/macapp/Sources/GoCodeUI/SettingsView.swift
+++ b/macapp/Sources/GoCodeUI/SettingsView.swift
@@ -19,13 +19,13 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Spacing.none) {
             Picker("", selection: $tab) {
                 ForEach(Tab.allCases) { Text($0.title).tag($0) }
             }
             .pickerStyle(.segmented)
             .labelsHidden()
-            .padding(12)
+            .padding(Spacing.inset)
             Divider()
 
             switch tab {
@@ -53,9 +53,9 @@ private struct ProvidersTab: View {
                             ? "checkmark.seal.fill" : "exclamationmark.circle"
                     )
                     .foregroundStyle(provider.configured ? .green : Theme.foregroundTertiary)
-                    Text(provider.name).font(.callout.weight(.medium))
+                    Text(provider.name).font(Typography.body.weight(.medium))
                     if let count = provider.modelCount {
-                        Text("\(count) models").font(.caption).foregroundStyle(
+                        Text("\(count) models").font(Typography.caption).foregroundStyle(
                             Theme.foregroundQuaternary)
                     }
                     Spacer()
@@ -76,7 +76,7 @@ private struct ProvidersTab: View {
 
                 if let env = provider.apiKeyEnv, !provider.configured {
                     Text("Reads \(env), or set a key here.")
-                        .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
                 }
 
                 if editing == provider.name {
@@ -93,7 +93,7 @@ private struct ProvidersTab: View {
                     }
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, Spacing.compact)
         }
         .listStyle(.inset)
         .overlay(alignment: .bottom) { StatusToast(message: project.statusMessage) }
@@ -105,19 +105,19 @@ private struct ModelsTab: View {
     @State private var search = ""
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(spacing: Spacing.none) {
             HStack {
                 Image(systemName: "magnifyingglass").foregroundStyle(Theme.foregroundTertiary)
                 TextField("Filter models", text: $search).textFieldStyle(.plain)
             }
-            .padding(10)
+            .padding(Spacing.comfortable)
             Divider()
 
             List(filtered) { model in
                 HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(model.id).font(.callout)
-                        HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: Spacing.tight) {
+                        Text(model.id).font(Typography.body)
+                        HStack(spacing: Spacing.standard) {
                             Text(model.provider)
                             // Price and image support are the two facts that
                             // actually drive model choice; the TUI shows neither.
@@ -126,7 +126,7 @@ private struct ModelsTab: View {
                                 Label("images", systemImage: "photo").labelStyle(.titleAndIcon)
                             }
                         }
-                        .font(.caption).foregroundStyle(Theme.foregroundTertiary)
+                        .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
                     }
                     Spacer()
                     if project.selectedModel == model.id {
@@ -156,7 +156,7 @@ private struct ProjectTab: View {
     var body: some View {
         Form {
             LabeledContent("Workspace") {
-                Text(project.workspace.path).textSelection(.enabled).font(.callout.monospaced())
+                Text(project.workspace.path).textSelection(.enabled).font(Typography.code)
             }
             LabeledContent("Model") { Text(project.selectedModel ?? "Server default") }
             Picker("Profile", selection: $project.selectedProfile) {
@@ -167,7 +167,7 @@ private struct ProjectTab: View {
             }
             LabeledContent("Plan mode") { Text(project.planMode ? "On" : "Off") }
             LabeledContent("Conversation") {
-                Text(project.run?.conversationID ?? "None yet").font(.callout.monospaced())
+                Text(project.run?.conversationID ?? "None yet").font(Typography.code)
             }
             LabeledContent("Conversation actions") {
                 HStack {
@@ -185,10 +185,10 @@ private struct StatusToast: View {
     var body: some View {
         if let message {
             Text(message)
-                .font(.caption)
-                .padding(.horizontal, 12).padding(.vertical, 7)
+                .font(Typography.caption)
+                .padding(.horizontal, Spacing.inset).padding(.vertical, 7)
                 .background(Theme.surfaceElevated, in: .capsule)
-                .padding(.bottom, 12)
+                .padding(.bottom, Spacing.inset)
         }
     }
 }
@@ -199,19 +199,19 @@ private struct AccessTab: View {
     @Bindable var project: ProjectSession
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: Spacing.none) {
             HStack {
-                Text("Extra directories").font(.callout.weight(.medium))
+                Text("Extra directories").font(Typography.body.weight(.medium))
                 Spacer()
                 Button("Add…", action: add)
             }
-            .padding(12)
+            .padding(Spacing.inset)
             Text(
                 "Runs can read and write inside the workspace. Add a directory to grant access beyond it for this session."
             )
-            .font(.caption).foregroundStyle(Theme.foregroundTertiary)
-            .padding(.horizontal, 12)
-            Divider().padding(.top, 10)
+            .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
+            .padding(.horizontal, Spacing.inset)
+            Divider().padding(.top, Spacing.comfortable)
 
             if project.extraDirs.isEmpty {
                 EmptyState(
@@ -222,11 +222,11 @@ private struct AccessTab: View {
                 List(project.extraDirs, id: \.self) { url in
                     HStack {
                         Image(systemName: "folder").foregroundStyle(Theme.foregroundTertiary)
-                        Text(url.path).font(.callout.monospaced()).lineLimit(1)
+                        Text(url.path).font(Typography.code).lineLimit(1)
                             .truncationMode(.head)
                         Spacer()
                         Button("Remove") { project.removeDirectory(url) }
-                            .buttonStyle(.plain).font(.caption).foregroundStyle(
+                            .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
                                 Theme.foregroundTertiary)
                     }
                 }

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import GoCodeUI
+
+@Suite("Non-colour design tokens")
+struct DesignTokenTests {
+
+    @Test("spacing keeps the established layout rhythm")
+    func spacingRhythm() {
+        #expect(Spacing.none == 0)
+        #expect(Spacing.tight == 2)
+        #expect(Spacing.compact == 4)
+        #expect(Spacing.small == 6)
+        #expect(Spacing.standard == 8)
+        #expect(Spacing.comfortable == 10)
+        #expect(Spacing.inset == 12)
+        #expect(Spacing.large == 16)
+        #expect(Spacing.section == 18)
+    }
+
+    @Test("shape and icon roles preserve their current measurements")
+    func shapeAndIconMeasurements() {
+        #expect(CornerRadius.tag == 4)
+        #expect(CornerRadius.code == 6)
+        #expect(CornerRadius.control == 8)
+        #expect(CornerRadius.card == 10)
+        #expect(CornerRadius.composer == 14)
+        #expect(IconSize.status == 7)
+        #expect(IconSize.detail == 14)
+        #expect(IconSize.standard == 15)
+        #expect(IconSize.row == 18)
+        #expect(IconSize.emptyState == 30)
+        #expect(IconSize.launch == 44)
+    }
+}


### PR DESCRIPTION
Groundwork for the Codex look-and-feel work, and a code-quality fix in its own right.

Thirteen distinct spacing literals, five paddings, three radii and twelve widths were spread across the views, with opacities from 0.08–0.16. That isn't thirty-three design decisions — it's copy-paste, and it means retuning the look later would mean finding and editing every one.

Adds focused scales under `DesignSystem/` (spacing, typography, radius, icon size, layout, state opacity) and migrates ~264 call sites. The typography scale defines semantic roles with room for real hierarchy: the app currently sits inside a 4pt range where Codex spans 16pt.

**Deliberately visually neutral.** Values are preserved, not retuned — a later round moves one number instead of thirty. A few local literals are kept where collapsing them would visibly change dense metadata, code chrome or row density; the reasons are in the code.

155 tests pass, `swift build` clean, `swift format lint --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9