### PR TITLE
Composer scale, chrome colour, content width, nav contrast

### DIFF
--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -128,6 +128,11 @@ private struct ProjectView: View {
             }
         }
         .toolbar { ToolbarItem(placement: .navigation) { header } }
+        // The native toolbar material is warmer and much lighter than the
+        // page. Painting it with the root token lets the page run cleanly to
+        // the window edge instead of leaving a separate chrome band.
+        .toolbarBackground(Theme.background, for: .windowToolbar)
+        .toolbarBackground(.visible, for: .windowToolbar)
     }
 
     private var header: some View {
@@ -206,7 +211,7 @@ private struct IconRail: View {
                 }
                 .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundStyle(Theme.foregroundTertiary)
+                .foregroundStyle(Theme.foregroundSecondary)
                 .contentShape(.rect)
             }
             .buttonStyle(.plain)
@@ -250,7 +255,7 @@ private struct RailRow: View {
                 section == item ? Theme.accent.opacity(StateOpacity.selected) : .clear,
                 in: .rect(cornerRadius: CornerRadius.control)
             )
-            .foregroundStyle(section == item ? Theme.accent : Theme.foregroundTertiary)
+            .foregroundStyle(section == item ? Theme.accent : Theme.foregroundSecondary)
             .contentShape(.rect)
         }
         .buttonStyle(.plain)

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -77,7 +77,8 @@ struct TranscriptView: View {
                     Color.clear.frame(height: 1).id(bottomAnchor)
                 }
                 .padding(Spacing.large)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: Layout.chatContentMaximumWidth, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .center)
             }
             .onChange(of: items.last?.id) { _, _ in scrollIfPinned(proxy) }
             .onChange(of: lastItemLength) { _, _ in scrollIfPinned(proxy) }
@@ -774,7 +775,10 @@ struct Composer: View {
                             systemName: run.canSteer
                                 ? "arrow.turn.up.right" : "arrow.up.circle.fill"
                         )
-                        .font(Typography.display)
+                        // A title-sized SF Symbol makes its filled disc half
+                        // the target control; this restores the send target's
+                        // intended visual weight without changing its glyph.
+                        .font(.system(size: 34))
                     }
                     .buttonStyle(.plain)
                     .disabled(run.draft.trimmed.isEmpty)
@@ -783,7 +787,12 @@ struct Composer: View {
                 }
             }
             .padding(.horizontal, Spacing.large).padding(.vertical, Spacing.inset)
+            // The minimum keeps the idle composer at the reference height
+            // while allowing a multi-line draft to grow instead of clipping.
+            .frame(minHeight: 117)
             .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.composer))
+            .frame(maxWidth: Layout.chatContentMaximumWidth)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
         .padding(.horizontal, Spacing.large)
         .padding(.top, Spacing.standard)

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -9,6 +9,9 @@ enum Layout {
     static let inspectorWidth: CGFloat = 380
     static let chatMinimumWidth: CGFloat = 400
     static let chatIdealWidth: CGFloat = 520
+    /// Keep the transcript and composer on the same readable column instead
+    /// of turning either into a near-edge-to-edge control on wide windows.
+    static let chatContentMaximumWidth: CGFloat = 883
     static let providerMinimumWidth: CGFloat = 240
     static let providerIdealWidth: CGFloat = 280
     static let modelMinimumWidth: CGFloat = 380

--- a/macapp/Tests/GoCodeUITests/ThemeTests.swift
+++ b/macapp/Tests/GoCodeUITests/ThemeTests.swift
@@ -22,6 +22,15 @@ private func contrastRatio(_ a: Int, _ b: Int) -> Double {
 @Suite("Theme tokens — dark ramp separation and neutrality")
 struct ThemeTests {
 
+    /// Codex keeps the transcript, composer, and body-text extents on one
+    /// 883pt column even when the window grows. Keeping that constraint in
+    /// the layout vocabulary prevents either chat surface from reclaiming
+    /// the full pane width later.
+    @Test("chat content width stays capped at the measured Codex column")
+    func chatContentWidthMatchesCodex() {
+        #expect(Layout.chatContentMaximumWidth == 883)
+    }
+
     /// Baseline gap #1: GoCode's six surfaces spanned only 13 grey levels
     /// (40→53). Codex's five span 27 (24→51). A palette that doesn't clear a
     /// wide span is the same bug restated with new names.


### PR DESCRIPTION
Round 2 of the Codex look-and-feel gauntlet. Four gaps a critic measured against both running apps today.

| Gap | Was | Now | Codex |
|---|---|---|---|
| Composer height | 68.5pt | 117pt | 117pt |
| Send disc | 16.5pt | 34pt | 33.5pt |
| Toolbar surface | `#2B2A28`, warm, ~19 levels above page | `Theme.background` | no chrome band at all |
| Content max width | unbounded — 1276.5pt at a 1530pt window | 883pt | 883pt, confirmed 3 ways |
| Nav label contrast | `#A3A3A3` 6.31:1 | `#DEDEDE` 11.83:1 | 11.83:1 |

The composer's container, fill, insets and glyph were already correct — only the two sizes were wrong. The toolbar was the last surface not reading from the token layer and the only warm one left. The max-width constant lives in `DesignSystem/Layout.swift`, not inline.

156 tests pass, `swift build` clean, `swift format lint --strict` clean — verified locally, since the Codex sandbox couldn't run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9