### PR TITLE
Environment cards: content-sized inspector instead of a full-height split

### DIFF
--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -1,7 +1,7 @@
 import HarnessKit
 import SwiftUI
 
-/// Two-pane conversation surface: transcript + composer left, inspector right.
+/// Conversation surface with an on-demand environment card over the transcript.
 struct ChatView: View {
     @Bindable var project: ProjectSession
     @Bindable var run: RunSession
@@ -12,7 +12,7 @@ struct ChatView: View {
     @State private var showInspector = false
 
     var body: some View {
-        HStack(spacing: Spacing.none) {
+        ZStack(alignment: .topTrailing) {
             VStack(spacing: Spacing.none) {
                 TranscriptView(items: run.transcript.items, selected: $selected)
                 Divider()
@@ -30,12 +30,10 @@ struct ChatView: View {
             .frame(minWidth: Layout.chatMinimumWidth, idealWidth: Layout.chatIdealWidth)
 
             if showInspector {
-                Divider()
-                // Fixed rather than a resizable split: sized toward Codex's
-                // ~360pt card instead of stretching to consume half the
-                // window the way the old always-open HSplitView pane did.
-                InspectorPane(activity: selected)
-                    .frame(width: Layout.inspectorWidth)
+                EnvironmentInspector(
+                    project: project, activities: toolActivities, selected: $selected
+                )
+                .padding(Spacing.large)
             }
         }
         .toolbar {
@@ -54,6 +52,13 @@ struct ChatView: View {
         // like it did nothing because the pane defaults to closed.
         .onChange(of: selected) { _, activity in
             if activity != nil { showInspector = true }
+        }
+    }
+
+    private var toolActivities: [ToolActivity] {
+        run.transcript.items.compactMap { item in
+            guard case .toolActivity(let activity) = item.kind else { return nil }
+            return activity
         }
     }
 }
@@ -900,48 +905,167 @@ struct ModelChip: View {
     }
 }
 
-// MARK: - Inspector
+// MARK: - Environment
 
-struct InspectorPane: View {
-    let activity: ToolActivity?
+/// Codex groups environment state by kind. This card deliberately has no
+/// height constraint: it occupies only the space its present cards require,
+/// instead of reserving a permanent full-height column for an optional detail.
+struct EnvironmentInspector: View {
+    @Bindable var project: ProjectSession
+    let activities: [ToolActivity]
+    @Binding var selected: ToolActivity?
+
+    private var subagents: [TaskInfo] { project.tasks.filter { $0.type == "subagent" } }
+    private var backgroundTasks: [TaskInfo] { project.tasks.filter { $0.type != "subagent" } }
 
     var body: some View {
-        Group {
-            if let activity {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: Spacing.inset) {
-                        HStack {
-                            Text(activity.tool).font(Typography.heading)
-                            Spacer()
-                            Text(String(describing: activity.status))
-                                .font(Typography.caption).foregroundStyle(Theme.foregroundTertiary)
-                        }
-                        // An edit carries its before/after text, so it can be
-                        // shown as a diff instead of raw JSON arguments.
-                        if let edit = ToolEdit(tool: activity.tool, arguments: activity.arguments) {
-                            DiffView(edit: edit)
-                        } else if !activity.arguments.isEmpty {
-                            LabelledCode(title: "Arguments", body: activity.arguments)
-                        }
-                        if !activity.output.isEmpty {
-                            LabelledCode(title: "Output", body: activity.output)
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            Text("Environment")
+                .font(Typography.heading)
+
+            if !project.rewindPoints.isEmpty {
+                EnvironmentCard(title: "Changes", icon: "arrow.uturn.backward.circle") {
+                    ForEach(project.rewindPoints) { point in
+                        CheckpointSummary(point: point)
+                    }
+                }
+            }
+
+            if !subagents.isEmpty {
+                EnvironmentCard(title: "Subagents", icon: "person.2") {
+                    ForEach(subagents) { task in TaskSummary(task: task) }
+                }
+            }
+
+            if !backgroundTasks.isEmpty || !activities.isEmpty {
+                EnvironmentCard(title: "Background processes", icon: "gearshape.2") {
+                    ForEach(backgroundTasks) { task in TaskSummary(task: task) }
+                    ForEach(activities) { activity in
+                        ToolActivitySummary(
+                            activity: activity, isSelected: selected?.id == activity.id
+                        ) {
+                            selected = activity
                         }
                     }
-                    .padding(Spacing.large)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    if let selected {
+                        Divider()
+                        ToolActivityDetail(activity: selected)
+                    }
                 }
-            } else {
-                VStack(spacing: Spacing.standard) {
-                    Image(systemName: "sidebar.right")
-                        .font(.system(size: IconSize.emptyState)).foregroundStyle(
-                            Theme.foregroundQuaternary)
-                    Text("Select a tool call to inspect it")
-                        .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
+            }
+
+            if project.rewindPoints.isEmpty && subagents.isEmpty && backgroundTasks.isEmpty
+                && activities.isEmpty
+            {
+                EnvironmentCard(title: "Environment", icon: "sidebar.right") {
+                    Text("No changes or background work yet.")
+                        .font(Typography.caption)
+                        .foregroundStyle(Theme.foregroundTertiary)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        .background(Theme.surface)
+        .padding(Spacing.inset)
+        .frame(width: Layout.inspectorCardWidth, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .cardStyle()
+        .task {
+            await project.refreshRewindPoints()
+            await project.refreshActivity()
+        }
+    }
+}
+
+/// Reused card chrome keeps each environment kind distinct without making the
+/// inspector a visually undifferentiated column again.
+private struct EnvironmentCard<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Label(title, systemImage: icon)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(Theme.foregroundSecondary)
+            VStack(alignment: .leading, spacing: Spacing.small) { content }
+        }
+        .padding(Spacing.standard)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .compactElevatedSurface()
+    }
+}
+
+private struct CheckpointSummary: View {
+    let point: RewindPoint
+
+    var body: some View {
+        HStack(spacing: Spacing.small) {
+            Text(point.tool.map { "Before \($0)" } ?? "Checkpoint")
+                .font(Typography.caption)
+                .lineLimit(1)
+            Spacer(minLength: Spacing.none)
+            if let date = point.createdAt {
+                Text(date.formatted(date: .omitted, time: .shortened))
+                    .font(Typography.detail)
+                    .foregroundStyle(Theme.foregroundTertiary)
+            }
+        }
+    }
+}
+
+private struct TaskSummary: View {
+    let task: TaskInfo
+
+    var body: some View {
+        HStack(spacing: Spacing.small) {
+            Text(task.label).font(Typography.caption).lineLimit(1)
+            Spacer(minLength: Spacing.none)
+            Text(task.status).font(Typography.detail).foregroundStyle(Theme.foregroundTertiary)
+        }
+    }
+}
+
+private struct ToolActivitySummary: View {
+    let activity: ToolActivity
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: Spacing.small) {
+                Text(activity.tool).font(Typography.caption).lineLimit(1)
+                Spacer(minLength: Spacing.none)
+                Text(String(describing: activity.status))
+                    .font(Typography.detail)
+                    .foregroundStyle(Theme.foregroundTertiary)
+            }
+            .padding(Spacing.compact)
+            .background(
+                isSelected ? Theme.surfaceHighest : .clear,
+                in: .rect(cornerRadius: CornerRadius.tag)
+            )
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// The selected activity stays in its kind's card so detail does not cause a
+/// second, permanent inspector region to reappear beside the conversation.
+private struct ToolActivityDetail: View {
+    let activity: ToolActivity
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            if let edit = ToolEdit(tool: activity.tool, arguments: activity.arguments) {
+                DiffView(edit: edit)
+            } else if !activity.arguments.isEmpty {
+                LabelledCode(title: "Arguments", body: activity.arguments)
+            }
+            if !activity.output.isEmpty {
+                LabelledCode(title: "Output", body: activity.output)
+            }
+        }
     }
 }
 

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -6,7 +6,8 @@ enum Layout {
     static let appMinimumWidth: CGFloat = 1_040
     static let appMinimumHeight: CGFloat = 600
     static let railWidth: CGFloat = 220
-    static let inspectorWidth: CGFloat = 380
+    /// Codex's environment surface is a compact overlay card, not a sidebar.
+    static let inspectorCardWidth: CGFloat = 361
     static let chatMinimumWidth: CGFloat = 400
     static let chatIdealWidth: CGFloat = 520
     static let providerMinimumWidth: CGFloat = 240

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -32,4 +32,12 @@ struct DesignTokenTests {
         #expect(IconSize.emptyState == 30)
         #expect(IconSize.launch == 44)
     }
+
+    /// The environment inspector is an overlay card, not a window-height
+    /// split. Keeping its measured footprint in the token layer prevents a
+    /// future layout pass from quietly turning it back into a sidebar.
+    @Test("environment inspector retains its compact card footprint")
+    func environmentInspectorFootprint() {
+        #expect(Layout.inspectorCardWidth == 361)
+    }
 }


### PR DESCRIPTION
Round 3 of the Codex gauntlet. The critic named this the single biggest remaining gap, unchanged since round 1.

| | GoCode was | Codex | Now |
|---|---|---|---|
| Inspector | 380 × 848pt fixed split, **33.6%** of window | content-sized card 361 × 241pt, **4.7%** | content-sized card at the 361pt token |

Seven times the footprint for the same job.

It is now a trailing overlay sized vertically to its content, grouped by kind the way Codex groups its Environment panel — **Changes** from existing rewind points, **Subagents** from subagent tasks, **Background processes** from remaining tasks plus transcript tool activity.

Deliberately **no branch or commit-or-push card**: the app has no data for them, and an empty card is worse than an absent one.

Shared `EnvironmentCard`, `CheckpointSummary`, `TaskSummary`, `ToolActivitySummary` and `ToolActivityDetail` components rather than the layout repeated per section. Every value from the token layer.

156 tests, `swift build` clean, `swift format lint --strict` clean — verified locally, since the Codex sandbox can't run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9