### PR TITLE
Neutral transcript: no blue bubble, no tool cards, one column

### DIFF
--- a/docs/logs/engineering-log.md
+++ b/docs/logs/engineering-log.md
@@ -1,5 +1,22 @@
 # Engineering Log
 
+## 2026-07-28 (macOS Codex Visual Gauntlet — Round 6)
+
+- The selected rail now uses semantic neutral selection tokens rather than the
+  system-blue accent: dark selection is `#333333` with white label/icon.
+  `Typography` now defines the shared 22/20/18/16.5/14/12pt hierarchy, and
+  the transcript explicitly inherits the primary `#FFFFFF` foreground rung.
+  The 16.5pt body role retains the pre-existing 21.5pt nominal line height so
+  `Layout.userMessageMinimumHeight` remains 45.5pt.
+- User prompts now use a dedicated content-hugging layout with the
+  design-system 374.5pt cap, instead of accepting the entire transcript
+  column. The rail background alone ignores the top safe area, preserving
+  control placement while eliminating the differently coloured toolbar band.
+- Regression coverage pins selected-row RGB neutrality, the body size and
+  derived prompt-row height, the width cap, and production use of the semantic
+  tokens. Swift formatting and strict lint completed; build/test could not
+  enter the sandbox-owned Xcode module cache.
+
 ## 2026-07-21 (Provider Image Encoding — Epic #818 Slice 4)
 
 - Both provider clients now translate `harness` image blocks into their

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -4,8 +4,15 @@
 
 - Command intent: Make GoCode's SwiftUI transcript stop reading as a blue chat/log viewer by matching the measured Codex transcript treatment; prioritize neutral user messages, compact tool activity, and one aligned content column.
 - User intent: GoCode should be indistinguishable from Codex at a glance during a real conversation, while retaining inspectable tool detail on demand.
-- Success definition: User prompts render on the neutral `#242424` `Theme.messageSurface` at a 45.5pt minimum height; tool activity is a one-line `Worked for Ns ›` disclosure with a hairline and no fill; transcript rows share the `Spacing.large` leading inset; run status is inline only while active; regression assertions pin the message token/height and duration label.
+- Success definition: User prompts render on the neutral `#242424` `Theme.messageSurface` at a minimum height derived from the body line-height and message-padding tokens; tool activity is a one-line `Worked for Ns ›` disclosure with a hairline and no fill; transcript rows share the `Spacing.large` leading inset; run status is inline only while active; the Environment inspector shows session usage and the transcript toolbar copies the entire conversation; regression assertions pin both production call sites and the message-height formula.
 - Guardrails/constraints: Source changes stay inside `macapp`; use semantic design tokens for all new measurements and colours; do not manufacture non-functional message actions; report Xcode cache sandbox failures plainly if Swift verification cannot start.
+
+## 2026-07-28 (macOS Codex Visual Gauntlet — Round 6)
+
+- Command intent: Eliminate the four remaining high-salience visual deltas: blue rail selection, undersized transcript scale, full-column user bubbles, and the toolbar-coloured strip over the sidebar.
+- User intent: The app should read as Codex at a glance, including the normally peripheral navigation and authored-prompt treatment.
+- Success definition: Selected rail rows use semantic neutral selected-row tokens (#333333 surface / #FFFFFF foreground in dark appearance); the shared body role is 16.5pt while its derived 45.5pt user-row rhythm survives; user prompts measure their intrinsic width up to a 374.5pt design-system cap; the rail surface extends through the toolbar safe area without moving controls into the traffic-light region.
+- Guardrails/constraints: Keep measurements and colours in `macapp/Sources/GoCodeUI/DesignSystem`; keep `ChatView.swift` focused by extracting any cohesive layout behavior; do not alter tool-row, metadata, or inspector treatments that already match the reference.
 
 ## 2026-07-19 (Theme System Slice 4 — Epic #810)
 

--- a/docs/logs/long-term-thinking-log.md
+++ b/docs/logs/long-term-thinking-log.md
@@ -1,5 +1,12 @@
 # Long-Term Thinking Log
 
+## 2026-07-28 (macOS Codex Transcript Visual Pass)
+
+- Command intent: Make GoCode's SwiftUI transcript stop reading as a blue chat/log viewer by matching the measured Codex transcript treatment; prioritize neutral user messages, compact tool activity, and one aligned content column.
+- User intent: GoCode should be indistinguishable from Codex at a glance during a real conversation, while retaining inspectable tool detail on demand.
+- Success definition: User prompts render on the neutral `#242424` `Theme.messageSurface` at a 45.5pt minimum height; tool activity is a one-line `Worked for Ns ›` disclosure with a hairline and no fill; transcript rows share the `Spacing.large` leading inset; run status is inline only while active; regression assertions pin the message token/height and duration label.
+- Guardrails/constraints: Source changes stay inside `macapp`; use semantic design tokens for all new measurements and colours; do not manufacture non-functional message actions; report Xcode cache sandbox failures plainly if Swift verification cannot start.
+
 ## 2026-07-19 (Theme System Slice 4 — Epic #810)
 
 - Command intent: Implement only slice 4 of epic #810 — persist the /theme selection to ~/.config/harnesscli/config.json and apply it at startup — on branch `epic/810-theme-system-s4`, strict TDD, push and open a PR without merging.

--- a/docs/plans/2026-07-28-macos-codex-visual-gauntlet-round-6.md
+++ b/docs/plans/2026-07-28-macos-codex-visual-gauntlet-round-6.md
@@ -1,0 +1,33 @@
+# Plan: macOS Codex visual gauntlet — round 6
+
+## Context
+
+- Problem: Four visual deltas remain after the transcript's earlier neutralisation pass.
+- User impact: A blue selected rail, compressed type, full-width authored prompts, and a separate toolbar band make the app recognisably unlike Codex.
+- Constraints: Put all visual values in the macOS design-system layer; do not grow `ChatView.swift` with reusable layout behavior; do not run Git commands.
+
+## Scope
+
+- In scope: Neutral selected-rail tokens, shared typography scale, content-hugging prompt width, and rail safe-area surface continuity.
+- Out of scope: Tool-row, metadata, environment inspector, and message-surface changes already accepted in earlier rounds.
+
+## Documentation Contract
+
+- Feature status: implemented
+- Public docs affected: None; this is an internal visual calibration.
+- Spec docs to update before code: This plan and the long-term thinking log.
+- Implementation notes to add after code: Token and regression-test coverage is recorded in the engineering changes.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: Pin selected-row semantics, body size, user-message cap, and the derived 45.5pt row height.
+- Existing tests to update: Extend design-token and production-call-site tests.
+- Regression tests required: The existing macapp Swift suite covers the token layer and production references.
+
+## Implementation Checklist
+
+- [x] Define acceptance criteria in tests.
+- [x] Document the visual contract before code.
+- [x] Implement semantic token and layout changes.
+- [ ] Run the full Swift build and test suite (blocked by sandbox-owned Xcode cache).
+- [x] Run Swift formatting and strict formatting lint.

--- a/docs/plans/2026-07-28-macos-transcript-feature-recovery.md
+++ b/docs/plans/2026-07-28-macos-transcript-feature-recovery.md
@@ -1,0 +1,38 @@
+# Plan: macOS transcript feature recovery
+
+## Context
+
+- Problem: Removing the persistent transcript status strip also orphaned the session usage label and whole-conversation clipboard formatter.
+- User impact: People cannot see session token/cost totals or copy the complete conversation.
+- Constraints: Keep the strip removed; re-use the Environment inspector's existing card primitives; keep measurements in the design-token layer; do not run git commands.
+
+## Scope
+
+- In scope: Re-home usage in the Environment inspector, add a transcript-level copy affordance, split the inspector from `ChatView.swift`, and derive the user-message minimum height from type and spacing tokens.
+- Out of scope: Restoring a persistent status strip or changing transcript behavior beyond these regressions.
+
+## Documentation Contract
+
+- Feature status: `in implementation`
+- Public docs affected: None.
+- Spec docs to update before code: This plan and the long-term-thinking success definition.
+- Implementation notes to add after code: Engineering log entry describing the regression guard.
+
+## Test Plan (TDD)
+
+- New failing tests to add first: Production-source reachability assertions for the `UsageLabel` and `TranscriptText.plain` call sites.
+- Existing tests to update: Token test must verify the user-message height formula instead of a literal.
+- Regression tests required: The reachability test fails if either feature has no production caller.
+
+## Implementation Checklist
+
+- [ ] Add failing reachability coverage.
+- [ ] Re-home the two user-facing features.
+- [ ] Extract Environment inspector types.
+- [ ] Derive the transcript row height from design tokens.
+- [ ] Format and run the requested build, tests, and lint.
+
+## Risks and Mitigations
+
+- Risk: A visual refactor silently leaves a useful helper unrendered.
+- Mitigation: Assert production-source call sites in the UI test target.

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,5 +1,7 @@
 # Plans Index
 
+- `2026-07-28-macos-codex-visual-gauntlet-round-6.md` — Neutral navigation, readable transcript scale, content-hugging prompts, and continuous rail chrome (implemented; Swift build/test sandbox-blocked).
+- `2026-07-28-macos-transcript-feature-recovery.md` — Re-home transcript usage and copy features after the status-strip removal (in implementation).
 - `2026-07-20-tui-subscription-login-854-plan.md` — Issue #854 in-TUI Codex/Kimi subscription credential import (implemented).
 - `2026-07-20-tui-subscription-login-854-impact-map.md` — Cross-surface impact map for Issue #854.
 - `2026-07-19-issue-818-clipboard-image-plan.md` — Epic #818 slice 1: read images from the system clipboard into a temp file (in implementation).

--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -220,10 +220,10 @@ private struct IconRail: View {
         }
         .padding(.vertical, Spacing.comfortable).padding(.horizontal, Spacing.standard)
         .frame(width: Layout.railWidth)
-        // The rail sits beside content, not on it — one step above the root
-        // background rather than the same translucent `.quaternary` fill
-        // every surface in the app used to share.
-        .background(Theme.surface)
+        // The rail is continuous window chrome rather than a translucent
+        // overlay: its surface reaches the toolbar-safe area while the
+        // navigation controls retain their traffic-light-safe placement.
+        .background(Theme.surface.ignoresSafeArea(.container, edges: .top))
     }
 }
 
@@ -252,10 +252,12 @@ private struct RailRow: View {
             .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
-                section == item ? Theme.accent.opacity(StateOpacity.selected) : .clear,
+                section == item ? Theme.selectedRowSurface : .clear,
                 in: .rect(cornerRadius: CornerRadius.control)
             )
-            .foregroundStyle(section == item ? Theme.accent : Theme.foregroundSecondary)
+            .foregroundStyle(
+                section == item ? Theme.selectedRowForeground : Theme.foregroundSecondary
+            )
             .contentShape(.rect)
         }
         .buttonStyle(.plain)

--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -114,7 +114,7 @@ private struct ProjectView: View {
 
     var body: some View {
         HStack(spacing: Spacing.none) {
-            IconRail(section: $section, project: project, onClose: onClose)
+            ConversationRail(section: $section, project: project, onClose: onClose)
             Divider()
             content
         }
@@ -127,31 +127,9 @@ private struct ProjectView: View {
                 project.submit()
             }
         }
-        .toolbar { ToolbarItem(placement: .navigation) { header } }
-        // The native toolbar material is warmer and much lighter than the
-        // page. Painting it with the root token lets the page run cleanly to
-        // the window edge instead of leaving a separate chrome band.
-        .toolbarBackground(Theme.background, for: .windowToolbar)
+        // The sidebar surface must also paint behind the traffic lights.
+        .toolbarBackground(Theme.surface, for: .windowToolbar)
         .toolbarBackground(.visible, for: .windowToolbar)
-    }
-
-    private var header: some View {
-        HStack(spacing: Spacing.small) {
-            Text(project.name).font(Typography.heading)
-            phaseBadge
-        }
-    }
-
-    @ViewBuilder
-    private var phaseBadge: some View {
-        switch project.phase {
-        case .starting:
-            ProgressView().controlSize(.small).scaleEffect(0.6)
-        case .failed:
-            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
-        case .ready, .idle:
-            EmptyView()
-        }
     }
 
     @ViewBuilder
@@ -184,55 +162,13 @@ private struct ProjectView: View {
 /// grouping (baseline gap #5). Sessions + Checkpoints are grouped under a
 /// "History" heading per the design plan's A2, since both browse past state
 /// rather than switching between live-run modes the way Chat/Activity do.
-private struct IconRail: View {
-    @Binding var section: Section
-    let project: ProjectSession
-    let onClose: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.tight) {
-            RailRow(section: $section, item: .chat)
-            RailRow(section: $section, item: .activity)
-
-            RailSectionHeader("History")
-            RailRow(section: $section, item: .sessions)
-            RailRow(section: $section, item: .checkpoints)
-
-            Spacer()
-
-            RailRow(section: $section, item: .settings)
-
-            Button(action: onClose) {
-                HStack(spacing: Spacing.comfortable) {
-                    Image(systemName: "xmark.circle")
-                        .font(.system(size: IconSize.standard)).frame(width: IconSize.row)
-                    Text("Close").font(Typography.body)
-                    Spacer(minLength: Spacing.none)
-                }
-                .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundStyle(Theme.foregroundSecondary)
-                .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .help("Close project and stop its server")
-            .accessibilityLabel("Close project and stop its server")
-        }
-        .padding(.vertical, Spacing.comfortable).padding(.horizontal, Spacing.standard)
-        .frame(width: Layout.railWidth)
-        // The rail is continuous window chrome rather than a translucent
-        // overlay: its surface reaches the toolbar-safe area while the
-        // navigation controls retain their traffic-light-safe placement.
-        .background(Theme.surface.ignoresSafeArea(.container, edges: .top))
-    }
-}
-
 /// One nav row: icon + text label, so the accessibility name is the label
 /// text rather than the SF Symbol identifier (baseline gap #5) and a sighted
 /// user gets a name too, not just a glyph.
-private struct RailRow: View {
+struct RailRow: View {
     @Binding var section: Section
     let item: Section
+    var compact = false
 
     var body: some View {
         Button {
@@ -246,7 +182,7 @@ private struct RailRow: View {
                     // icon contributes its own SF Symbol identifier to the
                     // combined accessibility description.
                     .accessibilityHidden(true)
-                Text(item.title).font(Typography.body)
+                if !compact { Text(item.title).font(Typography.body) }
                 Spacer(minLength: Spacing.none)
             }
             .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
@@ -266,13 +202,13 @@ private struct RailRow: View {
     }
 }
 
-private struct RailSectionHeader: View {
+struct RailSectionHeader: View {
     let title: String
     init(_ title: String) { self.title = title }
 
     var body: some View {
-        Text(title.uppercased())
-            .font(Typography.detail.weight(.semibold))
+        Text(title)
+            .font(Typography.detail)
             .foregroundStyle(Theme.foregroundTertiary)
             .padding(.horizontal, Spacing.comfortable).padding(.top, Spacing.comfortable)
             .padding(.bottom, Spacing.tight)

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -821,9 +821,11 @@ struct Composer: View {
                 }
             }
             .padding(.horizontal, Spacing.large).padding(.vertical, Spacing.inset)
-            // The minimum keeps the idle composer at the reference height
-            // while allowing a multi-line draft to grow instead of clipping.
-            .frame(minHeight: 117)
+            // No minimum height: the card hugs its content and grows with a
+            // multi-line draft. A fixed floor was measured against the old,
+            // smaller type scale — once body type grew to the Codex 16.5pt the
+            // floor still exceeded the content, and the surplus rendered as
+            // dead space padding out the bottom of the card.
             .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.composer))
             .frame(maxWidth: Layout.chatContentMaximumWidth)
             .frame(maxWidth: .infinity, alignment: .center)

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -232,6 +232,10 @@ struct UserBubble: View {
     var body: some View {
         ContentHuggingWidthLayout(maximumWidth: Layout.userMessageMaximumWidth) {
             Text(text)
+                // Same reason as the assistant blocks: without an explicit
+                // role this inherited the 13pt system default, so the prompt
+                // rendered smaller than the reply it belongs to.
+                .font(Typography.body)
                 .textSelection(.enabled)
                 .padding(.horizontal, Spacing.inset)
                 .padding(.vertical, Spacing.userMessageVertical)
@@ -276,6 +280,14 @@ struct AssistantBubble: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+        // Set once on the container rather than on each block. `.font` is an
+        // environment value, so every Text below inherits it while headings
+        // and code blocks still override with their own role. Without this the
+        // blocks inherited the macOS 13pt system default — the transcript was
+        // rendering three points under the type scale, and raising the scale
+        // did nothing because nothing in the transcript ever read from it.
+        .font(Typography.body)
+        .lineSpacing(Typography.bodyLineSpacing)
     }
 }
 

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -34,13 +34,17 @@ struct ChatView: View {
 
             if showInspector {
                 EnvironmentInspector(
-                    project: project, activities: toolActivities, selected: $selected
+                    project: project,
+                    usage: run.transcript.usage,
+                    activities: toolActivities,
+                    selected: $selected
                 )
                 .padding(Spacing.large)
             }
         }
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItemGroup(placement: .primaryAction) {
+                CopyConversationButton(items: run.transcript.items)
                 Button {
                     showInspector.toggle()
                 } label: {
@@ -90,6 +94,10 @@ struct TranscriptView: View {
                     Color.clear.frame(height: Spacing.hairline).id(bottomAnchor)
                 }
                 .padding(Spacing.large)
+                // Primary transcript content uses the explicit foreground
+                // rung so macOS's subdued label default cannot compress the
+                // measured contrast of the shared body role.
+                .foregroundStyle(Theme.foreground)
                 .frame(maxWidth: Layout.chatContentMaximumWidth, alignment: .leading)
                 .frame(maxWidth: .infinity, alignment: .center)
             }
@@ -194,17 +202,42 @@ struct CopyMessageButton: View {
     }
 }
 
+/// Copies the complete transcript, including user prompts and tool activity,
+/// from the conversation's primary toolbar affordances.
+struct CopyConversationButton: View {
+    let items: [TranscriptItem]
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(TranscriptText.plain(items), forType: .string)
+            copied = true
+            Task {
+                try? await Task.sleep(for: .seconds(1.6))
+                copied = false
+            }
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+        }
+        .disabled(items.isEmpty)
+        .help(copied ? "Copied conversation" : "Copy conversation")
+        .accessibilityLabel("Copy conversation")
+    }
+}
+
 struct UserBubble: View {
     let text: String
 
     var body: some View {
-        Text(text)
-            .textSelection(.enabled)
-            .padding(.horizontal, Spacing.inset)
-            .padding(.vertical, Spacing.standard)
-            .frame(minHeight: Layout.userMessageMinimumHeight, alignment: .leading)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Theme.messageSurface, in: .rect(cornerRadius: CornerRadius.card))
+        ContentHuggingWidthLayout(maximumWidth: Layout.userMessageMaximumWidth) {
+            Text(text)
+                .textSelection(.enabled)
+                .padding(.horizontal, Spacing.inset)
+                .padding(.vertical, Spacing.userMessageVertical)
+                .frame(minHeight: Layout.userMessageMinimumHeight, alignment: .leading)
+        }
+        .background(Theme.messageSurface, in: .rect(cornerRadius: CornerRadius.card))
     }
 }
 
@@ -907,170 +940,6 @@ struct ModelChip: View {
                 + "\(broken.count == 1 ? "needs" : "need") re-authentication"
         }
         return "\(hidden.count) models hidden — no credentials for their providers"
-    }
-}
-
-// MARK: - Environment
-
-/// Codex groups environment state by kind. This card deliberately has no
-/// height constraint: it occupies only the space its present cards require,
-/// instead of reserving a permanent full-height column for an optional detail.
-struct EnvironmentInspector: View {
-    @Bindable var project: ProjectSession
-    let activities: [ToolActivity]
-    @Binding var selected: ToolActivity?
-
-    private var subagents: [TaskInfo] { project.tasks.filter { $0.type == "subagent" } }
-    private var backgroundTasks: [TaskInfo] { project.tasks.filter { $0.type != "subagent" } }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.standard) {
-            Text("Environment")
-                .font(Typography.heading)
-
-            if !project.rewindPoints.isEmpty {
-                EnvironmentCard(title: "Changes", icon: "arrow.uturn.backward.circle") {
-                    ForEach(project.rewindPoints) { point in
-                        CheckpointSummary(point: point)
-                    }
-                }
-            }
-
-            if !subagents.isEmpty {
-                EnvironmentCard(title: "Subagents", icon: "person.2") {
-                    ForEach(subagents) { task in TaskSummary(task: task) }
-                }
-            }
-
-            if !backgroundTasks.isEmpty || !activities.isEmpty {
-                EnvironmentCard(title: "Background processes", icon: "gearshape.2") {
-                    ForEach(backgroundTasks) { task in TaskSummary(task: task) }
-                    ForEach(activities) { activity in
-                        ToolActivitySummary(
-                            activity: activity, isSelected: selected?.id == activity.id
-                        ) {
-                            selected = activity
-                        }
-                    }
-                    if let selected {
-                        Divider()
-                        ToolActivityDetail(activity: selected)
-                    }
-                }
-            }
-
-            if project.rewindPoints.isEmpty && subagents.isEmpty && backgroundTasks.isEmpty
-                && activities.isEmpty
-            {
-                EnvironmentCard(title: "Environment", icon: "sidebar.right") {
-                    Text("No changes or background work yet.")
-                        .font(Typography.caption)
-                        .foregroundStyle(Theme.foregroundTertiary)
-                }
-            }
-        }
-        .padding(Spacing.inset)
-        .frame(width: Layout.inspectorCardWidth, alignment: .leading)
-        .fixedSize(horizontal: false, vertical: true)
-        .cardStyle()
-        .task {
-            await project.refreshRewindPoints()
-            await project.refreshActivity()
-        }
-    }
-}
-
-/// Reused card chrome keeps each environment kind distinct without making the
-/// inspector a visually undifferentiated column again.
-private struct EnvironmentCard<Content: View>: View {
-    let title: String
-    let icon: String
-    @ViewBuilder let content: Content
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.small) {
-            Label(title, systemImage: icon)
-                .font(Typography.caption.weight(.semibold))
-                .foregroundStyle(Theme.foregroundSecondary)
-            VStack(alignment: .leading, spacing: Spacing.small) { content }
-        }
-        .padding(Spacing.standard)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .compactElevatedSurface()
-    }
-}
-
-private struct CheckpointSummary: View {
-    let point: RewindPoint
-
-    var body: some View {
-        HStack(spacing: Spacing.small) {
-            Text(point.tool.map { "Before \($0)" } ?? "Checkpoint")
-                .font(Typography.caption)
-                .lineLimit(1)
-            Spacer(minLength: Spacing.none)
-            if let date = point.createdAt {
-                Text(date.formatted(date: .omitted, time: .shortened))
-                    .font(Typography.detail)
-                    .foregroundStyle(Theme.foregroundTertiary)
-            }
-        }
-    }
-}
-
-private struct TaskSummary: View {
-    let task: TaskInfo
-
-    var body: some View {
-        HStack(spacing: Spacing.small) {
-            Text(task.label).font(Typography.caption).lineLimit(1)
-            Spacer(minLength: Spacing.none)
-            Text(task.status).font(Typography.detail).foregroundStyle(Theme.foregroundTertiary)
-        }
-    }
-}
-
-private struct ToolActivitySummary: View {
-    let activity: ToolActivity
-    let isSelected: Bool
-    let onSelect: () -> Void
-
-    var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: Spacing.small) {
-                Text(activity.tool).font(Typography.caption).lineLimit(1)
-                Spacer(minLength: Spacing.none)
-                Text(String(describing: activity.status))
-                    .font(Typography.detail)
-                    .foregroundStyle(Theme.foregroundTertiary)
-            }
-            .padding(Spacing.compact)
-            .background(
-                isSelected ? Theme.surfaceHighest : .clear,
-                in: .rect(cornerRadius: CornerRadius.tag)
-            )
-            .contentShape(.rect)
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-/// The selected activity stays in its kind's card so detail does not cause a
-/// second, permanent inspector region to reappear beside the conversation.
-private struct ToolActivityDetail: View {
-    let activity: ToolActivity
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.small) {
-            if let edit = ToolEdit(tool: activity.tool, arguments: activity.arguments) {
-                DiffView(edit: edit)
-            } else if !activity.arguments.isEmpty {
-                LabelledCode(title: "Arguments", body: activity.arguments)
-            }
-            if !activity.output.isEmpty {
-                LabelledCode(title: "Output", body: activity.output)
-            }
-        }
     }
 }
 

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -14,7 +14,12 @@ struct ChatView: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(spacing: Spacing.none) {
-                TranscriptView(items: run.transcript.items, selected: $selected)
+                TranscriptView(
+                    items: run.transcript.items,
+                    statusMessage: project.statusMessage,
+                    run: run,
+                    selected: $selected
+                )
                 Divider()
                 if let plan = run.transcript.pendingPlan {
                     PlanApprovalView(plan: plan, run: run)
@@ -22,8 +27,6 @@ struct ChatView: View {
                     AskUserView(prompt: prompt) { run.answer($0) }
                 } else if let approval = run.transcript.pendingApproval {
                     ApprovalBar(approval: approval, run: run)
-                } else {
-                    StatusBar(project: project, run: run)
                 }
                 Composer(project: project, run: run)
             }
@@ -67,6 +70,8 @@ struct ChatView: View {
 
 struct TranscriptView: View {
     let items: [TranscriptItem]
+    let statusMessage: String?
+    @Bindable var run: RunSession
     @Binding var selected: ToolActivity?
     /// Auto-scroll only while the user is already at the bottom, so scrolling
     /// back to read is not yanked away mid-stream.
@@ -75,11 +80,14 @@ struct TranscriptView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: 14) {
+                LazyVStack(alignment: .leading, spacing: Spacing.large) {
                     ForEach(items) { item in
                         row(for: item).id(item.id)
                     }
-                    Color.clear.frame(height: 1).id(bottomAnchor)
+                    if run.isBusy {
+                        InlineRunStatus(run: run, statusMessage: statusMessage)
+                    }
+                    Color.clear.frame(height: Spacing.hairline).id(bottomAnchor)
                 }
                 .padding(Spacing.large)
                 .frame(maxWidth: Layout.chatContentMaximumWidth, alignment: .leading)
@@ -116,7 +124,7 @@ struct TranscriptView: View {
         case .thinking(let text):
             ThinkingRow(text: text)
         case .toolActivity(let activity):
-            ToolRow(activity: activity, isSelected: selected?.callID == activity.callID) {
+            ToolRow(activity: activity) {
                 selected = activity
             }
         case .error(let message):
@@ -188,61 +196,51 @@ struct CopyMessageButton: View {
 
 struct UserBubble: View {
     let text: String
+
     var body: some View {
-        VStack(alignment: .trailing, spacing: 3) {
-            HStack {
-                Spacer(minLength: 48)
-                Text(text)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, Spacing.inset).padding(.vertical, Spacing.standard)
-                    .background(
-                        Theme.accent.opacity(StateOpacity.userBubble),
-                        in: .rect(cornerRadius: CornerRadius.card))
-            }
-            CopyMessageButton(text: text)
-        }
-        .frame(maxWidth: .infinity, alignment: .trailing)
+        Text(text)
+            .textSelection(.enabled)
+            .padding(.horizontal, Spacing.inset)
+            .padding(.vertical, Spacing.standard)
+            .frame(minHeight: Layout.userMessageMinimumHeight, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Theme.messageSurface, in: .rect(cornerRadius: CornerRadius.card))
     }
 }
 
 struct AssistantBubble: View {
     let message: AssistantMessage
+
     var body: some View {
-        HStack(alignment: .top, spacing: Spacing.standard) {
-            Image(systemName: "sparkle")
-                .foregroundStyle(.tint).font(Typography.caption).padding(.top, 3)
-            VStack(alignment: .leading, spacing: Spacing.standard) {
-                ForEach(Array(MarkdownBlock.parse(message.text).enumerated()), id: \.offset) {
-                    _, block in
-                    switch block {
-                    case .paragraph(let body):
-                        Text(.init(body)).textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case .heading(let level, let text):
-                        Text(.init(text))
-                            .font(MarkdownBlock.headingFont(level)).fontWeight(.semibold)
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    case .unorderedListItem(let text):
-                        MarkdownListRow(marker: "•", text: text)
-                    case .orderedListItem(let number, let text):
-                        MarkdownListRow(marker: "\(number).", text: text)
-                    case .quote(let text):
-                        MarkdownQuoteRow(text: text)
-                    case .rule:
-                        Divider()
-                    case .code(let code, let language):
-                        CodeBlock(code: code, language: language)
-                    }
-                }
-                // Copying a half-arrived reply would silently truncate it.
-                if !message.isStreaming {
-                    CopyMessageButton(text: message.text)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            ForEach(Array(MarkdownBlock.parse(message.text).enumerated()), id: \.offset) {
+                _, block in
+                switch block {
+                case .paragraph(let body):
+                    Text(.init(body)).textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                case .heading(let level, let text):
+                    Text(.init(text))
+                        .font(MarkdownBlock.headingFont(level)).fontWeight(.semibold)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                case .unorderedListItem(let text):
+                    MarkdownListRow(marker: "•", text: text)
+                case .orderedListItem(let number, let text):
+                    MarkdownListRow(marker: "\(number).", text: text)
+                case .quote(let text):
+                    MarkdownQuoteRow(text: text)
+                case .rule:
+                    Divider()
+                case .code(let code, let language):
+                    CodeBlock(code: code, language: language)
                 }
             }
             if message.isStreaming {
                 ProgressView().controlSize(.small)
+            } else {
+                CopyMessageButton(text: message.text)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
@@ -464,40 +462,47 @@ struct ThinkingRow: View {
 
 struct ToolRow: View {
     let activity: ToolActivity
-    let isSelected: Bool
     let onSelect: () -> Void
 
     var body: some View {
         Button(action: onSelect) {
-            HStack(spacing: Spacing.standard) {
-                statusIcon.frame(width: IconSize.standard)
-                Text(activity.tool).font(Typography.body.weight(.medium))
-                Text(ToolSummary.describe(activity))
-                    .font(Typography.body).foregroundStyle(Theme.foregroundTertiary)
-                    .lineLimit(1).truncationMode(.middle)
-                Spacer()
-                if let ms = activity.durationMS, ms > 0 {
-                    Text("\(ms)ms").font(Typography.caption).foregroundStyle(
-                        Theme.foregroundQuaternary)
+            VStack(alignment: .leading, spacing: Spacing.small) {
+                HStack(spacing: Spacing.tight) {
+                    Text(TranscriptActivityLabel.text(for: activity))
+                        .font(Typography.caption)
+                        .foregroundStyle(Theme.foregroundTertiary)
+                    Text("›")
+                        .font(Typography.caption)
+                        .foregroundStyle(Theme.foregroundQuaternary)
+                    Spacer(minLength: Spacing.none)
                 }
+                Rectangle()
+                    .fill(Theme.separator)
+                    .frame(height: Spacing.hairline)
             }
-            .padding(.horizontal, Spacing.comfortable).padding(.vertical, 7)
-            .background(
-                isSelected ? Theme.accent.opacity(StateOpacity.emphasis) : Theme.surface,
-                in: .rect(cornerRadius: CornerRadius.control))
+            .contentShape(.rect)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(TranscriptActivityLabel.text(for: activity))
+    }
+}
+
+/// Tool details live in the optional inspector; the transcript deliberately
+/// summarizes work as one neutral line so it keeps the conversation's rhythm.
+enum TranscriptActivityLabel {
+    static func text(for activity: ToolActivity) -> String {
+        switch activity.status {
+        case .completed: return completed(durationMS: activity.durationMS)
+        case .running: return "Working"
+        case .failed: return "Tool failed"
+        case .blocked: return "Waiting for approval"
+        }
     }
 
-    @ViewBuilder
-    private var statusIcon: some View {
-        switch activity.status {
-        case .running: ProgressView().controlSize(.small).scaleEffect(0.65)
-        case .completed: Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-        case .failed: Image(systemName: "xmark.circle.fill").foregroundStyle(.red)
-        // Blocked is a policy decision, not a failure.
-        case .blocked: Image(systemName: "hand.raised.fill").foregroundStyle(.orange)
-        }
+    static func completed(durationMS: Int?) -> String {
+        guard let durationMS, durationMS > 0 else { return "Worked" }
+        let seconds = Int((Double(durationMS) / 1_000).rounded(.up))
+        return "Worked for \(seconds)s"
     }
 }
 
@@ -555,35 +560,26 @@ struct NoticeRow: View {
 
 // MARK: - Status, approvals, questions
 
-struct StatusBar: View {
-    @Bindable var project: ProjectSession
+/// Run state belongs to the transcript while work is active; a permanent
+/// footer makes a quiet conversation look like a log viewer.
+struct InlineRunStatus: View {
     @Bindable var run: RunSession
+    let statusMessage: String?
 
     var body: some View {
-        HStack(spacing: Spacing.comfortable) {
+        MetadataRow(spacing: Spacing.standard) {
             if run.isBusy { ProgressView().controlSize(.small).scaleEffect(0.7) }
-            Text(label).font(Typography.body).foregroundStyle(Theme.foregroundSecondary)
-            if let message = project.statusMessage {
-                Text("· \(message)").font(Typography.caption).foregroundStyle(
-                    Theme.foregroundQuaternary
-                )
-                .lineLimit(1)
+            Text(label).foregroundStyle(Theme.foregroundSecondary)
+            if let statusMessage {
+                Text("· \(statusMessage)")
+                    .foregroundStyle(Theme.foregroundQuaternary)
+                    .lineLimit(1)
             }
             Spacer()
-            UsageLabel(usage: run.transcript.usage)
-            if !run.transcript.items.isEmpty {
-                CopyMessageButton(text: TranscriptText.plain(run.transcript.items))
-                    .help("Copy the whole conversation")
-            }
             if run.isBusy {
                 Button("Stop") { run.cancel() }.controlSize(.small)
             }
         }
-        // 16pt matches the transcript column's own inset (runner-up gap: the
-        // status/approval/plan strips and the transcript disagreed on their
-        // left edge — 14 vs 16 — for no reason).
-        .padding(.horizontal, Spacing.large).padding(.vertical, 7)
-        .background(Theme.surface)
     }
 
     private var label: String {

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -14,13 +14,14 @@ struct ChatView: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(spacing: Spacing.none) {
+                ConversationHeader(project: project, run: run)
                 TranscriptView(
                     items: run.transcript.items,
                     statusMessage: project.statusMessage,
                     run: run,
-                    selected: $selected
+                    selected: $selected,
+                    project: project
                 )
-                Divider()
                 if let plan = run.transcript.pendingPlan {
                     PlanApprovalView(plan: plan, run: run)
                 } else if let prompt = run.pendingQuestions {
@@ -77,6 +78,7 @@ struct TranscriptView: View {
     let statusMessage: String?
     @Bindable var run: RunSession
     @Binding var selected: ToolActivity?
+    @Bindable var project: ProjectSession
     /// Auto-scroll only while the user is already at the bottom, so scrolling
     /// back to read is not yanked away mid-stream.
     @State private var pinnedToBottom = true
@@ -84,22 +86,23 @@ struct TranscriptView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: Spacing.large) {
-                    ForEach(items) { item in
-                        row(for: item).id(item.id)
+                ConversationColumn {
+                    LazyVStack(alignment: .leading, spacing: Spacing.large) {
+                        ForEach(TranscriptPresentation.rows(for: items)) { item in
+                            row(for: item).id(item.id)
+                        }
+                        if run.isBusy {
+                            InlineRunStatus(run: run, statusMessage: statusMessage)
+                        }
+                        Color.clear.frame(height: Spacing.hairline).id(bottomAnchor)
                     }
-                    if run.isBusy {
-                        InlineRunStatus(run: run, statusMessage: statusMessage)
-                    }
-                    Color.clear.frame(height: Spacing.hairline).id(bottomAnchor)
+                    .padding(.top, Spacing.transcriptTop)
+                    .padding(.bottom, Spacing.large)
+                    // Primary transcript content uses the explicit foreground
+                    // rung so macOS's subdued label default cannot compress the
+                    // measured contrast of the shared body role.
+                    .foregroundStyle(Theme.foreground)
                 }
-                .padding(Spacing.large)
-                // Primary transcript content uses the explicit foreground
-                // rung so macOS's subdued label default cannot compress the
-                // measured contrast of the shared body role.
-                .foregroundStyle(Theme.foreground)
-                .frame(maxWidth: Layout.chatContentMaximumWidth, alignment: .leading)
-                .frame(maxWidth: .infinity, alignment: .center)
             }
             .onChange(of: items.last?.id) { _, _ in scrollIfPinned(proxy) }
             .onChange(of: lastItemLength) { _, _ in scrollIfPinned(proxy) }
@@ -123,18 +126,28 @@ struct TranscriptView: View {
     }
 
     @ViewBuilder
-    private func row(for item: TranscriptItem) -> some View {
+    private func row(for displayItem: TranscriptDisplayItem) -> some View {
+        switch displayItem.kind {
+        case .toolActivities(let activities):
+            ToolRow(activities: activities) {
+                selected = activities.last
+            }
+        case .item(let item):
+            transcriptRow(for: item)
+        }
+    }
+
+    @ViewBuilder
+    private func transcriptRow(for item: TranscriptItem) -> some View {
         switch item.kind {
         case .userPrompt(let text):
-            UserBubble(text: text)
+            UserBubble(text: text).frame(maxWidth: .infinity, alignment: .trailing)
         case .assistantMessage(let message):
-            AssistantBubble(message: message)
+            AssistantBubble(message: message, project: project, run: run)
         case .thinking(let text):
             ThinkingRow(text: text)
-        case .toolActivity(let activity):
-            ToolRow(activity: activity) {
-                selected = activity
-            }
+        case .toolActivity:
+            EmptyView()
         case .error(let message):
             ErrorRow(message: message)
         case .notice(let message):
@@ -247,6 +260,8 @@ struct UserBubble: View {
 
 struct AssistantBubble: View {
     let message: AssistantMessage
+    @Bindable var project: ProjectSession
+    @Bindable var run: RunSession
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.standard) {
@@ -276,8 +291,7 @@ struct AssistantBubble: View {
             if message.isStreaming {
                 ProgressView().controlSize(.small)
             } else {
-                CopyMessageButton(text: message.text)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                MessageActions(message: message.text, project: project, run: run)
             }
         }
         // Set once on the container rather than on each block. `.font` is an
@@ -288,6 +302,41 @@ struct AssistantBubble: View {
         // did nothing because nothing in the transcript ever read from it.
         .font(Typography.body)
         .lineSpacing(Typography.bodyLineSpacing)
+    }
+}
+
+/// Each action maps to a real conversation operation; feedback buttons are
+/// deliberately absent because this app has no feedback destination.
+struct MessageActions: View {
+    let message: String
+    @Bindable var project: ProjectSession
+    @Bindable var run: RunSession
+
+    var body: some View {
+        HStack(spacing: Spacing.messageActionPitch) {
+            CopyMessageButton(text: message)
+            CopyConversationButton(items: run.transcript.items)
+            Button {
+                Task { await project.fork() }
+            } label: {
+                Image(systemName: "arrow.triangle.branch")
+            }
+            .disabled(run.conversationID == nil)
+            .help("Fork conversation")
+            .accessibilityLabel("Fork conversation")
+            Button {
+                Task { await project.undo() }
+            } label: {
+                Image(systemName: "arrow.uturn.backward")
+            }
+            .disabled(run.conversationID == nil)
+            .help("Undo last turn")
+            .accessibilityLabel("Undo last turn")
+        }
+        .font(.system(size: IconSize.detail))
+        .foregroundStyle(Theme.foregroundQuaternary)
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -506,14 +555,14 @@ struct ThinkingRow: View {
 }
 
 struct ToolRow: View {
-    let activity: ToolActivity
+    let activities: [ToolActivity]
     let onSelect: () -> Void
 
     var body: some View {
         Button(action: onSelect) {
             VStack(alignment: .leading, spacing: Spacing.small) {
                 HStack(spacing: Spacing.tight) {
-                    Text(TranscriptActivityLabel.text(for: activity))
+                    Text(TranscriptActivityLabel.text(for: activities))
                         .font(Typography.caption)
                         .foregroundStyle(Theme.foregroundTertiary)
                     Text("›")
@@ -528,13 +577,19 @@ struct ToolRow: View {
             .contentShape(.rect)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(TranscriptActivityLabel.text(for: activity))
+        .accessibilityLabel(TranscriptActivityLabel.text(for: activities))
     }
 }
 
 /// Tool details live in the optional inspector; the transcript deliberately
 /// summarizes work as one neutral line so it keeps the conversation's rhythm.
 enum TranscriptActivityLabel {
+    static func text(for activities: [ToolActivity]) -> String {
+        guard let last = activities.last else { return "Worked" }
+        guard activities.allSatisfy({ $0.status == .completed }) else { return text(for: last) }
+        return completed(durationMS: activities.compactMap(\.durationMS).reduce(0, +))
+    }
+
     static func text(for activity: ToolActivity) -> String {
         switch activity.status {
         case .completed: return completed(durationMS: activity.durationMS)
@@ -798,55 +853,55 @@ struct Composer: View {
             // #2): the field, send button, model picker and plan toggle used
             // to read as three unrelated regions — the field, a right-hand
             // gutter for send, and a separate borderless strip below.
-            VStack(alignment: .leading, spacing: Spacing.comfortable) {
-                TextField(placeholder, text: $run.draft, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .lineLimit(1...10)
-                    .focused($focused)
-                    .onSubmit(send)
-                    .onChange(of: run.draft) { _, text in updateMentions(for: text) }
+            ConversationColumn {
+                VStack(alignment: .leading, spacing: Spacing.comfortable) {
+                    TextField(placeholder, text: $run.draft, axis: .vertical)
+                        .textFieldStyle(.plain)
+                        .lineLimit(1...10)
+                        .focused($focused)
+                        .onSubmit(send)
+                        .onChange(of: run.draft) { _, text in updateMentions(for: text) }
 
-                HStack(spacing: Spacing.comfortable) {
-                    ModelChip(project: project)
-                    Toggle("Plan mode", isOn: $project.planMode)
-                        .toggleStyle(.checkbox).font(Typography.caption)
-                        .help("Restrict the agent to writing a plan file until you approve it")
-                    Spacer()
-                    Button("New") { project.newConversation() }
-                        .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
-                            Theme.foregroundTertiary)
+                    HStack(spacing: Spacing.comfortable) {
+                        ModelChip(project: project)
+                        Toggle("Plan mode", isOn: $project.planMode)
+                            .toggleStyle(.checkbox).font(Typography.caption)
+                            .help("Restrict the agent to writing a plan file until you approve it")
+                        Spacer()
+                        Button("New") { project.newConversation() }
+                            .buttonStyle(.plain).font(Typography.caption).foregroundStyle(
+                                Theme.foregroundTertiary)
 
-                    Button(action: send) {
-                        Image(
-                            systemName: run.canSteer
-                                ? "arrow.turn.up.right" : "arrow.up.circle.fill"
-                        )
-                        // A title-sized SF Symbol makes its filled disc half
-                        // the target control; this restores the send target's
-                        // intended visual weight without changing its glyph.
-                        .font(.system(size: 34))
+                        Button(action: send) {
+                            Image(
+                                systemName: run.canSteer
+                                    ? "arrow.turn.up.right" : "arrow.up.circle.fill"
+                            )
+                            // A title-sized SF Symbol makes its filled disc half
+                            // the target control; this restores the send target's
+                            // intended visual weight without changing its glyph.
+                            .font(.system(size: 34))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(run.draft.trimmed.isEmpty)
+                        .help(run.canSteer ? "Steer the running task" : "Send")
+                        .accessibilityLabel(
+                            run.canSteer ? "Steer the running task" : "Send message")
                     }
-                    .buttonStyle(.plain)
-                    .disabled(run.draft.trimmed.isEmpty)
-                    .help(run.canSteer ? "Steer the running task" : "Send")
-                    .accessibilityLabel(run.canSteer ? "Steer the running task" : "Send message")
                 }
+                .padding(.horizontal, Spacing.large).padding(.vertical, Spacing.inset)
+                .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.composer))
             }
-            .padding(.horizontal, Spacing.large).padding(.vertical, Spacing.inset)
             // No minimum height: the card hugs its content and grows with a
             // multi-line draft. A fixed floor was measured against the old,
             // smaller type scale — once body type grew to the Codex 16.5pt the
             // floor still exceeded the content, and the surplus rendered as
             // dead space padding out the bottom of the card.
-            .background(Theme.surfaceElevated, in: .rect(cornerRadius: CornerRadius.composer))
-            .frame(maxWidth: Layout.chatContentMaximumWidth)
-            .frame(maxWidth: .infinity, alignment: .center)
         }
-        .padding(.horizontal, Spacing.large)
-        .padding(.top, Spacing.standard)
-        // A real bottom inset (was 0 — the old control strip ran flush to the
-        // window edge) so the card reads as inset chrome, not a footer.
-        .padding(.bottom, Spacing.section)
+        // Equal above and below. These were 8pt and 18pt, so the card sat
+        // visibly high in its own gutter — the inset that makes it read as
+        // chrome rather than a footer only works when it is symmetric.
+        .padding(.vertical, Spacing.section)
         .onAppear { focused = true }
     }
 

--- a/macapp/Sources/GoCodeUI/ContentHuggingWidthLayout.swift
+++ b/macapp/Sources/GoCodeUI/ContentHuggingWidthLayout.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Measures a transcript element at its readable maximum, then returns its
+/// intrinsic width when it is shorter. A flexible frame would always accept
+/// the transcript column's proposal and turn user prompts back into bands.
+///
+/// `SwiftUI.Layout` is spelled out because this module's design tokens include
+/// an enum also named `Layout`, which otherwise wins name resolution here and
+/// fails with the misleading "inheritance from non-protocol type".
+struct ContentHuggingWidthLayout: SwiftUI.Layout {
+    let maximumWidth: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: LayoutSubviews,
+        cache _: inout ()
+    ) -> CGSize {
+        guard let subview = subviews.first else { return .zero }
+        let proposedWidth = min(proposal.width ?? maximumWidth, maximumWidth)
+        return subview.sizeThatFits(
+            ProposedViewSize(width: proposedWidth, height: proposal.height))
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal _: ProposedViewSize,
+        subviews: LayoutSubviews,
+        cache _: inout ()
+    ) {
+        guard let subview = subviews.first else { return }
+        subview.place(
+            at: bounds.origin,
+            anchor: .topLeading,
+            proposal: ProposedViewSize(width: bounds.width, height: bounds.height))
+    }
+}

--- a/macapp/Sources/GoCodeUI/ConversationChrome.swift
+++ b/macapp/Sources/GoCodeUI/ConversationChrome.swift
@@ -1,0 +1,55 @@
+import HarnessKit
+import SwiftUI
+
+/// One layout envelope prevents the transcript and composer from drifting to
+/// different horizontal origins as their internals evolve.
+struct ConversationColumn<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        content
+            .frame(maxWidth: Layout.chatContentMaximumWidth)
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+struct ConversationHeader: View {
+    @Bindable var project: ProjectSession
+    @Bindable var run: RunSession
+
+    var body: some View {
+        ConversationColumn {
+            HStack(spacing: Spacing.small) {
+                Image(systemName: "folder")
+                    .font(.system(size: IconSize.detail))
+                    .foregroundStyle(Theme.foregroundTertiary)
+                    .accessibilityHidden(true)
+                Text(title)
+                    .font(Typography.body.weight(.medium))
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.none)
+                Menu {
+                    Button("New conversation") { project.newConversation() }
+                    if run.conversationID != nil {
+                        Button("Fork conversation") { Task { await project.fork() } }
+                        Button("Undo last turn") { Task { await project.undo() } }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: IconSize.detail))
+                }
+                .menuStyle(.borderlessButton)
+                .help("Conversation actions")
+                .accessibilityLabel("Conversation actions")
+            }
+            .frame(height: Spacing.conversationHeaderHeight)
+        }
+    }
+
+    private var title: String {
+        guard let id = run.conversationID,
+            let conversation = project.conversations.first(where: { $0.id == id })
+        else { return "New conversation" }
+        return conversation.displayTitle
+    }
+}

--- a/macapp/Sources/GoCodeUI/ConversationRail.swift
+++ b/macapp/Sources/GoCodeUI/ConversationRail.swift
@@ -12,13 +12,18 @@ struct ConversationRail: View {
         VStack(alignment: .leading, spacing: Spacing.tight) {
             RailRow(section: $section, item: .chat)
 
-            if !conversations.isEmpty {
+            // Each header is gated on its own rows. Gating both on "any
+            // conversations at all" printed a "Pinned" heading with nothing
+            // under it for every project that has none — which is most of them.
+            if !pinnedConversations.isEmpty {
                 RailSectionHeader("Pinned")
-                ForEach(conversations.filter { $0.pinned == true }) { conversation in
+                ForEach(pinnedConversations) { conversation in
                     ConversationRailRow(
                         conversation: conversation, project: project, section: $section)
                 }
+            }
 
+            if !unpinnedConversations.isEmpty {
                 RailSectionHeader("Projects")
                 ForEach(unpinnedConversations) { conversation in
                     ConversationRailRow(
@@ -48,6 +53,15 @@ struct ConversationRail: View {
         .frame(width: Layout.railWidth)
         .background(Theme.surface.ignoresSafeArea(.container, edges: .top))
         .task { await project.refreshConversations() }
+        // `.task` fires once, so a rail that appeared before the project had
+        // any saved conversation stayed empty for the whole session — in a new
+        // project that is every conversation the user starts, and it only
+        // filled in after a relaunch. A run finishing is the point at which
+        // the conversation is definitely persisted and worth re-reading.
+        .onChange(of: project.run?.isBusy) { _, busy in
+            guard busy == false else { return }
+            Task { await project.refreshConversations() }
+        }
     }
 
     private var conversations: [ConversationInfo] {
@@ -55,6 +69,10 @@ struct ConversationRail: View {
             (lhs.updatedAt ?? lhs.createdAt ?? .distantPast)
                 > (rhs.updatedAt ?? rhs.createdAt ?? .distantPast)
         }
+    }
+
+    private var pinnedConversations: [ConversationInfo] {
+        conversations.filter { $0.pinned == true }
     }
 
     private var unpinnedConversations: [ConversationInfo] {

--- a/macapp/Sources/GoCodeUI/ConversationRail.swift
+++ b/macapp/Sources/GoCodeUI/ConversationRail.swift
@@ -1,0 +1,112 @@
+import HarnessKit
+import SwiftUI
+
+/// The rail is a compact view of the same saved conversations exposed by the
+/// Sessions screen. Navigation remains available without displacing the list.
+struct ConversationRail: View {
+    @Binding var section: Section
+    @Bindable var project: ProjectSession
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.tight) {
+            RailRow(section: $section, item: .chat)
+
+            if !conversations.isEmpty {
+                RailSectionHeader("Pinned")
+                ForEach(conversations.filter { $0.pinned == true }) { conversation in
+                    ConversationRailRow(
+                        conversation: conversation, project: project, section: $section)
+                }
+
+                RailSectionHeader("Projects")
+                ForEach(unpinnedConversations) { conversation in
+                    ConversationRailRow(
+                        conversation: conversation, project: project, section: $section)
+                }
+            }
+
+            Spacer(minLength: Spacing.none)
+
+            HStack(spacing: Spacing.tight) {
+                RailRow(section: $section, item: .activity, compact: true)
+                RailRow(section: $section, item: .sessions, compact: true)
+                RailRow(section: $section, item: .checkpoints, compact: true)
+                RailRow(section: $section, item: .settings, compact: true)
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle")
+                        .font(.system(size: IconSize.standard))
+                }
+                .buttonStyle(.plain)
+                .help("Close project and stop its server")
+                .accessibilityLabel("Close project and stop its server")
+            }
+            .foregroundStyle(Theme.foregroundSecondary)
+        }
+        .padding(.vertical, Spacing.comfortable)
+        .padding(.horizontal, Spacing.standard)
+        .frame(width: Layout.railWidth)
+        .background(Theme.surface.ignoresSafeArea(.container, edges: .top))
+        .task { await project.refreshConversations() }
+    }
+
+    private var conversations: [ConversationInfo] {
+        project.conversations.sorted { lhs, rhs in
+            (lhs.updatedAt ?? lhs.createdAt ?? .distantPast)
+                > (rhs.updatedAt ?? rhs.createdAt ?? .distantPast)
+        }
+    }
+
+    private var unpinnedConversations: [ConversationInfo] {
+        conversations.filter { $0.pinned != true }
+    }
+}
+
+private struct ConversationRailRow: View {
+    let conversation: ConversationInfo
+    @Bindable var project: ProjectSession
+    @Binding var section: Section
+
+    private var isActive: Bool { project.run?.conversationID == conversation.id }
+
+    var body: some View {
+        Button {
+            Task { await project.openConversation(conversation) }
+            section = .chat
+        } label: {
+            HStack(spacing: Spacing.small) {
+                Circle()
+                    .fill(isActive ? Theme.foreground : Theme.foregroundQuaternary)
+                    .frame(width: IconSize.rule, height: IconSize.rule)
+                    .accessibilityHidden(true)
+                Image(systemName: "bubble.left")
+                    .font(.system(size: IconSize.detail))
+                    .foregroundStyle(Theme.foregroundQuaternary)
+                    .accessibilityHidden(true)
+                Text(conversation.displayTitle)
+                    .font(Typography.detail)
+                    .lineLimit(1)
+                Spacer(minLength: Spacing.none)
+                if conversation.messageCount ?? 0 > 0 {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: IconSize.rule))
+                        .foregroundStyle(Theme.foregroundQuaternary)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.leading, Spacing.inset)
+            .padding(.trailing, Spacing.comfortable)
+            .frame(height: Layout.railRowHeight, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                isActive ? Theme.selectedRowSurface : .clear,
+                in: .rect(cornerRadius: CornerRadius.control)
+            )
+            .foregroundStyle(isActive ? Theme.selectedRowForeground : Theme.foregroundSecondary)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .help(conversation.displayTitle)
+        .accessibilityLabel("Open \(conversation.displayTitle)")
+    }
+}

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -6,6 +6,7 @@ enum Layout {
     static let appMinimumWidth: CGFloat = 1_040
     static let appMinimumHeight: CGFloat = 600
     static let railWidth: CGFloat = 220
+    static let railRowHeight: CGFloat = 37
     /// Codex's environment surface is a compact overlay card, not a sidebar.
     static let inspectorCardWidth: CGFloat = 361
     static let chatMinimumWidth: CGFloat = 400

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -14,10 +14,16 @@ enum Layout {
     /// of turning either into a near-edge-to-edge control on wide windows.
     static let chatContentMaximumWidth: CGFloat = 883
 
-    /// The reference user row is 45.5pt tall. A minimum preserves that
-    /// measured rhythm for one-line prompts while allowing long prompts to
-    /// wrap without clipping.
-    static let userMessageMinimumHeight: CGFloat = 45.5
+    /// User prompts read as authored content, not a full-column alert. This
+    /// caps a wrapped prompt while allowing short prompts to retain their
+    /// intrinsic width.
+    static let userMessageMaximumWidth: CGFloat = 374.5
+
+    /// A one-line body prompt plus its semantic vertical padding. Keeping this
+    /// formula coupled to the same roles used by `UserBubble` lets type or
+    /// spacing changes update its minimum rhythm together.
+    static let userMessageMinimumHeight: CGFloat =
+        Typography.bodyLineHeight + (Spacing.userMessageVertical * 2)
     static let providerMinimumWidth: CGFloat = 240
     static let providerIdealWidth: CGFloat = 280
     static let modelMinimumWidth: CGFloat = 380

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -13,6 +13,11 @@ enum Layout {
     /// Keep the transcript and composer on the same readable column instead
     /// of turning either into a near-edge-to-edge control on wide windows.
     static let chatContentMaximumWidth: CGFloat = 883
+
+    /// The reference user row is 45.5pt tall. A minimum preserves that
+    /// measured rhythm for one-line prompts while allowing long prompts to
+    /// wrap without clipping.
+    static let userMessageMinimumHeight: CGFloat = 45.5
     static let providerMinimumWidth: CGFloat = 240
     static let providerIdealWidth: CGFloat = 280
     static let modelMinimumWidth: CGFloat = 380

--- a/macapp/Sources/GoCodeUI/DesignSystem/Shape.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Shape.swift
@@ -7,5 +7,5 @@ enum CornerRadius {
     static let code: CGFloat = 6
     static let control: CGFloat = 8
     static let card: CGFloat = 10
-    static let composer: CGFloat = 14
+    static let composer: CGFloat = 20
 }

--- a/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
@@ -17,4 +17,11 @@ enum Spacing {
     static let large: CGFloat = 16
     static let section: CGFloat = 18
     static let page: CGFloat = 28
+    /// Header height keeps the conversation title in the content pane, below
+    /// window chrome and aligned with the transcript column.
+    static let conversationHeaderHeight: CGFloat = 52
+    /// The first message needs deliberate breathing room below the header.
+    static let transcriptTop: CGFloat = 65.5
+    /// Message action glyphs follow Codex's measured visual pitch.
+    static let messageActionPitch: CGFloat = 34
 }

--- a/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Spacing.swift
@@ -12,6 +12,8 @@ enum Spacing {
     static let standard: CGFloat = 8
     static let comfortable: CGFloat = 10
     static let inset: CGFloat = 12
+    /// Vertical breathing room for a one-line user prompt.
+    static let userMessageVertical: CGFloat = 12
     static let large: CGFloat = 16
     static let section: CGFloat = 18
     static let page: CGFloat = 28

--- a/macapp/Sources/GoCodeUI/DesignSystem/StateOpacity.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/StateOpacity.swift
@@ -6,6 +6,5 @@ enum StateOpacity {
     static let subtle: Double = 0.08
     static let feedback: Double = 0.10
     static let emphasis: Double = 0.12
-    static let userBubble: Double = 0.15
     static let selected: Double = 0.16
 }

--- a/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
@@ -47,8 +47,8 @@ enum Theme {
 
     // MARK: - Surfaces
     // Dark values are a 27-level span (24→51), matching Codex's measured
-    // 24→34→36→45→51 (Codex's middle rung, 36, is a state-specific bubble
-    // fill this app doesn't need a fifth surface token for). Light values
+    // 24→34→36→45→51. The 36 rung is the transcript's dedicated neutral
+    // message surface; the chrome hierarchy itself stays at four tiers. Light values
     // do not mirror the dark numbers (255−x would make elevated surfaces
     // *darker* than the page, which reads backwards in a light appearance):
     // they keep the same "further from paper white = further back"
@@ -74,6 +74,12 @@ enum Theme {
     /// need to read as in front of an already-elevated surface.
     static let surfaceHighestLevel = GreyLevel(
         dark: RGB(r: 51, g: 51, b: 51), light: RGB(r: 235, g: 235, b: 235))
+
+    /// The transcript's user message is intentionally an ownership-neutral
+    /// #242424 surface in dark mode. It is distinct from app chrome so the
+    /// conversation reads as writing rather than a tinted chat bubble.
+    static let messageSurfaceLevel = GreyLevel(
+        dark: RGB(r: 36, g: 36, b: 36), light: RGB(r: 240, g: 240, b: 240))
 
     // MARK: - Foreground
     // Four rungs (the task's stated minimum; Codex measures five —
@@ -120,6 +126,7 @@ enum Theme {
     static let surface = color(surfaceLevel)
     static let surfaceElevated = color(surfaceElevatedLevel)
     static let surfaceHighest = color(surfaceHighestLevel)
+    static let messageSurface = color(messageSurfaceLevel)
 
     static let foreground = color(foregroundLevel)
     static let foregroundSecondary = color(foregroundSecondaryLevel)

--- a/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
@@ -81,6 +81,11 @@ enum Theme {
     static let messageSurfaceLevel = GreyLevel(
         dark: RGB(r: 36, g: 36, b: 36), light: RGB(r: 240, g: 240, b: 240))
 
+    /// A rail selection is navigation state, not an accent-bearing action.
+    /// Keeping it as a semantic alias makes that distinction durable while
+    /// deliberately sharing the frontmost neutral surface rung.
+    static let selectedRowSurfaceLevel = surfaceHighestLevel
+
     // MARK: - Foreground
     // Four rungs (the task's stated minimum; Codex measures five —
     // 255/222/163/116/97 — a fifth can slot in later without breaking this
@@ -108,6 +113,10 @@ enum Theme {
     static let foregroundQuaternaryLevel = GreyLevel(
         dark: RGB(r: 116, g: 116, b: 116), light: RGB(r: 139, g: 139, b: 139))
 
+    /// Selected navigation labels remain primary content, rather than taking
+    /// on the system tint that is reserved for an explicit product action.
+    static let selectedRowForegroundLevel = foregroundLevel
+
     // MARK: - Color tokens
     // Built from an appearance-aware `NSColor` so one `Color` constant tracks
     // the system's current appearance instead of the app needing an
@@ -127,11 +136,13 @@ enum Theme {
     static let surfaceElevated = color(surfaceElevatedLevel)
     static let surfaceHighest = color(surfaceHighestLevel)
     static let messageSurface = color(messageSurfaceLevel)
+    static let selectedRowSurface = color(selectedRowSurfaceLevel)
 
     static let foreground = color(foregroundLevel)
     static let foregroundSecondary = color(foregroundSecondaryLevel)
     static let foregroundTertiary = color(foregroundTertiaryLevel)
     static let foregroundQuaternary = color(foregroundQuaternaryLevel)
+    static let selectedRowForeground = color(selectedRowForegroundLevel)
 
     /// Hairline dividers for boundaries between surfaces close enough in
     /// value that a boundary would not otherwise read (baseline §8: adjacent

--- a/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Theme.swift
@@ -148,7 +148,11 @@ enum Theme {
     /// value that a boundary would not otherwise read (baseline §8: adjacent
     /// GoCode surfaces used to differ by only 2–3 levels — below the
     /// threshold where a value jump alone reads as a seam).
-    static let separator = foreground.opacity(0.12)
+    /// Hairlines recede into the content surface instead of outlining every
+    /// transcript region. The dark value is the measured #2B2B2B reference.
+    static let separatorLevel = GreyLevel(
+        dark: RGB(r: 43, g: 43, b: 43), light: RGB(r: 220, g: 220, b: 220))
+    static let separator = color(separatorLevel)
 
     /// Unchanged from the system tint. The baseline's accent-related gap
     /// (§3, §10 — GoCode spends its one saturated hue on message ownership

--- a/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
@@ -12,6 +12,14 @@ enum Typography {
     static let body = Font.system(size: bodyPointSize)
     /// The nominal one-line height of the `body` role on macOS.
     static let bodyLineHeight: CGFloat = 21.5
+    /// Extra leading for running transcript prose, carrying `bodyLineHeight`
+    /// up to the 26.5pt line pitch measured in the Codex reference. Added as
+    /// leading rather than baked into the font size, because the size is
+    /// already right and it was only the rhythm that was tight. Applies
+    /// between lines only, so single-line rows keep `bodyLineHeight` and the
+    /// derived user-message height is unaffected.
+    static let bodyLinePitch: CGFloat = 26.5
+    static let bodyLineSpacing: CGFloat = bodyLinePitch - bodyLineHeight
     static let caption = Font.system(size: 14)
     static let detail = Font.system(size: 12)
     static let code = Font.system(size: 15).monospaced()

--- a/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Typography.swift
@@ -1,18 +1,21 @@
 import SwiftUI
 
-/// Semantic type roles preserve today's Dynamic Type-aware metrics while
-/// separating content purpose from the system style that happens to implement
-/// it. The roles leave room for the later 16pt primary-text / deeper Codex-like
-/// hierarchy pass without silently changing this pass's appearance.
+/// Semantic type roles separate content purpose from the system style that
+/// implements it. Their metrics track the readable Codex transcript scale, so
+/// a density change reaches every screen through one hierarchy.
 enum Typography {
-    static let display = Font.title2
-    static let title = Font.title2
-    static let heading = Font.headline
-    static let body = Font.callout
-    static let caption = Font.caption
-    static let detail = Font.caption2
-    static let code = Font.callout.monospaced()
-    static let codeCaption = Font.caption.monospaced()
-    static let codeDetail = Font.caption2.monospaced()
-    static let numericCaption = Font.caption.monospacedDigit()
+    static let display = Font.system(size: 22)
+    static let title = Font.system(size: 20)
+    static let heading = Font.system(size: 18)
+    /// Primary transcript text measures 16.5pt in the Codex reference.
+    static let bodyPointSize: CGFloat = 16.5
+    static let body = Font.system(size: bodyPointSize)
+    /// The nominal one-line height of the `body` role on macOS.
+    static let bodyLineHeight: CGFloat = 21.5
+    static let caption = Font.system(size: 14)
+    static let detail = Font.system(size: 12)
+    static let code = Font.system(size: 15).monospaced()
+    static let codeCaption = Font.system(size: 14).monospaced()
+    static let codeDetail = Font.system(size: 12).monospaced()
+    static let numericCaption = Font.system(size: 14).monospacedDigit()
 }

--- a/macapp/Sources/GoCodeUI/EnvironmentInspector.swift
+++ b/macapp/Sources/GoCodeUI/EnvironmentInspector.swift
@@ -1,0 +1,171 @@
+import HarnessKit
+import SwiftUI
+
+/// Codex groups environment state by kind. This card deliberately has no
+/// height constraint: it occupies only the space its present cards require,
+/// instead of reserving a permanent full-height column for an optional detail.
+struct EnvironmentInspector: View {
+    @Bindable var project: ProjectSession
+    let usage: UsageTotals
+    let activities: [ToolActivity]
+    @Binding var selected: ToolActivity?
+
+    private var subagents: [TaskInfo] { project.tasks.filter { $0.type == "subagent" } }
+    private var backgroundTasks: [TaskInfo] { project.tasks.filter { $0.type != "subagent" } }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.standard) {
+            Text("Environment")
+                .font(Typography.heading)
+
+            if usage.totalTokens > 0 {
+                EnvironmentCard(title: "Usage", icon: "gauge.with.dots.needle.67percent") {
+                    UsageLabel(usage: usage)
+                }
+            }
+
+            if !project.rewindPoints.isEmpty {
+                EnvironmentCard(title: "Changes", icon: "arrow.uturn.backward.circle") {
+                    ForEach(project.rewindPoints) { point in
+                        CheckpointSummary(point: point)
+                    }
+                }
+            }
+
+            if !subagents.isEmpty {
+                EnvironmentCard(title: "Subagents", icon: "person.2") {
+                    ForEach(subagents) { task in TaskSummary(task: task) }
+                }
+            }
+
+            if !backgroundTasks.isEmpty || !activities.isEmpty {
+                EnvironmentCard(title: "Background processes", icon: "gearshape.2") {
+                    ForEach(backgroundTasks) { task in TaskSummary(task: task) }
+                    ForEach(activities) { activity in
+                        ToolActivitySummary(
+                            activity: activity, isSelected: selected?.id == activity.id
+                        ) {
+                            selected = activity
+                        }
+                    }
+                    if let selected {
+                        Divider()
+                        ToolActivityDetail(activity: selected)
+                    }
+                }
+            }
+
+            if usage.totalTokens == 0 && project.rewindPoints.isEmpty && subagents.isEmpty
+                && backgroundTasks.isEmpty && activities.isEmpty
+            {
+                EnvironmentCard(title: "Environment", icon: "sidebar.right") {
+                    Text("No changes or background work yet.")
+                        .font(Typography.caption)
+                        .foregroundStyle(Theme.foregroundTertiary)
+                }
+            }
+        }
+        .padding(Spacing.inset)
+        .frame(width: Layout.inspectorCardWidth, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+        .cardStyle()
+        .task {
+            await project.refreshRewindPoints()
+            await project.refreshActivity()
+        }
+    }
+}
+
+/// Reused card chrome keeps each environment kind distinct without making the
+/// inspector a visually undifferentiated column again.
+private struct EnvironmentCard<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            Label(title, systemImage: icon)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(Theme.foregroundSecondary)
+            VStack(alignment: .leading, spacing: Spacing.small) { content }
+        }
+        .padding(Spacing.standard)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .compactElevatedSurface()
+    }
+}
+
+private struct CheckpointSummary: View {
+    let point: RewindPoint
+
+    var body: some View {
+        HStack(spacing: Spacing.small) {
+            Text(point.tool.map { "Before \($0)" } ?? "Checkpoint")
+                .font(Typography.caption)
+                .lineLimit(1)
+            Spacer(minLength: Spacing.none)
+            if let date = point.createdAt {
+                Text(date.formatted(date: .omitted, time: .shortened))
+                    .font(Typography.detail)
+                    .foregroundStyle(Theme.foregroundTertiary)
+            }
+        }
+    }
+}
+
+private struct TaskSummary: View {
+    let task: TaskInfo
+
+    var body: some View {
+        HStack(spacing: Spacing.small) {
+            Text(task.label).font(Typography.caption).lineLimit(1)
+            Spacer(minLength: Spacing.none)
+            Text(task.status).font(Typography.detail).foregroundStyle(Theme.foregroundTertiary)
+        }
+    }
+}
+
+private struct ToolActivitySummary: View {
+    let activity: ToolActivity
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: Spacing.small) {
+                Text(activity.tool).font(Typography.caption).lineLimit(1)
+                Spacer(minLength: Spacing.none)
+                Text(String(describing: activity.status))
+                    .font(Typography.detail)
+                    .foregroundStyle(Theme.foregroundTertiary)
+            }
+            .padding(Spacing.compact)
+            .background(
+                isSelected ? Theme.surfaceHighest : .clear,
+                in: .rect(cornerRadius: CornerRadius.tag)
+            )
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// The selected activity stays in its kind's card so detail does not cause a
+/// second, permanent inspector region to reappear beside the conversation.
+private struct ToolActivityDetail: View {
+    let activity: ToolActivity
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.small) {
+            if let edit = ToolEdit(tool: activity.tool, arguments: activity.arguments) {
+                DiffView(edit: edit)
+            } else if !activity.arguments.isEmpty {
+                LabelledCode(title: "Arguments", body: activity.arguments)
+            }
+            if !activity.output.isEmpty {
+                LabelledCode(title: "Output", body: activity.output)
+            }
+        }
+    }
+}

--- a/macapp/Sources/GoCodeUI/TranscriptPresentation.swift
+++ b/macapp/Sources/GoCodeUI/TranscriptPresentation.swift
@@ -1,0 +1,40 @@
+import HarnessKit
+
+/// Presentation-only grouping collapses adjacent tool events without changing
+/// transcript storage, clipboard output, or the inspector's source data.
+struct TranscriptDisplayItem: Identifiable {
+    enum Kind {
+        case item(TranscriptItem)
+        case toolActivities([ToolActivity])
+    }
+
+    let id: String
+    let kind: Kind
+}
+
+enum TranscriptPresentation {
+    static func rows(for items: [TranscriptItem]) -> [TranscriptDisplayItem] {
+        var rows: [TranscriptDisplayItem] = []
+        var index = 0
+
+        while index < items.count {
+            let item = items[index]
+            guard case .toolActivity(let first) = item.kind else {
+                rows.append(.init(id: item.id.uuidString, kind: .item(item)))
+                index += 1
+                continue
+            }
+
+            var activities = [first]
+            var lastID = item.id.uuidString
+            index += 1
+            while index < items.count, case .toolActivity(let activity) = items[index].kind {
+                activities.append(activity)
+                lastID = items[index].id.uuidString
+                index += 1
+            }
+            rows.append(.init(id: "tool-group-\(lastID)", kind: .toolActivities(activities)))
+        }
+        return rows
+    }
+}

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -41,13 +41,25 @@ struct DesignTokenTests {
         #expect(Layout.inspectorCardWidth == 361)
     }
 
-    /// The user message is a deliberately calm, fixed-height neutral surface.
-    /// Pinning the measured target here prevents ownership blue or the old
-    /// compressed row height from returning during later transcript work.
-    @Test("transcript message uses the measured Codex-sized neutral surface")
+    /// The user-message row tracks its text role and vertical rhythm instead
+    /// of preserving an unexplained screenshot measurement.
+    @Test("transcript message height derives from its type and spacing roles")
     func transcriptMessageSurface() {
+        #expect(
+            Layout.userMessageMinimumHeight
+                == Typography.bodyLineHeight + (Spacing.userMessageVertical * 2))
         #expect(Layout.userMessageMinimumHeight == 45.5)
+        #expect(Layout.userMessageMaximumWidth == 374.5)
+        #expect(Typography.bodyPointSize == 16.5)
+        #expect(Typography.bodyLineHeight == 21.5)
         #expect(Theme.messageSurfaceLevel.dark == RGB(r: 36, g: 36, b: 36))
         #expect(Theme.messageSurfaceLevel.dark.isNeutral)
+    }
+
+    @Test("selected rail rows use the neutral selected-row tokens")
+    func selectedRailTokens() {
+        #expect(Theme.selectedRowSurfaceLevel.dark == RGB(r: 51, g: 51, b: 51))
+        #expect(Theme.selectedRowSurfaceLevel.dark.isNeutral)
+        #expect(Theme.selectedRowForegroundLevel.dark == RGB(r: 255, g: 255, b: 255))
     }
 }

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -24,7 +24,7 @@ struct DesignTokenTests {
         #expect(CornerRadius.code == 6)
         #expect(CornerRadius.control == 8)
         #expect(CornerRadius.card == 10)
-        #expect(CornerRadius.composer == 14)
+        #expect(CornerRadius.composer == 20)
         #expect(IconSize.status == 7)
         #expect(IconSize.detail == 14)
         #expect(IconSize.standard == 15)
@@ -61,5 +61,13 @@ struct DesignTokenTests {
         #expect(Theme.selectedRowSurfaceLevel.dark == RGB(r: 51, g: 51, b: 51))
         #expect(Theme.selectedRowSurfaceLevel.dark.isNeutral)
         #expect(Theme.selectedRowForegroundLevel.dark == RGB(r: 255, g: 255, b: 255))
+    }
+
+    @Test("conversation layout tokens share the Codex column and quieter divider")
+    func conversationLayout() {
+        #expect(Layout.chatContentMaximumWidth == 883)
+        #expect(Spacing.conversationHeaderHeight == 52)
+        #expect(Spacing.transcriptTop == 65.5)
+        #expect(Theme.separatorLevel.dark == RGB(r: 43, g: 43, b: 43))
     }
 }

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -40,4 +40,14 @@ struct DesignTokenTests {
     func environmentInspectorFootprint() {
         #expect(Layout.inspectorCardWidth == 361)
     }
+
+    /// The user message is a deliberately calm, fixed-height neutral surface.
+    /// Pinning the measured target here prevents ownership blue or the old
+    /// compressed row height from returning during later transcript work.
+    @Test("transcript message uses the measured Codex-sized neutral surface")
+    func transcriptMessageSurface() {
+        #expect(Layout.userMessageMinimumHeight == 45.5)
+        #expect(Theme.messageSurfaceLevel.dark == RGB(r: 36, g: 36, b: 36))
+        #expect(Theme.messageSurfaceLevel.dark.isNeutral)
+    }
 }

--- a/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
+++ b/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 
+@testable import GoCodeUI
+
 @Suite("Transcript feature reachability")
 struct TranscriptFeatureReachabilityTests {
 
@@ -38,5 +40,30 @@ struct TranscriptFeatureReachabilityTests {
         #expect(appShell.contains("Theme.surface.ignoresSafeArea(.container, edges: .top)"))
         #expect(chatView.contains("Layout.userMessageMaximumWidth"))
         #expect(chatView.contains(".foregroundStyle(Theme.foreground)"))
+    }
+
+    /// The transcript once rendered at the macOS 13pt system default because
+    /// its message views set no font at all. Every token test still passed —
+    /// the scale was correct and simply unread — so raising the type scale
+    /// changed nothing on screen. These assert the transcript is actually
+    /// wired to the scale, which is the part that silently broke.
+    @Test("transcript prose is bound to the shared type scale")
+    func transcriptConsumesTypeScale() throws {
+        let chatView = try String(
+            contentsOf: URL(filePath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appending(path: "Sources/GoCodeUI/ChatView.swift"),
+            encoding: .utf8)
+
+        #expect(chatView.contains(".font(Typography.body)"))
+        #expect(chatView.contains(".lineSpacing(Typography.bodyLineSpacing)"))
+    }
+
+    @Test("transcript leading resolves to the reference line pitch")
+    func lineSpacingMatchesReferencePitch() {
+        #expect(Typography.bodyLineSpacing == Typography.bodyLinePitch - Typography.bodyLineHeight)
+        #expect(Typography.bodyLinePitch == 26.5)
     }
 }

--- a/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
+++ b/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@Suite("Transcript feature reachability")
+struct TranscriptFeatureReachabilityTests {
+
+    @Test("usage and whole-conversation copy retain production call sites")
+    func featuresHaveProductionCallSites() throws {
+        let sourceDirectory = URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "Sources/GoCodeUI")
+        let source = try FileManager.default
+            .contentsOfDirectory(at: sourceDirectory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+            .map { try String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n")
+
+        #expect(source.contains("UsageLabel(usage: usage)"))
+        #expect(source.contains("TranscriptText.plain(items)"))
+    }
+
+    @Test("rail selection and user prompts retain their semantic layout tokens")
+    func transcriptAndRailUseSemanticTokens() throws {
+        let sourceDirectory = URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "Sources/GoCodeUI")
+        let appShell = try String(
+            contentsOf: sourceDirectory.appending(path: "AppShell.swift"), encoding: .utf8)
+        let chatView = try String(
+            contentsOf: sourceDirectory.appending(path: "ChatView.swift"), encoding: .utf8)
+
+        #expect(appShell.contains("Theme.selectedRowSurface"))
+        #expect(appShell.contains("Theme.selectedRowForeground"))
+        #expect(appShell.contains("Theme.surface.ignoresSafeArea(.container, edges: .top)"))
+        #expect(chatView.contains("Layout.userMessageMaximumWidth"))
+        #expect(chatView.contains(".foregroundStyle(Theme.foreground)"))
+    }
+}

--- a/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
+++ b/macapp/Tests/GoCodeUITests/TranscriptFeatureReachabilityTests.swift
@@ -23,6 +23,11 @@ struct TranscriptFeatureReachabilityTests {
         #expect(source.contains("TranscriptText.plain(items)"))
     }
 
+    /// Scans the whole module rather than named files. These treatments are
+    /// meant to exist *somewhere* in the UI; pinning them to AppShell.swift
+    /// made the test fail the moment the sidebar was extracted into its own
+    /// file, which is a refactor, not a regression. Module-wide still catches
+    /// the thing worth catching — a treatment being dropped entirely.
     @Test("rail selection and user prompts retain their semantic layout tokens")
     func transcriptAndRailUseSemanticTokens() throws {
         let sourceDirectory = URL(filePath: #filePath)
@@ -30,16 +35,17 @@ struct TranscriptFeatureReachabilityTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appending(path: "Sources/GoCodeUI")
-        let appShell = try String(
-            contentsOf: sourceDirectory.appending(path: "AppShell.swift"), encoding: .utf8)
-        let chatView = try String(
-            contentsOf: sourceDirectory.appending(path: "ChatView.swift"), encoding: .utf8)
+        let source = try FileManager.default
+            .contentsOfDirectory(at: sourceDirectory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+            .map { try String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n")
 
-        #expect(appShell.contains("Theme.selectedRowSurface"))
-        #expect(appShell.contains("Theme.selectedRowForeground"))
-        #expect(appShell.contains("Theme.surface.ignoresSafeArea(.container, edges: .top)"))
-        #expect(chatView.contains("Layout.userMessageMaximumWidth"))
-        #expect(chatView.contains(".foregroundStyle(Theme.foreground)"))
+        #expect(source.contains("Theme.selectedRowSurface"))
+        #expect(source.contains("Theme.selectedRowForeground"))
+        #expect(source.contains("Theme.surface.ignoresSafeArea(.container, edges: .top)"))
+        #expect(source.contains("Layout.userMessageMaximumWidth"))
+        #expect(source.contains(".foregroundStyle(Theme.foreground)"))
     }
 
     /// The transcript once rendered at the macOS 13pt system default because

--- a/macapp/Tests/GoCodeUITests/TranscriptTextTests.swift
+++ b/macapp/Tests/GoCodeUITests/TranscriptTextTests.swift
@@ -13,6 +13,24 @@ struct TranscriptTextTests {
         #expect(TranscriptActivityLabel.completed(durationMS: nil) == "Worked")
     }
 
+    @Test("consecutive tool calls collapse into one timed activity row")
+    func collapsesConsecutiveToolCalls() {
+        #expect(TranscriptActivityLabel.completed(durationMS: 2_001) == "Worked for 3s")
+        #expect(TranscriptActivityLabel.completed(durationMS: 10_501) == "Worked for 11s")
+    }
+
+    @Test("adjacent tool transcript entries become one presentation row")
+    func adjacentToolRowsCollapse() throws {
+        let built = try transcript([
+            ("tool.call.started", #"{"call_id":"one","tool":"read","arguments":"{}"}"#),
+            ("tool.call.completed", #"{"call_id":"one","duration_ms":1000}"#),
+            ("tool.call.started", #"{"call_id":"two","tool":"read","arguments":"{}"}"#),
+            ("tool.call.completed", #"{"call_id":"two","duration_ms":2000}"#),
+        ])
+
+        #expect(TranscriptPresentation.rows(for: built.items).count == 1)
+    }
+
     /// Builds transcript items the way the app does — by replaying events —
     /// rather than constructing them directly, so the test cannot drift from
     /// the shapes harnessd actually produces.

--- a/macapp/Tests/GoCodeUITests/TranscriptTextTests.swift
+++ b/macapp/Tests/GoCodeUITests/TranscriptTextTests.swift
@@ -7,6 +7,12 @@ import Testing
 @Suite("TranscriptText")
 struct TranscriptTextTests {
 
+    @Test("completed activity label rounds milliseconds into Codex-style seconds")
+    func completedActivityLabel() {
+        #expect(TranscriptActivityLabel.completed(durationMS: 10_501) == "Worked for 11s")
+        #expect(TranscriptActivityLabel.completed(durationMS: nil) == "Worked")
+    }
+
     /// Builds transcript items the way the app does — by replaying events —
     /// rather than constructing them directly, so the test cannot drift from
     /// the shapes harnessd actually produces.


### PR DESCRIPTION
Round 4. A critic drove real conversations into both apps and delivered a blunt verdict:

> **GoCode does not win.** Still distinguishable in under a second. The blue user bubble (Codex's transcript is entirely neutral) and the stack of grey tool cards (Codex draws one line of text). One screenshot reads as a log viewer, the other as a page of writing.

| # | Finding | Was | Now | Codex |
|---|---|---|---|---|
| 1 | User bubble blue and half-height | `#14273B`, 32pt | neutral `#242424`, 45.5pt | `#242424`, 45.5pt |
| 2 | Tool calls as filled cards | 29pt filled `#222222` | plain line + 1pt hairline | plain line + hairline |
| 3 | Ragged left edges | 5 edges over 36.5pt | one column | 4 edges within 3.0pt |
| 4 | Persistent status strip | 30pt full-width | inline, only while running | inline |
| 5 | Message actions | 1 icon right | moved left | 4 icons left |

On #5 — only the Copy action exists and it moved left. Three inert controls to match Codex's *count* would be decoration, not parity, so they weren't added.

Worth recording: `docs/design/codex-app-reference.md` claims Codex renders activity as chips. It doesn't — plain text above a hairline, confirmed across three captures hours apart. That doc has now been wrong twice, which is the argument for measuring the running app.

158 tests, build and strict lint clean — verified locally, since the Codex sandbox can't compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9