### PR TITLE
fix(macapp): configure a run store so the Activity screen has data

### DIFF
--- a/macapp/Sources/HarnessKit/HarnessSupervisor.swift
+++ b/macapp/Sources/HarnessKit/HarnessSupervisor.swift
@@ -66,6 +66,16 @@ public actor HarnessSupervisor {
             env["HARNESS_CONVERSATION_DB"] =
                 harnessDirectory.appending(path: "conversations.db").path
         }
+        // Same story for runs: with no run store harnessd answers 501 on
+        // /v1/runs, so the Activity screen could only ever report "this server
+        // has no run store configured" — a dead panel in every app-supervised
+        // daemon, since nothing else was ever going to set this.
+        if env["HARNESS_RUN_DB"] == nil {
+            let harnessDirectory = workspace.appending(path: ".harness")
+            try? FileManager.default.createDirectory(
+                at: harnessDirectory, withIntermediateDirectories: true)
+            env["HARNESS_RUN_DB"] = harnessDirectory.appending(path: "runs.db").path
+        }
         // harnessd resolves its prompts and model catalog relative to its
         // *working directory* and workspace — both of which are the user's
         // project here, and neither contains those files. Without pinning them

--- a/macapp/Tests/HarnessKitTests/SupervisorTests.swift
+++ b/macapp/Tests/HarnessKitTests/SupervisorTests.swift
@@ -157,6 +157,23 @@ struct SupervisorTests {
         await supervisor.stop()
     }
 
+    /// Without this the daemon answers 501 on /v1/runs, so the Activity screen
+    /// can only ever say the server has no run store — which is what it did,
+    /// permanently, because nothing else sets this variable.
+    @Test("configures a run store for the project")
+    func configuresRunStore() async throws {
+        let workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "proj-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        let supervisor = HarnessSupervisor(binary: try makeStubServer(), workspace: workspace)
+        _ = try await supervisor.start()
+        let path = await supervisor.environment["HARNESS_RUN_DB"]
+        #expect(path?.hasPrefix(workspace.path) == true)
+        #expect(path?.hasSuffix("runs.db") == true)
+        await supervisor.stop()
+    }
+
     @Test("passes the workspace to the child so it serves the right project")
     func passesWorkspace() async throws {
         let workspace = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
## Problem

The Activity screen's **Runs** section could only ever render:

> This server has no run store configured, so past runs are not listed.

This was not user misconfiguration. The app supervises its own `harnessd`, and `HarnessSupervisor` never set `HARNESS_RUN_DB` — so `GET /v1/runs` answered `501` for every app-launched daemon and the panel was permanently dead.

## Fix

The supervisor already configures a conversation store for exactly this reason (without it, sessions/fork/undo/rewind are all dead routes). Runs now get the same treatment, in the same `.harness/` directory beside the project.

## Verification

Checked against running daemons, not just the environment variable — a passing env-var assertion would not have proved the route works:

| Daemon | `GET /v1/runs` |
|---|---|
| started before this change | `501` |
| started after this change | `401` — route live, wants the app's token |

`runs.db` is created and migrated at startup. 157 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9