### PR TITLE
docs: correct an overstated claim about the Codex reference doc

### DIFF
--- a/.ux/design-baseline.md
+++ b/.ux/design-baseline.md
@@ -1,8 +1,16 @@
 # Design baseline — GoCode vs. Codex (ChatGPT.app)
 
 **The bar.** Every number here was measured from the two apps running live. Live
-numbers outrank anything written in prose, including our own design docs —
-`docs/design/codex-app-reference.md` has been wrong twice.
+numbers outrank anything written in prose, including our own design docs.
+
+One recorded divergence, stated precisely rather than as a general warning:
+`docs/design/codex-app-reference.md` §2 describes Codex's collapsed activity as
+chips or pills; in two captures 8.5 hours apart it rendered as plain text over a
+1pt hairline, with the page colour sampled either side and no fill. That is
+**one** divergence observed twice, not two separate errors — and the doc may be
+describing a different app state rather than being wrong, since only the
+text-and-rule form was ever observed here. Prefer the live measurement; do not
+infer from this that the doc is generally unreliable.
 
 - **Reference**: the Codex surface inside `ChatGPT.app`. Window `1728 × 1079 pt`.
   Capture: `/tmp/gauntlet/codex.png` (3456 × 2158 px @2x).

--- a/.ux/gauntlet.md
+++ b/.ux/gauntlet.md
@@ -205,5 +205,7 @@ verified live: the rail now fills in without a relaunch.
   land that round, so nobody has measured it rendered. Not counted closed.
 - One round measured both sides by pixel probe alone (no accessibility tree).
   Instruments are stated per round rather than blurred.
-- `docs/design/codex-app-reference.md` has now been wrong twice. The running app
-  is the bar for a reason.
+- `docs/design/codex-app-reference.md` §2 describes collapsed activity as chips;
+  it rendered as text over a hairline in two captures 8.5 hours apart. That is one
+  divergence seen twice, not two errors, and the doc may simply describe a state
+  we never hit. The running app is the bar; the doc is not therefore unreliable.


### PR DESCRIPTION
Both `.ux/design-baseline.md` and `.ux/gauntlet.md` said `docs/design/codex-app-reference.md` "has now been wrong twice."

Checking the evidence behind that: there is **one** divergence — §2 describes Codex's collapsed activity as chips or pills, and it rendered as plain text over a 1pt hairline — observed in two captures 8.5 hours apart. One divergence seen twice is not two errors.

The baseline itself already carried the caveat that both forms may exist in different app states and only the text-and-rule form was ever observed here, so the doc may not be wrong at all.

That phrasing was mine, in a file whose entire purpose is to be trusted over prose. Replaced with the specific observation and its caveat, and an explicit note not to infer general unreliability from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9