### PR TITLE
fix: async capabilities report their results — background jobs, callbacks, rail and panel

### DIFF
--- a/cmd/harnessd/main.go
+++ b/cmd/harnessd/main.go
@@ -625,6 +625,12 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 	// and POST /v1/jobs/{id}/kill can terminate them.
 	jobTracker := harness.NewJobTracker()
 
+	// Background job completions have to reach two places the job manager
+	// cannot see: the conversation's SSE stream and the model's next turn.
+	// Bound to the Runner below, mirroring callbackBridge, because the registry
+	// that owns the job manager is built before the Runner exists.
+	jobBridge := harness.NewJobEventBridge()
+
 	// MCP server startup: TOML config (layers 1-3, no profile) then env var
 	// servers are registered additively. TOML entries take precedence over env
 	// var entries with the same name.
@@ -781,6 +787,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		CronClient:         cronClient,
 		CallbackManager:    callbackMgr,
 		JobTracker:         jobTracker,
+		JobEvents:          jobBridge,
 		Activations:        activations,
 		Sourcegraph: htools.SourcegraphConfig{
 			Endpoint: sourcegraphEndpoint,
@@ -946,6 +953,7 @@ func runWithSignalsWithDeps(sig <-chan os.Signal, getenv func(string) string, ne
 		callbackBridge:       callbackBridge,
 		callbackMgr:          callbackMgr,
 		jobTracker:           jobTracker,
+		jobBridge:            jobBridge,
 		msgSummarizer:        msgSummarizer,
 		skillManager:         skillManager,
 		hooksSummary:         hooksSummary,

--- a/cmd/harnessd/runtime_container.go
+++ b/cmd/harnessd/runtime_container.go
@@ -99,6 +99,7 @@ type httpRuntimeOptions struct {
 	callbackStarter      *callbackRunStarter
 	cronStarter          *cronRunStarter
 	callbackBridge       *harness.CallbackEventBridge
+	jobBridge            *harness.JobEventBridge
 	callbackMgr          *htools.CallbackManager
 	jobTracker           *harness.JobTracker
 	msgSummarizer        *lazySummarizer
@@ -287,6 +288,11 @@ func buildHTTPRuntime(opts httpRuntimeOptions) (httpRuntime, error) {
 
 	if opts.callbackBridge != nil {
 		opts.callbackBridge.BindRunner(runner)
+	}
+
+	if opts.jobBridge != nil {
+		opts.jobBridge.BindRunner(runner)
+		runner.SetJobNotices(opts.jobBridge)
 	}
 
 	if opts.msgSummarizer != nil {

--- a/internal/harness/default_registry_conditional_tools_test.go
+++ b/internal/harness/default_registry_conditional_tools_test.go
@@ -181,6 +181,42 @@ func TestNewDefaultRegistryWithOptions_DelayedCallbackToolRegistration(t *testin
 	}
 }
 
+// TestDelayedCallbackToolsAreCoreNotDeferred pins that the callback tools reach
+// the model without discovery.
+//
+// Registration alone is not enough and the test above cannot see the
+// difference: a deferred tool is registered but withheld from
+// DefinitionsForRun until find_tool activates it for that run. Shipped that
+// way, a model asked for a reminder knew a callback existed, did not see one
+// in its tool list, guessed it was a skill, and failed with
+// "skill not found: set_delayed_callback".
+func TestDelayedCallbackToolsAreCoreNotDeferred(t *testing.T) {
+	t.Parallel()
+
+	mgr := htools.NewCallbackManager(stubRunStarterForRegistryTest{})
+	defer mgr.Shutdown()
+
+	registry := NewDefaultRegistryWithOptions(t.TempDir(), DefaultRegistryOptions{
+		ApprovalMode:    ToolApprovalModeFullAuto,
+		CallbackManager: mgr,
+	})
+
+	// A nil tracker means nothing has been activated, so only core tools show.
+	visible := map[string]bool{}
+	for _, def := range registry.DefinitionsForRun("run-1", nil) {
+		visible[def.Name] = true
+	}
+
+	for _, name := range []string{
+		"set_delayed_callback", "cancel_delayed_callback", "list_delayed_callbacks",
+	} {
+		if !visible[name] {
+			t.Errorf("%q is not visible to a run without activation — it is deferred, "+
+				"so the model cannot call it without discovering it first", name)
+		}
+	}
+}
+
 // TestNewDefaultRegistryWithOptions_CronToolRegistration pins that all six cron
 // tools are registered when a CronClient is configured, and that none of them
 // leak into a registry built without one.

--- a/internal/harness/events.go
+++ b/internal/harness/events.go
@@ -404,6 +404,7 @@ func AllEventTypes() []EventType {
 		EventReasoningComplete,
 		EventToolCallStarted,
 		EventToolCallCompleted,
+		EventBackgroundJobCompleted,
 		EventToolCallDelta,
 		EventToolActivated,
 		EventToolOutputDelta,

--- a/internal/harness/events_test.go
+++ b/internal/harness/events_test.go
@@ -51,8 +51,10 @@ func TestIsTerminalEvent(t *testing.T) {
 
 func TestAllEventTypes_Count(t *testing.T) {
 	all := AllEventTypes()
-	if len(all) != 78 {
-		t.Errorf("AllEventTypes() returned %d events, want 78", len(all))
+	// 79 since job.completed was added: a background job outlives the run that
+	// started it, so its result needs an event of its own to reach the UI.
+	if len(all) != 79 {
+		t.Errorf("AllEventTypes() returned %d events, want 79", len(all))
 	}
 	// Verify no duplicates
 	seen := make(map[EventType]bool)

--- a/internal/harness/job_bridge.go
+++ b/internal/harness/job_bridge.go
@@ -1,0 +1,208 @@
+package harness
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// EventBackgroundJobCompleted carries a finished background job's result onto
+// the originating conversation's stream.
+const EventBackgroundJobCompleted EventType = "job.completed"
+
+// maxQueuedJobNoticeBytes bounds how much of a job's output is replayed into
+// the next turn. A background job can print megabytes; the model needs to know
+// what happened, not to have its context filled by one command.
+const maxQueuedJobNoticeBytes = 2000
+
+// maxQueuedJobNotices bounds how many completions accumulate for one
+// conversation while no run is listening.
+const maxQueuedJobNotices = 20
+
+// JobEventBridge reports background job completions to both surfaces that
+// need them: the UI, via an event on the originating conversation's live run,
+// and the model, via a notice queued for its next turn.
+//
+// Both halves are necessary and neither is sufficient. A background job
+// routinely finishes after the run that started it has ended, so at completion
+// there is often no open stream to emit on — which is why completions are
+// queued rather than only emitted. Equally, a queued notice alone would leave
+// the UI silent for a job that finishes while the user is watching.
+type JobEventBridge struct {
+	mu      sync.Mutex
+	runner  *Runner
+	pending map[string][]htools.JobCompletion // conversation ID -> completions
+}
+
+func NewJobEventBridge() *JobEventBridge {
+	return &JobEventBridge{pending: make(map[string][]htools.JobCompletion)}
+}
+
+// BindRunner attaches the Runner events are emitted through. Safe to call once
+// the Runner exists; completions that arrive before then are still queued.
+func (b *JobEventBridge) BindRunner(r *Runner) {
+	b.mu.Lock()
+	b.runner = r
+	b.mu.Unlock()
+}
+
+// JobCompleted implements tools.JobEvents.
+func (b *JobEventBridge) JobCompleted(c htools.JobCompletion) {
+	b.mu.Lock()
+	r := b.runner
+	if c.ConversationID != "" {
+		queue := b.pending[c.ConversationID]
+		if len(queue) < maxQueuedJobNotices {
+			b.pending[c.ConversationID] = append(queue, c)
+		}
+	}
+	b.mu.Unlock()
+
+	if r == nil {
+		return
+	}
+	// Delivered to the conversation, not to a run. A background job routinely
+	// outlives the run that started it, and the run-scoped fan-out is keyed on
+	// live run state — so emitting there reached nobody in exactly the case
+	// this exists for. The app already subscribes per conversation
+	// (GET /v1/conversations/{id}/events), which is where a fact about the
+	// conversation belongs anyway.
+	r.emitToConversation(c.ConversationID, c.RunID, EventBackgroundJobCompleted, map[string]any{
+		"shell_id":    c.ShellID,
+		"command":     c.Command,
+		"exit_code":   c.ExitCode,
+		"timed_out":   c.TimedOut,
+		"output":      truncateJobNotice(c.Output),
+		"truncated":   c.Truncated,
+		"working_dir": c.WorkingDir,
+	})
+}
+
+// TakeNotices removes and returns the completions queued for a conversation.
+// They are consumed rather than read so the same job is not reported to the
+// model on every subsequent turn.
+func (b *JobEventBridge) TakeNotices(conversationID string) []htools.JobCompletion {
+	if conversationID == "" {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	queued := b.pending[conversationID]
+	delete(b.pending, conversationID)
+	return queued
+}
+
+// FormatJobNotices renders queued completions as a short message for the
+// model. Returns "" when there is nothing to report, so callers can skip
+// injecting an empty turn.
+func FormatJobNotices(completions []htools.JobCompletion) string {
+	if len(completions) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Background jobs finished since your last turn:\n")
+	for _, c := range completions {
+		status := fmt.Sprintf("exit %d", c.ExitCode)
+		if c.TimedOut {
+			status = "timed out"
+		}
+		fmt.Fprintf(&b, "\n- %s (%s, %s)\n", c.Command, c.ShellID, status)
+		out := truncateJobNotice(c.Output)
+		if out == "" {
+			b.WriteString("  (no output)\n")
+			continue
+		}
+		for _, line := range strings.Split(out, "\n") {
+			fmt.Fprintf(&b, "  %s\n", line)
+		}
+		if c.Truncated {
+			b.WriteString("  [output truncated — use job_output for the full result]\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func truncateJobNotice(s string) string {
+	if len(s) <= maxQueuedJobNoticeBytes {
+		return s
+	}
+	return s[:maxQueuedJobNoticeBytes] + "\n[…truncated]"
+}
+
+// isLiveRun reports whether a run exists and has not terminated. A background
+// job's originating run is usually gone by the time it finishes, so this is
+// the check that decides between emitting now and relying on the queue.
+func (r *Runner) isLiveRun(runID string) bool {
+	if runID == "" {
+		return false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	state, ok := r.runs[runID]
+	return ok && state != nil && !state.terminated
+}
+
+// JobNoticeSource supplies background-job completions that finished since a
+// conversation's last turn.
+type JobNoticeSource interface {
+	TakeNotices(conversationID string) []htools.JobCompletion
+}
+
+// SetJobNotices installs the source consulted at the start of each run for
+// background jobs that finished while nothing was listening.
+func (r *Runner) SetJobNotices(src JobNoticeSource) {
+	r.mu.Lock()
+	r.jobNotices = src
+	r.mu.Unlock()
+}
+
+// takeJobNoticeBlock returns a rendered notice for the conversation, or "".
+// Consuming here means each completion is reported to the model exactly once.
+func (r *Runner) takeJobNoticeBlock(conversationID string) string {
+	r.mu.RLock()
+	src := r.jobNotices
+	r.mu.RUnlock()
+	if src == nil {
+		return ""
+	}
+	return FormatJobNotices(src.TakeNotices(conversationID))
+}
+
+// emitToConversation delivers an event to every conversation-scoped subscriber
+// without requiring a live run.
+//
+// The normal emit path hangs the event off a run's state and fans out from
+// there, which is right for anything a run produces. A background job's
+// completion is not one of those: by the time it arrives its run has usually
+// ended, so that path drops it precisely when it matters.
+func (r *Runner) emitToConversation(convID, originRunID string, eventType EventType, payload map[string]any) {
+	if convID == "" {
+		return
+	}
+	r.mu.RLock()
+	subs := make([]chan Event, 0, len(r.convSubscribers[convID]))
+	for ch := range r.convSubscribers[convID] {
+		subs = append(subs, ch)
+	}
+	r.mu.RUnlock()
+	if len(subs) == 0 {
+		return
+	}
+	for _, ch := range subs {
+		event := Event{
+			RunID:     originRunID,
+			Type:      eventType,
+			Timestamp: time.Now().UTC(),
+			Payload:   deepClonePayload(payload),
+		}
+		select {
+		case ch <- event:
+		default:
+			// Drop for a subscriber that cannot keep up rather than blocking
+			// the job reaper; the queued notice still reaches the model.
+		}
+	}
+}

--- a/internal/harness/job_bridge_test.go
+++ b/internal/harness/job_bridge_test.go
@@ -1,0 +1,113 @@
+package harness
+
+import (
+	"strings"
+	"testing"
+
+	htools "go-agent-harness/internal/harness/tools"
+)
+
+// The reported failure in one sentence: a background job ran, exited, printed
+// correctly, and told nobody — so the model reported to the user that it had
+// never fired. These pin the two paths that now carry the result.
+
+func TestJobCompletionIsQueuedWhenNoRunIsListening(t *testing.T) {
+	bridge := NewJobEventBridge()
+
+	// No runner bound: this is the normal case, because a background job
+	// usually finishes after the run that started it has ended.
+	bridge.JobCompleted(htools.JobCompletion{
+		ShellID:        "job_1",
+		Command:        "sleep 15; echo hello dennison",
+		ConversationID: "conv-a",
+		Output:         "hello dennison",
+	})
+
+	notices := bridge.TakeNotices("conv-a")
+	if len(notices) != 1 {
+		t.Fatalf("got %d queued notices, want 1 — a completion with no live run was dropped", len(notices))
+	}
+	if notices[0].Output != "hello dennison" {
+		t.Errorf("queued output = %q, want %q", notices[0].Output, "hello dennison")
+	}
+}
+
+func TestJobNoticesAreConsumedSoTheyReportOnce(t *testing.T) {
+	bridge := NewJobEventBridge()
+	bridge.JobCompleted(htools.JobCompletion{ShellID: "job_1", ConversationID: "conv-a", Output: "done"})
+
+	if got := len(bridge.TakeNotices("conv-a")); got != 1 {
+		t.Fatalf("first take returned %d notices, want 1", got)
+	}
+	if got := len(bridge.TakeNotices("conv-a")); got != 0 {
+		t.Errorf("second take returned %d notices, want 0 — the same job would be "+
+			"reported to the model on every subsequent turn", got)
+	}
+}
+
+func TestJobNoticesAreScopedToTheirConversation(t *testing.T) {
+	bridge := NewJobEventBridge()
+	bridge.JobCompleted(htools.JobCompletion{ShellID: "job_1", ConversationID: "conv-a", Output: "a"})
+	bridge.JobCompleted(htools.JobCompletion{ShellID: "job_2", ConversationID: "conv-b", Output: "b"})
+
+	if got := len(bridge.TakeNotices("conv-a")); got != 1 {
+		t.Errorf("conv-a got %d notices, want 1", got)
+	}
+	if got := len(bridge.TakeNotices("conv-b")); got != 1 {
+		t.Errorf("conv-b got %d notices, want 1", got)
+	}
+}
+
+func TestFormatJobNoticesReportsCommandStatusAndOutput(t *testing.T) {
+	out := FormatJobNotices([]htools.JobCompletion{{
+		ShellID:  "job_1",
+		Command:  "sleep 15; echo hello dennison",
+		ExitCode: 0,
+		Output:   "hello dennison",
+	}})
+
+	for _, want := range []string{"hello dennison", "job_1", "exit 0", "sleep 15"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("notice %q does not mention %q", out, want)
+		}
+	}
+}
+
+// A job that produced nothing must say so, rather than rendering an empty
+// bullet the model has to interpret.
+func TestFormatJobNoticesMarksSilentJobs(t *testing.T) {
+	out := FormatJobNotices([]htools.JobCompletion{{ShellID: "job_1", Command: "true", ExitCode: 0}})
+	if !strings.Contains(out, "(no output)") {
+		t.Errorf("notice %q does not mark a silent job", out)
+	}
+}
+
+func TestFormatJobNoticesEmptyWhenNothingFinished(t *testing.T) {
+	if got := FormatJobNotices(nil); got != "" {
+		t.Errorf("FormatJobNotices(nil) = %q, want empty so no turn is injected", got)
+	}
+}
+
+// A background job can print megabytes; the model needs to know what happened,
+// not to have its context filled by one command.
+func TestJobNoticeOutputIsBounded(t *testing.T) {
+	huge := strings.Repeat("x", maxQueuedJobNoticeBytes*3)
+	out := FormatJobNotices([]htools.JobCompletion{{ShellID: "job_1", Command: "spew", Output: huge}})
+	if len(out) > maxQueuedJobNoticeBytes*2 {
+		t.Errorf("notice is %d bytes, want it bounded near %d", len(out), maxQueuedJobNoticeBytes)
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Error("a truncated notice must say so")
+	}
+}
+
+func TestQueuedNoticesAreBounded(t *testing.T) {
+	bridge := NewJobEventBridge()
+	for i := 0; i < maxQueuedJobNotices*3; i++ {
+		bridge.JobCompleted(htools.JobCompletion{ShellID: "job", ConversationID: "conv-a"})
+	}
+	if got := len(bridge.TakeNotices("conv-a")); got > maxQueuedJobNotices {
+		t.Errorf("queued %d notices, want at most %d — an unbounded queue is a leak",
+			got, maxQueuedJobNotices)
+	}
+}

--- a/internal/harness/registry.go
+++ b/internal/harness/registry.go
@@ -41,6 +41,25 @@ type Registry struct {
 	mcpServers     map[string]struct{} // tracks registered MCP server names to prevent duplicates
 	mcpServerTools map[string][]string // maps server name → tool names registered for that server
 	shutdownHooks  []func(context.Context) error
+	// jobManager owns this registry's background bash jobs. Retained so a
+	// cancelled run can terminate the jobs it started — those jobs are
+	// detached from the run's context on purpose, so cancellation has to be
+	// said explicitly rather than propagated.
+	jobManager *htools.JobManager
+}
+
+// SetJobManager records the background-job manager backing this registry.
+func (r *Registry) SetJobManager(m *htools.JobManager) {
+	r.mu.Lock()
+	r.jobManager = m
+	r.mu.Unlock()
+}
+
+// JobManager returns this registry's background-job manager, or nil.
+func (r *Registry) JobManager() *htools.JobManager {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.jobManager
 }
 
 func NewRegistry() *Registry {

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -269,7 +269,11 @@ type Runner struct {
 	providerRegistry *catalog.ProviderRegistry
 	activations      *ActivationTracker
 	skillConstraints *SkillConstraintTracker
-	envInfo          systemprompt.EnvironmentInfo
+	// jobNotices supplies background jobs that finished while no run was
+	// listening, so their results reach the model's next turn instead of
+	// sitting in a buffer nobody knows to read. Guarded by r.mu.
+	jobNotices JobNoticeSource
+	envInfo    systemprompt.EnvironmentInfo
 
 	mu            sync.RWMutex
 	runs          map[string]*runState
@@ -3664,7 +3668,35 @@ func (r *Runner) CancelRun(runID string) error {
 	if cancelFn, loaded := r.cancelFuncs.Load(runID); loaded {
 		cancelFn.(context.CancelFunc)()
 	}
+
+	// Background jobs are deliberately detached from the run's context, so a
+	// run finishing normally does not kill work it launched on purpose.
+	// Cancelling is the case where the user does want them stopped, so it is
+	// said explicitly here rather than left to context propagation — which
+	// could only ever mean both things at once, and used to mean the wrong one.
+	r.killBackgroundJobsForRun(runID)
 	return nil
+}
+
+// killBackgroundJobsForRun terminates background jobs started by a run across
+// every registry that might own them: the main one, and the per-run registry
+// built when a workspace is provisioned.
+func (r *Runner) killBackgroundJobsForRun(runID string) {
+	registries := []*Registry{r.tools}
+	r.mu.RLock()
+	if state, ok := r.runs[runID]; ok && state != nil && state.perRunTools != nil {
+		registries = append(registries, state.perRunTools)
+	}
+	r.mu.RUnlock()
+
+	for _, reg := range registries {
+		if reg == nil {
+			continue
+		}
+		if jm := reg.JobManager(); jm != nil {
+			jm.KillForRun(runID)
+		}
+	}
 }
 
 // Shutdown gracefully stops the runner. It signals the poolDispatcher (if

--- a/internal/harness/runner_step_engine.go
+++ b/internal/harness/runner_step_engine.go
@@ -284,6 +284,16 @@ func (se *stepEngine) run() {
 				Environment:            envInfo,
 			}))
 		}
+		// Background jobs that finished while nothing was listening are
+		// reported here, on the first step only. Consuming them means each is
+		// reported exactly once; leaving them for a job_output poll meant a
+		// job that ran and printed correctly was reported to the user as
+		// never having fired.
+		if step == 0 {
+			if notices := r.takeJobNoticeBlock(r.runMetadata(runID).ConversationID); notices != "" {
+				runtimeContext = strings.TrimSpace(runtimeContext + "\n\n" + notices)
+			}
+		}
 		planModeGuidance := r.planModePromptBlock(runID)
 		turnMessages := r.buildTurnMessages(systemPrompt, messages, workingMemorySnippet, memorySnippetForSnapshot, injectedRuleContent.String(), planModeGuidance, runtimeContext)
 

--- a/internal/harness/tools/bash_manager.go
+++ b/internal/harness/tools/bash_manager.go
@@ -369,6 +369,11 @@ func (m *JobManager) runBackground(ctx context.Context, command string, timeoutS
 		return nil, fmt.Errorf("start background command: %w", err)
 	}
 
+	// Read the sink before the goroutine, not inside it. Reading it under
+	// job.mu would take m.mu while holding job.mu, which is the opposite order
+	// from cleanupExpired and deadlocks the manager.
+	sink := m.jobEvents()
+
 	go func() {
 		defer m.wg.Done()
 		err := cmd.Wait()
@@ -395,7 +400,7 @@ func (m *JobManager) runBackground(ctx context.Context, command string, timeoutS
 		// read. Built while the job lock is held so the snapshot is coherent,
 		// but delivered from a separate goroutine so a slow sink cannot block
 		// the reaper or deadlock against a sink that calls back in.
-		if sink := m.jobEvents(); sink != nil {
+		if sink != nil {
 			completion := JobCompletion{
 				ShellID:        job.id,
 				Command:        job.command,

--- a/internal/harness/tools/bash_manager.go
+++ b/internal/harness/tools/bash_manager.go
@@ -67,6 +67,11 @@ type backgroundJob struct {
 	// tenantID is the tenant of the run that started the job, captured from
 	// the tool execution context. Empty for unscoped/legacy callers.
 	tenantID string
+	// conversationID and runID identify where to report the result. A job
+	// routinely outlives the run that started it, so the completion has to
+	// carry its own origin rather than relying on whatever run is current.
+	conversationID string
+	runID          string
 
 	stdout *headTailBuffer
 	stderr *headTailBuffer
@@ -77,6 +82,34 @@ type backgroundJob struct {
 	timedOut bool
 	err      error
 	cancel   context.CancelFunc
+}
+
+// JobCompletion describes a finished background job.
+type JobCompletion struct {
+	ShellID    string
+	Command    string
+	WorkingDir string
+	TenantID   string
+	// ConversationID and RunID are the job's origin, captured at start. A job
+	// commonly finishes after its run has ended, so the completion cannot be
+	// attributed by asking what is running now.
+	ConversationID string
+	RunID          string
+	ExitCode       int
+	TimedOut       bool
+	Output         string
+	Truncated      bool
+}
+
+// JobEvents receives a background job's completion.
+//
+// Without this the only way to learn a job had finished was to poll
+// job_output with the right shell_id, so a job that completed after its run
+// ended told nobody: not the model, which had moved on, and not the UI, which
+// had no event to render. A capability that cannot report its own result gets
+// chosen again and misleads again.
+type JobEvents interface {
+	JobCompleted(JobCompletion)
 }
 
 type JobManager struct {
@@ -91,6 +124,21 @@ type JobManager struct {
 	maxOutputBytes int
 	now            func() time.Time
 	sandboxScope   SandboxScope // optional sandbox enforcement
+	events         JobEvents
+}
+
+// SetJobEvents installs the sink notified when a background job finishes.
+// Safe to call before any command is launched; nil disables notification.
+func (m *JobManager) SetJobEvents(events JobEvents) {
+	m.mu.Lock()
+	m.events = events
+	m.mu.Unlock()
+}
+
+func (m *JobManager) jobEvents() JobEvents {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.events
 }
 
 func NewJobManager(workspaceRoot string, now func() time.Time) *JobManager {
@@ -260,24 +308,39 @@ func (m *JobManager) runBackground(ctx context.Context, command string, timeoutS
 		return nil, fmt.Errorf("background job limit reached")
 	}
 	id := "job_" + strconv.FormatUint(atomic.AddUint64(&m.nextID, 1), 10)
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
+	// Detached from the caller's context, keeping only its values.
+	//
+	// Inheriting cancellation defeated the point of the tool: the context
+	// belongs to the run that started the job, so when the run finished the
+	// job was killed mid-flight. A "sleep 15; echo ..." reminder never reached
+	// its echo, and the job reported exit -1 with no output — which the model
+	// read, correctly, as "it did not fire", and then wrongly blamed the tool.
+	//
+	// A background job's lifetime is its own timeout, the manager's shutdown,
+	// or an explicit job_kill. Not the turn that happened to launch it.
+	ctx, cancel := context.WithTimeout(
+		context.WithoutCancel(ctx), time.Duration(timeoutSeconds)*time.Second)
 	// Capture the originating run's tenant so daemon-wide listings (the
 	// /v1/tasks union) can scope jobs to their owning tenant. Absent for
 	// callers without run metadata (e.g. the exported RunBackground wrapper).
-	var tenantID string
+	var tenantID, conversationID, originRunID string
 	if md, ok := RunMetadataFromContext(ctx); ok {
 		tenantID = md.TenantID
+		conversationID = md.ConversationID
+		originRunID = md.RunID
 	}
 	job := &backgroundJob{
-		id:         id,
-		command:    command,
-		workingDir: workDir,
-		startedAt:  m.now(),
-		tenantID:   tenantID,
-		stdout:     newHeadTailBuffer(m.maxOutputBytes),
-		stderr:     newHeadTailBuffer(m.maxOutputBytes),
-		cancel:     cancel,
-		exitCode:   0,
+		id:             id,
+		command:        command,
+		workingDir:     workDir,
+		startedAt:      m.now(),
+		tenantID:       tenantID,
+		conversationID: conversationID,
+		runID:          originRunID,
+		stdout:         newHeadTailBuffer(m.maxOutputBytes),
+		stderr:         newHeadTailBuffer(m.maxOutputBytes),
+		cancel:         cancel,
+		exitCode:       0,
 	}
 	m.jobs[id] = job
 	m.wg.Add(1)
@@ -327,6 +390,28 @@ func (m *JobManager) runBackground(ctx context.Context, command string, timeoutS
 		}
 		job.timedOut = errors.Is(ctx.Err(), context.DeadlineExceeded)
 		job.done = true
+
+		// Report the result rather than leaving it in a buffer nobody knows to
+		// read. Built while the job lock is held so the snapshot is coherent,
+		// but delivered from a separate goroutine so a slow sink cannot block
+		// the reaper or deadlock against a sink that calls back in.
+		if sink := m.jobEvents(); sink != nil {
+			completion := JobCompletion{
+				ShellID:        job.id,
+				Command:        job.command,
+				WorkingDir:     NormalizeRelPath(m.root, job.workingDir),
+				TenantID:       job.tenantID,
+				ConversationID: job.conversationID,
+				RunID:          job.runID,
+				ExitCode:       job.exitCode,
+				TimedOut:       job.timedOut,
+				Output: mergeCommandStreams(
+					strings.TrimSpace(job.stdout.String()),
+					strings.TrimSpace(job.stderr.String())),
+				Truncated: job.stdout.Truncated() || job.stderr.Truncated(),
+			}
+			go sink.JobCompleted(completion)
+		}
 	}()
 
 	result := map[string]any{
@@ -450,6 +535,36 @@ func (m *JobManager) output(shellID string, wait bool) (map[string]any, error) {
 		result["hint"] = "[output truncated — use grep/head/tail to narrow results]"
 	}
 	return result, nil
+}
+
+// KillForRun terminates every background job started by a run, and returns
+// how many it killed.
+//
+// Background jobs are deliberately detached from the context of the run that
+// starts them, so that a run finishing normally does not kill work it launched
+// on purpose. Cancellation is the other case: a user who aborts a run does not
+// expect its processes to keep going, so the runner calls this explicitly
+// rather than relying on context propagation to mean both things at once.
+func (m *JobManager) KillForRun(runID string) int {
+	if runID == "" {
+		return 0
+	}
+	m.mu.RLock()
+	var ids []string
+	for id, job := range m.jobs {
+		if job.runID == runID {
+			ids = append(ids, id)
+		}
+	}
+	m.mu.RUnlock()
+
+	killed := 0
+	for _, id := range ids {
+		if _, err := m.kill(id); err == nil {
+			killed++
+		}
+	}
+	return killed
 }
 
 func (m *JobManager) kill(shellID string) (map[string]any, error) {

--- a/internal/harness/tools/bash_manager_background_output_test.go
+++ b/internal/harness/tools/bash_manager_background_output_test.go
@@ -113,3 +113,37 @@ func TestBackgroundJobSurvivesItsCallersContext(t *testing.T) {
 			"terminated rather than allowed to finish", exit)
 	}
 }
+
+// Guards a lock-order inversion: the completion goroutine held job.mu and then
+// wanted m.mu, while cleanupExpired takes m.mu and then job.mu. Under load the
+// manager deadlocked and the whole package timed out. The sink is now read
+// before the goroutine starts, so completion never reaches for m.mu.
+func TestCompletionDoesNotDeadlockAgainstManagerLock(t *testing.T) {
+	m := NewJobManager(t.TempDir(), time.Now)
+	defer func() { _ = m.Shutdown(context.Background()) }()
+	m.SetJobEvents(countingJobSink{})
+
+	for i := 0; i < 12; i++ {
+		if _, err := m.runBackground(context.Background(), "true", 30, ""); err != nil {
+			t.Fatalf("start job %d: %v", i, err)
+		}
+		// Contend on m.mu from another goroutine while completions land.
+		go m.cleanupExpired()
+		go func() { _ = m.list() }()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_ = m.Shutdown(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("manager deadlocked: shutdown did not return within 20s")
+	}
+}
+
+type countingJobSink struct{}
+
+func (countingJobSink) JobCompleted(JobCompletion) {}

--- a/internal/harness/tools/bash_manager_background_output_test.go
+++ b/internal/harness/tools/bash_manager_background_output_test.go
@@ -1,0 +1,115 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Reproduces the reported failure: a background job that prints after a delay
+// reported no output, so the model concluded it had never fired.
+func TestBackgroundJobOutputIsReadableAfterItPrints(t *testing.T) {
+	m := NewJobManager(t.TempDir(), time.Now)
+	defer func() { _ = m.Shutdown(context.Background()) }()
+
+	started, err := m.runBackground(context.Background(), "sleep 1; echo hello dennison", 30, "")
+	if err != nil {
+		t.Fatalf("start background job: %v", err)
+	}
+	id, _ := started["shell_id"].(string)
+	if id == "" {
+		t.Fatal("background start returned no shell_id")
+	}
+
+	// Poll the way an agent would, rather than assuming a fixed delay.
+	deadline := time.Now().Add(10 * time.Second)
+	var out map[string]any
+	for time.Now().Before(deadline) {
+		out, err = m.output(id, false)
+		if err != nil {
+			t.Fatalf("read job output: %v", err)
+		}
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if running, _ := out["running"].(bool); running {
+		t.Fatal("job never finished within 10s")
+	}
+	got, _ := out["output"].(string)
+	if !strings.Contains(got, "hello dennison") {
+		t.Errorf("finished job reported output %q, want it to contain %q — this is the\n"+
+			"defect the model hit: the job ran, exited, and its output was unreachable",
+			got, "hello dennison")
+	}
+}
+
+// The trailing-ampersand form the model actually used. `a; b &` backgrounds
+// only `b`, so the echo is a detached grandchild of the shell we capture.
+func TestBackgroundJobOutputWithTrailingAmpersand(t *testing.T) {
+	m := NewJobManager(t.TempDir(), time.Now)
+	defer func() { _ = m.Shutdown(context.Background()) }()
+
+	started, err := m.runBackground(context.Background(), "sleep 1; echo hello dennison &", 30, "")
+	if err != nil {
+		t.Fatalf("start background job: %v", err)
+	}
+	id, _ := started["shell_id"].(string)
+
+	deadline := time.Now().Add(10 * time.Second)
+	var out map[string]any
+	for time.Now().Before(deadline) {
+		out, _ = m.output(id, false)
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	got, _ := out["output"].(string)
+	t.Logf("trailing-ampersand form produced output %q (running=%v exit=%v)",
+		got, out["running"], out["exit_code"])
+}
+
+// The defect that made background jobs look broken: the job inherited the
+// caller's context, so when the run that started it ended, the job was killed
+// mid-flight. A delayed echo never ran, and the job reported exit -1 with no
+// output — indistinguishable, from the model's side, from a tool that does
+// not work.
+func TestBackgroundJobSurvivesItsCallersContext(t *testing.T) {
+	m := NewJobManager(t.TempDir(), time.Now)
+	defer func() { _ = m.Shutdown(context.Background()) }()
+
+	callerCtx, cancelCaller := context.WithCancel(context.Background())
+	started, err := m.runBackground(callerCtx, "sleep 1; echo survived", 30, "")
+	if err != nil {
+		t.Fatalf("start background job: %v", err)
+	}
+	id, _ := started["shell_id"].(string)
+
+	// The run ends immediately, as it does in practice.
+	cancelCaller()
+
+	deadline := time.Now().Add(10 * time.Second)
+	var out map[string]any
+	for time.Now().Before(deadline) {
+		out, _ = m.output(id, false)
+		if running, _ := out["running"].(bool); !running {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	got, _ := out["output"].(string)
+	exit, _ := out["exit_code"].(int)
+	if !strings.Contains(got, "survived") {
+		t.Errorf("output = %q (exit %d), want it to contain %q — the job was killed "+
+			"when its caller's context was cancelled", got, exit, "survived")
+	}
+	if exit != 0 {
+		t.Errorf("exit code = %d, want 0 — a non-zero code here means the job was "+
+			"terminated rather than allowed to finish", exit)
+	}
+}

--- a/internal/harness/tools/bash_manager_test.go
+++ b/internal/harness/tools/bash_manager_test.go
@@ -278,9 +278,19 @@ func TestOutputStreamerFromContext(t *testing.T) {
 	}
 }
 
-func TestRunBackgroundCancelsWithRunContext(t *testing.T) {
+// Cancelling a run terminates the jobs it started — but through an explicit
+// call, not context propagation.
+//
+// This test previously cancelled the caller's context and asserted the job
+// died. That conflated two different things: a run *finishing* also cancels
+// its context, so background jobs were killed on every normal turn. A
+// "sleep 15; echo ..." reminder never reached its echo and reported exit -1
+// with no output, which reads as a broken tool rather than a killed process.
+// Detaching the job fixed that; this is the other half, so cancellation still
+// leaves nothing orphaned.
+func TestRunCancellationKillsItsBackgroundJobs(t *testing.T) {
 	mgr := NewJobManager(t.TempDir(), nil)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run-1"})
 
 	result, err := mgr.runBackground(ctx, "sleep 60", 60, "")
 	if err != nil {
@@ -292,7 +302,9 @@ func TestRunBackgroundCancelsWithRunContext(t *testing.T) {
 	}
 	defer mgr.kill(shellID)
 
-	cancel()
+	if killed := mgr.KillForRun("run-1"); killed != 1 {
+		t.Fatalf("KillForRun killed %d jobs, want 1", killed)
+	}
 	waitForBackgroundJobDone(t, mgr, shellID, time.Second)
 
 	output, err := mgr.output(shellID, false)
@@ -300,7 +312,30 @@ func TestRunBackgroundCancelsWithRunContext(t *testing.T) {
 		t.Fatalf("output: %v", err)
 	}
 	if running, _ := output["running"].(bool); running {
-		t.Fatalf("background job %s still running after context cancellation: %#v", shellID, output)
+		t.Fatalf("background job %s still running after its run was cancelled: %#v", shellID, output)
+	}
+}
+
+// The counterpart: another run's jobs are untouched.
+func TestKillForRunOnlyKillsThatRunsJobs(t *testing.T) {
+	mgr := NewJobManager(t.TempDir(), nil)
+	ctxA := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run-a"})
+	ctxB := context.WithValue(context.Background(), ContextKeyRunMetadata, RunMetadata{RunID: "run-b"})
+
+	a, _ := mgr.runBackground(ctxA, "sleep 60", 60, "")
+	b, _ := mgr.runBackground(ctxB, "sleep 60", 60, "")
+	defer mgr.kill(a["shell_id"].(string))
+	defer mgr.kill(b["shell_id"].(string))
+
+	mgr.KillForRun("run-a")
+	waitForBackgroundJobDone(t, mgr, a["shell_id"].(string), time.Second)
+
+	out, err := mgr.output(b["shell_id"].(string), false)
+	if err != nil {
+		t.Fatalf("output: %v", err)
+	}
+	if running, _ := out["running"].(bool); !running {
+		t.Error("killing run-a also stopped run-b's job")
 	}
 }
 

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -95,6 +95,12 @@ type DefaultRegistryOptions struct {
 	// POST /v1/jobs/{id}/kill; epic #814 slice 2). The manager unregisters
 	// itself when the registry shuts down.
 	JobTracker *JobTracker
+	// JobEvents, when non-nil, is notified when a background job finishes so
+	// its result can reach the UI and the model's next turn. Without it a
+	// completed job's output sits in a buffer that only a job_output poll with
+	// the right shell_id can read — which is how a job that ran, exited, and
+	// printed correctly was reported to the user as never having fired.
+	JobEvents htools.JobEvents
 }
 
 // conversationStoreAdapter adapts ConversationStore (harness package) to htools.ConversationReader.
@@ -189,6 +195,9 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 	jobManager := htools.NewJobManager(workspaceRoot, time.Now)
 	if opts.SandboxScope != "" {
 		jobManager.SetSandboxScope(htools.SandboxScope(opts.SandboxScope))
+	}
+	if opts.JobEvents != nil {
+		jobManager.SetJobEvents(opts.JobEvents)
 	}
 	policyAdapter := toolPolicyAdapter{policy: opts.Policy}
 
@@ -541,6 +550,7 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 
 	// -- Register all tools in the registry --
 	registry = NewRegistry()
+	registry.SetJobManager(jobManager)
 	registry.RegisterShutdownHook(jobManager.Shutdown)
 
 	// Expose this registry's background jobs to the daemon-wide /v1/tasks

--- a/internal/harness/tools_default.go
+++ b/internal/harness/tools_default.go
@@ -287,6 +287,20 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 		)
 	}
 
+	// Delayed callbacks are core rather than deferred. "Remind me in N
+	// seconds" is a first-contact request, and a deferred tool is invisible
+	// until find_tool activates it — so the model, knowing a callback exists
+	// but not seeing one, reached for the skill tool instead and produced
+	// "skill not found: set_delayed_callback". Discovery cost is only worth
+	// paying for tools a run is unlikely to need; this is not one of those.
+	if buildOpts.EnableCallbacks && opts.CallbackManager != nil {
+		coreTools = append(coreTools,
+			deferred.SetDelayedCallbackTool(opts.CallbackManager),
+			deferred.CancelDelayedCallbackTool(opts.CallbackManager),
+			deferred.ListDelayedCallbacksTool(opts.CallbackManager),
+		)
+	}
+
 	// -- Build deferred tools --
 	var deferredTools []htools.Tool
 
@@ -354,13 +368,7 @@ func NewDefaultRegistryWithOptions(workspaceRoot string, opts DefaultRegistryOpt
 			deferred.CronResumeTool(opts.CronClient),
 		)
 	}
-	if buildOpts.EnableCallbacks && opts.CallbackManager != nil {
-		deferredTools = append(deferredTools,
-			deferred.SetDelayedCallbackTool(opts.CallbackManager),
-			deferred.CancelDelayedCallbackTool(opts.CallbackManager),
-			deferred.ListDelayedCallbacksTool(opts.CallbackManager),
-		)
-	}
+	// (Delayed callbacks moved to the core set above — see the comment there.)
 	if buildOpts.EnableSkills && opts.SkillVerifier != nil {
 		deferredTools = append(deferredTools, deferred.VerifySkillTool(opts.SkillVerifier))
 	}

--- a/macapp/Sources/GoCodeUI/AppShell.swift
+++ b/macapp/Sources/GoCodeUI/AppShell.swift
@@ -182,11 +182,19 @@ struct RailRow: View {
                     // icon contributes its own SF Symbol identifier to the
                     // combined accessibility description.
                     .accessibilityHidden(true)
-                if !compact { Text(item.title).font(Typography.body) }
-                Spacer(minLength: Spacing.none)
+                if !compact {
+                    Text(item.title).font(Typography.body)
+                    Spacer(minLength: Spacing.none)
+                }
             }
-            .padding(.horizontal, Spacing.comfortable).padding(.vertical, Spacing.standard)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            // A compact row carries an icon and nothing else, so it takes the
+            // tighter inset. At the labelled inset five of them needed 249pt
+            // inside a 204pt column: the overflow widened the whole rail and
+            // pushed its rows off-centre, which is why the selected pill sat
+            // 1pt from the left edge and 15pt from the right.
+            .padding(.horizontal, compact ? Spacing.small : Spacing.comfortable)
+            .padding(.vertical, Spacing.standard)
+            .frame(maxWidth: compact ? nil : .infinity, alignment: .leading)
             .background(
                 section == item ? Theme.selectedRowSurface : .clear,
                 in: .rect(cornerRadius: CornerRadius.control)

--- a/macapp/Sources/GoCodeUI/ChatView.swift
+++ b/macapp/Sources/GoCodeUI/ChatView.swift
@@ -12,7 +12,11 @@ struct ChatView: View {
     @State private var showInspector = false
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        // A row, not a ZStack. As an overlay the card covered the transcript it
+        // was describing, because this app's content column fills 94% of the
+        // pane and leaves no margin to float over. As a sibling the transcript
+        // simply reflows around it.
+        HStack(alignment: .top, spacing: Spacing.none) {
             VStack(spacing: Spacing.none) {
                 ConversationHeader(project: project, run: run)
                 TranscriptView(
@@ -40,7 +44,9 @@ struct ChatView: View {
                     activities: toolActivities,
                     selected: $selected
                 )
-                .padding(Spacing.large)
+                .padding(.trailing, Spacing.comfortable)
+                .padding(.vertical, Spacing.comfortable)
+                .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
         .toolbar {

--- a/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
+++ b/macapp/Sources/GoCodeUI/DesignSystem/Layout.swift
@@ -7,8 +7,13 @@ enum Layout {
     static let appMinimumHeight: CGFloat = 600
     static let railWidth: CGFloat = 220
     static let railRowHeight: CGFloat = 37
-    /// Codex's environment surface is a compact overlay card, not a sidebar.
-    static let inspectorCardWidth: CGFloat = 361
+    /// Codex's environment surface is a compact card, not a sidebar. 361pt was
+    /// measured from the reference, but the reference fills only 64% of its
+    /// pane with content and so has room to float the card over the margin.
+    /// This app fills 94%, so at that width the card sat on top of the
+    /// transcript. It is a sibling column here rather than an overlay, and
+    /// narrow enough that opening it costs the transcript little.
+    static let inspectorCardWidth: CGFloat = 217
     static let chatMinimumWidth: CGFloat = 400
     static let chatIdealWidth: CGFloat = 520
     /// Keep the transcript and composer on the same readable column instead

--- a/macapp/Sources/GoCodeUI/EnvironmentInspector.swift
+++ b/macapp/Sources/GoCodeUI/EnvironmentInspector.swift
@@ -19,9 +19,13 @@ struct EnvironmentInspector: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Spacing.standard) {
+        // Compact by intent: this is a glanceable summary beside the
+        // transcript, so it takes the tighter rhythm and the caption rung
+        // rather than the heading one.
+        VStack(alignment: .leading, spacing: Spacing.small) {
             Text("Environment")
-                .font(Typography.heading)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(Theme.foregroundSecondary)
 
             if usage.totalTokens > 0 {
                 EnvironmentCard(title: "Usage", icon: "gauge.with.dots.needle.67percent") {
@@ -76,7 +80,7 @@ struct EnvironmentInspector: View {
                 }
             }
         }
-        .padding(Spacing.inset)
+        .padding(Spacing.comfortable)
         .frame(width: Layout.inspectorCardWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
         .cardStyle()

--- a/macapp/Sources/HarnessKit/HarnessEvent.swift
+++ b/macapp/Sources/HarnessKit/HarnessEvent.swift
@@ -24,6 +24,9 @@ public enum HarnessEventType: Sendable, Hashable {
     // Tools
     case toolCallStarted, toolCallDelta, toolCallCompleted, toolCallBlocked
     case toolOutputDelta
+    /// A background job finished. It routinely outlives the run that started
+    /// it, so this is the only signal the UI gets that it ever completed.
+    case backgroundJobCompleted
     case toolApprovalRequired, toolApprovalGranted, toolApprovalDenied
 
     // Plan mode
@@ -69,6 +72,7 @@ extension HarnessEventType: RawRepresentable {
         .maxTurnsExhausted, .providerResolved, .promptResolved, .promptWarning,
         .llmTurnRequested, .llmTurnCompleted, .assistantMessage, .assistantMessageDelta,
         .assistantThinkingDelta, .toolCallStarted, .toolCallDelta, .toolCallCompleted,
+        .backgroundJobCompleted,
         .toolCallBlocked, .toolOutputDelta, .toolApprovalRequired, .toolApprovalGranted,
         .toolApprovalDenied, .planApprovalRequired, .planApprovalGranted, .planApprovalDenied,
         .usageDelta, .todosUpdated, .steeringReceived, .contextWindowWarning,
@@ -107,6 +111,7 @@ extension HarnessEventType: RawRepresentable {
         case .toolCallCompleted: return "tool.call.completed"
         case .toolCallBlocked: return "tool.call.blocked"
         case .toolOutputDelta: return "tool.output.delta"
+        case .backgroundJobCompleted: return "job.completed"
         case .toolApprovalRequired: return "tool.approval_required"
         case .toolApprovalGranted: return "tool.approval_granted"
         case .toolApprovalDenied: return "tool.approval_denied"

--- a/macapp/Sources/HarnessKit/HarnessSupervisor.swift
+++ b/macapp/Sources/HarnessKit/HarnessSupervisor.swift
@@ -76,6 +76,20 @@ public actor HarnessSupervisor {
                 at: harnessDirectory, withIntermediateDirectories: true)
             env["HARNESS_RUN_DB"] = harnessDirectory.appending(path: "runs.db").path
         }
+        // The run store doubles as harnessd's API-key store, and its mere
+        // presence switches auth on — so configuring run persistence above
+        // silently turned every route 401 and made Settings unreachable. The
+        // app has no way to mint or carry a key.
+        //
+        // This is not a loosening: before the run store existed, auth was
+        // already off for every app-supervised daemon, because a nil store
+        // disables it implicitly. This states that same posture explicitly
+        // instead of depending on a store being absent. The daemon binds
+        // 127.0.0.1 and is spawned by this app for the user's own project.
+        // Issue #979 tracks provisioning a real key so this can be removed.
+        if env["HARNESS_AUTH_DISABLED"] == nil {
+            env["HARNESS_AUTH_DISABLED"] = "true"
+        }
         // harnessd resolves its prompts and model catalog relative to its
         // *working directory* and workspace — both of which are the user's
         // project here, and neither contains those files. Without pinning them

--- a/macapp/Sources/HarnessKit/Transcript.swift
+++ b/macapp/Sources/HarnessKit/Transcript.swift
@@ -200,6 +200,20 @@ public struct Transcript: Sendable {
         case .toolCallBlocked:
             mutateActivity(payload) { $0.status = .blocked }
 
+        // A background job routinely finishes after the run that started it
+        // has ended, so this is the only moment the transcript can show that
+        // it ran at all. Rendered as a notice rather than folded into a tool
+        // row, because by now there is no tool row left to fold it into.
+        case .backgroundJobCompleted:
+            let command = payload["command"]?.stringValue ?? "background job"
+            let output = payload["output"]?.stringValue ?? ""
+            let exitCode = payload["exit_code"]?.intValue ?? 0
+            let timedOut = payload["timed_out"]?.boolValue ?? false
+            var message = timedOut ? "\(command) — timed out" : "\(command) — finished"
+            if !timedOut && exitCode != 0 { message += " (exit \(exitCode))" }
+            if !output.isEmpty { message += "\n\(output)" }
+            items.append(.init(id: UUID(), kind: .notice(message)))
+
         case .toolApprovalRequired:
             guard let callID = payload["call_id"]?.stringValue else { break }
             pendingApproval = PendingApproval(

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -41,6 +41,19 @@ struct DesignTokenTests {
         #expect(Layout.inspectorCardWidth == 361)
     }
 
+    /// Five compact rows once needed 249pt inside the rail's 204pt content
+    /// width. The overflow widened the column and pushed every row off-centre,
+    /// so the selected pill rendered 1pt from the left edge and 15pt from the
+    /// right. This pins the arithmetic that keeps the footer inside its column.
+    @Test("the compact rail footer fits inside the rail's content width")
+    func compactRailFooterFits() {
+        let iconRow = IconSize.row
+        let compactRowWidth = iconRow + (Spacing.small * 2)
+        let footer = (compactRowWidth * 5) + (Spacing.tight * 4)
+        let available = Layout.railWidth - (Spacing.standard * 2)
+        #expect(footer <= available)
+    }
+
     @Test("loading placeholders use named row and inline-control geometry")
     func loadingGeometryIsTokenized() {
         #expect(Layout.loadingRowHeight > Spacing.large)

--- a/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
+++ b/macapp/Tests/GoCodeUITests/DesignTokenTests.swift
@@ -33,12 +33,19 @@ struct DesignTokenTests {
         #expect(IconSize.launch == 44)
     }
 
-    /// The environment inspector is an overlay card, not a window-height
-    /// split. Keeping its measured footprint in the token layer prevents a
-    /// future layout pass from quietly turning it back into a sidebar.
+    /// The environment inspector is a compact card, not a window-height split.
+    /// Keeping its footprint in the token layer prevents a future layout pass
+    /// from quietly turning it back into a sidebar.
+    ///
+    /// 361pt was the reference's own width, but the reference floats its card
+    /// over a pane that is only 64% filled. This app fills 94%, so at that
+    /// width the card covered the transcript it describes. It is now a sibling
+    /// column at 60% of that width.
     @Test("environment inspector retains its compact card footprint")
     func environmentInspectorFootprint() {
-        #expect(Layout.inspectorCardWidth == 361)
+        #expect(Layout.inspectorCardWidth == 217)
+        // Narrow enough that opening it leaves the transcript readable.
+        #expect(Layout.inspectorCardWidth < Layout.chatContentMaximumWidth / 3)
     }
 
     /// Five compact rows once needed 249pt inside the rail's 204pt content

--- a/macapp/Tests/HarnessKitTests/SupervisorTests.swift
+++ b/macapp/Tests/HarnessKitTests/SupervisorTests.swift
@@ -174,6 +174,24 @@ struct SupervisorTests {
         await supervisor.stop()
     }
 
+    /// Configuring a run store silently switched auth on for every route,
+    /// because harnessd treats that store as its API-key store and a nil store
+    /// as "auth disabled". The app carries no key, so Settings, Providers and
+    /// Models all answered 401. These must stay together.
+    @Test("run persistence does not lock the app out of its own daemon")
+    func runStoreDoesNotEnableAuth() async throws {
+        let workspace = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appending(path: "proj-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: workspace, withIntermediateDirectories: true)
+
+        let supervisor = HarnessSupervisor(binary: try makeStubServer(), workspace: workspace)
+        _ = try await supervisor.start()
+        let environment = await supervisor.environment
+        #expect(environment["HARNESS_RUN_DB"] != nil)
+        #expect(environment["HARNESS_AUTH_DISABLED"] == "true")
+        await supervisor.stop()
+    }
+
     @Test("passes the workspace to the child so it serves the right project")
     func passesWorkspace() async throws {
         let workspace = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/macapp/Tests/HarnessKitTests/TranscriptTests.swift
+++ b/macapp/Tests/HarnessKitTests/TranscriptTests.swift
@@ -292,3 +292,44 @@ private func event(_ type: HarnessEventType, _ payload: [String: Any]) -> Harnes
         frame: SSEFrame(
             id: "run_t:0", event: type.rawValue, data: String(decoding: data, as: UTF8.self)))
 }
+
+extension TranscriptTests {
+    /// A background job finishes after its run has ended, so this event is the
+    /// only signal the transcript gets that it ran at all. Before it existed, a
+    /// job that ran and printed correctly was reported to the user as never
+    /// having fired.
+    @Test("a finished background job appears in the transcript with its output")
+    func backgroundJobCompletionSurfaces() {
+        var transcript = Transcript()
+        transcript.apply(
+            event(
+                .backgroundJobCompleted,
+                [
+                    "command": "sleep 15; echo hello dennison",
+                    "output": "hello dennison",
+                    "exit_code": 0,
+                ]))
+
+        let notices = transcript.items.compactMap { item -> String? in
+            if case .notice(let text) = item.kind { return text }
+            return nil
+        }
+        #expect(notices.count == 1)
+        #expect(notices.first?.contains("hello dennison") == true)
+        #expect(notices.first?.contains("sleep 15") == true)
+    }
+
+    @Test("a background job that timed out says so")
+    func backgroundJobTimeoutSurfaces() {
+        var transcript = Transcript()
+        transcript.apply(
+            event(
+                .backgroundJobCompleted,
+                ["command": "sleep 999", "timed_out": true, "exit_code": -1]))
+        let notices = transcript.items.compactMap { item -> String? in
+            if case .notice(let text) = item.kind { return text }
+            return nil
+        }
+        #expect(notices.first?.contains("timed out") == true)
+    }
+}

--- a/scripts/gui-app-target.sh
+++ b/scripts/gui-app-target.sh
@@ -1,0 +1,57 @@
+#!/bin/zsh
+# Resolve, and PROVE, which GoCode instance you are about to drive.
+#
+# Several GoCode processes routinely coexist — one per worktree build, plus
+# whatever a subagent launched — and they all answer to the same app name. Data
+# gathered from the wrong one looks entirely plausible, which is how a stale
+# build got reported as a new measurement twice.
+#
+# Usage: gui-app-target.sh <expected-workspace-name>
+#   prints "<pid> <window-id>" and exits non-zero if identity cannot be proven.
+set -u
+EXPECT="${1:?usage: gui-app-target.sh <expected-workspace-name>}"
+
+pids=$(pgrep -f "macapp/.build/debug/GoCode" | tr '\n' ' ')
+[ -z "$pids" ] && { echo "no GoCode process running" >&2; exit 2; }
+
+count=$(echo "$pids" | wc -w | tr -d ' ')
+[ "$count" -gt 1 ] && echo "note: $count GoCode instances running ($pids) — matching on workspace" >&2
+
+for pid in ${=pids}; do
+  win=$(/tmp/winlist "$pid" 2>/dev/null | grep "^window:" | python3 -c "
+import sys,re
+best,area=None,0
+for l in sys.stdin:
+    i=re.search(r'\bid=(\d+)',l); w=re.search(r'\"Width\": (\d+)',l); h=re.search(r'\"Height\": (\d+)',l)
+    if i and w and h:
+        a=int(w.group(1))*int(h.group(1))
+        if a>area: area,best=a,i.group(1)
+print(best or '')")
+  [ -z "$win" ] && continue
+  # The window title carries the workspace name. That is the only identity
+  # check that survives a stale process still holding an old window.
+  shot=$(mktemp -t gocodeid).png
+  screencapture -x -o -l"$win" "$shot" 2>/dev/null
+  title=$(/tmp/guidrive "$pid" ocr "$shot" 2>/dev/null | head -1)
+  rm -f "$shot"
+  if echo "$title" | grep -q "$EXPECT"; then
+    # Matching the workspace name proves WHICH app, not WHICH BUILD. A critic
+    # once certified a binary started six minutes before the fix it was sent to
+    # verify — right window, stale code. So also require the running process to
+    # be no older than the binary it was launched from.
+    if [ -n "${BINARY:-}" ] && [ -f "$BINARY" ]; then
+      started=$(ps -o lstart= -p "$pid" 2>/dev/null)
+      started_epoch=$(date -j -f "%a %b %d %T %Y" "$started" +%s 2>/dev/null || echo 0)
+      binary_epoch=$(stat -f %m "$BINARY" 2>/dev/null || echo 0)
+      if [ "$started_epoch" -gt 0 ] && [ "$binary_epoch" -gt "$started_epoch" ]; then
+        echo "pid $pid is running a build older than $BINARY — relaunch before measuring" >&2
+        exit 4
+      fi
+    fi
+    echo "$pid $win"
+    exit 0
+  fi
+done
+
+echo "no GoCode window titled '$EXPECT' — refusing to guess" >&2
+exit 3


### PR DESCRIPTION
Six fixes from real use of the app, all verified against the running build rather than the diff.

## Background jobs were killed by their own caller

`runBackground` derived the job's context from the tool call's, and that context belongs to the run. So when a run **finished** — every normal turn — its background jobs were cancelled mid-flight. A `sleep 15; echo …` reminder never reached its echo and reported `exit -1` with no output, which reads as a broken tool rather than a killed process.

Jobs are now detached from the caller, keeping only its values. The reproduction test fails with exactly the reported signature (`output "" exit -1`) when the detachment is reverted.

An existing test asserted the old behaviour, and it was **not simply wrong** — cancelling a run *should* stop its jobs. That is a different requirement from a run *finishing*, and one context could not express both. `CancelRun` now kills its jobs explicitly, with a counterpart test proving one run's cancellation leaves another's alone.

## Nothing reported a job's result

Output sat in a buffer only a `job_output` poll with the right shell id could read, so a job finishing after its run had ended told neither the model nor the UI. Completions now reach both:

- **UI** — a `job.completed` event delivered to the **conversation**, not a run. The run-scoped fan-out is keyed on live run state and dropped these in exactly the case they exist for.
- **Model** — a notice consumed at the start of its next turn. Consumed rather than read, so a job reports once. Output and queue depth bounded.

A lock-order inversion in the first version of this deadlocked the manager and timed out CI after 20 minutes; the sink is now read before the completion goroutine starts, with a regression test that contends on the manager lock.

## The callback tool was invisible to the model

Registered in the deferred tier, so it was in the catalog and absent from the conversation. The model knew a callback existed, guessed it was a skill, and failed with `skill not found: set_delayed_callback`. Core now — a reminder is a first-contact request, not something worth paying discovery cost for.

The existing test could not have caught this: it asserts the tools are *registered*, which they were. The new one asserts they are *visible to a run*.

## Configuring run persistence locked the app out of its own daemon

harnessd uses the run store as its API-key store and treats a nil store as "auth disabled" — so giving the Activity screen data silently switched auth on for every route and every settings tab answered 401. Not a loosening: auth was already off for app-supervised daemons, implicitly. #979 tracks provisioning a real key.

## Rail rows sat off-centre

The selected pill was 1pt from the left edge and 15pt from the right. Not the pill — five compact footer rows needed 249pt inside a 204pt column, and the overflow shifted everything. Measured after: **8.0pt / 8.0pt**.

## The environment card covered the transcript

A `ZStack` overlay at 361pt. That width is the reference's, but the reference floats its card over a pane filled to 64% while this app fills 94%. Now a sibling column at 217pt with tighter internals.

---

Go suite green under `-race`; 174 Swift tests pass. Closes #981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPFeSNp49415WenKDF7gy9